### PR TITLE
Clean up `RequestParts` API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed `extract::UrlParams` and `extract::UrlParamsMap`. Use `extract::Path` instead
 - `EmptyRouter` now requires the response body to implement `Send + Sync + 'static'` ([#108](https://github.com/tokio-rs/axum/pull/108))
 - `ServiceExt` has been removed and its methods have been moved to `RoutingDsl` ([#160](https://github.com/tokio-rs/axum/pull/160))
+- `extractor_middleware` now requires `RequestBody: Default` ([#167](https://github.com/tokio-rs/axum/pull/167))
+- Convert `RequestAlreadyExtracted` to an enum with each possible error variant ([#167](https://github.com/tokio-rs/axum/pull/167))
 - These future types have been moved
     - `extract::extractor_middleware::ExtractorMiddlewareResponseFuture` moved
       to `extract::extractor_middleware::future::ResponseFuture` ([#133](https://github.com/tokio-rs/axum/pull/133))

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ bitflags = "1.0"
 bytes = "1.0"
 futures-util = "0.3"
 http = "0.2"
-http-body = "0.4.2"
+http-body = "0.4.3"
 hyper = { version = "0.14", features = ["server", "tcp", "http1", "stream"] }
 pin-project-lite = "0.2.7"
 regex = "1.5"

--- a/src/error.rs
+++ b/src/error.rs
@@ -13,6 +13,16 @@ impl Error {
             inner: error.into(),
         }
     }
+
+    pub(crate) fn downcast<T>(self) -> Result<T, Self>
+    where
+        T: StdError + 'static,
+    {
+        match self.inner.downcast::<T>() {
+            Ok(t) => Ok(*t),
+            Err(err) => Err(*err.downcast().unwrap()),
+        }
+    }
 }
 
 impl fmt::Display for Error {

--- a/src/extract/rejection.rs
+++ b/src/extract/rejection.rs
@@ -13,14 +13,15 @@ use tower::BoxError;
 define_rejection! {
     #[status = INTERNAL_SERVER_ERROR]
     #[body = "Extensions taken by other extractor"]
-    /// Rejection used if the method has been taken by another extractor.
+    /// Rejection used if the request extension has been taken by another
+    /// extractor.
     pub struct ExtensionsAlreadyExtracted;
 }
 
 define_rejection! {
     #[status = INTERNAL_SERVER_ERROR]
     #[body = "Headers taken by other extractor"]
-    /// Rejection used if the URI has been taken by another extractor.
+    /// Rejection used if the headers has been taken by another extractor.
     pub struct HeadersAlreadyExtracted;
 }
 
@@ -92,13 +93,6 @@ define_rejection! {
     /// Rejection type used if you try and extract the request body more than
     /// once.
     pub struct BodyAlreadyExtracted;
-}
-
-define_rejection! {
-    #[status = INTERNAL_SERVER_ERROR]
-    #[body = "Cannot have two `Request<_>` extractors for a single handler"]
-    /// Rejection type used if you try and extract the request more than once.
-    pub struct RequestAlreadyExtracted;
 }
 
 define_rejection! {
@@ -269,6 +263,19 @@ composite_rejection! {
         BodyAlreadyExtracted,
         FailedToBufferBody,
         InvalidUtf8,
+    }
+}
+
+composite_rejection! {
+    /// Rejection used for [`Request<_>`].
+    ///
+    /// Contains one variant for each way the [`Request<_>`] extractor can fail.
+    ///
+    /// [`Request<_>`]: http::Request
+    pub enum RequestAlreadyExtracted {
+        BodyAlreadyExtracted,
+        HeadersAlreadyExtracted,
+        ExtensionsAlreadyExtracted,
     }
 }
 

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -605,7 +605,7 @@ async fn wrong_method_service() {
 }
 
 /// Run a `tower::Service` in the background and get a URI for it.
-async fn run_in_background<S, ResBody>(svc: S) -> SocketAddr
+pub(crate) async fn run_in_background<S, ResBody>(svc: S) -> SocketAddr
 where
     S: Service<Request<Body>, Response = Response<ResBody>> + Clone + Send + 'static,
     ResBody: http_body::Body + Send + 'static,


### PR DESCRIPTION
In http-body 0.4.3 `BoxBody` implements `Default`. This allows us to
clean up the internal API of `RequestParts` quite a bit. No more panics!