### PR TITLE
Improve compile times

### DIFF
--- a/src/handler/future.rs
+++ b/src/handler/future.rs
@@ -6,6 +6,7 @@ use http::{Method, Request, Response};
 use http_body::Empty;
 use pin_project_lite::pin_project;
 use std::{
+    fmt,
     future::Future,
     pin::Pin,
     task::{Context, Poll},
@@ -27,8 +28,6 @@ pin_project! {
     }
 }
 
-// TODO(david): impl debug for `OnMethodFuture`
-
 impl<F, B> Future for OnMethodFuture<F, B>
 where
     F: Service<Request<B>, Response = Response<BoxBody>>,
@@ -44,5 +43,14 @@ where
         } else {
             Poll::Ready(Ok(response))
         }
+    }
+}
+
+impl<F, B> fmt::Debug for OnMethodFuture<F, B>
+where
+    F: Service<Request<B>>,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("OnMethodFuture").finish()
     }
 }

--- a/src/handler/future.rs
+++ b/src/handler/future.rs
@@ -1,43 +1,36 @@
 //! Handler future types.
 
 use crate::body::{box_body, BoxBody};
+use futures_util::future::{BoxFuture, Either};
 use http::{Method, Request, Response};
 use http_body::Empty;
 use pin_project_lite::pin_project;
 use std::{
-    convert::Infallible,
     future::Future,
     pin::Pin,
     task::{Context, Poll},
 };
-use tower::Service;
-
-opaque_future! {
-    /// The response future for [`IntoService`](super::IntoService).
-    pub type IntoServiceFuture =
-        futures_util::future::BoxFuture<'static, Result<Response<BoxBody>, Infallible>>;
-}
+use tower::{util::Oneshot, Service};
 
 pin_project! {
     /// The response future for [`OnMethod`](super::OnMethod).
-    #[derive(Debug)]
-    pub struct OnMethodFuture<S, F, B>
+    pub struct OnMethodFuture<F, B>
     where
-        S: Service<Request<B>>,
         F: Service<Request<B>>
     {
         #[pin]
-        pub(super) inner: crate::routing::future::RouteFuture<S, F, B>,
+        pub(super) inner: Either<BoxFuture<'static, Result<Response<BoxBody>, F::Error>>, Oneshot<F, Request<B>>>,
         pub(super) req_method: Method,
     }
 }
 
-impl<S, F, B> Future for OnMethodFuture<S, F, B>
+// TODO(david): impl debug for `OnMethodFuture`
+
+impl<F, B> Future for OnMethodFuture<F, B>
 where
-    S: Service<Request<B>, Response = Response<BoxBody>>,
-    F: Service<Request<B>, Response = Response<BoxBody>, Error = S::Error>,
+    F: Service<Request<B>, Response = Response<BoxBody>>,
 {
-    type Output = Result<Response<BoxBody>, S::Error>;
+    type Output = Result<Response<BoxBody>, F::Error>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.project();

--- a/src/handler/future.rs
+++ b/src/handler/future.rs
@@ -19,7 +19,10 @@ pin_project! {
         F: Service<Request<B>>
     {
         #[pin]
-        pub(super) inner: Either<BoxFuture<'static, Result<Response<BoxBody>, F::Error>>, Oneshot<F, Request<B>>>,
+        pub(super) inner: Either<
+            BoxFuture<'static, Result<Response<BoxBody>, F::Error>>,
+            Oneshot<F, Request<B>>,
+        >,
         pub(super) req_method: Method,
     }
 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -354,10 +354,7 @@ async fn routing_between_services() {
             }),
         ),
     )
-    .route(
-        "/two",
-        service::on(MethodFilter::GET, handle.into_service()),
-    );
+    .route("/two", service::on(MethodFilter::GET, any(handle)));
 
     let addr = run_in_background(app).await;
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,4 +1,5 @@
 use bytes::Bytes;
+use pin_project_lite::pin_project;
 use std::ops::Deref;
 
 /// A string like type backed by `Bytes` making it cheap to clone.

--- a/src/util.rs
+++ b/src/util.rs
@@ -29,3 +29,11 @@ impl ByteStr {
         std::str::from_utf8(&self.0).unwrap()
     }
 }
+
+pin_project! {
+    #[project = EitherProj]
+    pub(crate) enum Either<A, B> {
+        A { #[pin] inner: A },
+        B { #[pin] inner: B },
+    }
+}


### PR DESCRIPTION
This improves compiles quite a bit by reducing the size of common types.

The type of `route("/", get(handler).post(handler))` used to be 

```
Route<
  axum::handler::OnMethod<
    axum::handler::IntoService<
      fn() -> impl Future {handler},
      _,
      ()
    >,
    axum::handler::OnMethod<
      axum::handler::IntoService<
        fn() -> impl Future {handler},
        _,
        ()
      >,
      EmptyRouter
    >
  >,
  EmptyRouter,
>
```

but with this change it becomes

```
Route<
  axum::handler::OnMethod<
    fn() -> impl Future {handler},
    _,
    (),
    axum::handler::OnMethod<
      fn() -> impl Future {handler},
      _,
      (),
      EmptyRouter,
    >
  >,
  EmptyRouter
>
```

You'll notice the `axum::handler::IntoService` wrapper is gone. Its basically been inlined into `axum::handler::OnMethod`.

In the example shown [here](https://github.com/rust-lang/rust/issues/87924#issuecomment-898981502) (with `.boxed()` removed) it takes the `cargo check` time from 9.01s to 4.74s which is a 47% improvement! Whether these numbers will generally is yet to be seen.

Tested and compared with `touch src/main.rs && CARGO_INCREMENTAL=0 cargo check`.

Related to https://github.com/tokio-rs/axum/issues/145