### PR TITLE
Make `FromRequest` default to use `axum::body::Body`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
-None.
+- Make `FromRequest` default to being generic over `axum::body::Body` ([#146](https://github.com/tokio-rs/axum/pull/146))
 
 ## Breaking changes
 

--- a/src/body.rs
+++ b/src/body.rs
@@ -5,6 +5,7 @@ use http_body::Body as _;
 use std::{error::Error as StdError, fmt};
 use tower::BoxError;
 
+#[doc(no_inline)]
 pub use hyper::body::Body;
 
 /// A boxed [`Body`] trait object.


### PR DESCRIPTION
Most users will implement `FromRequest<axum::body::Body>` so making that
the default makes things a bit easier to use.