### PR TITLE
Add support for extracting typed headers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ tower-http = { version = "0.1", features = ["add-extension", "map-response-body"
 tokio-tungstenite = { optional = true, version = "0.14" }
 sha-1 = { optional = true, version = "0.9.6" }
 base64 = { optional = true, version = "0.13" }
+headers = { optional = true, version = "0.3" }
 
 [dev-dependencies]
 askama = "0.10.5"

--- a/src/extract/rejection.rs
+++ b/src/extract/rejection.rs
@@ -1,5 +1,6 @@
 //! Rejection response types.
 
+use http::StatusCode;
 use tower::BoxError;
 
 use super::IntoResponse;
@@ -339,5 +340,24 @@ where
             Self::LengthRequired(inner) => inner.into_response(),
             Self::Inner(inner) => inner.into_response(),
         }
+    }
+}
+
+/// Rejection used for [`TypedHeader`](super::TypedHeader).
+#[cfg(feature = "headers")]
+#[cfg_attr(docsrs, doc(cfg(feature = "headers")))]
+#[derive(Debug)]
+pub struct TypedHeaderRejection {
+    pub(super) name: &'static http::header::HeaderName,
+    pub(super) err: headers::Error,
+}
+
+#[cfg(feature = "headers")]
+#[cfg_attr(docsrs, doc(cfg(feature = "headers")))]
+impl IntoResponse for TypedHeaderRejection {
+    fn into_response(self) -> http::Response<Body> {
+        let mut res = format!("{} ({})", self.err, self.name).into_response();
+        *res.status_mut() = StatusCode::BAD_REQUEST;
+        res
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -551,6 +551,7 @@
 //! - `ws`: Enables WebSockets support.
 //! - `hyper-h1`: Enables hyper's `http1` feature. On by default.
 //! - `hyper-h2`: Enables hyper's `http2` feature.
+//! - `headers`: Enables extracing typed headers via [`extract::TypedHeader`].
 //!
 //! [tower]: https://crates.io/crates/tower
 //! [tower-http]: https://crates.io/crates/tower-http


### PR DESCRIPTION
Uses the `headers` crate.