### PR TITLE
Support `multipart` conversion to `HashMap<String, Field>`

### DIFF
--- a/examples/multipart_form.rs
+++ b/examples/multipart_form.rs
@@ -60,10 +60,34 @@ async fn accept_form(
         },
     >,
 ) {
-    while let Some(field) = multipart.next_field().await.unwrap() {
-        let name = field.name().unwrap().to_string();
-        let data = field.bytes().await.unwrap();
 
-        println!("Length of `{}` is {} bytes", name, data.len());
+    let v = multipart.map().await.unwrap();
+
+    let text = v.0;
+    let file = v.1;
+
+    println!("Form-Data: Text\n");
+    for i in text {
+
+        println!("{}: {:?}", i.0, i.1);
+
     }
+
+    println!("\nForm-Data: File\n");
+    for i in file {
+
+        println!("{}: size({})", i.0, i.1.content.len());
+
+    }
+
+    println!();
+
+    // This is another way to use it
+    //
+    // while let Some(field) = multipart.next_field().await.unwrap() {
+    //     let name = field.name().unwrap().to_string();
+    //     let data = field.bytes().await.unwrap();
+    //
+    //     println!("Length of `{}` is {} bytes", name, data.len());
+    // }
 }

--- a/src/extract/multipart.rs
+++ b/src/extract/multipart.rs
@@ -14,6 +14,7 @@ use std::{
     task::{Context, Poll},
 };
 use tower::BoxError;
+use std::collections::HashMap;
 
 /// Extractor that parses `multipart/form-data` requests commonly used with file uploads.
 ///
@@ -80,6 +81,21 @@ impl Multipart {
             Ok(None)
         }
     }
+
+    /// make all fields to a hashmap
+    /// you can easy to check & get field data.
+    pub async fn map(&mut self) -> Result<HashMap<String, Field<'_>>, MultipartError> {
+
+        let mut result = HashMap::new();
+
+        while let Some(mut field) = self.next_field().await? {
+            let name = field.name()?.to_string();
+            result.insert(name, field);
+        }
+
+        Ok(result)
+    }
+
 }
 
 /// A single field in a multipart stream.


### PR DESCRIPTION
## Motivation

When I use `axum` to try to get value from `form-data`, it need use `next_field + while` to get value.

But I think if the data can be make a `HashMap` will be more better.

for example: 

```rust
let map: HashMap<String, Field> = multipart.map();

let v = map.get("value").unwrap();

```

## Solution

I create a new function: `map`, it can get all `field` from `Multipart` and make it to a `HashMap`.

but if developer want to use `next_field`, it also ok.

if you have any suggest or problem, please tell me. thanks.