### PR TITLE
Implement `Sink` and `Stream` for `WebSocket`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
-None.
+- Implement `Stream` for `WebSocket`.
+- Implement `Sink` for `WebSocket`.
 
 ## Breaking changes
 


### PR DESCRIPTION
Among other things, this makes [`StreamExt::split`](https://docs.rs/futures/0.3.16/futures/stream/trait.StreamExt.html#method.split) accessible so one can read and write at the same time.