### PR TITLE
Handle `METHOD_NOT_ALLOWED` in 404 example

### DIFF
--- a/examples/404.rs
+++ b/examples/404.rs
@@ -39,12 +39,14 @@ async fn handler() -> response::Html<&'static str> {
 }
 
 fn map_404(response: Response<BoxBody>) -> Response<BoxBody> {
-    if response.status() != StatusCode::NOT_FOUND {
-        return response;
+    if response.status() == StatusCode::NOT_FOUND
+        || response.status() == StatusCode::METHOD_NOT_ALLOWED
+    {
+        return Response::builder()
+            .status(StatusCode::NOT_FOUND)
+            .body(box_body(Body::from("nothing to see here")))
+            .unwrap();
     }
 
-    Response::builder()
-        .status(StatusCode::NOT_FOUND)
-        .body(box_body(Body::from("nothing to see here")))
-        .unwrap()
+    response
 }


### PR DESCRIPTION
If a route existed but had no handler for the method, the code used in
the 404 example wouldn't catch it.