### PR TITLE
Deprecate `QueryStringMissing`

### DIFF
--- a/src/extract/rejection.rs
+++ b/src/extract/rejection.rs
@@ -42,6 +42,7 @@ define_rejection! {
 define_rejection! {
     #[status = BAD_REQUEST]
     #[body = "Query string was invalid or missing"]
+    #[deprecated(since = "0.1.3", note = "No longer used. See https://github.com/tokio-rs/axum/pull/117")]
     /// Rejection type for [`Query`](super::Query).
     pub struct QueryStringMissing;
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -47,6 +47,7 @@ macro_rules! define_rejection {
         #[non_exhaustive]
         pub struct $name;
 
+        #[allow(deprecated)]
         impl $crate::response::IntoResponse for $name {
             fn into_response(self) -> http::Response<$crate::body::Body> {
                 let mut res = http::Response::new($crate::body::Body::from($body));
@@ -99,7 +100,7 @@ macro_rules! composite_rejection {
         #[non_exhaustive]
         pub enum $name {
             $(
-                #[allow(missing_docs)]
+                #[allow(missing_docs, deprecated)]
                 $variant($variant)
             ),+
         }
@@ -115,6 +116,7 @@ macro_rules! composite_rejection {
         }
 
         $(
+            #[allow(deprecated)]
             impl From<$variant> for $name {
                 fn from(inner: $variant) -> Self {
                     Self::$variant(inner)


### PR DESCRIPTION
Since https://github.com/tokio-rs/axum/pull/117 its no longer used. Will be removed in 0.2.