### PR TITLE
remove a seeming redundant code and possible clerical errors in examples/tls_rustls.rs

### DIFF
--- a/examples/tls_rustls.rs
+++ b/examples/tls_rustls.rs
@@ -62,7 +62,7 @@ fn rustls_server_config(key: &str, cert: &str) -> Arc<ServerConfig> {
 
     config.set_single_cert(certs, key).unwrap();
 
-    config.set_protocols(&[b"h2".to_vec(), b"http/1.1".to_vec()]);
+    config.set_protocols(&[b"http/1.1".to_vec()]);
 
     Arc::new(config)
 }


### PR DESCRIPTION
when I run this example tls_rustls.rs cargo run --release is ok,  then, curl -k http://127.0.0.1:3000/ got a error: response empty.

service info: 
```
thread 'tokio-runtime-worker' panicked at 'called `Result::unwrap()` on an `Err` value: hyper::Error(Parse(VersionH2))', src/main.rs:
```

I try to check the example code, found keyword b"h2", when I remove it, all is ok.