### PR TITLE
Bring back `Handler::into_service`

### DIFF
--- a/src/handler/future.rs
+++ b/src/handler/future.rs
@@ -2,11 +2,15 @@
 
 use crate::body::{box_body, BoxBody};
 use crate::util::{Either, EitherProj};
-use futures_util::{future::BoxFuture, ready};
+use futures_util::{
+    future::{BoxFuture, Map},
+    ready,
+};
 use http::{Method, Request, Response};
 use http_body::Empty;
 use pin_project_lite::pin_project;
 use std::{
+    convert::Infallible,
     fmt,
     future::Future,
     pin::Pin,
@@ -58,4 +62,13 @@ where
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("OnMethodFuture").finish()
     }
+}
+
+opaque_future! {
+    /// The response future for [`IntoService`](super::IntoService).
+    pub type IntoServiceFuture =
+        Map<
+            BoxFuture<'static, Response<BoxBody>>,
+            fn(Response<BoxBody>) -> Result<Response<BoxBody>, Infallible>,
+        >;
 }

--- a/src/handler/into_service.rs
+++ b/src/handler/into_service.rs
@@ -1,0 +1,73 @@
+use super::Handler;
+use crate::body::BoxBody;
+use http::{Request, Response};
+use std::{
+    convert::Infallible,
+    fmt,
+    marker::PhantomData,
+    task::{Context, Poll},
+};
+use tower::Service;
+
+/// An adapter that makes a [`Handler`] into a [`Service`].
+///
+/// Created with [`Handler::into_service`].
+pub struct IntoService<H, B, T> {
+    handler: H,
+    _marker: PhantomData<fn() -> (B, T)>,
+}
+
+impl<H, B, T> IntoService<H, B, T> {
+    pub(super) fn new(handler: H) -> Self {
+        Self {
+            handler,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<H, B, T> fmt::Debug for IntoService<H, B, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("IntoService")
+            .field(&format_args!("..."))
+            .finish()
+    }
+}
+
+impl<H, B, T> Clone for IntoService<H, B, T>
+where
+    H: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            handler: self.handler.clone(),
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<H, T, B> Service<Request<B>> for IntoService<H, B, T>
+where
+    H: Handler<B, T> + Clone + Send + 'static,
+    B: Send + 'static,
+{
+    type Response = Response<BoxBody>;
+    type Error = Infallible;
+    type Future = super::future::IntoServiceFuture;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        // `IntoService` can only be constructed from async functions which are always ready, or from
+        // `Layered` which bufferes in `<Layered as Handler>::call` and is therefore also always
+        // ready.
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, req: Request<B>) -> Self::Future {
+        use futures_util::future::FutureExt;
+
+        let handler = self.handler.clone();
+        let future = Handler::call(handler, req).map(Ok::<_, Infallible> as _);
+
+        super::future::IntoServiceFuture { future }
+    }
+}


### PR DESCRIPTION
It was removed as part of https://github.com/tokio-rs/axum/pull/184 but
I do actually think it has some utility. So makes sense to keep even if
axum doesn't use it directly for routing.