### PR TITLE
Correctly handle HEAD requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   required for returning responses with bodies other than `hyper::Body` from
   handlers. See the docs for advice on how to implement `IntoResponse` ([#86](https://github.com/tokio-rs/axum/pull/86))
 - Replace `body::BoxStdError` with `Error`, which supports downcasting ([#150](https://github.com/tokio-rs/axum/pull/150))
+- `get` routes will now also be called for `HEAD` requests but will always have
+  the response body removed ([#129](https://github.com/tokio-rs/axum/pull/129))
 - Change WebSocket API to use an extractor ([#121](https://github.com/tokio-rs/axum/pull/121))
 - Make WebSocket `Message` an enum ([#116](https://github.com/tokio-rs/axum/pull/116))
 - `WebSocket` now uses `Error` as its error type ([#150](https://github.com/tokio-rs/axum/pull/150))

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ mime = { optional = true, version = "0.3" }
 
 [dev-dependencies]
 askama = "0.10.5"
-bb8 = "0.7.0"
+bb8 = "0.7.1"
 bb8-postgres = "0.7.0"
 futures = "0.3"
 hyper = { version = "0.14", features = ["full"] }

--- a/src/tests/get_to_head.rs
+++ b/src/tests/get_to_head.rs
@@ -1,0 +1,73 @@
+use super::*;
+use http::Method;
+use tower::ServiceExt;
+
+mod for_handlers {
+    use super::*;
+
+    #[tokio::test]
+    async fn get_handles_head() {
+        let app = route(
+            "/",
+            get(|| async {
+                let mut headers = HeaderMap::new();
+                headers.insert("x-some-header", "foobar".parse().unwrap());
+                (headers, "you shouldn't see this")
+            }),
+        );
+
+        // don't use reqwest because it always strips bodies from HEAD responses
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .uri("/")
+                    .method(Method::HEAD)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(res.status(), StatusCode::OK);
+        assert_eq!(res.headers()["x-some-header"], "foobar");
+
+        let body = hyper::body::to_bytes(res.into_body()).await.unwrap();
+        assert_eq!(body.len(), 0);
+    }
+}
+
+mod for_services {
+    use super::*;
+    use crate::service::get;
+
+    #[tokio::test]
+    async fn get_handles_head() {
+        let app = route(
+            "/",
+            get((|| async {
+                let mut headers = HeaderMap::new();
+                headers.insert("x-some-header", "foobar".parse().unwrap());
+                (headers, "you shouldn't see this")
+            })
+            .into_service()),
+        );
+
+        // don't use reqwest because it always strips bodies from HEAD responses
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .uri("/")
+                    .method(Method::HEAD)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(res.status(), StatusCode::OK);
+        assert_eq!(res.headers()["x-some-header"], "foobar");
+
+        let body = hyper::body::to_bytes(res.into_body()).await.unwrap();
+        assert_eq!(body.len(), 0);
+    }
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -5,7 +5,10 @@ use crate::{
 };
 use bytes::Bytes;
 use futures_util::future::Ready;
-use http::{header::AUTHORIZATION, Request, Response, StatusCode, Uri};
+use http::{
+    header::{HeaderMap, AUTHORIZATION},
+    Request, Response, StatusCode, Uri,
+};
 use hyper::{Body, Server};
 use serde::Deserialize;
 use serde_json::json;
@@ -18,6 +21,7 @@ use std::{
 };
 use tower::{make::Shared, service_fn, BoxError, Service};
 
+mod get_to_head;
 mod handle_error;
 mod nest;
 mod or;


### PR DESCRIPTION
HEAD requests will be routed to GET handlers, unless an explicit HEAD handler exists:

```rust
// this will receive `GET /` and `HEAD /` and send both to `handler`
route("/", get(handler));

// `GET /` goes to `handler`, `HEAD /` goes to `other_handler`
route("/", get(handler).head(other_handler));
```

Reponses to `HEAD` requests will always have the body stripped.

Fixes https://github.com/tokio-rs/axum/issues/84