### PR TITLE
Remove `Copy` some impls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Breaking changes
 
-- The following types no longer implement `Copy`:
+- The following types no longer implement `Copy` ([#132](https://github.com/tokio-rs/axum/pull/132)):
     - `EmptyRouter`
     - `ExtractorMiddleware`
     - `ExtractorMiddlewareLayer`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Breaking changes
 
-None.
+- The following types no longer implement `Copy`:
+    - `EmptyRouter`
+    - `ExtractorMiddleware`
+    - `ExtractorMiddlewareLayer`
 
 # 0.1.2 (01. August, 2021)
 

--- a/src/extract/extractor_middleware.rs
+++ b/src/extract/extractor_middleware.rs
@@ -98,8 +98,6 @@ impl<E> Clone for ExtractorMiddlewareLayer<E> {
     }
 }
 
-impl<E> Copy for ExtractorMiddlewareLayer<E> {}
-
 impl<E> fmt::Debug for ExtractorMiddlewareLayer<E> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ExtractorMiddleware")
@@ -138,8 +136,6 @@ where
         }
     }
 }
-
-impl<S, E> Copy for ExtractorMiddleware<S, E> where S: Copy {}
 
 impl<S, E> fmt::Debug for ExtractorMiddleware<S, E>
 where

--- a/src/routing.rs
+++ b/src/routing.rs
@@ -495,8 +495,6 @@ impl<E> Clone for EmptyRouter<E> {
     }
 }
 
-impl<E> Copy for EmptyRouter<E> {}
-
 impl<E> fmt::Debug for EmptyRouter<E> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_tuple("EmptyRouter").finish()


### PR DESCRIPTION
https://github.com/tokio-rs/axum/pull/129 was a breaking change, in part
because I had to remove the `Copy` impl from `OnMethod`.

For the sake of future proofing I think we should remove other `Copy`
impls from services as well. We can always bring them back once things
have matured more.

These types no longer implement `Copy`:

- `EmptyRouter`
- `ExtractorMiddleware`
- `ExtractorMiddlewareLayer`