### PR TITLE
Add extractor for remote connection info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Implement `Stream` for `WebSocket`.
 - Implement `Sink` for `WebSocket`.
+- Add extractor for remote connection info.
 
 ## Breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Implement `Stream` for `WebSocket`.
 - Implement `Sink` for `WebSocket`.
-- Add extractor for remote connection info.
+- Add extractor for remote connection info ([#55](https://github.com/tokio-rs/axum/pull/55))
 
 ## Breaking changes
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ bytes = "1.0"
 futures-util = "0.3"
 http = "0.2"
 http-body = "0.4"
-hyper = { version = "0.14", features = ["server", "tcp"] }
+hyper = { version = "0.14", features = ["server", "tcp", "http1"] }
 pin-project = "1.0"
 regex = "1.5"
 serde = "1.0"

--- a/src/extract/connect_info.rs
+++ b/src/extract/connect_info.rs
@@ -1,4 +1,8 @@
 //! Extractor for getting connection information from a client.
+//!
+//! See [`RoutingDsl::into_make_service_with_connect_info`] for more details.
+//!
+//! [`RoutingDsl::into_make_service_with_connect_info`]: crate::routing::RoutingDsl::into_make_service_with_connect_info
 
 use super::{Extension, FromRequest, RequestParts};
 use async_trait::async_trait;

--- a/src/extract/connect_info.rs
+++ b/src/extract/connect_info.rs
@@ -1,0 +1,167 @@
+#![allow(missing_docs)]
+
+use crate::extract::{FromRequest, RequestParts};
+use async_trait::async_trait;
+use hyper::server::conn::AddrStream;
+use std::convert::Infallible;
+use std::fmt;
+use std::marker::PhantomData;
+use std::net::SocketAddr;
+use std::task::{Context, Poll};
+use tower::Service;
+use tower_http::add_extension::AddExtension;
+
+use super::Extension;
+
+pub struct IntoMakeServiceWithConnectInfo<S, C> {
+    svc: S,
+    _connect_info: PhantomData<fn() -> C>,
+}
+
+impl<S, C> IntoMakeServiceWithConnectInfo<S, C> {
+    pub(crate) fn new(svc: S) -> Self {
+        Self {
+            svc,
+            _connect_info: PhantomData,
+        }
+    }
+}
+
+impl<S, C> fmt::Debug for IntoMakeServiceWithConnectInfo<S, C>
+where
+    S: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("IntoMakeServiceWithConnectInfo")
+            .field("svc", &self.svc)
+            .finish()
+    }
+}
+
+pub trait Connected<T> {
+    type ConnectInfo: Clone + Send + Sync + 'static;
+
+    fn connect_info(target: &T) -> Self::ConnectInfo;
+}
+
+impl<S, C, T> Service<T> for IntoMakeServiceWithConnectInfo<S, C>
+where
+    S: Clone,
+    C: Connected<T>,
+{
+    type Response = AddExtension<S, ConnectInfo<C::ConnectInfo>>;
+    type Error = Infallible;
+    type Future = futures_util::future::Ready<Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, target: T) -> Self::Future {
+        let connect_info = ConnectInfo(C::connect_info(&target));
+        let svc = AddExtension::new(self.svc.clone(), connect_info);
+        futures_util::future::ok(svc)
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct ConnectInfo<T>(pub T);
+
+#[async_trait]
+impl<B, T> FromRequest<B> for ConnectInfo<T>
+where
+    B: Send,
+    T: Clone + Send + Sync + 'static,
+{
+    type Rejection = <Extension<Self> as FromRequest<B>>::Rejection;
+
+    async fn from_request(req: &mut RequestParts<B>) -> Result<Self, Self::Rejection> {
+        let Extension(connect_info) = Extension::<Self>::from_request(req).await?;
+        Ok(connect_info)
+    }
+}
+
+impl Connected<&AddrStream> for SocketAddr {
+    type ConnectInfo = SocketAddr;
+
+    fn connect_info(target: &&AddrStream) -> Self::ConnectInfo {
+        target.remote_addr()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::prelude::*;
+    use hyper::Server;
+    use std::net::{SocketAddr, TcpListener};
+
+    #[tokio::test]
+    async fn socket_addr() {
+        async fn handler(ConnectInfo(addr): ConnectInfo<SocketAddr>) -> String {
+            format!("{}", addr)
+        }
+
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        tokio::spawn(async move {
+            let app = route("/", get(handler));
+            let server = Server::from_tcp(listener)
+                .unwrap()
+                .serve(app.into_make_service_with_connect_info::<SocketAddr, _>());
+            tx.send(()).unwrap();
+            server.await.expect("server error");
+        });
+        rx.await.unwrap();
+
+        let client = reqwest::Client::new();
+
+        let res = client.get(format!("http://{}", addr)).send().await.unwrap();
+        let body = res.text().await.unwrap();
+        assert!(body.starts_with("127.0.0.1:"));
+    }
+
+    #[tokio::test]
+    async fn custom() {
+        #[derive(Clone, Debug)]
+        struct MyConnectInfo {
+            value: &'static str,
+        }
+
+        impl Connected<&AddrStream> for MyConnectInfo {
+            type ConnectInfo = MyConnectInfo;
+
+            fn connect_info(_target: &&AddrStream) -> Self::ConnectInfo {
+                MyConnectInfo {
+                    value: "it worked!",
+                }
+            }
+        }
+
+        async fn handler(ConnectInfo(addr): ConnectInfo<MyConnectInfo>) -> &'static str {
+            addr.value
+        }
+
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        tokio::spawn(async move {
+            let app = route("/", get(handler));
+            let server = Server::from_tcp(listener)
+                .unwrap()
+                .serve(app.into_make_service_with_connect_info::<MyConnectInfo, _>());
+            tx.send(()).unwrap();
+            server.await.expect("server error");
+        });
+        rx.await.unwrap();
+
+        let client = reqwest::Client::new();
+
+        let res = client.get(format!("http://{}", addr)).send().await.unwrap();
+        let body = res.text().await.unwrap();
+        assert_eq!(body, "it worked!");
+    }
+}

--- a/src/extract/mod.rs
+++ b/src/extract/mod.rs
@@ -875,6 +875,8 @@ where
 /// # hyper::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
 /// # };
 /// ```
+///
+/// [`Stream`]: https://docs.rs/futures/latest/futures/stream/trait.Stream.html
 #[derive(Debug)]
 pub struct BodyStream<B = crate::body::Body>(B);
 

--- a/src/extract/mod.rs
+++ b/src/extract/mod.rs
@@ -259,11 +259,15 @@ use std::{
     task::{Context, Poll},
 };
 
+pub mod connect_info;
 pub mod extractor_middleware;
 pub mod rejection;
 
 #[doc(inline)]
 pub use self::extractor_middleware::extractor_middleware;
+
+#[doc(inline)]
+pub use self::connect_info::ConnectInfo;
 
 #[cfg(feature = "multipart")]
 #[cfg_attr(docsrs, doc(cfg(feature = "multipart")))]

--- a/src/routing.rs
+++ b/src/routing.rs
@@ -322,7 +322,7 @@ pub trait RoutingDsl: crate::sealed::Sealed + Sized {
     /// impl Connected<&AddrStream> for MyConnectInfo {
     ///     type ConnectInfo = MyConnectInfo;
     ///
-    ///     fn connect_info(target: &&AddrStream) -> Self::ConnectInfo {
+    ///     fn connect_info(target: &AddrStream) -> Self::ConnectInfo {
     ///         MyConnectInfo {
     ///             // ...
     ///         }
@@ -339,9 +339,13 @@ pub trait RoutingDsl: crate::sealed::Sealed + Sized {
     /// # };
     /// ```
     ///
+    /// See the [unix domain socket example][uds] for an example of how to use
+    /// this to collect UDS connection info.
+    ///
     /// [`MakeService`]: tower::make::MakeService
     /// [`Connected`]: crate::extract::connect_info::Connected
     /// [`ConnectInfo`]: crate::extract::connect_info::ConnectInfo
+    /// [uds]: https://github.com/tokio-rs/axum/blob/main/examples/unix_domain_socket.rs
     fn into_make_service_with_connect_info<C, Target>(
         self,
     ) -> IntoMakeServiceWithConnectInfo<Self, C>


### PR DESCRIPTION
Fixes https://github.com/tokio-rs/axum/issues/43

With this you can get the remote address like so:

```rust
use axum::{prelude::*, extract::ConnectInfo};
use std::net::SocketAddr;

let app = route("/", get(handler));

async fn handler(ConnectInfo(addr): ConnectInfo<SocketAddr>) -> String {
    format!("Hello {}", addr)
}

// Starting the app with `into_make_service_with_connect_info` is required
// for `ConnectInfo` to work.
let make_svc = app.into_make_service_with_connect_info::<SocketAddr, _>();

hyper::Server::bind(&"0.0.0.0:3000".parse().unwrap())
    .serve(make_svc)
    .await
    .expect("server failed");
```

This API is fully generic and supports whatever transport layer you're using with Hyper. I've updated the unix domain socket example to extract `peer_creds` and `peer_addr`.