### PR TITLE
Use `pin-project-lite` instead of `pin-project`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix stripping prefix when nesting services at `/` ([#91](https://github.com/tokio-rs/axum/pull/91))
 - Add support for WebSocket protocol negotiation. ([#83](https://github.com/tokio-rs/axum/pull/83))
+- Use `pin-project-lite` instead of `pin-project`. ([#95](https://github.com/tokio-rs/axum/pull/95))
 
 ## Breaking changes
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ futures-util = "0.3"
 http = "0.2"
 http-body = "0.4.2"
 hyper = { version = "0.14", features = ["server", "tcp", "http1", "stream"] }
-pin-project = "1.0"
+pin-project-lite = "0.2.7"
 regex = "1.5"
 serde = "1.0"
 serde_json = "1.0"

--- a/src/extract/connect_info.rs
+++ b/src/extract/connect_info.rs
@@ -89,7 +89,9 @@ where
     fn call(&mut self, target: T) -> Self::Future {
         let connect_info = ConnectInfo(C::connect_info(target));
         let svc = AddExtension::new(self.svc.clone(), connect_info);
-        ResponseFuture(futures_util::future::ok(svc))
+        ResponseFuture {
+            future: futures_util::future::ok(svc),
+        }
     }
 }
 

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -444,7 +444,7 @@ where
             let res = Handler::call(handler, req).await;
             Ok(res)
         });
-        future::IntoServiceFuture(future)
+        future::IntoServiceFuture { future }
     }
 }
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -9,10 +9,12 @@ macro_rules! opaque_future {
     };
 
     ($(#[$m:meta])* pub type $name:ident<$($param:ident),*> = $actual:ty;) => {
-        #[pin_project::pin_project]
-        $(#[$m])*
-        pub struct $name<$($param),*>(#[pin] pub(crate) $actual)
-        where;
+        pin_project_lite::pin_project! {
+            $(#[$m])*
+            pub struct $name<$($param),*> {
+                #[pin] pub(crate) future: $actual,
+            }
+        }
 
         impl<$($param),*> std::fmt::Debug for $name<$($param),*> {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -27,7 +29,7 @@ macro_rules! opaque_future {
             type Output = <$actual as std::future::Future>::Output;
             #[inline]
             fn poll(self: std::pin::Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> std::task::Poll<Self::Output> {
-                self.project().0.poll(cx)
+                self.project().future.poll(cx)
             }
         }
     };

--- a/src/service/future.rs
+++ b/src/service/future.rs
@@ -7,7 +7,7 @@ use crate::{
 use bytes::Bytes;
 use futures_util::ready;
 use http::Response;
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 use std::{
     future::Future,
     pin::Pin,
@@ -15,13 +15,14 @@ use std::{
 };
 use tower::BoxError;
 
-/// Response future for [`HandleError`](super::HandleError).
-#[pin_project]
-#[derive(Debug)]
-pub struct HandleErrorFuture<Fut, F> {
-    #[pin]
-    pub(super) inner: Fut,
-    pub(super) f: Option<F>,
+pin_project! {
+    /// Response future for [`HandleError`](super::HandleError).
+    #[derive(Debug)]
+    pub struct HandleErrorFuture<Fut, F> {
+        #[pin]
+        pub(super) inner: Fut,
+        pub(super) f: Option<F>,
+    }
 }
 
 impl<Fut, F, E, E2, B, Res> Future for HandleErrorFuture<Fut, F>


### PR DESCRIPTION
The compilation speed has not improved much, at least it looks like this on my Mac. But pin_project_lite is not a procedural macro, so the IDE can correctly analyze the return type of the `project` function. I believe this can make the code easier to maintain.