### PR TITLE
Reduce size of response body types

### DIFF
--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -39,7 +39,7 @@
 //! the [`extract`](crate::extract) module.
 
 use crate::{
-    body::{self, Body, BoxBody},
+    body::{Body, BoxBody},
     extract::FromRequest,
     response::IntoResponse,
     routing::{EmptyRouter, MethodFilter, RouteFuture},
@@ -643,17 +643,12 @@ impl<S, F> OnMethod<S, F> {
     }
 }
 
-impl<S, F, SB, FB> Service<Request<Body>> for OnMethod<S, F>
+impl<S, F> Service<Request<Body>> for OnMethod<S, F>
 where
-    S: Service<Request<Body>, Response = Response<SB>, Error = Infallible> + Clone,
-    F: Service<Request<Body>, Response = Response<FB>, Error = Infallible> + Clone,
-
-    SB: http_body::Body<Data = Bytes>,
-    SB::Error: Into<BoxError>,
-    FB: http_body::Body<Data = Bytes>,
-    FB::Error: Into<BoxError>,
+    S: Service<Request<Body>, Response = Response<BoxBody>, Error = Infallible> + Clone,
+    F: Service<Request<Body>, Response = Response<BoxBody>, Error = Infallible> + Clone,
 {
-    type Response = Response<body::Or<SB, FB>>;
+    type Response = Response<BoxBody>;
     type Error = Infallible;
     type Future = RouteFuture<S, F>;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -479,10 +479,10 @@
 //! let app = route(
 //!     // Any request to `/` goes to a service
 //!     "/",
-//!     service_fn(|_: Request<Body>| async {
+//!     service::any(service_fn(|_: Request<Body>| async {
 //!         let res = Response::new(Body::from("Hi from `GET /`"));
 //!         Ok::<_, Infallible>(res)
-//!     })
+//!     }))
 //! ).route(
 //!     // GET `/static/Cargo.toml` goes to a service from tower-http
 //!     "/static/Cargo.toml",

--- a/src/ws/mod.rs
+++ b/src/ws/mod.rs
@@ -15,7 +15,10 @@
 //! }
 //! ```
 
-use crate::{routing::EmptyRouter, service::OnMethod};
+use crate::{
+    routing::EmptyRouter,
+    service::{BoxResponseBody, OnMethod},
+};
 use bytes::Bytes;
 use future::ResponseFuture;
 use futures_util::{sink::SinkExt, stream::StreamExt};
@@ -38,7 +41,7 @@ pub mod future;
 /// each connection.
 ///
 /// See the [module docs](crate::ws) for more details.
-pub fn ws<F, Fut>(callback: F) -> OnMethod<WebSocketUpgrade<F>, EmptyRouter>
+pub fn ws<F, Fut>(callback: F) -> OnMethod<BoxResponseBody<WebSocketUpgrade<F>>, EmptyRouter>
 where
     F: FnOnce(WebSocket) -> Fut + Clone + Send + 'static,
     Fut: Future<Output = ()> + Send + 'static,


### PR DESCRIPTION
Wrapping everything in `crate::body::Either` wasn't actually necessary
ans probably causes large body types. You can instead box the bodies in
the leaf services.