### PR TITLE
Version 0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
+None.
+
+## Breaking changes
+
+None.
+
+# 0.1.2 (01. August, 2021)
+
 - Implement `Stream` for `WebSocket` ([#52](https://github.com/tokio-rs/axum/pull/52))
 - Implement `Sink` for `WebSocket` ([#52](https://github.com/tokio-rs/axum/pull/52))
 - Implement `Deref` most extractors ([#56](https://github.com/tokio-rs/axum/pull/56))
@@ -19,10 +27,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `axum::sse` for Server-Sent Events ([#75](https://github.com/tokio-rs/axum/pull/75))
 - Mention required dependencies in docs ([#77](https://github.com/tokio-rs/axum/pull/77))
 - Fix WebSockets failing on Firefox ([#76](https://github.com/tokio-rs/axum/pull/76))
-
-## Breaking changes
-
-None.
 
 # 0.1.1 (30. July, 2021)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["David Pedersen <david.pdrsn@gmail.com>"]
 categories = ["asynchronous", "network-programming", "web-programming"]
 description = "Web framework that focuses on ergonomics and modularity"
-documentation = "https://docs.rs/axum/0.1.1"
+documentation = "https://docs.rs/axum/0.1.2"
 edition = "2018"
 homepage = "https://github.com/tokio-rs/axum"
 keywords = ["http", "web", "framework"]
@@ -10,7 +10,7 @@ license = "MIT"
 name = "axum"
 readme = "README.md"
 repository = "https://github.com/tokio-rs/axum"
-version = "0.1.1"
+version = "0.1.2"
 
 [features]
 default = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -672,7 +672,7 @@
 //! [`Timeout`]: tower::timeout::Timeout
 //! [examples]: https://github.com/tokio-rs/axum/tree/main/examples
 
-#![doc(html_root_url = "https://docs.rs/axum/0.1.1")]
+#![doc(html_root_url = "https://docs.rs/axum/0.1.2")]
 #![warn(
     clippy::all,
     clippy::dbg_macro,


### PR DESCRIPTION
# 0.1.2 (01. August, 2021)

- Implement `Stream` for `WebSocket` ([#52](https://github.com/tokio-rs/axum/pull/52))
- Implement `Sink` for `WebSocket` ([#52](https://github.com/tokio-rs/axum/pull/52))
- Implement `Deref` most extractors ([#56](https://github.com/tokio-rs/axum/pull/56))
- Return `405 Method Not Allowed` for unsupported method for route ([#63](https://github.com/tokio-rs/axum/pull/63))
- Add extractor for remote connection info ([#55](https://github.com/tokio-rs/axum/pull/55))
- Improve error message of `MissingExtension` rejections ([#72](https://github.com/tokio-rs/axum/pull/72))
- Improve documentation for routing ([#71](https://github.com/tokio-rs/axum/pull/71))
- Clarify required response body type when routing to `tower::Service`s ([#69](https://github.com/tokio-rs/axum/pull/69))
- Add `axum::body::box_body` to converting an `http_body::Body` to `axum::body::BoxBody` ([#69](https://github.com/tokio-rs/axum/pull/69))
- Add `axum::sse` for Server-Sent Events ([#75](https://github.com/tokio-rs/axum/pull/75))
- Mention required dependencies in docs ([#77](https://github.com/tokio-rs/axum/pull/77))
- Fix WebSockets failing on Firefox ([#76](https://github.com/tokio-rs/axum/pull/76))