### PR TITLE
Re-export `http_body::Body`

### DIFF
--- a/src/body.rs
+++ b/src/body.rs
@@ -2,9 +2,10 @@
 
 use crate::Error;
 use bytes::Bytes;
-use http_body::Body as _;
 use tower::BoxError;
 
+#[doc(no_inline)]
+pub use http_body::Body as HttpBody;
 #[doc(no_inline)]
 pub use hyper::body::Body;
 

--- a/src/response.rs
+++ b/src/response.rs
@@ -107,7 +107,7 @@ pub trait IntoResponse {
     /// Generally it should be possible to set this to:
     ///
     /// ```rust,ignore
-    /// type BodyError = <Self::Body as http_body::Body>::Error;
+    /// type BodyError = <Self::Body as axum::body::HttpBody>::Error;
     /// ```
     ///
     /// This associated type exists mainly to make returning `impl IntoResponse`


### PR DESCRIPTION
Makes writing `IntoResponse` impls easier.