### PR TITLE
Move response futures into their own modules

### DIFF
--- a/src/extract/extractor_middleware.rs
+++ b/src/extract/extractor_middleware.rs
@@ -163,7 +163,7 @@ where
 {
     type Response = Response<BoxBody>;
     type Error = S::Error;
-    type Future = ExtractorMiddlewareResponseFuture<ReqBody, S, E>;
+    type Future = ResponseFuture<ReqBody, S, E>;
 
     #[inline]
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
@@ -177,7 +177,7 @@ where
             (req, extracted)
         });
 
-        ExtractorMiddlewareResponseFuture {
+        ResponseFuture {
             state: State::Extracting {
                 future: extract_future,
             },
@@ -186,10 +186,17 @@ where
     }
 }
 
+#[doc(hidden)]
+#[deprecated(
+    since = "0.1.3",
+    note = "Use axum::extract::extractor_middleware::ResponseFuture"
+)]
+pub type ExtractorMiddlewareResponseFuture<B, S, E> = ResponseFuture<B, S, E>;
+
 pin_project! {
     /// Response future for [`ExtractorMiddleware`].
     #[allow(missing_debug_implementations)]
-    pub struct ExtractorMiddlewareResponseFuture<ReqBody, S, E>
+    pub struct ResponseFuture<ReqBody, S, E>
     where
         E: FromRequest<ReqBody>,
         S: Service<Request<ReqBody>>,
@@ -212,7 +219,7 @@ pin_project! {
     }
 }
 
-impl<ReqBody, S, E, ResBody> Future for ExtractorMiddlewareResponseFuture<ReqBody, S, E>
+impl<ReqBody, S, E, ResBody> Future for ResponseFuture<ReqBody, S, E>
 where
     E: FromRequest<ReqBody>,
     S: Service<Request<ReqBody>, Response = Response<ResBody>>,

--- a/src/routing.rs
+++ b/src/routing.rs
@@ -9,25 +9,28 @@ use crate::{
 };
 use async_trait::async_trait;
 use bytes::Bytes;
-use futures_util::future;
 use http::{Method, Request, Response, StatusCode, Uri};
-use pin_project_lite::pin_project;
 use regex::Regex;
 use std::{
     borrow::Cow,
     convert::Infallible,
     fmt,
-    future::Future,
     marker::PhantomData,
-    pin::Pin,
     sync::Arc,
     task::{Context, Poll},
 };
 use tower::{
-    util::{BoxService, Oneshot, ServiceExt},
+    util::{BoxService, ServiceExt},
     BoxError, Layer, Service, ServiceBuilder,
 };
 use tower_http::map_response_body::MapResponseBodyLayer;
+
+pub mod future;
+
+// for backwards compatibility
+// TODO: remove these in 0.2
+#[doc(hidden)]
+pub use self::future::{BoxRouteFuture, EmptyRouterFuture, RouteFuture};
 
 /// A filter that matches one or more HTTP methods.
 #[derive(Debug, Copy, Clone)]
@@ -385,63 +388,6 @@ where
     }
 }
 
-pin_project! {
-    /// The response future for [`Route`].
-    #[derive(Debug)]
-    pub struct RouteFuture<S, F, B>
-    where
-        S: Service<Request<B>>,
-        F: Service<Request<B>> {
-        #[pin] inner: RouteFutureInner<S, F, B>,
-    }
-}
-
-impl<S, F, B> RouteFuture<S, F, B>
-where
-    S: Service<Request<B>>,
-    F: Service<Request<B>>,
-{
-    pub(crate) fn a(a: Oneshot<S, Request<B>>) -> Self {
-        RouteFuture {
-            inner: RouteFutureInner::A { a },
-        }
-    }
-
-    pub(crate) fn b(b: Oneshot<F, Request<B>>) -> Self {
-        RouteFuture {
-            inner: RouteFutureInner::B { b },
-        }
-    }
-}
-
-pin_project! {
-    #[project = RouteFutureInnerProj]
-    #[derive(Debug)]
-    enum RouteFutureInner<S, F, B>
-    where
-        S: Service<Request<B>>,
-        F: Service<Request<B>>,
-    {
-        A { #[pin] a: Oneshot<S, Request<B>> },
-        B { #[pin] b: Oneshot<F, Request<B>> },
-    }
-}
-
-impl<S, F, B> Future for RouteFuture<S, F, B>
-where
-    S: Service<Request<B>, Response = Response<BoxBody>>,
-    F: Service<Request<B>, Response = Response<BoxBody>, Error = S::Error>,
-{
-    type Output = Result<Response<BoxBody>, S::Error>;
-
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        match self.project().inner.project() {
-            RouteFutureInnerProj::A { a } => a.poll(cx),
-            RouteFutureInnerProj::B { b } => b.poll(cx),
-        }
-    }
-}
-
 #[derive(Debug)]
 pub(crate) struct UrlParams(pub(crate) Vec<(ByteStr, ByteStr)>);
 
@@ -520,15 +466,9 @@ impl<B, E> Service<Request<B>> for EmptyRouter<E> {
         let mut res = Response::new(crate::body::empty());
         *res.status_mut() = self.status;
         EmptyRouterFuture {
-            future: future::ok(res),
+            future: futures_util::future::ok(res),
         }
     }
-}
-
-opaque_future! {
-    /// Response future for [`EmptyRouter`].
-    pub type EmptyRouterFuture<E> =
-        future::Ready<Result<Response<BoxBody>, E>>;
 }
 
 #[derive(Debug, Clone)]
@@ -663,36 +603,6 @@ where
         BoxRouteFuture {
             inner: self.0.clone().oneshot(req),
         }
-    }
-}
-
-pin_project! {
-    /// The response future for [`BoxRoute`].
-    pub struct BoxRouteFuture<B, E>
-    where
-        E: Into<BoxError>,
-    {
-        #[pin] inner: Oneshot<MpscBuffer<BoxService<Request<B>, Response<BoxBody>, E>, Request<B>>, Request<B>>,
-    }
-}
-
-impl<B, E> Future for BoxRouteFuture<B, E>
-where
-    E: Into<BoxError>,
-{
-    type Output = Result<Response<BoxBody>, E>;
-
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        self.project().inner.poll(cx)
-    }
-}
-
-impl<B, E> fmt::Debug for BoxRouteFuture<B, E>
-where
-    E: Into<BoxError>,
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("BoxRouteFuture").finish()
     }
 }
 

--- a/src/routing/future.rs
+++ b/src/routing/future.rs
@@ -1,0 +1,117 @@
+//! Future types.
+
+use crate::{body::BoxBody, buffer::MpscBuffer};
+use http::{Request, Response};
+use pin_project_lite::pin_project;
+use std::{
+    fmt,
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+use tower::{
+    util::{BoxService, Oneshot},
+    BoxError, Service,
+};
+
+opaque_future! {
+    /// Response future for [`EmptyRouter`](super::EmptyRouter).
+    pub type EmptyRouterFuture<E> =
+        futures_util::future::Ready<Result<Response<BoxBody>, E>>;
+}
+
+pin_project! {
+    /// The response future for [`BoxRoute`](super::BoxRoute).
+    pub struct BoxRouteFuture<B, E>
+    where
+        E: Into<BoxError>,
+    {
+        #[pin]
+        pub(super) inner: Oneshot<
+            MpscBuffer<
+                BoxService<Request<B>, Response<BoxBody>, E >,
+                Request<B>
+            >,
+            Request<B>,
+        >,
+    }
+}
+
+impl<B, E> Future for BoxRouteFuture<B, E>
+where
+    E: Into<BoxError>,
+{
+    type Output = Result<Response<BoxBody>, E>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        self.project().inner.poll(cx)
+    }
+}
+
+impl<B, E> fmt::Debug for BoxRouteFuture<B, E>
+where
+    E: Into<BoxError>,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("BoxRouteFuture").finish()
+    }
+}
+
+pin_project! {
+    /// The response future for [`Route`](super::Route).
+    #[derive(Debug)]
+    pub struct RouteFuture<S, F, B>
+    where
+        S: Service<Request<B>>,
+        F: Service<Request<B>>
+    {
+        #[pin]
+        inner: RouteFutureInner<S, F, B>,
+    }
+}
+
+impl<S, F, B> RouteFuture<S, F, B>
+where
+    S: Service<Request<B>>,
+    F: Service<Request<B>>,
+{
+    pub(crate) fn a(a: Oneshot<S, Request<B>>) -> Self {
+        RouteFuture {
+            inner: RouteFutureInner::A { a },
+        }
+    }
+
+    pub(crate) fn b(b: Oneshot<F, Request<B>>) -> Self {
+        RouteFuture {
+            inner: RouteFutureInner::B { b },
+        }
+    }
+}
+
+pin_project! {
+    #[project = RouteFutureInnerProj]
+    #[derive(Debug)]
+    enum RouteFutureInner<S, F, B>
+    where
+        S: Service<Request<B>>,
+        F: Service<Request<B>>,
+    {
+        A { #[pin] a: Oneshot<S, Request<B>> },
+        B { #[pin] b: Oneshot<F, Request<B>> },
+    }
+}
+
+impl<S, F, B> Future for RouteFuture<S, F, B>
+where
+    S: Service<Request<B>, Response = Response<BoxBody>>,
+    F: Service<Request<B>, Response = Response<BoxBody>, Error = S::Error>,
+{
+    type Output = Result<Response<BoxBody>, S::Error>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        match self.project().inner.project() {
+            RouteFutureInnerProj::A { a } => a.poll(cx),
+            RouteFutureInnerProj::B { b } => b.poll(cx),
+        }
+    }
+}

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -87,24 +87,25 @@
 //! [load shed]: tower::load_shed
 
 use crate::{
-    body::{box_body, BoxBody},
+    body::BoxBody,
     response::IntoResponse,
     routing::{EmptyRouter, MethodFilter, RouteFuture},
 };
 use bytes::Bytes;
-use futures_util::ready;
 use http::{Request, Response};
-use pin_project_lite::pin_project;
 use std::{
     convert::Infallible,
     fmt,
-    future::Future,
     marker::PhantomData,
     task::{Context, Poll},
 };
 use tower::{util::Oneshot, BoxError, Service, ServiceExt as _};
 
 pub mod future;
+
+// for backwards compatibility
+#[doc(hidden)]
+pub use future::BoxResponseBodyFuture;
 
 /// Route requests to the given service regardless of the HTTP method.
 ///
@@ -637,7 +638,7 @@ where
 {
     type Response = Response<BoxBody>;
     type Error = S::Error;
-    type Future = BoxResponseBodyFuture<Oneshot<S, Request<ReqBody>>>;
+    type Future = future::BoxResponseBodyFuture<Oneshot<S, Request<ReqBody>>>;
 
     fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         Poll::Ready(Ok(()))
@@ -645,29 +646,6 @@ where
 
     fn call(&mut self, req: Request<ReqBody>) -> Self::Future {
         let fut = self.inner.clone().oneshot(req);
-        BoxResponseBodyFuture { future: fut }
-    }
-}
-
-pin_project! {
-    /// Response future for [`BoxResponseBody`].
-    #[derive(Debug)]
-    pub struct BoxResponseBodyFuture<F> {
-        #[pin] future: F,
-    }
-}
-
-impl<F, B, E> Future for BoxResponseBodyFuture<F>
-where
-    F: Future<Output = Result<Response<B>, E>>,
-    B: http_body::Body<Data = Bytes> + Send + Sync + 'static,
-    B::Error: Into<BoxError> + Send + Sync + 'static,
-{
-    type Output = Result<Response<BoxBody>, E>;
-
-    fn poll(self: std::pin::Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let res = ready!(self.project().future.poll(cx))?;
-        let res = res.map(box_body);
-        Poll::Ready(Ok(res))
+        future::BoxResponseBodyFuture { future: fut }
     }
 }


### PR DESCRIPTION
It cleans up the docs to have the futures in their own modules as users
are unlikely to look at them. Also matches the pattern used in tower
https://docs.rs/tower/0.4.8/tower/util/future/index.html.

Added re-exports to the old locations so its not a breaking change.