### PR TITLE
Make extractors easier to write

### DIFF
--- a/examples/versioning.rs
+++ b/examples/versioning.rs
@@ -1,5 +1,9 @@
 use axum::response::IntoResponse;
-use axum::{async_trait, extract::FromRequest, prelude::*};
+use axum::{
+    async_trait,
+    extract::{FromRequest, RequestParts},
+    prelude::*,
+};
 use http::Response;
 use http::StatusCode;
 use std::net::SocketAddr;
@@ -36,7 +40,7 @@ where
 {
     type Rejection = Response<Body>;
 
-    async fn from_request(req: &mut Request<B>) -> Result<Self, Self::Rejection> {
+    async fn from_request(req: &mut RequestParts<B>) -> Result<Self, Self::Rejection> {
         let params = extract::UrlParamsMap::from_request(req)
             .await
             .map_err(IntoResponse::into_response)?;

--- a/src/body.rs
+++ b/src/body.rs
@@ -1,13 +1,8 @@
 //! HTTP body utilities.
 
 use bytes::Bytes;
-use http_body::{Empty, Full};
-use std::{
-    error::Error as StdError,
-    fmt,
-    pin::Pin,
-    task::{Context, Poll},
-};
+use http_body::Body as _;
+use std::{error::Error as StdError, fmt};
 use tower::BoxError;
 
 pub use hyper::body::Body;
@@ -16,75 +11,18 @@ pub use hyper::body::Body;
 ///
 /// This is used in axum as the response body type for applications. Its necessary to unify
 /// multiple response bodies types into one.
-pub struct BoxBody {
-    // when we've gotten rid of `BoxStdError` we should be able to change the error type to
-    // `BoxError`
-    inner: Pin<Box<dyn http_body::Body<Data = Bytes, Error = BoxStdError> + Send + Sync + 'static>>,
-}
+pub type BoxBody = http_body::combinators::BoxBody<Bytes, BoxStdError>;
 
-impl BoxBody {
-    /// Create a new `BoxBody`.
-    pub fn new<B>(body: B) -> Self
-    where
-        B: http_body::Body<Data = Bytes> + Send + Sync + 'static,
-        B::Error: Into<BoxError>,
-    {
-        Self {
-            inner: Box::pin(body.map_err(|error| BoxStdError(error.into()))),
-        }
-    }
-
-    pub(crate) fn empty() -> Self {
-        Self::new(Empty::new())
-    }
-}
-
-impl Default for BoxBody {
-    fn default() -> Self {
-        BoxBody::empty()
-    }
-}
-
-impl fmt::Debug for BoxBody {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("BoxBody").finish()
-    }
-}
-
-impl http_body::Body for BoxBody {
-    type Data = Bytes;
-    type Error = BoxStdError;
-
-    fn poll_data(
-        mut self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<Option<Result<Self::Data, Self::Error>>> {
-        self.inner.as_mut().poll_data(cx)
-    }
-
-    fn poll_trailers(
-        mut self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<Result<Option<http::HeaderMap>, Self::Error>> {
-        self.inner.as_mut().poll_trailers(cx)
-    }
-
-    fn is_end_stream(&self) -> bool {
-        self.inner.is_end_stream()
-    }
-
-    fn size_hint(&self) -> http_body::SizeHint {
-        self.inner.size_hint()
-    }
-}
-
-impl<B> From<B> for BoxBody
+pub(crate) fn box_body<B>(body: B) -> BoxBody
 where
-    B: Into<Bytes>,
+    B: http_body::Body<Data = Bytes> + Send + Sync + 'static,
+    B::Error: Into<BoxError>,
 {
-    fn from(s: B) -> Self {
-        BoxBody::new(Full::from(s.into()))
-    }
+    body.map_err(|err| BoxStdError(err.into())).boxed()
+}
+
+pub(crate) fn empty() -> BoxBody {
+    box_body(http_body::Empty::new())
 }
 
 /// A boxed error trait object that implements [`std::error::Error`].

--- a/src/extract/rejection.rs
+++ b/src/extract/rejection.rs
@@ -5,6 +5,41 @@ use crate::body::Body;
 use tower::BoxError;
 
 define_rejection! {
+    #[status = INTERNAL_SERVER_ERROR]
+    #[body = "Version taken by other extractor"]
+    /// Rejection used if the HTTP version has been taken by another extractor.
+    pub struct VersionAlreadyExtracted;
+}
+
+define_rejection! {
+    #[status = INTERNAL_SERVER_ERROR]
+    #[body = "URI taken by other extractor"]
+    /// Rejection used if the URI has been taken by another extractor.
+    pub struct UriAlreadyExtracted;
+}
+
+define_rejection! {
+    #[status = INTERNAL_SERVER_ERROR]
+    #[body = "Method taken by other extractor"]
+    /// Rejection used if the method has been taken by another extractor.
+    pub struct MethodAlreadyExtracted;
+}
+
+define_rejection! {
+    #[status = INTERNAL_SERVER_ERROR]
+    #[body = "Extensions taken by other extractor"]
+    /// Rejection used if the method has been taken by another extractor.
+    pub struct ExtensionsAlreadyExtracted;
+}
+
+define_rejection! {
+    #[status = INTERNAL_SERVER_ERROR]
+    #[body = "Headers taken by other extractor"]
+    /// Rejection used if the URI has been taken by another extractor.
+    pub struct HeadersAlreadyExtracted;
+}
+
+define_rejection! {
     #[status = BAD_REQUEST]
     #[body = "Query string was invalid or missing"]
     /// Rejection type for [`Query`](super::Query).
@@ -160,6 +195,7 @@ composite_rejection! {
     /// Contains one variant for each way the [`Query`](super::Query) extractor
     /// can fail.
     pub enum QueryRejection {
+        UriAlreadyExtracted,
         QueryStringMissing,
         FailedToDeserializeQueryString,
     }
@@ -176,6 +212,9 @@ composite_rejection! {
         FailedToDeserializeQueryString,
         FailedToBufferBody,
         BodyAlreadyExtracted,
+        UriAlreadyExtracted,
+        HeadersAlreadyExtracted,
+        MethodAlreadyExtracted,
     }
 }
 
@@ -188,6 +227,18 @@ composite_rejection! {
         InvalidJsonBody,
         MissingJsonContentType,
         BodyAlreadyExtracted,
+        HeadersAlreadyExtracted,
+    }
+}
+
+composite_rejection! {
+    /// Rejection used for [`Extension`](super::Extension).
+    ///
+    /// Contains one variant for each way the [`Extension`](super::Extension) extractor
+    /// can fail.
+    pub enum ExtensionRejection {
+        MissingExtension,
+        ExtensionsAlreadyExtracted,
     }
 }
 
@@ -236,6 +287,8 @@ pub enum ContentLengthLimitRejection<T> {
     #[allow(missing_docs)]
     LengthRequired(LengthRequired),
     #[allow(missing_docs)]
+    HeadersAlreadyExtracted(HeadersAlreadyExtracted),
+    #[allow(missing_docs)]
     Inner(T),
 }
 
@@ -247,6 +300,7 @@ where
         match self {
             Self::PayloadTooLarge(inner) => inner.into_response(),
             Self::LengthRequired(inner) => inner.into_response(),
+            Self::HeadersAlreadyExtracted(inner) => inner.into_response(),
             Self::Inner(inner) => inner.into_response(),
         }
     }

--- a/src/routing.rs
+++ b/src/routing.rs
@@ -1,6 +1,11 @@
 //! Routing between [`Service`]s.
 
-use crate::{body::BoxBody, buffer::MpscBuffer, response::IntoResponse, util::ByteStr};
+use crate::{
+    body::{box_body, BoxBody},
+    buffer::MpscBuffer,
+    response::IntoResponse,
+    util::ByteStr,
+};
 use async_trait::async_trait;
 use bytes::Bytes;
 use futures_util::future;
@@ -165,7 +170,7 @@ pub trait RoutingDsl: crate::sealed::Sealed + Sized {
             .layer_fn(BoxRoute)
             .layer_fn(MpscBuffer::new)
             .layer(BoxService::layer())
-            .layer(MapResponseBodyLayer::new(BoxBody::new))
+            .layer(MapResponseBodyLayer::new(box_body))
             .service(self)
     }
 
@@ -399,7 +404,7 @@ impl<B, E> Service<Request<B>> for EmptyRouter<E> {
     }
 
     fn call(&mut self, _req: Request<B>) -> Self::Future {
-        let mut res = Response::new(BoxBody::empty());
+        let mut res = Response::new(crate::body::empty());
         *res.status_mut() = StatusCode::NOT_FOUND;
         EmptyRouterFuture(future::ok(res))
     }

--- a/src/service/future.rs
+++ b/src/service/future.rs
@@ -1,6 +1,9 @@
 //! [`Service`](tower::Service) future types.
 
-use crate::{body::BoxBody, response::IntoResponse};
+use crate::{
+    body::{box_body, BoxBody},
+    response::IntoResponse,
+};
 use bytes::Bytes;
 use futures_util::ready;
 use http::Response;
@@ -36,11 +39,11 @@ where
         let this = self.project();
 
         match ready!(this.inner.poll(cx)) {
-            Ok(res) => Ok(res.map(BoxBody::new)).into(),
+            Ok(res) => Ok(res.map(box_body)).into(),
             Err(err) => {
                 let f = this.f.take().unwrap();
                 let res = f(err).into_response();
-                Ok(res.map(BoxBody::new)).into()
+                Ok(res.map(box_body)).into()
             }
         }
     }

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -87,7 +87,7 @@
 //! [load shed]: tower::load_shed
 
 use crate::{
-    body::BoxBody,
+    body::{box_body, BoxBody},
     response::IntoResponse,
     routing::{EmptyRouter, MethodFilter, RouteFuture},
 };
@@ -656,7 +656,7 @@ where
 
     fn poll(self: std::pin::Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let res = ready!(self.project().0.poll(cx))?;
-        let res = res.map(BoxBody::new);
+        let res = res.map(box_body);
         Poll::Ready(Ok(res))
     }
 }


### PR DESCRIPTION
Previously extractors worked directly on `Request<B>` which meant you
had to do weird tricks like `mem::take(req.headers_mut())` to get owned
parts of the request.

This changes that instead to use a new `RequestParts` type that have
methods to "take" each part of the request. Without having to do weird
tricks.

Also removed the need to have `B: Default` for body extractors.