### PR TITLE
Improve compile times of `handle_error` and `check_infallible`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `ServiceExt` has been removed and its methods have been moved to `RoutingDsl` ([#160](https://github.com/tokio-rs/axum/pull/160))
 - `extractor_middleware` now requires `RequestBody: Default` ([#167](https://github.com/tokio-rs/axum/pull/167))
 - Convert `RequestAlreadyExtracted` to an enum with each possible error variant ([#167](https://github.com/tokio-rs/axum/pull/167))
+- `RoutingDsl::check_infallible` now returns a `CheckInfallible` service. This
+  is to improve compile times.
 - These future types have been moved
     - `extract::extractor_middleware::ExtractorMiddlewareResponseFuture` moved
       to `extract::extractor_middleware::future::ResponseFuture` ([#133](https://github.com/tokio-rs/axum/pull/133))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implement SSE as an `IntoResponse` instead of a service ([#98](https://github.com/tokio-rs/axum/pull/98))
 - Add `Redirect` response. ([#192](https://github.com/tokio-rs/axum/pull/192))
 - Make `RequestParts::{new, try_into_request}` public ([#194](https://github.com/tokio-rs/axum/pull/194))
+- Overall compile time improvements
 
 ## Breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
+- Overall compile time improvements. If you're having issues with compile time
+  please file an issue!
 - Make `FromRequest` default to being generic over `body::Body` ([#146](https://github.com/tokio-rs/axum/pull/146))
 - Implement `std::error::Error` for all rejections ([#153](https://github.com/tokio-rs/axum/pull/153))
 - Add `RoutingDsl::or` for combining routes ([#108](https://github.com/tokio-rs/axum/pull/108))
@@ -16,7 +18,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implement SSE as an `IntoResponse` instead of a service ([#98](https://github.com/tokio-rs/axum/pull/98))
 - Add `Redirect` response. ([#192](https://github.com/tokio-rs/axum/pull/192))
 - Make `RequestParts::{new, try_into_request}` public ([#194](https://github.com/tokio-rs/axum/pull/194))
-- Overall compile time improvements
 
 ## Breaking changes
 

--- a/src/routing/mod.rs
+++ b/src/routing/mod.rs
@@ -425,11 +425,8 @@ pub trait RoutingDsl: crate::sealed::Sealed + Sized {
     /// Check that your service cannot fail.
     ///
     /// That is, its error type is [`Infallible`].
-    fn check_infallible<ReqBody>(self) -> Self
-    where
-        Self: Service<Request<ReqBody>, Error = Infallible>,
-    {
-        self
+    fn check_infallible(self) -> CheckInfallible<Self> {
+        CheckInfallible(self)
     }
 }
 
@@ -918,6 +915,35 @@ fn strip_prefix(uri: &Uri, prefix: &str) -> Uri {
 
     Uri::from_parts(parts).unwrap()
 }
+
+/// Middleware that statically verifies that a service cannot fail.
+///
+/// Created with [`check_infallible`](RoutingDsl::check_infallible).
+#[derive(Debug, Clone, Copy)]
+pub struct CheckInfallible<S>(S);
+
+impl<R, S> Service<R> for CheckInfallible<S>
+where
+    S: Service<R, Error = Infallible>,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = S::Future;
+
+    #[inline]
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.0.poll_ready(cx)
+    }
+
+    #[inline]
+    fn call(&mut self, req: R) -> Self::Future {
+        self.0.call(req)
+    }
+}
+
+impl<S> RoutingDsl for CheckInfallible<S> {}
+
+impl<S> crate::sealed::Sealed for CheckInfallible<S> {}
 
 #[cfg(test)]
 mod tests {

--- a/src/routing/mod.rs
+++ b/src/routing/mod.rs
@@ -8,7 +8,6 @@ use crate::{
         connect_info::{Connected, IntoMakeServiceWithConnectInfo},
         NestedUri,
     },
-    response::IntoResponse,
     service::{HandleError, HandleErrorFromRouter},
     util::ByteStr,
 };
@@ -416,17 +415,10 @@ pub trait RoutingDsl: crate::sealed::Sealed + Sized {
     /// # hyper::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
     /// # };
     /// ```
-    fn handle_error<ReqBody, ResBody, F, Res, E>(
+    fn handle_error<ReqBody, F>(
         self,
         f: F,
-    ) -> HandleError<Self, F, ReqBody, HandleErrorFromRouter>
-    where
-        Self: Service<Request<ReqBody>, Response = Response<ResBody>>,
-        F: FnOnce(Self::Error) -> Result<Res, E>,
-        Res: IntoResponse,
-        ResBody: http_body::Body<Data = Bytes> + Send + Sync + 'static,
-        ResBody::Error: Into<BoxError> + Send + Sync + 'static,
-    {
+    ) -> HandleError<Self, F, ReqBody, HandleErrorFromRouter> {
         HandleError::new(self, f)
     }
 

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -453,15 +453,10 @@ impl<S, F, B> OnMethod<S, F, B> {
     /// details.
     ///
     /// [`RoutingDsl::handle_error`]: crate::routing::RoutingDsl::handle_error
-    pub fn handle_error<ReqBody, H, Res, E>(
+    pub fn handle_error<ReqBody, H>(
         self,
         f: H,
-    ) -> HandleError<Self, H, ReqBody, HandleErrorFromService>
-    where
-        Self: Service<Request<ReqBody>, Response = Response<BoxBody>>,
-        H: FnOnce(<Self as Service<Request<ReqBody>>>::Error) -> Result<Res, E>,
-        Res: IntoResponse,
-    {
+    ) -> HandleError<Self, H, ReqBody, HandleErrorFromService> {
         HandleError::new(self, f)
     }
 }


### PR DESCRIPTION
This brings the compile time of the example posted [here][example] from
3 seconds down to 0.3 seconds for me. No clue why it works, but it does 🤷 

Having the bounds on the methods does improve UX but not worth
sacrificing 10x compile time for.

Tested using the command `touch src/main.rs && CARGO_INCREMENTAL=0 cargo check`.

Fixes https://github.com/tokio-rs/axum/issues/145

[example]: https://github.com/tokio-rs/axum/issues/145#issue-963183256