### PR TITLE
correct hyper link to add the .rs suffix.

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -18,7 +18,7 @@
 - [`chat`](../examples/chat.rs) - Chat application example.
 - [`404`](../examples/404.rs) - Custom 404 page.
 - [`async-graphql`](../examples/async-graphql) - GraphQL example using [`async-graphql`](https://crates.io/crates/async-graphql).
-- [`tracing_aka_logging`](../examples/tracing_aka_logging) - How to setup and configure tracing/logging.
+- [`tracing_aka_logging`](../examples/tracing_aka_logging.rs) - How to setup and configure tracing/logging.
 - [`oauth`](../examples/oauth.rs) - Implementing authentication using [`oauth2`](https://crates.io/crates/oauth2) and [`async-session`](https://crates.io/crates/async-session).
 
 


### PR DESCRIPTION
This fixes the broken redirect for `tracing_aka_logging` which current redirects to what it thinks is a folder instead of a file, resulting in a 404.

This is not a code change.
