### PR TITLE
Reduce body boxing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ serde_json = "1.0"
 serde_urlencoded = "0.7"
 tokio = { version = "1", features = ["time"] }
 tower = { version = "0.4", features = ["util", "buffer", "make"] }
-tower-http = { version = "0.1", features = ["add-extension"] }
+tower-http = { version = "0.1", features = ["add-extension", "map-response-body"] }
 
 # optional dependencies
 tokio-tungstenite = { optional = true, version = "0.14" }

--- a/examples/key_value_store.rs
+++ b/examples/key_value_store.rs
@@ -21,7 +21,6 @@ use tower_http::{
     compression::CompressionLayer, trace::TraceLayer,
 };
 use tower_web::{
-    body::BoxBody,
     extract::{ContentLengthLimit, Extension, UrlParams},
     prelude::*,
     response::IntoResponse,
@@ -99,7 +98,7 @@ async fn list_keys(Extension(state): Extension<SharedState>) -> String {
         .join("\n")
 }
 
-fn admin_routes() -> BoxRoute<BoxBody> {
+fn admin_routes() -> BoxRoute {
     async fn delete_all_keys(Extension(state): Extension<SharedState>) {
         state.write().unwrap().db.clear();
     }

--- a/src/body.rs
+++ b/src/body.rs
@@ -1,7 +1,8 @@
 //! HTTP body utilities.
 
 use bytes::Bytes;
-use http_body::{Empty, Full};
+use http_body::{Empty, Full, SizeHint};
+use pin_project::pin_project;
 use std::{
     error::Error as StdError,
     fmt,
@@ -32,12 +33,6 @@ impl BoxBody {
         Self {
             inner: Box::pin(body.map_err(|error| BoxStdError(error.into()))),
         }
-    }
-}
-
-impl Default for BoxBody {
-    fn default() -> Self {
-        BoxBody::new(Empty::<Bytes>::new())
     }
 }
 
@@ -100,4 +95,104 @@ impl fmt::Display for BoxStdError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.0.fmt(f)
     }
+}
+
+/// Type that combines two body types into one.
+#[pin_project]
+#[derive(Debug)]
+pub struct Or<A, B>(#[pin] Either<A, B>);
+
+impl<A, B> Or<A, B> {
+    #[inline]
+    pub(crate) fn a(a: A) -> Self {
+        Or(Either::A(a))
+    }
+
+    #[inline]
+    pub(crate) fn b(b: B) -> Self {
+        Or(Either::B(b))
+    }
+}
+
+impl<A, B> Default for Or<A, B> {
+    fn default() -> Self {
+        Self(Either::Empty(Empty::new()))
+    }
+}
+
+#[pin_project(project = EitherProj)]
+#[derive(Debug)]
+enum Either<A, B> {
+    Empty(Empty<Bytes>), // required for `Default`
+    A(#[pin] A),
+    B(#[pin] B),
+}
+
+impl<A, B> http_body::Body for Or<A, B>
+where
+    A: http_body::Body<Data = Bytes>,
+    A::Error: Into<BoxError>,
+    B: http_body::Body<Data = Bytes>,
+    B::Error: Into<BoxError>,
+{
+    type Data = Bytes;
+    type Error = BoxStdError;
+
+    #[inline]
+    fn poll_data(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Self::Data, Self::Error>>> {
+        match self.project().0.project() {
+            EitherProj::Empty(inner) => Pin::new(inner).poll_data(cx).map(map_option_error),
+            EitherProj::A(inner) => inner.poll_data(cx).map(map_option_error),
+            EitherProj::B(inner) => inner.poll_data(cx).map(map_option_error),
+        }
+    }
+
+    #[inline]
+    fn poll_trailers(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<Option<http::HeaderMap>, Self::Error>> {
+        match self.project().0.project() {
+            EitherProj::Empty(inner) => Pin::new(inner)
+                .poll_trailers(cx)
+                .map_err(Into::into)
+                .map_err(BoxStdError),
+            EitherProj::A(inner) => inner
+                .poll_trailers(cx)
+                .map_err(Into::into)
+                .map_err(BoxStdError),
+            EitherProj::B(inner) => inner
+                .poll_trailers(cx)
+                .map_err(Into::into)
+                .map_err(BoxStdError),
+        }
+    }
+
+    #[inline]
+    fn size_hint(&self) -> SizeHint {
+        match &self.0 {
+            Either::Empty(inner) => inner.size_hint(),
+            Either::A(inner) => inner.size_hint(),
+            Either::B(inner) => inner.size_hint(),
+        }
+    }
+
+    #[inline]
+    fn is_end_stream(&self) -> bool {
+        match &self.0 {
+            Either::Empty(inner) => inner.is_end_stream(),
+            Either::A(inner) => inner.is_end_stream(),
+            Either::B(inner) => inner.is_end_stream(),
+        }
+    }
+}
+
+fn map_option_error<T, E>(opt: Option<Result<T, E>>) -> Option<Result<T, BoxStdError>>
+where
+    E: Into<BoxError>,
+{
+    opt.map(|result| result.map_err(Into::<BoxError>::into).map_err(BoxStdError))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -510,7 +510,7 @@
 //! use http::Response;
 //! use std::convert::Infallible;
 //!
-//! fn api_routes() -> BoxRoute<BoxBody> {
+//! fn api_routes() -> BoxRoute {
 //!     route("/users", get(|_: Request<Body>| async { /* ... */ })).boxed()
 //! }
 //!
@@ -690,19 +690,6 @@ where
     use routing::RoutingDsl;
 
     routing::EmptyRouter.route(description, service)
-}
-
-pub(crate) trait ResultExt<T> {
-    fn unwrap_infallible(self) -> T;
-}
-
-impl<T> ResultExt<T> for Result<T, Infallible> {
-    fn unwrap_infallible(self) -> T {
-        match self {
-            Ok(value) => value,
-            Err(err) => match err {},
-        }
-    }
 }
 
 mod sealed {

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -84,12 +84,11 @@
 //! [load shed]: tower::load_shed
 
 use crate::{
-    body::{Body, BoxBody},
+    body::{self, Body, BoxBody},
     response::IntoResponse,
-    routing::{BoxResponseBody, EmptyRouter, MethodFilter, RouteFuture},
+    routing::{EmptyRouter, MethodFilter, RouteFuture},
 };
 use bytes::Bytes;
-use futures_util::future::Either;
 use http::{Request, Response};
 use std::{
     convert::Infallible,
@@ -408,14 +407,14 @@ impl<S, F> OnMethod<S, F> {
 impl<S, F, SB, FB> Service<Request<Body>> for OnMethod<S, F>
 where
     S: Service<Request<Body>, Response = Response<SB>, Error = Infallible> + Clone,
-    SB: http_body::Body<Data = Bytes> + Send + Sync + 'static,
-    SB::Error: Into<BoxError>,
-
     F: Service<Request<Body>, Response = Response<FB>, Error = Infallible> + Clone,
-    FB: http_body::Body<Data = Bytes> + Send + Sync + 'static,
+
+    SB: http_body::Body<Data = Bytes>,
+    SB::Error: Into<BoxError>,
+    FB: http_body::Body<Data = Bytes>,
     FB::Error: Into<BoxError>,
 {
-    type Response = Response<BoxBody>;
+    type Response = Response<body::Or<SB, FB>>;
     type Error = Infallible;
     type Future = RouteFuture<S, F>;
 
@@ -424,14 +423,13 @@ where
     }
 
     fn call(&mut self, req: Request<Body>) -> Self::Future {
-        let f = if self.method.matches(req.method()) {
-            let response_future = self.svc.clone().oneshot(req);
-            Either::Left(BoxResponseBody(response_future))
+        if self.method.matches(req.method()) {
+            let fut = self.svc.clone().oneshot(req);
+            RouteFuture::a(fut)
         } else {
-            let response_future = self.fallback.clone().oneshot(req);
-            Either::Right(BoxResponseBody(response_future))
-        };
-        RouteFuture(f)
+            let fut = self.fallback.clone().oneshot(req);
+            RouteFuture::b(fut)
+        }
     }
 }
 


### PR DESCRIPTION
Previously, when routing between one or two requests the two body types
would be merged by boxing them. This isn't ideal since it introduces a
layer indirection for each route.

We can't require the services to be routed between as not all services
use the same body type.

This changes that so it instead uses an `Either` enum that implements
`http_body::Body` if each variant does. Will reduce the overall
allocations and hopefully the compiler can optimize things if both
variants are the same.