### PR TITLE
Set RUST_LOG environment var for all examples using tracing

### DIFF
--- a/examples/404.rs
+++ b/examples/404.rs
@@ -14,7 +14,13 @@ use tower::util::MapResponseLayer;
 
 #[tokio::main]
 async fn main() {
-    tracing_subscriber::fmt::init();
+    // Set the RUST_LOG, if it hasn't been explicitly defined
+    if std::env::var("RUST_LOG").is_err() {
+        std::env::set_var("RUST_LOG", "404=debug")
+    }
+    tracing_subscriber::fmt::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
 
     // build our application with a route
     let app = route("/", get(handler))

--- a/examples/error_handling_and_dependency_injection.rs
+++ b/examples/error_handling_and_dependency_injection.rs
@@ -24,7 +24,13 @@ use uuid::Uuid;
 
 #[tokio::main]
 async fn main() {
-    tracing_subscriber::fmt::init();
+    // Set the RUST_LOG, if it hasn't been explicitly defined
+    if std::env::var("RUST_LOG").is_err() {
+        std::env::set_var("RUST_LOG", "error_handling_and_dependency_injection=debug")
+    }
+    tracing_subscriber::fmt::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
 
     // Inject a `UserRepo` into our handlers via a trait object. This could be
     // the live implementation or just a mock for testing.

--- a/examples/form.rs
+++ b/examples/form.rs
@@ -10,7 +10,13 @@ use std::net::SocketAddr;
 
 #[tokio::main]
 async fn main() {
-    tracing_subscriber::fmt::init();
+    // Set the RUST_LOG, if it hasn't been explicitly defined
+    if std::env::var("RUST_LOG").is_err() {
+        std::env::set_var("RUST_LOG", "form=debug")
+    }
+    tracing_subscriber::fmt::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
 
     // build our application with some routes
     let app = route("/", get(show_form).post(accept_form));

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -9,7 +9,13 @@ use std::net::SocketAddr;
 
 #[tokio::main]
 async fn main() {
-    tracing_subscriber::fmt::init();
+    // Set the RUST_LOG, if it hasn't been explicitly defined
+    if std::env::var("RUST_LOG").is_err() {
+        std::env::set_var("RUST_LOG", "hello_world=debug")
+    }
+    tracing_subscriber::fmt::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
 
     // build our application with a route
     let app = route("/", get(handler));

--- a/examples/key_value_store.rs
+++ b/examples/key_value_store.rs
@@ -31,7 +31,13 @@ use tower_http::{
 
 #[tokio::main]
 async fn main() {
-    tracing_subscriber::fmt::init();
+    // Set the RUST_LOG, if it hasn't been explicitly defined
+    if std::env::var("RUST_LOG").is_err() {
+        std::env::set_var("RUST_LOG", "key_value_store=debug,tower_http=debug")
+    }
+    tracing_subscriber::fmt::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
 
     // Build our application by composing routes
     let app = route(

--- a/examples/multipart_form.rs
+++ b/examples/multipart_form.rs
@@ -14,7 +14,7 @@ use std::net::SocketAddr;
 async fn main() {
     // Set the RUST_LOG, if it hasn't been explicitly defined
     if std::env::var("RUST_LOG").is_err() {
-        std::env::set_var("RUST_LOG", "multipart_form=debug")
+        std::env::set_var("RUST_LOG", "multipart_form=debug,tower_http=debug")
     }
     tracing_subscriber::fmt::fmt()
         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())

--- a/examples/multipart_form.rs
+++ b/examples/multipart_form.rs
@@ -12,7 +12,13 @@ use std::net::SocketAddr;
 
 #[tokio::main]
 async fn main() {
-    tracing_subscriber::fmt::init();
+    // Set the RUST_LOG, if it hasn't been explicitly defined
+    if std::env::var("RUST_LOG").is_err() {
+        std::env::set_var("RUST_LOG", "multipart_form=debug")
+    }
+    tracing_subscriber::fmt::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
 
     // build our application with some routes
     let app = route("/", get(show_form).post(accept_form))

--- a/examples/sessions.rs
+++ b/examples/sessions.rs
@@ -20,7 +20,13 @@ use uuid::Uuid;
 
 #[tokio::main]
 async fn main() {
-    tracing_subscriber::fmt::init();
+    // Set the RUST_LOG, if it hasn't been explicitly defined
+    if std::env::var("RUST_LOG").is_err() {
+        std::env::set_var("RUST_LOG", "sessions=debug")
+    }
+    tracing_subscriber::fmt::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
 
     // `MemoryStore` just used as an example. Don't use this in production.
     let store = MemoryStore::new();

--- a/examples/sse.rs
+++ b/examples/sse.rs
@@ -13,7 +13,13 @@ use tower_http::{services::ServeDir, trace::TraceLayer};
 
 #[tokio::main]
 async fn main() {
-    tracing_subscriber::fmt::init();
+    // Set the RUST_LOG, if it hasn't been explicitly defined
+    if std::env::var("RUST_LOG").is_err() {
+        std::env::set_var("RUST_LOG", "sse=debug,tower_http=debug")
+    }
+    tracing_subscriber::fmt::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
 
     // build our application with a route
     let app = nest(

--- a/examples/static_file_server.rs
+++ b/examples/static_file_server.rs
@@ -11,7 +11,13 @@ use tower_http::{services::ServeDir, trace::TraceLayer};
 
 #[tokio::main]
 async fn main() {
-    tracing_subscriber::fmt::init();
+    // Set the RUST_LOG, if it hasn't been explicitly defined
+    if std::env::var("RUST_LOG").is_err() {
+        std::env::set_var("RUST_LOG", "static_file_server=debug,tower_http=debug")
+    }
+    tracing_subscriber::fmt::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
 
     let app = nest(
         "/static",

--- a/examples/templates.rs
+++ b/examples/templates.rs
@@ -11,7 +11,13 @@ use std::net::SocketAddr;
 
 #[tokio::main]
 async fn main() {
-    tracing_subscriber::fmt::init();
+    // Set the RUST_LOG, if it hasn't been explicitly defined
+    if std::env::var("RUST_LOG").is_err() {
+        std::env::set_var("RUST_LOG", "templates=debug")
+    }
+    tracing_subscriber::fmt::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
 
     // build our application with some routes
     let app = route("/greet/:name", get(greet));

--- a/examples/testing.rs
+++ b/examples/testing.rs
@@ -9,7 +9,13 @@ use tower_http::trace::TraceLayer;
 
 #[tokio::main]
 async fn main() {
-    tracing_subscriber::fmt::init();
+    // Set the RUST_LOG, if it hasn't been explicitly defined
+    if std::env::var("RUST_LOG").is_err() {
+        std::env::set_var("RUST_LOG", "testing=debug,tower_http=debug")
+    }
+    tracing_subscriber::fmt::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
 
     let addr = std::net::SocketAddr::from(([127, 0, 0, 1], 3000));
 

--- a/examples/tls_rustls.rs
+++ b/examples/tls_rustls.rs
@@ -17,7 +17,13 @@ use tokio_rustls::{
 
 #[tokio::main]
 async fn main() {
-    tracing_subscriber::fmt::init();
+    // Set the RUST_LOG, if it hasn't been explicitly defined
+    if std::env::var("RUST_LOG").is_err() {
+        std::env::set_var("RUST_LOG", "rustls=debug")
+    }
+    tracing_subscriber::fmt::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
 
     let rustls_config = rustls_server_config(
         "examples/self_signed_certs/key.pem",

--- a/examples/todos.rs
+++ b/examples/todos.rs
@@ -34,7 +34,13 @@ use uuid::Uuid;
 
 #[tokio::main]
 async fn main() {
-    tracing_subscriber::fmt::init();
+    // Set the RUST_LOG, if it hasn't been explicitly defined
+    if std::env::var("RUST_LOG").is_err() {
+        std::env::set_var("RUST_LOG", "todos=debug,tower_http=debug")
+    }
+    tracing_subscriber::fmt::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
 
     let db = Db::default();
 

--- a/examples/tokio_postgres.rs
+++ b/examples/tokio_postgres.rs
@@ -13,7 +13,13 @@ use tokio_postgres::NoTls;
 
 #[tokio::main]
 async fn main() {
-    tracing_subscriber::fmt::init();
+    // Set the RUST_LOG, if it hasn't been explicitly defined
+    if std::env::var("RUST_LOG").is_err() {
+        std::env::set_var("RUST_LOG", "tokio_postgres=debug")
+    }
+    tracing_subscriber::fmt::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
 
     // setup connection pool
     let manager =

--- a/examples/unix_domain_socket.rs
+++ b/examples/unix_domain_socket.rs
@@ -36,7 +36,13 @@ fn main() {
 #[cfg(unix)]
 #[tokio::main]
 async fn main() {
-    tracing_subscriber::fmt::init();
+    // Set the RUST_LOG, if it hasn't been explicitly defined
+    if std::env::var("RUST_LOG").is_err() {
+        std::env::set_var("RUST_LOG", "debug")
+    }
+    tracing_subscriber::fmt::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
 
     let path = PathBuf::from("/tmp/axum/helloworld");
 

--- a/examples/versioning.rs
+++ b/examples/versioning.rs
@@ -16,7 +16,13 @@ use std::net::SocketAddr;
 
 #[tokio::main]
 async fn main() {
-    tracing_subscriber::fmt::init();
+    // Set the RUST_LOG, if it hasn't been explicitly defined
+    if std::env::var("RUST_LOG").is_err() {
+        std::env::set_var("RUST_LOG", "versioning=debug")
+    }
+    tracing_subscriber::fmt::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
 
     // build our application with some routes
     let app = route("/:version/foo", get(handler));

--- a/examples/websocket.rs
+++ b/examples/websocket.rs
@@ -3,7 +3,7 @@
 //! Run with
 //!
 //! ```not_rust
-//! RUST_LOG=tower_http=debug,key_value_store=trace cargo run --features=ws,headers --example websocket
+//! cargo run --features=ws,headers --example websocket
 //! ```
 
 use axum::{
@@ -22,7 +22,13 @@ use tower_http::{
 
 #[tokio::main]
 async fn main() {
-    tracing_subscriber::fmt::init();
+    // Set the RUST_LOG, if it hasn't been explicitly defined
+    if std::env::var("RUST_LOG").is_err() {
+        std::env::set_var("RUST_LOG", "websocket=debug,tower_http=debug")
+    }
+    tracing_subscriber::fmt::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
 
     // build our application with some routes
     let app = nest(


### PR DESCRIPTION
Signed-off-by: Spencer Gilbert <spencer.gilbert@gmail.com>

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation

As discussed in Discord, it would be nice to configure tracing for all of the examples
provided.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

I added environment variable based filtering (with fallbacks) at what seemed reasonable
for each example. I could add additional instructions on setting RUST_LOG in the readme
if desired.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
