### PR TITLE
Deprecate `extract::UrlParams` and `extract::UrlParamsMap`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Re-export `http` crate and `hyper::Server`. ([#110](https://github.com/tokio-rs/axum/pull/110))
 - Fix `Query` and `Form` extractors giving bad request error when query string is empty. ([#117](https://github.com/tokio-rs/axum/pull/117))
 - Add `Path` extractor. ([#124](https://github.com/tokio-rs/axum/pull/124))
+- Deprecate `extract::UrlParams` and `extract::UrlParamsMap`. Use `extract::Path` instead.
 
 ## Breaking changes
 

--- a/src/extract/mod.rs
+++ b/src/extract/mod.rs
@@ -267,6 +267,7 @@ mod url_params;
 mod url_params_map;
 
 #[doc(inline)]
+#[allow(deprecated)]
 pub use self::{
     connect_info::ConnectInfo,
     content_length_limit::ContentLengthLimit,

--- a/src/extract/url_params.rs
+++ b/src/extract/url_params.rs
@@ -28,6 +28,7 @@ use std::{ops::Deref, str::FromStr};
 /// Note that you can only have one URL params extractor per handler. If you
 /// have multiple it'll response with `500 Internal Server Error`.
 #[derive(Debug)]
+#[deprecated(since = "0.1.3", note = "Use `axum::extract::Path` instead.")]
 pub struct UrlParams<T>(pub T);
 
 macro_rules! impl_parse_url {
@@ -35,6 +36,7 @@ macro_rules! impl_parse_url {
 
     ( $head:ident, $($tail:ident),* $(,)? ) => {
         #[async_trait]
+        #[allow(deprecated)]
         impl<B, $head, $($tail,)*> FromRequest<B> for UrlParams<($head, $($tail,)*)>
         where
             $head: FromStr + Send,
@@ -88,6 +90,7 @@ macro_rules! impl_parse_url {
 
 impl_parse_url!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16);
 
+#[allow(deprecated)]
 impl<T> Deref for UrlParams<T> {
     type Target = T;
 

--- a/src/extract/url_params_map.rs
+++ b/src/extract/url_params_map.rs
@@ -25,8 +25,10 @@ use std::{collections::HashMap, str::FromStr};
 /// Note that you can only have one URL params extractor per handler. If you
 /// have multiple it'll response with `500 Internal Server Error`.
 #[derive(Debug)]
+#[deprecated(since = "0.1.3", note = "Use `axum::extract::Path` instead.")]
 pub struct UrlParamsMap(HashMap<ByteStr, ByteStr>);
 
+#[allow(deprecated)]
 impl UrlParamsMap {
     /// Look up the value for a key.
     pub fn get(&self, key: &str) -> Option<&str> {
@@ -43,6 +45,7 @@ impl UrlParamsMap {
 }
 
 #[async_trait]
+#[allow(deprecated)]
 impl<B> FromRequest<B> for UrlParamsMap
 where
     B: Send,


### PR DESCRIPTION
Use `extract::Path` instead. It supports everything the two other do, and more.