### PR TITLE
very-much-work-in-progress: Support generating OpenAPI docs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ version = "0.1.3"
 default = []
 ws = ["tokio-tungstenite", "sha-1", "base64"]
 multipart = ["multer", "mime"]
+open_api = ["openapiv3", "indexmap"]
 
 [dependencies]
 async-trait = "0.1"
@@ -41,6 +42,8 @@ base64 = { optional = true, version = "0.13" }
 headers = { optional = true, version = "0.3" }
 multer = { optional = true, version = "2.0.0" }
 mime = { optional = true, version = "0.3" }
+openapiv3 = { optional = true, version = "0.5.0" }
+indexmap = { optional = true, version = "1.7" }
 
 [dev-dependencies]
 askama = "0.10.5"
@@ -111,3 +114,7 @@ required-features = ["headers"]
 [[example]]
 name = "oauth"
 required-features = ["headers"]
+
+[[example]]
+name = "open_api"
+required-features = ["open_api"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ tracing-subscriber = "0.2"
 uuid = { version = "0.8", features = ["serde", "v4"] }
 async-session = "3.0.0"
 tokio-stream = "0.1.7"
+serde_yaml = "0.8.17"
 
 # for oauth example
 oauth2 = "4.1"

--- a/examples/open_api.rs
+++ b/examples/open_api.rs
@@ -1,0 +1,103 @@
+//! Run with
+//!
+//! ```not_rust
+//! cargo run --example open_api --features open_api
+//! ```
+
+#![allow(dead_code)]
+
+use axum::{
+    extract::{Extension, Query},
+    open_api::{self, ToQueryParameter},
+    prelude::*,
+    response::IntoResponse,
+    AddExtensionLayer, Json,
+};
+use openapiv3::OpenAPI;
+use serde::Deserialize;
+use std::sync::Arc;
+
+#[tokio::main]
+async fn main() {
+    let app = route("/api/users", get(get_users).post(|| async {}));
+
+    let open_api = open_api::to_open_api(&app);
+
+    let app = app
+        .route("/openapi.json", get(open_api_json))
+        .layer(AddExtensionLayer::new(Arc::new(open_api)));
+
+    axum::Server::bind(&"0.0.0.0:3000".parse().unwrap())
+        .serve(app.into_make_service())
+        .await
+        .unwrap();
+}
+
+async fn open_api_json(Extension(open_api): Extension<Arc<OpenAPI>>) -> impl IntoResponse {
+    Json(open_api)
+}
+
+async fn get_users(_: Query<Pagination>) -> &'static str {
+    "users"
+}
+
+#[derive(Deserialize)]
+struct Pagination {
+    offset: Option<usize>,
+    limit: Option<usize>,
+}
+
+// we're gonna need #[derive(ToQueryParameter)] for this :/
+impl ToQueryParameter for Pagination {
+    fn to_query_parameter() -> open_api::Query {
+        use openapiv3::*;
+
+        let mut obj = ObjectType::default();
+
+        let offset_schema_data = SchemaData {
+            nullable: true,
+            ..Default::default()
+        };
+        let offset_schema = Box::new(Schema {
+            schema_data: offset_schema_data,
+            schema_kind: SchemaKind::Type(Type::Number(NumberType::default())),
+        });
+        obj.properties
+            .insert("offset".to_string(), ReferenceOr::Item(offset_schema));
+
+        let limit_schema_data = SchemaData {
+            nullable: true,
+            ..Default::default()
+        };
+        let limit_schema = Box::new(Schema {
+            schema_data: limit_schema_data,
+            schema_kind: SchemaKind::Type(Type::Number(NumberType::default())),
+        });
+        obj.properties
+            .insert("limit".to_string(), ReferenceOr::Item(limit_schema));
+
+        let schema = Schema {
+            schema_data: SchemaData::default(),
+            schema_kind: SchemaKind::Type(Type::Object(obj)),
+        };
+
+        let parameter_data = ParameterData {
+            name: "Pagination".to_string(),
+            description: None,
+            required: false,
+            deprecated: Some(false),
+            format: ParameterSchemaOrContent::Schema(ReferenceOr::Item(schema)),
+            example: None,
+            examples: Default::default(),
+            explode: None,
+            extensions: Default::default(),
+        };
+
+        open_api::Query {
+            parameter_data,
+            allow_reserved: false,
+            style: QueryStyle::default(),
+            allow_empty_value: Some(true),
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -727,6 +727,10 @@ pub mod routing;
 pub mod service;
 pub mod sse;
 
+#[cfg(feature = "open_api")]
+#[cfg_attr(docsrs, doc(cfg(feature = "open_api")))]
+pub mod open_api;
+
 #[cfg(test)]
 mod tests;
 

--- a/src/open_api.rs
+++ b/src/open_api.rs
@@ -3,7 +3,7 @@
 use crate::{
     extract, handler,
     response::IntoResponse,
-    routing::{EmptyRouter, MethodFilter, Route},
+    routing::{EmptyRouter, MethodFilter, Nested, Route, RoutingDsl},
 };
 use indexmap::IndexMap;
 use openapiv3::{
@@ -11,27 +11,59 @@ use openapiv3::{
     ParameterSchemaOrContent, PathItem, QueryStyle, ReferenceOr, RequestBody, Response, Responses,
     Schema, SchemaData, SchemaKind, StringType, Type,
 };
-use std::future::Future;
+use std::{
+    future::Future,
+    ops::{Deref, DerefMut},
+    sync::Arc,
+    task::{Context, Poll},
+};
+use tower::Service;
 
 pub fn to_open_api<S>(svc: &S) -> OpenAPI
 where
-    S: ToOpenApi,
+    S: DescribePaths,
 {
+    let mut paths = IndexMap::new();
+    svc.describe_paths(&mut paths);
+    let paths = paths
+        .into_iter()
+        .map(|(key, paths)| (key, ReferenceOr::Item(paths)))
+        .collect();
+
     let mut open_api = OpenAPI::default();
-    svc.to_open_api(&mut open_api);
+    open_api.paths = paths;
     open_api
 }
 
-pub trait ToOpenApi {
-    fn to_open_api(&self, open_api: &mut OpenAPI);
+impl<R, T> Service<R> for WithPaths<T>
+where
+    T: Service<R>,
+{
+    type Response = T::Response;
+    type Error = T::Error;
+    type Future = T::Future;
+
+    #[inline]
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    #[inline]
+    fn call(&mut self, req: R) -> Self::Future {
+        self.inner.call(req)
+    }
 }
 
-pub trait ToPathItem {
-    fn to_path_item(&self, path_item: &mut PathItem);
+pub trait DescribePaths {
+    fn describe_paths(&self, paths: &mut IndexMap<String, PathItem>);
+}
+
+pub trait DescribePathItem {
+    fn describe_path_item(&self, path_item: &mut PathItem);
 }
 
 pub trait ToOperation<In> {
-    fn to_operation(&self, operation: &mut Operation);
+    fn to_operation(&self) -> Operation;
 }
 
 pub trait ToOperationInput {
@@ -42,6 +74,10 @@ pub trait ToOperationInput {
     fn to_request_body() -> Option<RequestBody> {
         None
     }
+}
+
+pub trait ToSchema {
+    fn to_schema() -> Schema;
 }
 
 pub struct Query {
@@ -59,41 +95,126 @@ pub trait ToResponse {
     fn to_response(response: &mut Response);
 }
 
-impl<S, F> ToOpenApi for Route<S, F>
+impl<S, F> DescribePaths for Route<S, F>
 where
-    S: ToPathItem,
-    F: ToOpenApi,
+    S: DescribePathItem,
+    F: DescribePaths,
 {
-    fn to_open_api(&self, open_api: &mut OpenAPI) {
+    fn describe_paths(&self, paths: &mut IndexMap<String, PathItem>) {
         let mut path_item = PathItem::default();
-        self.svc.to_path_item(&mut path_item);
-        open_api.paths.insert(
-            self.pattern.original_pattern().to_string(),
-            ReferenceOr::Item(path_item),
-        );
+        self.svc.describe_path_item(&mut path_item);
 
-        self.fallback.to_open_api(open_api);
+        paths.insert(self.pattern.original_pattern().to_string(), path_item);
+
+        self.fallback.describe_paths(paths);
     }
 }
 
-impl<E> ToOpenApi for EmptyRouter<E> {
-    fn to_open_api(&self, open_api: &mut OpenAPI) {}
+impl<E> DescribePaths for EmptyRouter<E> {
+    fn describe_paths(&self, paths: &mut IndexMap<String, PathItem>) {}
 }
 
-impl<E> ToPathItem for EmptyRouter<E> {
-    fn to_path_item(&self, path_item: &mut PathItem) {}
+impl<E> DescribePathItem for EmptyRouter<E> {
+    fn describe_path_item(&self, path_item: &mut PathItem) {}
 }
 
-impl<H, B, T, F> ToPathItem for handler::OnMethod<handler::IntoService<H, B, T>, F>
+impl<S, F> DescribePaths for Nested<S, F>
+where
+    S: DescribePaths,
+    F: DescribePaths,
+{
+    fn describe_paths(&self, paths: &mut IndexMap<String, PathItem>) {
+        let mut nested_paths = IndexMap::new();
+        self.svc.describe_paths(&mut nested_paths);
+
+        let nested_paths = nested_paths.into_iter().map(|(path, item)| {
+            let path = format!("{}{}", self.pattern.original_pattern(), path);
+            (path, item)
+        });
+
+        paths.extend(nested_paths);
+
+        self.fallback.describe_paths(paths);
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct WithPaths<T> {
+    pub(crate) inner: T,
+    pub(crate) paths: Arc<IndexMap<String, PathItem>>,
+}
+
+impl<T> WithPaths<T> {
+    pub fn into_inner(self) -> T {
+        self.inner
+    }
+}
+
+impl<T> Deref for WithPaths<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl<T> DerefMut for WithPaths<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+
+impl<T> DescribePaths for WithPaths<T> {
+    fn describe_paths(&self, paths: &mut IndexMap<String, PathItem>) {
+        paths.extend((&*self.paths).clone());
+    }
+}
+
+impl<T> RoutingDsl for WithPaths<T> where T: RoutingDsl {}
+
+impl<T> crate::sealed::Sealed for WithPaths<T> where T: crate::sealed::Sealed {}
+
+impl ToSchema for usize {
+    fn to_schema() -> Schema {
+        let limit_schema_data = SchemaData {
+            nullable: false,
+            ..Default::default()
+        };
+        Schema {
+            schema_data: limit_schema_data,
+            schema_kind: SchemaKind::Type(Type::Number(NumberType::default())),
+        }
+    }
+}
+
+impl ToSchema for &str {
+    fn to_schema() -> Schema {
+        Schema {
+            schema_data: SchemaData::default(),
+            schema_kind: SchemaKind::Type(Type::String(StringType::default())),
+        }
+    }
+}
+
+impl<T> ToSchema for Option<T>
+where
+    T: ToSchema,
+{
+    fn to_schema() -> Schema {
+        let mut schema = T::to_schema();
+        schema.schema_data.nullable = true;
+        schema
+    }
+}
+
+impl<H, B, T, F> DescribePathItem for handler::OnMethod<handler::IntoService<H, B, T>, F>
 where
     H: handler::Handler<B, T> + ToOperation<T>,
     H::Response: ToResponse,
-    F: ToPathItem,
+    F: DescribePathItem,
 {
-    fn to_path_item(&self, path_item: &mut PathItem) {
-        let mut operation = Operation::default();
-        // TODO(david): operation_id
-        self.svc.to_operation(&mut operation);
+    fn describe_path_item(&self, path_item: &mut PathItem) {
+        let mut operation = self.svc.to_operation();
 
         // CONNECT not supported
 
@@ -129,7 +250,7 @@ where
             path_item.trace = Some(operation);
         }
 
-        self.fallback.to_path_item(path_item);
+        self.fallback.describe_path_item(path_item);
     }
 }
 
@@ -137,8 +258,8 @@ impl<H, B, T> ToOperation<T> for handler::IntoService<H, B, T>
 where
     H: ToOperation<T>,
 {
-    fn to_operation(&self, operation: &mut Operation) {
-        self.handler.to_operation(operation)
+    fn to_operation(&self) -> Operation {
+        self.handler.to_operation()
     }
 }
 
@@ -148,10 +269,14 @@ where
     Fut: Future<Output = Res>,
     Res: ToResponse,
 {
-    fn to_operation(&self, operation: &mut Operation) {
+    fn to_operation(&self) -> Operation {
+        let mut operation = Operation::default();
+
         let mut response = Response::default();
         Res::to_response(&mut response);
         operation.responses.default = Some(ReferenceOr::Item(response));
+
+        operation
     }
 }
 
@@ -162,7 +287,9 @@ where
     Res: ToResponse,
     T1: ToOperationInput,
 {
-    fn to_operation(&self, operation: &mut Operation) {
+    fn to_operation(&self) -> Operation {
+        let mut operation = Operation::default();
+
         let mut response = Response::default();
         Res::to_response(&mut response);
         operation.responses.default = Some(ReferenceOr::Item(response));
@@ -174,6 +301,8 @@ where
         if let Some(request_body) = T1::to_request_body() {
             operation.request_body = Some(ReferenceOr::Item(request_body));
         }
+
+        operation
     }
 }
 
@@ -234,15 +363,14 @@ impl ToResponse for &str {
         response.description = "Plain text".to_string();
 
         let mut media_type = MediaType::default();
-        let schema = Schema {
-            schema_data: SchemaData::default(),
-            schema_kind: SchemaKind::Type(Type::String(StringType::default())),
-        };
         let mut encoding = Encoding::default();
         encoding.content_type = Some("text/plain".to_string());
         media_type
             .encoding
             .insert("text/plain".to_string(), encoding);
+
+        let schema = Self::to_schema();
+
         media_type.schema = Some(ReferenceOr::Item(schema));
 
         response

--- a/src/open_api.rs
+++ b/src/open_api.rs
@@ -1,0 +1,252 @@
+#![allow(warnings)]
+
+use crate::{
+    extract, handler,
+    response::IntoResponse,
+    routing::{EmptyRouter, MethodFilter, Route},
+};
+use indexmap::IndexMap;
+use openapiv3::{
+    Encoding, MediaType, NumberType, ObjectType, OpenAPI, Operation, Parameter, ParameterData,
+    ParameterSchemaOrContent, PathItem, QueryStyle, ReferenceOr, RequestBody, Response, Responses,
+    Schema, SchemaData, SchemaKind, StringType, Type,
+};
+use std::future::Future;
+
+pub fn to_open_api<S>(svc: &S) -> OpenAPI
+where
+    S: ToOpenApi,
+{
+    let mut open_api = OpenAPI::default();
+    svc.to_open_api(&mut open_api);
+    open_api
+}
+
+pub trait ToOpenApi {
+    fn to_open_api(&self, open_api: &mut OpenAPI);
+}
+
+pub trait ToPathItem {
+    fn to_path_item(&self, path_item: &mut PathItem);
+}
+
+pub trait ToOperation<In> {
+    fn to_operation(&self, operation: &mut Operation);
+}
+
+pub trait ToOperationInput {
+    fn to_parameter() -> Option<Parameter> {
+        None
+    }
+
+    fn to_request_body() -> Option<RequestBody> {
+        None
+    }
+}
+
+pub struct Query {
+    pub parameter_data: ParameterData,
+    pub allow_reserved: bool,
+    pub style: QueryStyle,
+    pub allow_empty_value: Option<bool>,
+}
+
+pub trait ToQueryParameter {
+    fn to_query_parameter() -> Query;
+}
+
+pub trait ToResponse {
+    fn to_response(response: &mut Response);
+}
+
+impl<S, F> ToOpenApi for Route<S, F>
+where
+    S: ToPathItem,
+    F: ToOpenApi,
+{
+    fn to_open_api(&self, open_api: &mut OpenAPI) {
+        let mut path_item = PathItem::default();
+        self.svc.to_path_item(&mut path_item);
+        open_api.paths.insert(
+            self.pattern.original_pattern().to_string(),
+            ReferenceOr::Item(path_item),
+        );
+
+        self.fallback.to_open_api(open_api);
+    }
+}
+
+impl<E> ToOpenApi for EmptyRouter<E> {
+    fn to_open_api(&self, open_api: &mut OpenAPI) {}
+}
+
+impl<E> ToPathItem for EmptyRouter<E> {
+    fn to_path_item(&self, path_item: &mut PathItem) {}
+}
+
+impl<H, B, T, F> ToPathItem for handler::OnMethod<handler::IntoService<H, B, T>, F>
+where
+    H: handler::Handler<B, T> + ToOperation<T>,
+    H::Response: ToResponse,
+    F: ToPathItem,
+{
+    fn to_path_item(&self, path_item: &mut PathItem) {
+        let mut operation = Operation::default();
+        // TODO(david): operation_id
+        self.svc.to_operation(&mut operation);
+
+        // CONNECT not supported
+
+        if self.method.contains(MethodFilter::DELETE) {
+            path_item.delete = Some(operation.clone());
+        }
+
+        if self.method.contains(MethodFilter::GET) {
+            path_item.get = Some(operation.clone());
+        }
+
+        if self.method.contains(MethodFilter::HEAD) {
+            path_item.head = Some(operation.clone());
+        }
+
+        if self.method.contains(MethodFilter::OPTIONS) {
+            path_item.options = Some(operation.clone());
+        }
+
+        if self.method.contains(MethodFilter::PATCH) {
+            path_item.patch = Some(operation.clone());
+        }
+
+        if self.method.contains(MethodFilter::POST) {
+            path_item.post = Some(operation.clone());
+        }
+
+        if self.method.contains(MethodFilter::PUT) {
+            path_item.put = Some(operation.clone());
+        }
+
+        if self.method.contains(MethodFilter::TRACE) {
+            path_item.trace = Some(operation);
+        }
+
+        self.fallback.to_path_item(path_item);
+    }
+}
+
+impl<H, B, T> ToOperation<T> for handler::IntoService<H, B, T>
+where
+    H: ToOperation<T>,
+{
+    fn to_operation(&self, operation: &mut Operation) {
+        self.handler.to_operation(operation)
+    }
+}
+
+impl<F, Fut, Res> ToOperation<()> for F
+where
+    F: FnOnce() -> Fut,
+    Fut: Future<Output = Res>,
+    Res: ToResponse,
+{
+    fn to_operation(&self, operation: &mut Operation) {
+        let mut response = Response::default();
+        Res::to_response(&mut response);
+        operation.responses.default = Some(ReferenceOr::Item(response));
+    }
+}
+
+impl<F, Fut, Res, T1> ToOperation<(T1,)> for F
+where
+    F: FnOnce(T1) -> Fut,
+    Fut: Future<Output = Res>,
+    Res: ToResponse,
+    T1: ToOperationInput,
+{
+    fn to_operation(&self, operation: &mut Operation) {
+        let mut response = Response::default();
+        Res::to_response(&mut response);
+        operation.responses.default = Some(ReferenceOr::Item(response));
+
+        if let Some(parameter) = T1::to_parameter() {
+            operation.parameters = vec![ReferenceOr::Item(parameter)];
+        }
+
+        if let Some(request_body) = T1::to_request_body() {
+            operation.request_body = Some(ReferenceOr::Item(request_body));
+        }
+    }
+}
+
+impl<T> ToOperationInput for Option<T>
+where
+    T: ToOperationInput,
+{
+    fn to_parameter() -> Option<Parameter> {
+        T::to_parameter().map(|mut parameter| {
+            match &mut parameter {
+                Parameter::Query { parameter_data, .. } => {
+                    parameter_data.required = false;
+                }
+                _ => todo!(),
+            }
+
+            parameter
+        })
+    }
+
+    fn to_request_body() -> Option<RequestBody> {
+        T::to_request_body().map(|mut request_body| {
+            request_body.required = false;
+            request_body
+        })
+    }
+}
+
+impl<T> ToOperationInput for extract::Query<T>
+where
+    T: ToQueryParameter,
+{
+    fn to_parameter() -> Option<Parameter> {
+        let Query {
+            parameter_data,
+            allow_reserved,
+            style,
+            allow_empty_value,
+        } = T::to_query_parameter();
+
+        Some(Parameter::Query {
+            parameter_data,
+            allow_reserved,
+            style,
+            allow_empty_value,
+        })
+    }
+}
+
+impl ToResponse for () {
+    fn to_response(response: &mut Response) {
+        response.description = "Always empty".to_string();
+    }
+}
+
+impl ToResponse for &str {
+    fn to_response(response: &mut Response) {
+        response.description = "Plain text".to_string();
+
+        let mut media_type = MediaType::default();
+        let schema = Schema {
+            schema_data: SchemaData::default(),
+            schema_kind: SchemaKind::Type(Type::String(StringType::default())),
+        };
+        let mut encoding = Encoding::default();
+        encoding.content_type = Some("text/plain".to_string());
+        media_type
+            .encoding
+            .insert("text/plain".to_string(), encoding);
+        media_type.schema = Some(ReferenceOr::Item(schema));
+
+        response
+            .content
+            .insert("text/plain".to_string(), media_type);
+    }
+}

--- a/src/routing/or.rs
+++ b/src/routing/or.rs
@@ -19,8 +19,8 @@ use tower::{util::Oneshot, Service, ServiceExt};
 /// [`RoutingDsl::or`]: super::RoutingDsl::or
 #[derive(Debug, Clone, Copy)]
 pub struct Or<A, B> {
-    pub(super) first: A,
-    pub(super) second: B,
+    pub(crate) first: A,
+    pub(crate) second: B,
 }
 
 impl<A, B> RoutingDsl for Or<A, B> {}


### PR DESCRIPTION
This will probably be a long running PR and will eventually contain some version of OpenAPI docs generation.

Nothing is set in stone, everything you see is work in progress, and I have no clue if/when we'll ship anything.

With that said here is an example:

```rust
use axum::{
    extract::{Extension, Query},
    open_api::{self, ToQueryParameter},
    prelude::*,
    response::IntoResponse,
    AddExtensionLayer, Json,
};
use openapiv3::OpenAPI;
use serde::Deserialize;
use std::sync::Arc;

#[tokio::main]
async fn main() {
    let app = route("/api/users", get(get_users).post(|| async {}));

    let open_api = open_api::to_open_api(&app);

    let app = app
        .route("/openapi.json", get(open_api_json))
        .layer(AddExtensionLayer::new(Arc::new(open_api)));

    axum::Server::bind(&"0.0.0.0:3000".parse().unwrap())
        .serve(app.into_make_service())
        .await
        .unwrap();
}

async fn open_api_json(Extension(open_api): Extension<Arc<OpenAPI>>) -> impl IntoResponse {
    Json(open_api)
}

async fn get_users(_: Query<Pagination>) -> &'static str {
    "users"
}

#[derive(Deserialize)]
struct Pagination {
    offset: Option<usize>,
    limit: Option<usize>,
}

// we're gonna need #[derive(ToQueryParameter)] for this
// way too much boilerplate here :/
impl ToQueryParameter for Pagination {
    fn to_query_parameter() -> open_api::Query {
        use openapiv3::*;

        let mut obj = ObjectType::default();

        let offset_schema_data = SchemaData {
            nullable: true,
            ..Default::default()
        };
        let offset_schema = Box::new(Schema {
            schema_data: offset_schema_data,
            schema_kind: SchemaKind::Type(Type::Number(NumberType::default())),
        });
        obj.properties
            .insert("offset".to_string(), ReferenceOr::Item(offset_schema));

        let limit_schema_data = SchemaData {
            nullable: true,
            ..Default::default()
        };
        let limit_schema = Box::new(Schema {
            schema_data: limit_schema_data,
            schema_kind: SchemaKind::Type(Type::Number(NumberType::default())),
        });
        obj.properties
            .insert("limit".to_string(), ReferenceOr::Item(limit_schema));

        let schema = Schema {
            schema_data: SchemaData::default(),
            schema_kind: SchemaKind::Type(Type::Object(obj)),
        };

        let parameter_data = ParameterData {
            name: "Pagination".to_string(),
            description: None,
            required: false,
            deprecated: Some(false),
            format: ParameterSchemaOrContent::Schema(ReferenceOr::Item(schema)),
            example: None,
            examples: Default::default(),
            explode: None,
            extensions: Default::default(),
        };

        open_api::Query {
            parameter_data,
            allow_reserved: false,
            style: QueryStyle::default(),
            allow_empty_value: Some(true),
        }
    }
}
```

This responds with

```json
{
  "openapi": "",
  "info": {
    "title": "",
    "version": ""
  },
  "paths": {
    "/api/users": {
      "get": {
        "parameters": [
          {
            "in": "query",
            "name": "Pagination",
            "deprecated": false,
            "schema": {
              "type": "object",
              "properties": {
                "offset": {
                  "nullable": true,
                  "type": "number"
                },
                "limit": {
                  "nullable": true,
                  "type": "number"
                }
              }
            },
            "style": "form",
            "allowEmptyValue": true
          }
        ],
        "responses": {
          "default": {
            "description": "Plain text",
            "content": {
              "text/plain": {
                "schema": {
                  "type": "string"
                },
                "encoding": {
                  "text/plain": {
                    "contentType": "text/plain"
                  }
                }
              }
            }
          }
        }
      },
      "post": {
        "responses": {
          "default": {
            "description": "Always empty"
          }
        }
      }
    }
  }
}
```

I haven't actually checked this against a client generating/linter but doesn't seem too horrible.

## Hard questions

- [ ] How do we support handlers with layers applied?
- [x] Is `BoxRoute` going to be problematic since it erases type info?
- [ ] How do we allow users to customize the schema?
- [ ] Path parameters
- [x] Operation ids?

Fixes https://github.com/tokio-rs/axum/issues/50