### PR TITLE
Implement `FromRequest` for `http::Extensions`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `RoutingDsl::or` for combining routes ([#108](https://github.com/tokio-rs/axum/pull/108))
 - Add `handle_error` to `service::OnMethod` ([#160](https://github.com/tokio-rs/axum/pull/160))
 - Add `NestedUri` for extracting request URI in nested services ([#161](https://github.com/tokio-rs/axum/pull/161))
+- Implement `FromRequest` for `http::Extensions`
 
 ## Breaking changes
 

--- a/src/extract/request_parts.rs
+++ b/src/extract/request_parts.rs
@@ -2,7 +2,7 @@ use super::{rejection::*, take_body, Extension, FromRequest, RequestParts};
 use async_trait::async_trait;
 use bytes::Bytes;
 use futures_util::stream::Stream;
-use http::{HeaderMap, Method, Request, Uri, Version};
+use http::{Extensions, HeaderMap, Method, Request, Uri, Version};
 use std::{
     convert::Infallible,
     pin::Pin,
@@ -145,6 +145,18 @@ where
 
     async fn from_request(req: &mut RequestParts<B>) -> Result<Self, Self::Rejection> {
         req.take_headers().ok_or(HeadersAlreadyExtracted)
+    }
+}
+
+#[async_trait]
+impl<B> FromRequest<B> for Extensions
+where
+    B: Send,
+{
+    type Rejection = ExtensionsAlreadyExtracted;
+
+    async fn from_request(req: &mut RequestParts<B>) -> Result<Self, Self::Rejection> {
+        req.take_extensions().ok_or(ExtensionsAlreadyExtracted)
     }
 }
 


### PR DESCRIPTION
Not sure its very useful but odd to not provide this. All other request
parts have an extractor and we already have the rejection for it.