### PR TITLE
Make sure nested services still see full URI

### DIFF
--- a/src/extract/mod.rs
+++ b/src/extract/mod.rs
@@ -244,7 +244,7 @@
 //!
 //! [`body::Body`]: crate::body::Body
 
-use crate::{response::IntoResponse, routing::OriginalUri};
+use crate::response::IntoResponse;
 use async_trait::async_trait;
 use http::{header, Extensions, HeaderMap, Method, Request, Uri, Version};
 use rejection::*;
@@ -378,7 +378,7 @@ impl<B> RequestParts<B> {
         let (
             http::request::Parts {
                 method,
-                mut uri,
+                uri,
                 version,
                 headers,
                 extensions,
@@ -386,10 +386,6 @@ impl<B> RequestParts<B> {
             },
             body,
         ) = req.into_parts();
-
-        if let Some(original_uri) = extensions.get::<OriginalUri>() {
-            uri = original_uri.0.clone();
-        };
 
         RequestParts {
             method,


### PR DESCRIPTION
They'd previously see the nested URI as we mutated the request. Now we
always route based on the nested URI (if present) without mutating the
request. Also meant we could get rid of `OriginalUri` which is nice.