### PR TITLE
Remove unused imports from example

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,9 +47,6 @@
 //!
 //! ```rust,no_run
 //! use axum::prelude::*;
-//! use hyper::Server;
-//! use std::net::SocketAddr;
-//! use tower::make::Shared;
 //!
 //! #[tokio::main]
 //! async fn main() {


### PR DESCRIPTION
Remove unused imports from the first crate documentation example.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation
Axium minimal hello world has unused imports that can confuse newbies to rust and the framework on why they are there.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution
Remove the unused imports as they really are unused
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
