### PR TITLE
Changed http-body dependency version to 0.4.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ async-trait = "0.1"
 bytes = "1.0"
 futures-util = "0.3"
 http = "0.2"
-http-body = "0.4"
+http-body = "0.4.2"
 hyper = { version = "0.14", features = ["server", "tcp", "http1", "stream"] }
 pin-project = "1.0"
 regex = "1.5"


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation

`http_body::Full` (used here in [src/ws/mod.rs line 72](https://github.com/tokio-rs/axum/blob/55c1a294206bc7e9fce940a81582e875e98eefda/src/ws/mod.rs#L72)) is not available in versions before 0.4.2, and this may lead to error when version 0.4.0 or 0.4.1 is pulled from crates.io.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

Changing the dependency version of `http-body` from 0.4 to 0.4.2. This will ensure the availability of `http_body::Full`.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
