### PR TITLE
Reduce futures-util features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ multipart = ["multer", "mime"]
 async-trait = "0.1"
 bitflags = "1.0"
 bytes = "1.0"
-futures-util = "0.3"
+futures-util = { version = "0.3", default-features = false, features = ["alloc"] }
 http = "0.2"
 http-body = "0.4.3"
 hyper = { version = "0.14", features = ["server", "tcp", "http1", "stream"] }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation

`futures-util` enables the `async-await-macro` feature by default, which imports `futures-macro`, `proc-macro-hack` and `proc-macro-nested`, which are unnecessary and slow to compile.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Disable unnecessary features.