### PR TITLE
Replace `hyper::Server` with `axum::Server` in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,7 @@ applications written using [`hyper`] or [`tonic`].
 ## Usage example
 
 ```rust
-use axum::{prelude::*, response::IntoResponse};
-use http::StatusCode;
+use axum::{prelude::*, response::IntoResponse, http::StatusCode};
 use serde::{Deserialize, Serialize};
 use std::net::SocketAddr;
 
@@ -44,9 +43,10 @@ async fn main() {
         .route("/users", post(create_user));
 
     // run our app with hyper
+    // `axum::Server` is a re-export of `hyper::Server`
     let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
     tracing::debug!("listening on {}", addr);
-    hyper::Server::bind(&addr)
+    axum::Server::bind(&addr)
         .serve(app.into_make_service())
         .await
         .unwrap();

--- a/examples/404.rs
+++ b/examples/404.rs
@@ -24,7 +24,7 @@ async fn main() {
     // run it
     let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
     tracing::debug!("listening on {}", addr);
-    hyper::Server::bind(&addr)
+    axum::Server::bind(&addr)
         .serve(app.into_make_service())
         .await
         .unwrap();

--- a/examples/async-graphql/main.rs
+++ b/examples/async-graphql/main.rs
@@ -28,7 +28,7 @@ async fn main() {
 
     println!("Playground: http://localhost:3000");
 
-    hyper::Server::bind(&"0.0.0.0:3000".parse().unwrap())
+    axum::Server::bind(&"0.0.0.0:3000".parse().unwrap())
         .serve(app.into_make_service())
         .await
         .unwrap();

--- a/examples/chat.rs
+++ b/examples/chat.rs
@@ -38,7 +38,7 @@ async fn main() {
 
     let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
 
-    hyper::Server::bind(&addr)
+    axum::Server::bind(&addr)
         .serve(app.into_make_service())
         .await
         .unwrap();

--- a/examples/error_handling_and_dependency_injection.rs
+++ b/examples/error_handling_and_dependency_injection.rs
@@ -40,7 +40,7 @@ async fn main() {
     // Run our application
     let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
     tracing::debug!("listening on {}", addr);
-    hyper::Server::bind(&addr)
+    axum::Server::bind(&addr)
         .serve(app.into_make_service())
         .await
         .unwrap();

--- a/examples/form.rs
+++ b/examples/form.rs
@@ -18,7 +18,7 @@ async fn main() {
     // run it with hyper
     let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
     tracing::debug!("listening on {}", addr);
-    hyper::Server::bind(&addr)
+    axum::Server::bind(&addr)
         .serve(app.into_make_service())
         .await
         .unwrap();

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -17,7 +17,7 @@ async fn main() {
     // run it
     let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
     tracing::debug!("listening on {}", addr);
-    hyper::Server::bind(&addr)
+    axum::Server::bind(&addr)
         .serve(app.into_make_service())
         .await
         .unwrap();

--- a/examples/key_value_store.rs
+++ b/examples/key_value_store.rs
@@ -61,7 +61,7 @@ async fn main() {
     // Run our app with hyper
     let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
     tracing::debug!("listening on {}", addr);
-    hyper::Server::bind(&addr)
+    axum::Server::bind(&addr)
         .serve(app.into_make_service())
         .await
         .unwrap();

--- a/examples/multipart_form.rs
+++ b/examples/multipart_form.rs
@@ -21,7 +21,7 @@ async fn main() {
     // run it with hyper
     let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
     tracing::debug!("listening on {}", addr);
-    hyper::Server::bind(&addr)
+    axum::Server::bind(&addr)
         .serve(app.into_make_service())
         .await
         .unwrap();

--- a/examples/sessions.rs
+++ b/examples/sessions.rs
@@ -29,7 +29,7 @@ async fn main() {
 
     let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
     tracing::debug!("listening on {}", addr);
-    hyper::Server::bind(&addr)
+    axum::Server::bind(&addr)
         .serve(app.into_make_service())
         .await
         .unwrap();

--- a/examples/sse.rs
+++ b/examples/sse.rs
@@ -35,7 +35,7 @@ async fn main() {
     // run it
     let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
     tracing::debug!("listening on {}", addr);
-    hyper::Server::bind(&addr)
+    axum::Server::bind(&addr)
         .serve(app.into_make_service())
         .await
         .unwrap();

--- a/examples/static_file_server.rs
+++ b/examples/static_file_server.rs
@@ -26,7 +26,7 @@ async fn main() {
 
     let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
     tracing::debug!("listening on {}", addr);
-    hyper::Server::bind(&addr)
+    axum::Server::bind(&addr)
         .serve(app.into_make_service())
         .await
         .unwrap();

--- a/examples/templates.rs
+++ b/examples/templates.rs
@@ -19,7 +19,7 @@ async fn main() {
     // run it
     let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
     tracing::debug!("listening on {}", addr);
-    hyper::Server::bind(&addr)
+    axum::Server::bind(&addr)
         .serve(app.into_make_service())
         .await
         .unwrap();

--- a/examples/testing.rs
+++ b/examples/testing.rs
@@ -15,7 +15,7 @@ async fn main() {
 
     tracing::debug!("listening on {}", addr);
 
-    hyper::Server::bind(&addr)
+    axum::Server::bind(&addr)
         .serve(app().into_make_service())
         .await
         .unwrap();
@@ -113,7 +113,7 @@ mod tests {
         let addr = listener.local_addr().unwrap();
 
         tokio::spawn(async move {
-            hyper::Server::from_tcp(listener)
+            axum::Server::from_tcp(listener)
                 .unwrap()
                 .serve(app().into_make_service())
                 .await

--- a/examples/todos.rs
+++ b/examples/todos.rs
@@ -67,7 +67,7 @@ async fn main() {
 
     let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
     tracing::debug!("listening on {}", addr);
-    hyper::Server::bind(&addr)
+    axum::Server::bind(&addr)
         .serve(app.into_make_service())
         .await
         .unwrap();

--- a/examples/tokio_postgres.rs
+++ b/examples/tokio_postgres.rs
@@ -27,7 +27,7 @@ async fn main() {
     // run it with hyper
     let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
     tracing::debug!("listening on {}", addr);
-    hyper::Server::bind(&addr)
+    axum::Server::bind(&addr)
         .serve(app.into_make_service())
         .await
         .unwrap();

--- a/examples/unix_domain_socket.rs
+++ b/examples/unix_domain_socket.rs
@@ -49,7 +49,7 @@ async fn main() {
     tokio::spawn(async {
         let app = route("/", get(handler));
 
-        hyper::Server::builder(ServerAccept { uds })
+        axum::Server::builder(ServerAccept { uds })
             .serve(app.into_make_service_with_connect_info::<UdsConnectInfo, _>())
             .await
             .unwrap();

--- a/examples/versioning.rs
+++ b/examples/versioning.rs
@@ -24,7 +24,7 @@ async fn main() {
     // run it
     let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
     tracing::debug!("listening on {}", addr);
-    hyper::Server::bind(&addr)
+    axum::Server::bind(&addr)
         .serve(app.into_make_service())
         .await
         .unwrap();

--- a/examples/websocket.rs
+++ b/examples/websocket.rs
@@ -49,7 +49,7 @@ async fn main() {
     // run it with hyper
     let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
     tracing::debug!("listening on {}", addr);
-    hyper::Server::bind(&addr)
+    axum::Server::bind(&addr)
         .serve(app.into_make_service())
         .await
         .unwrap();

--- a/src/extract/connect_info.rs
+++ b/src/extract/connect_info.rs
@@ -131,7 +131,7 @@ where
 mod tests {
     use super::*;
     use crate::prelude::*;
-    use hyper::Server;
+    use crate::Server;
     use std::net::{SocketAddr, TcpListener};
 
     #[tokio::test]

--- a/src/extract/content_length_limit.rs
+++ b/src/extract/content_length_limit.rs
@@ -15,7 +15,7 @@ use std::ops::Deref;
 ///
 /// let app = route("/", post(handler));
 /// # async {
-/// # hyper::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
+/// # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
 /// # };
 /// ```
 ///

--- a/src/extract/extension.rs
+++ b/src/extract/extension.rs
@@ -28,7 +28,7 @@ use std::ops::Deref;
 ///     // extensions.
 ///     .layer(AddExtensionLayer::new(state));
 /// # async {
-/// # hyper::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
+/// # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
 /// # };
 /// ```
 ///

--- a/src/extract/extractor_middleware.rs
+++ b/src/extract/extractor_middleware.rs
@@ -77,7 +77,7 @@ use tower::{BoxError, Layer, Service};
 ///     // The extractor will run before all routes
 ///     .layer(extractor_middleware::<RequireAuth>());
 /// # async {
-/// # hyper::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
+/// # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
 /// # };
 /// ```
 pub fn extractor_middleware<E>() -> ExtractorMiddlewareLayer<E> {

--- a/src/extract/form.rs
+++ b/src/extract/form.rs
@@ -30,7 +30,7 @@ use std::ops::Deref;
 ///
 /// let app = route("/sign_up", post(accept_form));
 /// # async {
-/// # hyper::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
+/// # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
 /// # };
 /// ```
 ///

--- a/src/extract/json.rs
+++ b/src/extract/json.rs
@@ -27,7 +27,7 @@ use std::ops::Deref;
 ///
 /// let app = route("/users", post(create_user));
 /// # async {
-/// # hyper::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
+/// # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
 /// # };
 /// ```
 ///

--- a/src/extract/mod.rs
+++ b/src/extract/mod.rs
@@ -25,7 +25,7 @@
 //!
 //! let app = route("/users", post(create_user));
 //! # async {
-//! # hyper::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
+//! # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
 //! # };
 //! ```
 //!
@@ -65,7 +65,7 @@
 //!
 //! let app = route("/foo", get(handler));
 //! # async {
-//! # hyper::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
+//! # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
 //! # };
 //! ```
 //!
@@ -90,7 +90,7 @@
 //!
 //! let app = route("/foo", get(handler));
 //! # async {
-//! # hyper::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
+//! # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
 //! # };
 //! ```
 //!
@@ -115,7 +115,7 @@
 //!
 //! let app = route("/users", post(create_user));
 //! # async {
-//! # hyper::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
+//! # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
 //! # };
 //! ```
 //!
@@ -150,7 +150,7 @@
 //!
 //! let app = route("/users", post(create_user));
 //! # async {
-//! # hyper::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
+//! # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
 //! # };
 //! ```
 //!
@@ -169,7 +169,7 @@
 //!
 //! let app = route("/users", post(create_user));
 //! # async {
-//! # hyper::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
+//! # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
 //! # };
 //! ```
 //!
@@ -238,7 +238,7 @@
 //!     // middleware that changes the request body type
 //!     .layer(MapRequestBodyLayer::new(MyBody));
 //! # async {
-//! # hyper::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
+//! # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
 //! # };
 //! ```
 //!

--- a/src/extract/multipart.rs
+++ b/src/extract/multipart.rs
@@ -34,7 +34,7 @@ use tower::BoxError;
 ///
 /// let app = route("/upload", post(upload));
 /// # async {
-/// # hyper::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
+/// # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
 /// # };
 /// ```
 ///

--- a/src/extract/query.rs
+++ b/src/extract/query.rs
@@ -29,7 +29,7 @@ use std::ops::Deref;
 ///
 /// let app = route("/list_things", get(list_things));
 /// # async {
-/// # hyper::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
+/// # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
 /// # };
 /// ```
 ///

--- a/src/extract/raw_query.rs
+++ b/src/extract/raw_query.rs
@@ -16,7 +16,7 @@ use std::convert::Infallible;
 ///
 /// let app = route("/users", get(handler));
 /// # async {
-/// # hyper::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
+/// # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
 /// # };
 /// ```
 #[derive(Debug)]

--- a/src/extract/request_parts.rs
+++ b/src/extract/request_parts.rs
@@ -118,7 +118,7 @@ where
 ///
 /// let app = route("/users", get(handler));
 /// # async {
-/// # hyper::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
+/// # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
 /// # };
 /// ```
 ///
@@ -165,7 +165,7 @@ where
 ///
 /// let app = route("/users", get(handler));
 /// # async {
-/// # hyper::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
+/// # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
 /// # };
 /// ```
 #[derive(Debug, Default, Clone)]

--- a/src/extract/typed_header.rs
+++ b/src/extract/typed_header.rs
@@ -19,7 +19,7 @@ use std::ops::Deref;
 ///
 /// let app = route("/users/:user_id/team/:team_id", get(users_teams_show));
 /// # async {
-/// # hyper::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
+/// # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
 /// # };
 /// ```
 #[cfg(feature = "headers")]

--- a/src/extract/url_params.rs
+++ b/src/extract/url_params.rs
@@ -21,7 +21,7 @@ use std::{ops::Deref, str::FromStr};
 ///
 /// let app = route("/users/:user_id/team/:team_id", get(users_teams_show));
 /// # async {
-/// # hyper::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
+/// # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
 /// # };
 /// ```
 ///

--- a/src/extract/url_params_map.rs
+++ b/src/extract/url_params_map.rs
@@ -18,7 +18,7 @@ use std::{collections::HashMap, str::FromStr};
 ///
 /// let app = route("/users/:id", get(users_show));
 /// # async {
-/// # hyper::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
+/// # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
 /// # };
 /// ```
 ///

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -34,7 +34,7 @@ pub mod future;
 /// // All requests to `/` will go to `handler` regardless of the HTTP method.
 /// let app = route("/", any(handler));
 /// # async {
-/// # hyper::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
+/// # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
 /// # };
 /// ```
 pub fn any<H, B, T>(handler: H) -> OnMethod<IntoService<H, B, T>, EmptyRouter>
@@ -76,7 +76,7 @@ where
 /// // Requests to `GET /` will go to `handler`.
 /// let app = route("/", get(handler));
 /// # async {
-/// # hyper::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
+/// # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
 /// # };
 /// ```
 pub fn get<H, B, T>(handler: H) -> OnMethod<IntoService<H, B, T>, EmptyRouter>
@@ -158,7 +158,7 @@ where
 /// // Requests to `POST /` will go to `handler`.
 /// let app = route("/", on(MethodFilter::Post, handler));
 /// # async {
-/// # hyper::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
+/// # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
 /// # };
 /// ```
 pub fn on<H, B, T>(method: MethodFilter, handler: H) -> OnMethod<IntoService<H, B, T>, EmptyRouter>
@@ -221,7 +221,7 @@ pub trait Handler<B, In>: Sized {
     /// let layered_handler = handler.layer(ConcurrencyLimitLayer::new(64));
     /// let app = route("/", get(layered_handler));
     /// # async {
-    /// # hyper::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
+    /// # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
     /// # };
     /// ```
     ///
@@ -504,7 +504,7 @@ impl<S, F> OnMethod<S, F> {
     /// // `other_handler`.
     /// let app = route("/", post(handler).get(other_handler));
     /// # async {
-    /// # hyper::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
+    /// # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
     /// # };
     /// ```
     pub fn get<H, B, T>(self, handler: H) -> OnMethod<IntoService<H, B, T>, Self>
@@ -590,7 +590,7 @@ impl<S, F> OnMethod<S, F> {
     /// // `other_handler`
     /// let app = route("/", get(handler).on(MethodFilter::Delete, other_handler));
     /// # async {
-    /// # hyper::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
+    /// # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
     /// # };
     /// ```
     pub fn on<H, B, T>(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,7 @@
 //!     let app = route("/", get(|| async { "Hello, World!" }));
 //!
 //!     // run it with hyper on localhost:3000
-//!     hyper::Server::bind(&"0.0.0.0:3000".parse().unwrap())
+//!     axum::Server::bind(&"0.0.0.0:3000".parse().unwrap())
 //!         .serve(app.into_make_service())
 //!         .await
 //!         .unwrap();
@@ -118,7 +118,7 @@
 //!     // `GET /foo` called
 //! }
 //! # async {
-//! # hyper::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
+//! # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
 //! # };
 //! ```
 //!
@@ -204,8 +204,8 @@
 //!
 //! async fn handler() {}
 //! # async {
-//! # hyper::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
-//! # hyper::Server::bind(&"".parse().unwrap()).serve(wont_work.into_make_service()).await.unwrap();
+//! # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
+//! # axum::Server::bind(&"".parse().unwrap()).serve(wont_work.into_make_service()).await.unwrap();
 //! # };
 //! ```
 //!
@@ -235,7 +235,7 @@
 //!     // ...
 //! }
 //! # async {
-//! # hyper::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
+//! # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
 //! # };
 //! ```
 //!
@@ -255,7 +255,7 @@
 //!     // ...
 //! }
 //! # async {
-//! # hyper::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
+//! # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
 //! # };
 //! ```
 //!
@@ -293,7 +293,7 @@
 //!     // ...
 //! }
 //! # async {
-//! # hyper::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
+//! # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
 //! # };
 //! ```
 //!
@@ -308,7 +308,7 @@
 //!     // ...
 //! }
 //! # async {
-//! # hyper::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
+//! # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
 //! # };
 //! ```
 //!
@@ -392,7 +392,7 @@
 //!     .route("/result", get(result))
 //!     .route("/response", get(response));
 //! # async {
-//! # hyper::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
+//! # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
 //! # };
 //! ```
 //!
@@ -416,7 +416,7 @@
 //!
 //! async fn handler() {}
 //! # async {
-//! # hyper::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
+//! # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
 //! # };
 //! ```
 //!
@@ -436,7 +436,7 @@
 //!
 //! async fn post_foo() {}
 //! # async {
-//! # hyper::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
+//! # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
 //! # };
 //! ```
 //!
@@ -489,7 +489,7 @@
 //!
 //! async fn handle() {}
 //! # async {
-//! # hyper::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
+//! # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
 //! # };
 //! ```
 //!
@@ -523,7 +523,7 @@
 //! let app = route("/", get(|_: Request<Body>| async { /* ... */ }))
 //!     .layer(middleware_stack);
 //! # async {
-//! # hyper::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
+//! # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
 //! # };
 //! ```
 //!
@@ -554,7 +554,7 @@
 //!     // ...
 //! }
 //! # async {
-//! # hyper::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
+//! # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
 //! # };
 //! ```
 //!
@@ -595,7 +595,7 @@
 //!     service::get(ServeFile::new("Cargo.toml"))
 //! );
 //! # async {
-//! # hyper::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
+//! # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
 //! # };
 //! ```
 //!
@@ -618,7 +618,7 @@
 //! let app = route("/", get(|_: Request<Body>| async { /* ... */ }))
 //!     .nest("/api", api_routes());
 //! # async {
-//! # hyper::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
+//! # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
 //! # };
 //! ```
 //!
@@ -637,7 +637,7 @@
 //! The `"full"` feature for hyper and tokio isn't strictly necessary but its
 //! the easiest way to get started.
 //!
-//! Note that [`hyper::Server`] is re-exported by axum so if thats all you need
+//! Note that [`axum::Server`] is re-exported by axum so if thats all you need
 //! then you don't have to explicitly depend on hyper.
 //!
 //! Tower isn't strictly necessary either but helpful for testing. See the
@@ -668,7 +668,7 @@
 //! [`IntoResponse`]: crate::response::IntoResponse
 //! [`Timeout`]: tower::timeout::Timeout
 //! [examples]: https://github.com/tokio-rs/axum/tree/main/examples
-//! [`hyper::Server`]: hyper::server::Server
+//! [`axum::Server`]: hyper::server::Server
 
 #![doc(html_root_url = "https://docs.rs/axum/0.1.2")]
 #![warn(

--- a/src/routing.rs
+++ b/src/routing.rs
@@ -105,7 +105,7 @@ pub trait RoutingDsl: crate::sealed::Sealed + Sized {
     /// let app = route("/", get(first_handler).post(second_handler))
     ///     .route("/foo", get(third_handler));
     /// # async {
-    /// # hyper::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
+    /// # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
     /// # };
     /// ```
     fn route<T, B>(self, description: &str, svc: T) -> Route<T, Self>
@@ -209,7 +209,7 @@ pub trait RoutingDsl: crate::sealed::Sealed + Sized {
     ///     // wont be sent through `ConcurrencyLimit`
     ///     .route("/bar", get(third_handler));
     /// # async {
-    /// # hyper::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
+    /// # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
     /// # };
     /// ```
     ///
@@ -231,7 +231,7 @@ pub trait RoutingDsl: crate::sealed::Sealed + Sized {
     ///     .route("/bar", get(third_handler))
     ///     .layer(TraceLayer::new_for_http());
     /// # async {
-    /// # hyper::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
+    /// # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
     /// # };
     /// ```
     fn layer<L>(self, layer: L) -> Layered<L::Service>
@@ -253,7 +253,7 @@ pub trait RoutingDsl: crate::sealed::Sealed + Sized {
     /// let app = route("/", get(|| async { "Hi!" }));
     ///
     /// # async {
-    /// hyper::Server::bind(&"0.0.0.0:3000".parse().unwrap())
+    /// axum::Server::bind(&"0.0.0.0:3000".parse().unwrap())
     ///     .serve(app.into_make_service())
     ///     .await
     ///     .expect("server failed");
@@ -287,7 +287,7 @@ pub trait RoutingDsl: crate::sealed::Sealed + Sized {
     /// }
     ///
     /// # async {
-    /// hyper::Server::bind(&"0.0.0.0:3000".parse().unwrap())
+    /// axum::Server::bind(&"0.0.0.0:3000".parse().unwrap())
     ///     .serve(
     ///         app.into_make_service_with_connect_info::<SocketAddr, _>()
     ///     )
@@ -329,7 +329,7 @@ pub trait RoutingDsl: crate::sealed::Sealed + Sized {
     /// }
     ///
     /// # async {
-    /// hyper::Server::bind(&"0.0.0.0:3000".parse().unwrap())
+    /// axum::Server::bind(&"0.0.0.0:3000".parse().unwrap())
     ///     .serve(
     ///         app.into_make_service_with_connect_info::<MyConnectInfo, _>()
     ///     )
@@ -769,7 +769,7 @@ impl<S> Layered<S> {
     ///     }
     /// });
     /// # async {
-    /// # hyper::Server::bind(&"".parse().unwrap())
+    /// # axum::Server::bind(&"".parse().unwrap())
     /// #     .serve(with_errors_handled.into_make_service())
     /// #     .await
     /// #     .unwrap();
@@ -803,7 +803,7 @@ impl<S> Layered<S> {
     ///     }
     /// });
     /// # async {
-    /// # hyper::Server::bind(&"".parse().unwrap())
+    /// # axum::Server::bind(&"".parse().unwrap())
     /// #     .serve(with_errors_handled.into_make_service())
     /// #     .await
     /// #     .unwrap();
@@ -867,7 +867,7 @@ where
 ///
 /// let app = nest("/api", users_api).route("/careers", get(careers));
 /// # async {
-/// # hyper::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
+/// # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
 /// # };
 /// ```
 ///
@@ -888,7 +888,7 @@ where
 ///
 /// let app = nest("/:version/api", users_api);
 /// # async {
-/// # hyper::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
+/// # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
 /// # };
 /// ```
 ///
@@ -906,7 +906,7 @@ where
 ///
 /// let app = nest("/public", get(serve_dir_service));
 /// # async {
-/// # hyper::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
+/// # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
 /// # };
 /// ```
 ///

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -20,7 +20,7 @@
 //! let app = route("/old", service::get(redirect_service))
 //!     .route("/new", handler::get(handler));
 //! # async {
-//! # hyper::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
+//! # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
 //! # };
 //! ```
 //!
@@ -71,7 +71,7 @@
 //!     .layer(some_backpressure_sensitive_middleware)
 //!     .service(app);
 //! # async {
-//! # hyper::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
+//! # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
 //! # };
 //! ```
 //!
@@ -153,7 +153,7 @@ where
 /// // Requests to `GET /` will go to `service`.
 /// let app = route("/", service::get(service));
 /// # async {
-/// # hyper::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
+/// # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
 /// # };
 /// ```
 pub fn get<S, B>(svc: S) -> OnMethod<BoxResponseBody<S, B>, EmptyRouter<S::Error>>
@@ -240,7 +240,7 @@ where
 /// // Requests to `POST /` will go to `service`.
 /// let app = route("/", service::on(MethodFilter::Post, service));
 /// # async {
-/// # hyper::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
+/// # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
 /// # };
 /// ```
 pub fn on<S, B>(
@@ -323,7 +323,7 @@ impl<S, F> OnMethod<S, F> {
     /// // `other_service`.
     /// let app = route("/", service::post(service).get(other_service));
     /// # async {
-    /// # hyper::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
+    /// # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
     /// # };
     /// ```
     pub fn get<T, B>(self, svc: T) -> OnMethod<BoxResponseBody<T, B>, Self>
@@ -415,7 +415,7 @@ impl<S, F> OnMethod<S, F> {
     /// // Requests to `DELETE /` will go to `service`
     /// let app = route("/", service::on(MethodFilter::Delete, service));
     /// # async {
-    /// # hyper::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
+    /// # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
     /// # };
     /// ```
     pub fn on<T, B>(self, method: MethodFilter, svc: T) -> OnMethod<BoxResponseBody<T, B>, Self>
@@ -566,7 +566,7 @@ pub trait ServiceExt<ReqBody, ResBody>:
     /// );
     /// #
     /// # async {
-    /// # hyper::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
+    /// # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
     /// # };
     /// ```
     ///

--- a/src/sse.rs
+++ b/src/sse.rs
@@ -23,7 +23,7 @@
 //!     Ok(stream)
 //! }
 //! # async {
-//! # hyper::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
+//! # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
 //! # };
 //! ```
 //!
@@ -65,7 +65,7 @@
 //!     # Ok(futures::stream::pending())
 //! }
 //! # async {
-//! # hyper::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
+//! # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
 //! # };
 //! ```
 

--- a/src/ws/mod.rs
+++ b/src/ws/mod.rs
@@ -14,7 +14,7 @@
 //!     }
 //! }
 //! # async {
-//! # hyper::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
+//! # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
 //! # };
 //! ```
 //!
@@ -51,7 +51,7 @@
 //!     // ...
 //! }
 //! # async {
-//! # hyper::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
+//! # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
 //! # };
 //! ```
 
@@ -238,7 +238,7 @@ impl<F, B, T> WebSocketUpgrade<F, B, T> {
     /// let app = route("/ws", ws(handle_socket).protocols(["graphql-ws", "graphql-transport-ws"]));
     /// #
     /// #   let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
-    /// #   hyper::Server::bind(&addr)
+    /// #   axum::Server::bind(&addr)
     /// #       .serve(app.into_make_service())
     /// #       .await
     /// #       .unwrap();


### PR DESCRIPTION
Hopefully makes it easier to get started for some.

Intentionally didn't change README.md because I wanna make it clear that axum directly runs no hyper, which isn't clear unless you can see from the docs that `axum::Server` is a re-export.