### PR TITLE
Move methods from `ServiceExt` to `RoutingDsl`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Make `FromRequest` default to being generic over `body::Body` ([#146](https://github.com/tokio-rs/axum/pull/146))
 - Implement `std::error::Error` for all rejections ([#153](https://github.com/tokio-rs/axum/pull/153))
-- Fix `Uri` extractor not being the full URI if using `nest` ([#156](https://github.com/tokio-rs/axum/pull/156))
 - Add `RoutingDsl::or` for combining routes ([#108](https://github.com/tokio-rs/axum/pull/108))
+- Add `handle_error` to `service::OnMethod` ([#160](https://github.com/tokio-rs/axum/pull/160))
 
 ## Breaking changes
 
@@ -24,9 +24,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ensure a `HandleError` service created from `ServiceExt::handle_error`
   _does not_ implement `RoutingDsl` as that could lead to confusing routing
   behavior ([#120](https://github.com/tokio-rs/axum/pull/120))
+- Fix `Uri` extractor not being the full URI if using `nest` ([#156](https://github.com/tokio-rs/axum/pull/156))
 - Implement `routing::MethodFilter` via [`bitflags`](https://crates.io/crates/bitflags)
 - Removed `extract::UrlParams` and `extract::UrlParamsMap`. Use `extract::Path` instead
 - `EmptyRouter` now requires the response body to implement `Send + Sync + 'static'` ([#108](https://github.com/tokio-rs/axum/pull/108))
+- `ServiceExt` has been removed and its methods have been moved to `RoutingDsl` ([#160](https://github.com/tokio-rs/axum/pull/160))
 - These future types have been moved
     - `extract::extractor_middleware::ExtractorMiddlewareResponseFuture` moved
       to `extract::extractor_middleware::future::ResponseFuture` ([#133](https://github.com/tokio-rs/axum/pull/133))

--- a/examples/key_value_store.rs
+++ b/examples/key_value_store.rs
@@ -12,7 +12,6 @@ use axum::{
     prelude::*,
     response::IntoResponse,
     routing::BoxRoute,
-    service::ServiceExt,
 };
 use bytes::Bytes;
 use http::StatusCode;

--- a/examples/static_file_server.rs
+++ b/examples/static_file_server.rs
@@ -4,7 +4,7 @@
 //! cargo run --example static_file_server
 //! ```
 
-use axum::{prelude::*, routing::nest, service::ServiceExt};
+use axum::{prelude::*, routing::nest};
 use http::StatusCode;
 use std::net::SocketAddr;
 use tower_http::{services::ServeDir, trace::TraceLayer};
@@ -19,12 +19,12 @@ async fn main() {
 
     let app = nest(
         "/static",
-        axum::service::get(ServeDir::new(".").handle_error(|error: std::io::Error| {
+        axum::service::get(ServeDir::new(".")).handle_error(|error: std::io::Error| {
             Ok::<_, std::convert::Infallible>((
                 StatusCode::INTERNAL_SERVER_ERROR,
                 format!("Unhandled internal error: {}", error),
             ))
-        })),
+        }),
     )
     .layer(TraceLayer::new_for_http());
 

--- a/examples/todos.rs
+++ b/examples/todos.rs
@@ -17,7 +17,6 @@ use axum::{
     extract::{Extension, Json, Path, Query},
     prelude::*,
     response::IntoResponse,
-    service::ServiceExt,
 };
 use http::StatusCode;
 use serde::{Deserialize, Serialize};

--- a/examples/websocket.rs
+++ b/examples/websocket.rs
@@ -14,7 +14,6 @@ use axum::{
     prelude::*,
     response::IntoResponse,
     routing::nest,
-    service::ServiceExt,
 };
 use http::StatusCode;
 use std::net::SocketAddr;
@@ -35,15 +34,14 @@ async fn main() {
     let app = nest(
         "/",
         axum::service::get(
-            ServeDir::new("examples/websocket")
-                .append_index_html_on_directories(true)
-                .handle_error(|error: std::io::Error| {
-                    Ok::<_, std::convert::Infallible>((
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        format!("Unhandled internal error: {}", error),
-                    ))
-                }),
-        ),
+            ServeDir::new("examples/websocket").append_index_html_on_directories(true),
+        )
+        .handle_error(|error: std::io::Error| {
+            Ok::<_, std::convert::Infallible>((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Unhandled internal error: {}", error),
+            ))
+        }),
     )
     // routes are matched from bottom to top, so we have to put `nest` at the
     // top since it matches all routes

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -366,9 +366,9 @@ impl<S, T> Layered<S, T> {
     /// This is used to convert errors to responses rather than simply
     /// terminating the connection.
     ///
-    /// It works similarly to [`routing::Layered::handle_error`]. See that for more details.
+    /// It works similarly to [`routing::RoutingDsl::handle_error`]. See that for more details.
     ///
-    /// [`routing::Layered::handle_error`]: crate::routing::Layered::handle_error
+    /// [`routing::RoutingDsl::handle_error`]: crate::routing::RoutingDsl::handle_error
     pub fn handle_error<F, ReqBody, ResBody, Res, E>(
         self,
         f: F,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -493,7 +493,7 @@
 //! return `Result<T, E>` where `T` implements
 //! [`IntoResponse`](response::IntoResponse).
 //!
-//! See [`routing::Layered::handle_error`] for more details.
+//! See [`routing::RoutingDsl::handle_error`] for more details.
 //!
 //! ## Applying multiple middleware
 //!

--- a/src/tests/handle_error.rs
+++ b/src/tests/handle_error.rs
@@ -1,0 +1,203 @@
+use super::*;
+use futures_util::future::{pending, ready};
+use tower::{timeout::TimeoutLayer, MakeService};
+
+async fn unit() {}
+
+async fn forever() {
+    pending().await
+}
+
+fn timeout() -> TimeoutLayer {
+    TimeoutLayer::new(Duration::from_millis(10))
+}
+
+#[derive(Clone)]
+struct Svc;
+
+impl<R> Service<R> for Svc {
+    type Response = Response<Body>;
+    type Error = hyper::Error;
+    type Future = Ready<Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, _req: R) -> Self::Future {
+        ready(Ok(Response::new(Body::empty())))
+    }
+}
+
+fn check_make_svc<M, R, T, E>(_make_svc: M)
+where
+    M: MakeService<(), R, Response = T, Error = E>,
+{
+}
+
+fn handle_error<E>(_: E) -> Result<StatusCode, Infallible> {
+    Ok(StatusCode::INTERNAL_SERVER_ERROR)
+}
+
+#[tokio::test]
+async fn handler() {
+    let app = route(
+        "/",
+        get(forever
+            .layer(timeout())
+            .handle_error(|_: BoxError| Ok::<_, Infallible>(StatusCode::REQUEST_TIMEOUT))),
+    );
+
+    let addr = run_in_background(app).await;
+
+    let client = reqwest::Client::new();
+
+    let res = client
+        .get(format!("http://{}/", addr))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::REQUEST_TIMEOUT);
+}
+
+#[tokio::test]
+async fn handler_multiple_methods_first() {
+    let app = route(
+        "/",
+        get(forever
+            .layer(timeout())
+            .handle_error(|_: BoxError| Ok::<_, Infallible>(StatusCode::REQUEST_TIMEOUT)))
+        .post(unit),
+    );
+
+    let addr = run_in_background(app).await;
+
+    let client = reqwest::Client::new();
+
+    let res = client
+        .get(format!("http://{}/", addr))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::REQUEST_TIMEOUT);
+}
+
+#[tokio::test]
+async fn handler_multiple_methods_middle() {
+    let app = route(
+        "/",
+        delete(unit)
+            .get(
+                forever
+                    .layer(timeout())
+                    .handle_error(|_: BoxError| Ok::<_, Infallible>(StatusCode::REQUEST_TIMEOUT)),
+            )
+            .post(unit),
+    );
+
+    let addr = run_in_background(app).await;
+
+    let client = reqwest::Client::new();
+
+    let res = client
+        .get(format!("http://{}/", addr))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::REQUEST_TIMEOUT);
+}
+
+#[tokio::test]
+async fn handler_multiple_methods_last() {
+    let app = route(
+        "/",
+        delete(unit).get(
+            forever
+                .layer(timeout())
+                .handle_error(|_: BoxError| Ok::<_, Infallible>(StatusCode::REQUEST_TIMEOUT)),
+        ),
+    );
+
+    let addr = run_in_background(app).await;
+
+    let client = reqwest::Client::new();
+
+    let res = client
+        .get(format!("http://{}/", addr))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::REQUEST_TIMEOUT);
+}
+
+#[test]
+fn service_propagates_errors() {
+    let app = route::<_, Body>("/echo", service::post(Svc));
+
+    check_make_svc::<_, _, _, hyper::Error>(app.into_make_service());
+}
+
+#[test]
+fn service_nested_propagates_errors() {
+    let app = route::<_, Body>("/echo", nest("/foo", service::post(Svc)));
+
+    check_make_svc::<_, _, _, hyper::Error>(app.into_make_service());
+}
+
+#[test]
+fn service_handle_on_method() {
+    let app = route::<_, Body>(
+        "/echo",
+        service::get(Svc).handle_error(handle_error::<hyper::Error>),
+    );
+
+    check_make_svc::<_, _, _, Infallible>(app.into_make_service());
+}
+
+#[test]
+fn service_handle_on_method_multiple() {
+    let app = route::<_, Body>(
+        "/echo",
+        service::get(Svc)
+            .post(Svc)
+            .handle_error(handle_error::<hyper::Error>),
+    );
+
+    check_make_svc::<_, _, _, Infallible>(app.into_make_service());
+}
+
+#[test]
+fn service_handle_on_router() {
+    let app =
+        route::<_, Body>("/echo", service::get(Svc)).handle_error(handle_error::<hyper::Error>);
+
+    check_make_svc::<_, _, _, Infallible>(app.into_make_service());
+}
+
+#[test]
+fn service_handle_on_router_still_impls_routing_dsl() {
+    let app = route::<_, Body>("/echo", service::get(Svc))
+        .handle_error(handle_error::<hyper::Error>)
+        .route("/", get(unit));
+
+    check_make_svc::<_, _, _, Infallible>(app.into_make_service());
+}
+
+#[test]
+fn layered() {
+    let app = route::<_, Body>("/echo", get(unit))
+        .layer(timeout())
+        .handle_error(handle_error::<BoxError>);
+
+    check_make_svc::<_, _, _, Infallible>(app.into_make_service());
+}
+
+#[tokio::test] // async because of `.boxed()`
+async fn layered_boxed() {
+    let app = route::<_, Body>("/echo", get(unit))
+        .layer(timeout())
+        .boxed()
+        .handle_error(handle_error::<BoxError>);
+
+    check_make_svc::<_, _, _, Infallible>(app.into_make_service());
+}


### PR DESCRIPTION
Previously, on `main`, this wouldn't compile:

```rust
let app = route("/", get(handler))
    .layer(
        ServiceBuilder::new()
            .timeout(Duration::from_secs(10))
            .into_inner(),
    )
    .handle_error(...)
    .route(...); // <-- doesn't work
```

That is because `handle_error` would be
`axum::service::ServiceExt::handle_error` which returns `HandleError<_,
_, _, HandleErrorFromService>` which does _not_ implement `RoutingDsl`.
So you couldn't call `route`. This was caused by
https://github.com/tokio-rs/axum/pull/120.

Basically `handle_error` when called on a `RoutingDsl`, the resulting
service should also implement `RoutingDsl`, but if called on another
random service it should _not_ implement `RoutingDsl`.

I don't think thats possible by having `handle_error` on `ServiceExt`
which is implemented for any service, since all axum routers are also
services by design.

This resolves the issue by removing `ServiceExt` and moving its methods
to `RoutingDsl`. Then we have more tight control over what has a
`handle_error` method.

`service::OnMethod` now also has a `handle_error` so you can still
handle errors from random services, by doing
`service::any(svc).handle_error(...)`.