### PR TITLE
Replace `route` with `Router::new().route()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   please file an issue!
 - Remove `prelude`. Explicit imports are now required.
 - Add dedicated `Router` to replace the `RoutingDsl` trait
+- Replace `axum::route(...)` with `axum::Router::new().route(...)`. This means
+  there is now only one way to create a new router. Same goes for
+  `axum::routing::nest`.
 - Make `FromRequest` default to being generic over `body::Body` ([#146](https://github.com/tokio-rs/axum/pull/146))
 - Implement `std::error::Error` for all rejections ([#153](https://github.com/tokio-rs/axum/pull/153))
 - Add `Router::or` for combining routes ([#108](https://github.com/tokio-rs/axum/pull/108))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Overall compile time improvements. If you're having issues with compile time
   please file an issue!
-- Remove `prelude`. Explicit imports are now required.
-- Add dedicated `Router` to replace the `RoutingDsl` trait
+- Remove `prelude`. Explicit imports are now required ([#195](https://github.com/tokio-rs/axum/pull/195))
+- Add dedicated `Router` to replace the `RoutingDsl` trait ([#214](https://github.com/tokio-rs/axum/pull/214))
 - Replace `axum::route(...)` with `axum::Router::new().route(...)`. This means
   there is now only one way to create a new router. Same goes for
-  `axum::routing::nest`.
+  `axum::routing::nest`. ([#215](https://github.com/tokio-rs/axum/pull/215))
 - Make `FromRequest` default to being generic over `body::Body` ([#146](https://github.com/tokio-rs/axum/pull/146))
 - Implement `std::error::Error` for all rejections ([#153](https://github.com/tokio-rs/axum/pull/153))
 - Add `Router::or` for combining routes ([#108](https://github.com/tokio-rs/axum/pull/108))

--- a/examples/async-graphql/src/main.rs
+++ b/examples/async-graphql/src/main.rs
@@ -3,7 +3,7 @@ mod starwars;
 use async_graphql::http::{playground_source, GraphQLPlaygroundConfig};
 use async_graphql::{EmptyMutation, EmptySubscription, Request, Response, Schema};
 use axum::response::IntoResponse;
-use axum::{extract::Extension, handler::get, response::Html, route, AddExtensionLayer, Json};
+use axum::{extract::Extension, handler::get, response::Html, AddExtensionLayer, Json, Router};
 use starwars::{QueryRoot, StarWars, StarWarsSchema};
 
 async fn graphql_handler(schema: Extension<StarWarsSchema>, req: Json<Request>) -> Json<Response> {
@@ -20,7 +20,8 @@ async fn main() {
         .data(StarWars::new())
         .finish();
 
-    let app = route("/", get(graphql_playground).post(graphql_handler))
+    let app = Router::new()
+        .route("/", get(graphql_playground).post(graphql_handler))
         .layer(AddExtensionLayer::new(schema));
 
     println!("Playground: http://localhost:3000");

--- a/examples/chat/src/main.rs
+++ b/examples/chat/src/main.rs
@@ -10,8 +10,8 @@ use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
 use axum::extract::Extension;
 use axum::handler::get;
 use axum::response::{Html, IntoResponse};
-use axum::route;
 use axum::AddExtensionLayer;
+use axum::Router;
 use futures::{sink::SinkExt, stream::StreamExt};
 use std::collections::HashSet;
 use std::net::SocketAddr;
@@ -31,7 +31,8 @@ async fn main() {
 
     let app_state = Arc::new(AppState { user_set, tx });
 
-    let app = route("/", get(index))
+    let app = Router::new()
+        .route("/", get(index))
         .route("/websocket", get(websocket_handler))
         .layer(AddExtensionLayer::new(app_state));
 

--- a/examples/error-handling-and-dependency-injection/src/main.rs
+++ b/examples/error-handling-and-dependency-injection/src/main.rs
@@ -14,7 +14,7 @@ use axum::{
     handler::{get, post},
     http::{Response, StatusCode},
     response::IntoResponse,
-    route, AddExtensionLayer, Json,
+    AddExtensionLayer, Json, Router,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -37,7 +37,8 @@ async fn main() {
     let user_repo = Arc::new(ExampleUserRepo) as DynUserRepo;
 
     // Build our application with some routes
-    let app = route("/users/:id", get(users_show))
+    let app = Router::new()
+        .route("/users/:id", get(users_show))
         .route("/users", post(users_create))
         // Add our `user_repo` to all request's extensions so handlers can access
         // it.

--- a/examples/form/src/main.rs
+++ b/examples/form/src/main.rs
@@ -4,7 +4,7 @@
 //! cargo run -p example-form
 //! ```
 
-use axum::{extract::Form, handler::get, response::Html, route};
+use axum::{extract::Form, handler::get, response::Html, Router};
 use serde::Deserialize;
 use std::net::SocketAddr;
 
@@ -17,7 +17,7 @@ async fn main() {
     tracing_subscriber::fmt::init();
 
     // build our application with some routes
-    let app = route("/", get(show_form).post(accept_form));
+    let app = Router::new().route("/", get(show_form).post(accept_form));
 
     // run it with hyper
     let addr = SocketAddr::from(([127, 0, 0, 1], 3000));

--- a/examples/global-404-handler/src/main.rs
+++ b/examples/global-404-handler/src/main.rs
@@ -9,7 +9,7 @@ use axum::{
     handler::get,
     http::{Response, StatusCode},
     response::Html,
-    route,
+    Router,
 };
 use std::net::SocketAddr;
 use tower::util::MapResponseLayer;
@@ -23,7 +23,8 @@ async fn main() {
     tracing_subscriber::fmt::init();
 
     // build our application with a route
-    let app = route("/", get(handler))
+    let app = Router::new()
+        .route("/", get(handler))
         // make sure this is added as the very last thing
         .layer(MapResponseLayer::new(map_404));
 

--- a/examples/hello-world/src/main.rs
+++ b/examples/hello-world/src/main.rs
@@ -4,13 +4,13 @@
 //! cargo run -p example-hello-world
 //! ```
 
-use axum::{handler::get, route};
+use axum::{handler::get, Router};
 use std::net::SocketAddr;
 
 #[tokio::main]
 async fn main() {
     // build our application with a route
-    let app = route("/foo", get(handler));
+    let app = Router::new().route("/", get(handler));
 
     // run it
     let addr = SocketAddr::from(([127, 0, 0, 1], 3000));

--- a/examples/multipart-form/src/main.rs
+++ b/examples/multipart-form/src/main.rs
@@ -8,7 +8,7 @@ use axum::{
     extract::{ContentLengthLimit, Multipart},
     handler::get,
     response::Html,
-    route,
+    Router,
 };
 use std::net::SocketAddr;
 
@@ -21,7 +21,8 @@ async fn main() {
     tracing_subscriber::fmt::init();
 
     // build our application with some routes
-    let app = route("/", get(show_form).post(accept_form))
+    let app = Router::new()
+        .route("/", get(show_form).post(accept_form))
         .layer(tower_http::trace::TraceLayer::new_for_http());
 
     // run it with hyper

--- a/examples/oauth/src/main.rs
+++ b/examples/oauth/src/main.rs
@@ -14,7 +14,7 @@ use axum::{
     handler::get,
     http::{header::SET_COOKIE, HeaderMap, Response},
     response::{IntoResponse, Redirect},
-    route, AddExtensionLayer,
+    AddExtensionLayer, Router,
 };
 use oauth2::{
     basic::BasicClient, reqwest::async_http_client, AuthUrl, AuthorizationCode, ClientId,
@@ -42,8 +42,11 @@ async fn main() {
 
     // `MemoryStore` just used as an example. Don't use this in production.
     let store = MemoryStore::new();
+
     let oauth_client = oauth_client();
-    let app = route("/", get(index))
+
+    let app = Router::new()
+        .route("/", get(index))
         .route("/auth/discord", get(discord_auth))
         .route("/auth/authorized", get(login_authorized))
         .route("/protected", get(protected))

--- a/examples/sessions/src/main.rs
+++ b/examples/sessions/src/main.rs
@@ -15,7 +15,7 @@ use axum::{
         StatusCode,
     },
     response::IntoResponse,
-    route, AddExtensionLayer,
+    AddExtensionLayer, Router,
 };
 use serde::{Deserialize, Serialize};
 use std::net::SocketAddr;
@@ -32,7 +32,9 @@ async fn main() {
     // `MemoryStore` just used as an example. Don't use this in production.
     let store = MemoryStore::new();
 
-    let app = route("/", get(handler)).layer(AddExtensionLayer::new(store));
+    let app = Router::new()
+        .route("/", get(handler))
+        .layer(AddExtensionLayer::new(store));
 
     let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
     tracing::debug!("listening on {}", addr);

--- a/examples/sse/src/main.rs
+++ b/examples/sse/src/main.rs
@@ -9,7 +9,7 @@ use axum::{
     handler::get,
     http::StatusCode,
     response::sse::{sse, Event, Sse},
-    routing::nest,
+    Router,
 };
 use futures::stream::{self, Stream};
 use std::{convert::Infallible, net::SocketAddr, time::Duration};
@@ -35,7 +35,8 @@ async fn main() {
     });
 
     // build our application with a route
-    let app = nest("/", static_files_service)
+    let app = Router::new()
+        .nest("/", static_files_service)
         .route("/sse", get(sse_handler))
         .layer(TraceLayer::new_for_http());
 

--- a/examples/templates/src/main.rs
+++ b/examples/templates/src/main.rs
@@ -11,7 +11,7 @@ use axum::{
     handler::get,
     http::{Response, StatusCode},
     response::{Html, IntoResponse},
-    route,
+    Router,
 };
 use std::{convert::Infallible, net::SocketAddr};
 
@@ -24,7 +24,7 @@ async fn main() {
     tracing_subscriber::fmt::init();
 
     // build our application with some routes
-    let app = route("/greet/:name", get(greet));
+    let app = Router::new().route("/greet/:name", get(greet));
 
     // run it
     let addr = SocketAddr::from(([127, 0, 0, 1], 3000));

--- a/examples/testing/src/main.rs
+++ b/examples/testing/src/main.rs
@@ -6,9 +6,8 @@
 
 use axum::{
     handler::{get, post},
-    route,
-    routing::{BoxRoute, Router},
-    Json,
+    routing::BoxRoute,
+    Json, Router,
 };
 use tower_http::trace::TraceLayer;
 
@@ -34,7 +33,8 @@ async fn main() {
 /// without having to create an HTTP server.
 #[allow(dead_code)]
 fn app() -> Router<BoxRoute> {
-    route("/", get(|| async { "Hello, World!" }))
+    Router::new()
+        .route("/", get(|| async { "Hello, World!" }))
         .route(
             "/json",
             post(|payload: Json<serde_json::Value>| async move {

--- a/examples/tls-rustls/src/main.rs
+++ b/examples/tls-rustls/src/main.rs
@@ -4,7 +4,7 @@
 //! cargo run -p example-tls-rustls
 //! ```
 
-use axum::{handler::get, route};
+use axum::{handler::get, Router};
 use hyper::server::conn::Http;
 use std::{fs::File, io::BufReader, sync::Arc};
 use tokio::net::TcpListener;
@@ -31,7 +31,7 @@ async fn main() {
     let acceptor = TlsAcceptor::from(rustls_config);
     let listener = TcpListener::bind("127.0.0.1:3000").await.unwrap();
 
-    let app = route("/", get(handler));
+    let app = Router::new().route("/", get(handler));
 
     loop {
         let (stream, _addr) = listener.accept().await.unwrap();

--- a/examples/todos/src/main.rs
+++ b/examples/todos/src/main.rs
@@ -18,7 +18,7 @@ use axum::{
     handler::{get, patch},
     http::StatusCode,
     response::IntoResponse,
-    route, Json,
+    Json, Router,
 };
 use serde::{Deserialize, Serialize};
 use std::{
@@ -43,7 +43,8 @@ async fn main() {
     let db = Db::default();
 
     // Compose the routes
-    let app = route("/todos", get(todos_index).post(todos_create))
+    let app = Router::new()
+        .route("/todos", get(todos_index).post(todos_create))
         .route("/todos/:id", patch(todos_update).delete(todos_delete))
         // Add middleware to all routes
         .layer(
@@ -53,7 +54,6 @@ async fn main() {
                 .layer(AddExtensionLayer::new(db))
                 .into_inner(),
         )
-        // If the timeout fails, map the error to a response
         .handle_error(|error: BoxError| {
             let result = if error.is::<tower::timeout::error::Elapsed>() {
                 Ok(StatusCode::REQUEST_TIMEOUT)

--- a/examples/tokio-postgres/src/main.rs
+++ b/examples/tokio-postgres/src/main.rs
@@ -9,7 +9,7 @@ use axum::{
     extract::{Extension, FromRequest, RequestParts},
     handler::get,
     http::StatusCode,
-    route, AddExtensionLayer,
+    AddExtensionLayer, Router,
 };
 use bb8::{Pool, PooledConnection};
 use bb8_postgres::PostgresConnectionManager;
@@ -31,11 +31,12 @@ async fn main() {
     let pool = Pool::builder().build(manager).await.unwrap();
 
     // build our application with some routes
-    let app = route(
-        "/",
-        get(using_connection_pool_extractor).post(using_connection_extractor),
-    )
-    .layer(AddExtensionLayer::new(pool));
+    let app = Router::new()
+        .route(
+            "/",
+            get(using_connection_pool_extractor).post(using_connection_extractor),
+        )
+        .layer(AddExtensionLayer::new(pool));
 
     // run it with hyper
     let addr = SocketAddr::from(([127, 0, 0, 1], 3000));

--- a/examples/tracing-aka-logging/src/main.rs
+++ b/examples/tracing-aka-logging/src/main.rs
@@ -4,7 +4,7 @@
 //! cargo run -p example-tracing-aka-logging
 //! ```
 
-use axum::{handler::get, response::Html, route};
+use axum::{handler::get, response::Html, Router};
 use std::net::SocketAddr;
 use tower_http::trace::TraceLayer;
 
@@ -20,7 +20,8 @@ async fn main() {
     tracing_subscriber::fmt::init();
 
     // build our application with a route
-    let app = route("/", get(handler))
+    let app = Router::new()
+        .route("/", get(handler))
         // `TraceLayer` is provided by tower-http so you have to add that as a dependency.
         // It provides good defaults but is also very customizable.
         // See https://docs.rs/tower-http/0.1.1/tower_http/trace/index.html for more details.

--- a/examples/unix-domain-socket/src/main.rs
+++ b/examples/unix-domain-socket/src/main.rs
@@ -9,7 +9,7 @@ use axum::{
     extract::connect_info::{self, ConnectInfo},
     handler::get,
     http::{Method, Request, StatusCode, Uri},
-    route,
+    Router,
 };
 use futures::ready;
 use hyper::{
@@ -53,7 +53,7 @@ async fn main() {
 
     let uds = UnixListener::bind(path.clone()).unwrap();
     tokio::spawn(async {
-        let app = route("/", get(handler));
+        let app = Router::new().route("/", get(handler));
 
         axum::Server::builder(ServerAccept { uds })
             .serve(app.into_make_service_with_connect_info::<UdsConnectInfo, _>())

--- a/examples/versioning/src/main.rs
+++ b/examples/versioning/src/main.rs
@@ -11,7 +11,7 @@ use axum::{
     handler::get,
     http::{Response, StatusCode},
     response::IntoResponse,
-    route,
+    Router,
 };
 use std::collections::HashMap;
 use std::net::SocketAddr;
@@ -25,7 +25,7 @@ async fn main() {
     tracing_subscriber::fmt::init();
 
     // build our application with some routes
-    let app = route("/:version/foo", get(handler));
+    let app = Router::new().route("/:version/foo", get(handler));
 
     // run it
     let addr = SocketAddr::from(([127, 0, 0, 1], 3000));

--- a/src/extract/connect_info.rs
+++ b/src/extract/connect_info.rs
@@ -131,7 +131,7 @@ where
 mod tests {
     use super::*;
     use crate::Server;
-    use crate::{handler::get, route};
+    use crate::{handler::get, Router};
     use std::net::{SocketAddr, TcpListener};
 
     #[tokio::test]
@@ -145,7 +145,7 @@ mod tests {
 
         let (tx, rx) = tokio::sync::oneshot::channel();
         tokio::spawn(async move {
-            let app = route("/", get(handler));
+            let app = Router::new().route("/", get(handler));
             let server = Server::from_tcp(listener)
                 .unwrap()
                 .serve(app.into_make_service_with_connect_info::<SocketAddr, _>());
@@ -187,7 +187,7 @@ mod tests {
 
         let (tx, rx) = tokio::sync::oneshot::channel();
         tokio::spawn(async move {
-            let app = route("/", get(handler));
+            let app = Router::new().route("/", get(handler));
             let server = Server::from_tcp(listener)
                 .unwrap()
                 .serve(app.into_make_service_with_connect_info::<MyConnectInfo, _>());

--- a/src/extract/content_length_limit.rs
+++ b/src/extract/content_length_limit.rs
@@ -12,14 +12,14 @@ use std::ops::Deref;
 /// use axum::{
 ///     extract::ContentLengthLimit,
 ///     handler::post,
-///     route,
+///     Router,
 /// };
 ///
 /// async fn handler(body: ContentLengthLimit<String, 1024>) {
 ///     // ...
 /// }
 ///
-/// let app = route("/", post(handler));
+/// let app = Router::new().route("/", post(handler));
 /// # async {
 /// # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
 /// # };

--- a/src/extract/extension.rs
+++ b/src/extract/extension.rs
@@ -13,7 +13,7 @@ use std::ops::Deref;
 ///     AddExtensionLayer,
 ///     extract::Extension,
 ///     handler::get,
-///     route,
+///     Router,
 /// };
 /// use std::sync::Arc;
 ///
@@ -28,7 +28,7 @@ use std::ops::Deref;
 ///
 /// let state = Arc::new(State { /* ... */ });
 ///
-/// let app = route("/", get(handler))
+/// let app = Router::new().route("/", get(handler))
 ///     // Add middleware that inserts the state into all incoming request's
 ///     // extensions.
 ///     .layer(AddExtensionLayer::new(state));

--- a/src/extract/extractor_middleware.rs
+++ b/src/extract/extractor_middleware.rs
@@ -37,7 +37,7 @@ use tower::{BoxError, Layer, Service};
 /// use axum::{
 ///     extract::{extractor_middleware, FromRequest, RequestParts},
 ///     handler::{get, post},
-///     route,
+///     Router,
 /// };
 /// use http::StatusCode;
 /// use async_trait::async_trait;
@@ -76,7 +76,8 @@ use tower::{BoxError, Layer, Service};
 ///     // If we get here the request has been authorized
 /// }
 ///
-/// let app = route("/", get(handler))
+/// let app = Router::new()
+///     .route("/", get(handler))
 ///     .route("/foo", post(other_handler))
 ///     // The extractor will run before all routes
 ///     .layer(extractor_middleware::<RequireAuth>());

--- a/src/extract/form.rs
+++ b/src/extract/form.rs
@@ -17,7 +17,7 @@ use tower::BoxError;
 /// use axum::{
 ///     extract::Form,
 ///     handler::post,
-///     route,
+///     Router,
 /// };
 /// use serde::Deserialize;
 ///
@@ -33,7 +33,7 @@ use tower::BoxError;
 ///     // ...
 /// }
 ///
-/// let app = route("/sign_up", post(accept_form));
+/// let app = Router::new().route("/sign_up", post(accept_form));
 /// # async {
 /// # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
 /// # };

--- a/src/extract/mod.rs
+++ b/src/extract/mod.rs
@@ -11,7 +11,7 @@
 //! use axum::{
 //!     Json,
 //!     handler::{post, Handler},
-//!     route,
+//!     Router,
 //! };
 //! use serde::Deserialize;
 //!
@@ -27,7 +27,7 @@
 //!     // ...
 //! }
 //!
-//! let app = route("/users", post(create_user));
+//! let app = Router::new().route("/users", post(create_user));
 //! # async {
 //! # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
 //! # };
@@ -42,7 +42,7 @@
 //!     async_trait,
 //!     extract::{FromRequest, RequestParts},
 //!     handler::get,
-//!     route,
+//!     Router,
 //! };
 //! use http::{StatusCode, header::{HeaderValue, USER_AGENT}};
 //!
@@ -72,7 +72,7 @@
 //!     // ...
 //! }
 //!
-//! let app = route("/foo", get(handler));
+//! let app = Router::new().route("/foo", get(handler));
 //! # async {
 //! # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
 //! # };
@@ -86,7 +86,7 @@
 //! use axum::{
 //!     extract::{Path, Query},
 //!     handler::get,
-//!     route,
+//!     Router,
 //! };
 //! use std::collections::HashMap;
 //!
@@ -101,7 +101,7 @@
 //!     // ...
 //! }
 //!
-//! let app = route("/foo", get(handler));
+//! let app = Router::new().route("/foo", get(handler));
 //! # async {
 //! # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
 //! # };
@@ -118,7 +118,7 @@
 //! use axum::{
 //!     extract::Json,
 //!     handler::post,
-//!     route,
+//!     Router,
 //! };
 //! use serde_json::Value;
 //!
@@ -130,7 +130,7 @@
 //!     }
 //! }
 //!
-//! let app = route("/users", post(create_user));
+//! let app = Router::new().route("/users", post(create_user));
 //! # async {
 //! # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
 //! # };
@@ -143,7 +143,7 @@
 //! use axum::{
 //!     extract::{Json, rejection::JsonRejection},
 //!     handler::post,
-//!     route,
+//!     Router,
 //! };
 //! use serde_json::Value;
 //!
@@ -169,7 +169,7 @@
 //!     }
 //! }
 //!
-//! let app = route("/users", post(create_user));
+//! let app = Router::new().route("/users", post(create_user));
 //! # async {
 //! # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
 //! # };
@@ -184,7 +184,7 @@
 //! use axum::{
 //!     extract::Json,
 //!     handler::post,
-//!     route,
+//!     Router,
 //! };
 //! use serde_json::Value;
 //!
@@ -192,7 +192,7 @@
 //!     // `value` is of type `Value`
 //! }
 //!
-//! let app = route("/users", post(create_user));
+//! let app = Router::new().route("/users", post(create_user));
 //! # async {
 //! # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
 //! # };
@@ -217,7 +217,7 @@
 //!     body::Body,
 //!     handler::get,
 //!     http::{header::HeaderMap, Request},
-//!     route,
+//!     Router,
 //! };
 //!
 //! struct MyBody<B>(B);
@@ -244,10 +244,10 @@
 //!     }
 //! }
 //!
-//! let app =
-//!     // `String` works directly with any body type
-//!     route(
+//! let app = Router::new()
+//!     .route(
 //!         "/string",
+//!         // `String` works directly with any body type
 //!         get(|_: String| async {})
 //!     )
 //!     .route(

--- a/src/extract/multipart.rs
+++ b/src/extract/multipart.rs
@@ -23,7 +23,7 @@ use tower::BoxError;
 /// use axum::{
 ///     extract::Multipart,
 ///     handler::post,
-///     route,
+///     Router,
 /// };
 /// use futures::stream::StreamExt;
 ///
@@ -36,7 +36,7 @@ use tower::BoxError;
 ///     }
 /// }
 ///
-/// let app = route("/upload", post(upload));
+/// let app = Router::new().route("/upload", post(upload));
 /// # async {
 /// # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
 /// # };

--- a/src/extract/path/mod.rs
+++ b/src/extract/path/mod.rs
@@ -14,7 +14,7 @@ use std::ops::{Deref, DerefMut};
 /// use axum::{
 ///     extract::Path,
 ///     handler::get,
-///     route,
+///     Router,
 /// };
 /// use uuid::Uuid;
 ///
@@ -24,7 +24,7 @@ use std::ops::{Deref, DerefMut};
 ///     // ...
 /// }
 ///
-/// let app = route("/users/:user_id/team/:team_id", get(users_teams_show));
+/// let app = Router::new().route("/users/:user_id/team/:team_id", get(users_teams_show));
 /// # async {
 /// # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
 /// # };
@@ -36,7 +36,7 @@ use std::ops::{Deref, DerefMut};
 /// use axum::{
 ///     extract::Path,
 ///     handler::get,
-///     route,
+///     Router,
 /// };
 /// use uuid::Uuid;
 ///
@@ -44,7 +44,7 @@ use std::ops::{Deref, DerefMut};
 ///     // ...
 /// }
 ///
-/// let app = route("/users/:user_id", get(user_info));
+/// let app = Router::new().route("/users/:user_id", get(user_info));
 /// # async {
 /// # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
 /// # };
@@ -57,7 +57,7 @@ use std::ops::{Deref, DerefMut};
 /// use axum::{
 ///     extract::Path,
 ///     handler::get,
-///     route,
+///     Router,
 /// };
 /// use serde::Deserialize;
 /// use uuid::Uuid;
@@ -74,7 +74,7 @@ use std::ops::{Deref, DerefMut};
 ///     // ...
 /// }
 ///
-/// let app = route("/users/:user_id/team/:team_id", get(users_teams_show));
+/// let app = Router::new().route("/users/:user_id/team/:team_id", get(users_teams_show));
 /// # async {
 /// # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
 /// # };

--- a/src/extract/query.rs
+++ b/src/extract/query.rs
@@ -13,7 +13,7 @@ use std::ops::Deref;
 /// use axum::{
 ///     extract::Query,
 ///     handler::get,
-///     route,
+///     Router,
 /// };
 /// use serde::Deserialize;
 ///
@@ -31,7 +31,7 @@ use std::ops::Deref;
 ///     // ...
 /// }
 ///
-/// let app = route("/list_things", get(list_things));
+/// let app = Router::new().route("/list_things", get(list_things));
 /// # async {
 /// # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
 /// # };

--- a/src/extract/raw_query.rs
+++ b/src/extract/raw_query.rs
@@ -10,7 +10,7 @@ use std::convert::Infallible;
 /// use axum::{
 ///     extract::RawQuery,
 ///     handler::get,
-///     route,
+///     Router,
 /// };
 /// use futures::StreamExt;
 ///
@@ -18,7 +18,7 @@ use std::convert::Infallible;
 ///     // ...
 /// }
 ///
-/// let app = route("/users", get(handler));
+/// let app = Router::new().route("/users", get(handler));
 /// # async {
 /// # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
 /// # };

--- a/src/extract/request_parts.rs
+++ b/src/extract/request_parts.rs
@@ -92,21 +92,21 @@ where
 /// ```
 /// use axum::{
 ///     handler::get,
-///     route,
-///     routing::nest,
+///     Router,
 ///     extract::OriginalUri,
 ///     http::Uri
 /// };
 ///
-/// let api_routes = route(
-///     "/users",
-///     get(|uri: Uri, OriginalUri(original_uri): OriginalUri| async {
-///         // `uri` is `/users`
-///         // `original_uri` is `/api/users`
-///     }),
-/// );
+/// let api_routes = Router::new()
+///     .route(
+///         "/users",
+///         get(|uri: Uri, OriginalUri(original_uri): OriginalUri| async {
+///             // `uri` is `/users`
+///             // `original_uri` is `/api/users`
+///         }),
+///     );
 ///
-/// let app = nest("/api", api_routes);
+/// let app = Router::new().nest("/api", api_routes);
 /// # async {
 /// # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
 /// # };
@@ -174,7 +174,7 @@ where
 /// use axum::{
 ///     extract::BodyStream,
 ///     handler::get,
-///     route,
+///     Router,
 /// };
 /// use futures::StreamExt;
 ///
@@ -184,7 +184,7 @@ where
 ///     }
 /// }
 ///
-/// let app = route("/users", get(handler));
+/// let app = Router::new().route("/users", get(handler));
 /// # async {
 /// # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
 /// # };
@@ -227,7 +227,7 @@ where
 /// use axum::{
 ///     extract::Body,
 ///     handler::get,
-///     route,
+///     Router,
 /// };
 /// use futures::StreamExt;
 ///
@@ -235,7 +235,7 @@ where
 ///     // ...
 /// }
 ///
-/// let app = route("/users", get(handler));
+/// let app = Router::new().route("/users", get(handler));
 /// # async {
 /// # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
 /// # };
@@ -289,14 +289,14 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{body::Body, handler::post, route, tests::*};
+    use crate::{body::Body, handler::post, tests::*, Router};
     use http::StatusCode;
 
     #[tokio::test]
     async fn multiple_request_extractors() {
         async fn handler(_: Request<Body>, _: Request<Body>) {}
 
-        let app = route("/", post(handler));
+        let app = Router::new().route("/", post(handler));
 
         let addr = run_in_background(app).await;
 

--- a/src/extract/typed_header.rs
+++ b/src/extract/typed_header.rs
@@ -14,7 +14,7 @@ use std::{convert::Infallible, ops::Deref};
 /// use axum::{
 ///     extract::TypedHeader,
 ///     handler::get,
-///     route,
+///     Router,
 /// };
 /// use headers::UserAgent;
 ///
@@ -24,7 +24,7 @@ use std::{convert::Infallible, ops::Deref};
 ///     // ...
 /// }
 ///
-/// let app = route("/users/:user_id/team/:team_id", get(users_teams_show));
+/// let app = Router::new().route("/users/:user_id/team/:team_id", get(users_teams_show));
 /// # async {
 /// # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
 /// # };
@@ -125,7 +125,7 @@ impl std::error::Error for TypedHeaderRejection {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{handler::get, response::IntoResponse, route, tests::*};
+    use crate::{handler::get, response::IntoResponse, tests::*, Router};
 
     #[tokio::test]
     async fn typed_header() {
@@ -135,7 +135,7 @@ mod tests {
             user_agent.to_string()
         }
 
-        let app = route("/", get(handle));
+        let app = Router::new().route("/", get(handle));
 
         let addr = run_in_background(app).await;
 

--- a/src/extract/ws.rs
+++ b/src/extract/ws.rs
@@ -7,10 +7,10 @@
 //!     extract::ws::{WebSocketUpgrade, WebSocket},
 //!     handler::get,
 //!     response::IntoResponse,
-//!     route,
+//!     Router,
 //! };
 //!
-//! let app = route("/ws", get(handler));
+//! let app = Router::new().route("/ws", get(handler));
 //!
 //! async fn handler(ws: WebSocketUpgrade) -> impl IntoResponse {
 //!     ws.on_upgrade(handle_socket)
@@ -113,10 +113,10 @@ impl WebSocketUpgrade {
     ///     extract::ws::{WebSocketUpgrade, WebSocket},
     ///     handler::get,
     ///     response::IntoResponse,
-    ///     route,
+    ///     Router,
     /// };
     ///
-    /// let app = route("/ws", get(handler));
+    /// let app = Router::new().route("/ws", get(handler));
     ///
     /// async fn handler(ws: WebSocketUpgrade) -> impl IntoResponse {
     ///     ws.protocols(["graphql-ws", "graphql-transport-ws"])

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -33,13 +33,13 @@ pub use self::into_service::IntoService;
 /// ```rust
 /// use axum::{
 ///     handler::any,
-///     route,
+///     Router,
 /// };
 ///
 /// async fn handler() {}
 ///
 /// // All requests to `/` will go to `handler` regardless of the HTTP method.
-/// let app = route("/", any(handler));
+/// let app = Router::new().route("/", any(handler));
 /// # async {
 /// # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
 /// # };
@@ -78,13 +78,13 @@ where
 /// ```rust
 /// use axum::{
 ///     handler::get,
-///     route,
+///     Router,
 /// };
 ///
 /// async fn handler() {}
 ///
 /// // Requests to `GET /` will go to `handler`.
-/// let app = route("/", get(handler));
+/// let app = Router::new().route("/", get(handler));
 /// # async {
 /// # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
 /// # };
@@ -167,14 +167,14 @@ where
 /// ```rust
 /// use axum::{
 ///     handler::on,
-///     route,
+///     Router,
 ///     routing::MethodFilter,
 /// };
 ///
 /// async fn handler() {}
 ///
 /// // Requests to `POST /` will go to `handler`.
-/// let app = route("/", on(MethodFilter::POST, handler));
+/// let app = Router::new().route("/", on(MethodFilter::POST, handler));
 /// # async {
 /// # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
 /// # };
@@ -234,14 +234,14 @@ pub trait Handler<B, T>: Clone + Send + Sized + 'static {
     /// ```rust
     /// use axum::{
     ///     handler::{get, Handler},
-    ///     route,
+    ///     Router,
     /// };
     /// use tower::limit::{ConcurrencyLimitLayer, ConcurrencyLimit};
     ///
     /// async fn handler() { /* ... */ }
     ///
     /// let layered_handler = handler.layer(ConcurrencyLimitLayer::new(64));
-    /// let app = route("/", get(layered_handler));
+    /// let app = Router::new().route("/", get(layered_handler));
     /// # async {
     /// # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
     /// # };
@@ -511,7 +511,7 @@ impl<H, B, T, F> OnMethod<H, B, T, F> {
     /// # Example
     ///
     /// ```rust
-    /// use axum::{handler::post, route};
+    /// use axum::{handler::post, Router};
     ///
     /// async fn handler() {}
     ///
@@ -519,7 +519,7 @@ impl<H, B, T, F> OnMethod<H, B, T, F> {
     ///
     /// // Requests to `GET /` will go to `handler` and `POST /` will go to
     /// // `other_handler`.
-    /// let app = route("/", post(handler).get(other_handler));
+    /// let app = Router::new().route("/", post(handler).get(other_handler));
     /// # async {
     /// # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
     /// # };
@@ -603,7 +603,7 @@ impl<H, B, T, F> OnMethod<H, B, T, F> {
     /// ```rust
     /// use axum::{
     ///     handler::get,
-    ///     route,
+    ///     Router,
     ///     routing::MethodFilter
     /// };
     ///
@@ -613,7 +613,7 @@ impl<H, B, T, F> OnMethod<H, B, T, F> {
     ///
     /// // Requests to `GET /` will go to `handler` and `DELETE /` will go to
     /// // `other_handler`
-    /// let app = route("/", get(handler).on(MethodFilter::DELETE, other_handler));
+    /// let app = Router::new().route("/", get(handler).on(MethodFilter::DELETE, other_handler));
     /// # async {
     /// # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
     /// # };

--- a/src/json.rs
+++ b/src/json.rs
@@ -30,7 +30,7 @@ use tower::BoxError;
 /// use axum::{
 ///     extract,
 ///     handler::post,
-///     route,
+///     Router,
 /// };
 /// use serde::Deserialize;
 ///
@@ -44,7 +44,7 @@ use tower::BoxError;
 ///     // payload is a `CreateUser`
 /// }
 ///
-/// let app = route("/users", post(create_user));
+/// let app = Router::new().route("/users", post(create_user));
 /// # async {
 /// # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
 /// # };
@@ -59,7 +59,7 @@ use tower::BoxError;
 /// use axum::{
 ///     extract::Path,
 ///     handler::get,
-///     route,
+///     Router,
 ///     Json,
 /// };
 /// use serde::Serialize;
@@ -81,7 +81,7 @@ use tower::BoxError;
 ///     # unimplemented!()
 /// }
 ///
-/// let app = route("/users/:id", get(get_user));
+/// let app = Router::new().route("/users/:id", get(get_user));
 /// # async {
 /// # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
 /// # };

--- a/src/response/headers.rs
+++ b/src/response/headers.rs
@@ -13,7 +13,7 @@ use tower::{util::Either, BoxError};
 ///
 /// ```rust
 /// use axum::{
-///     route,
+///     Router,
 ///     response::{IntoResponse, Headers},
 ///     handler::get,
 /// };
@@ -36,7 +36,8 @@ use tower::{util::Either, BoxError};
 ///
 /// // Or `[(&str, &str)]` if you're on Rust 1.53+
 ///
-/// let app = route("/just-headers", get(just_headers))
+/// let app = Router::new()
+///     .route("/just-headers", get(just_headers))
 ///     .route("/from-strings", get(from_strings));
 /// # async {
 /// # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();

--- a/src/response/mod.rs
+++ b/src/response/mod.rs
@@ -44,7 +44,7 @@ pub use self::{
 /// use axum::{
 ///     handler::get,
 ///     response::IntoResponse,
-///     route,
+///     Router,
 /// };
 /// use http_body::Body;
 /// use http::{Response, HeaderMap};
@@ -94,7 +94,7 @@ pub use self::{
 /// // covered by a blanket implementation in axum.
 ///
 /// // `MyBody` can now be returned from handlers.
-/// let app = route("/", get(|| async { MyBody }));
+/// let app = Router::new().route("/", get(|| async { MyBody }));
 /// # async {
 /// # hyper::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
 /// # };

--- a/src/response/redirect.rs
+++ b/src/response/redirect.rs
@@ -12,10 +12,11 @@ use std::convert::TryFrom;
 /// use axum::{
 ///     handler::get,
 ///     response::Redirect,
-///     route,
+///     Router,
 /// };
 ///
-/// let app = route("/old", get(|| async { Redirect::permanent("/new".parse().unwrap()) }))
+/// let app = Router::new()
+///     .route("/old", get(|| async { Redirect::permanent("/new".parse().unwrap()) }))
 ///     .route("/new", get(|| async { "Hello!" }));
 /// # async {
 /// # hyper::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();

--- a/src/response/sse.rs
+++ b/src/response/sse.rs
@@ -5,14 +5,14 @@
 //! ```
 //! use axum::{
 //!     handler::get,
-//!     route,
+//!     Router,
 //! };
 //! use axum::response::sse::{sse, Event, KeepAlive, Sse};
 //! use std::{time::Duration, convert::Infallible};
 //! use tokio_stream::StreamExt as _ ;
 //! use futures::stream::{self, Stream};
 //!
-//! let app = route("/sse", get(sse_handler));
+//! let app = Router::new().route("/sse", get(sse_handler));
 //!
 //! async fn sse_handler() -> Sse<impl Stream<Item = Result<Event, Infallible>>> {
 //!     // A `Stream` that repeats an event every second

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -15,7 +15,7 @@
 //!     body::Body,
 //!     handler::get,
 //!     http::Request,
-//!     route,
+//!     Router,
 //!     service,
 //! };
 //!
@@ -23,7 +23,8 @@
 //!
 //! let redirect_service = Redirect::<Body>::permanent("/new".parse().unwrap());
 //!
-//! let app = route("/old", service::get(redirect_service))
+//! let app = Router::new()
+//!     .route("/old", service::get(redirect_service))
 //!     .route("/new", get(handler));
 //! # async {
 //! # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
@@ -66,7 +67,7 @@
 //! ```rust
 //! use axum::{
 //!     handler::get,
-//!     route,
+//!     Router,
 //! };
 //! use tower::ServiceBuilder;
 //! # let some_backpressure_sensitive_middleware =
@@ -74,7 +75,7 @@
 //!
 //! async fn handler() { /* ... */ }
 //!
-//! let app = route("/", get(handler));
+//! let app = Router::new().route("/", get(handler));
 //!
 //! let app = ServiceBuilder::new()
 //!     .layer(some_backpressure_sensitive_middleware)
@@ -148,7 +149,7 @@ where
 /// ```rust
 /// use axum::{
 ///     http::Request,
-///     route,
+///     Router,
 ///     service,
 /// };
 /// use http::Response;
@@ -160,7 +161,7 @@ where
 /// });
 ///
 /// // Requests to `GET /` will go to `service`.
-/// let app = route("/", service::get(service));
+/// let app = Router::new().route("/", service::get(service));
 /// # async {
 /// # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
 /// # };
@@ -245,7 +246,7 @@ where
 ///     http::Request,
 ///     handler::on,
 ///     service,
-///     route,
+///     Router,
 ///     routing::MethodFilter,
 /// };
 /// use http::Response;
@@ -257,7 +258,7 @@ where
 /// });
 ///
 /// // Requests to `POST /` will go to `service`.
-/// let app = route("/", service::on(MethodFilter::POST, service));
+/// let app = Router::new().route("/", service::on(MethodFilter::POST, service));
 /// # async {
 /// # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
 /// # };
@@ -340,7 +341,7 @@ impl<S, F, B> OnMethod<S, F, B> {
     ///     http::Request,
     ///     handler::on,
     ///     service,
-    ///     route,
+    ///     Router,
     ///     routing::MethodFilter,
     /// };
     /// use http::Response;
@@ -357,7 +358,7 @@ impl<S, F, B> OnMethod<S, F, B> {
     ///
     /// // Requests to `GET /` will go to `service` and `POST /` will go to
     /// // `other_service`.
-    /// let app = route("/", service::post(service).get(other_service));
+    /// let app = Router::new().route("/", service::post(service).get(other_service));
     /// # async {
     /// # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
     /// # };
@@ -443,7 +444,7 @@ impl<S, F, B> OnMethod<S, F, B> {
     ///     http::Request,
     ///     handler::on,
     ///     service,
-    ///     route,
+    ///     Router,
     ///     routing::MethodFilter,
     /// };
     /// use http::Response;
@@ -459,7 +460,7 @@ impl<S, F, B> OnMethod<S, F, B> {
     /// });
     ///
     /// // Requests to `DELETE /` will go to `service`
-    /// let app = route("/", service::on(MethodFilter::DELETE, service));
+    /// let app = Router::new().route("/", service::on(MethodFilter::DELETE, service));
     /// # async {
     /// # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
     /// # };

--- a/src/tests/get_to_head.rs
+++ b/src/tests/get_to_head.rs
@@ -7,7 +7,7 @@ mod for_handlers {
 
     #[tokio::test]
     async fn get_handles_head() {
-        let app = route(
+        let app = Router::new().route(
             "/",
             get(|| async {
                 let mut headers = HeaderMap::new();
@@ -43,7 +43,7 @@ mod for_services {
 
     #[tokio::test]
     async fn get_handles_head() {
-        let app = route(
+        let app = Router::new().route(
             "/",
             get(service_fn(|_req: Request<Body>| async move {
                 let res = Response::builder()


### PR DESCRIPTION
This way there is now only one way to create a router:

```rust
use axum::{Router, handler::get};

let app = Router::new()
    .route("/foo", get(handler))
    .route("/foo", get(handler));
```

`nest` was changed in the same way:

```rust
use axum::Router;

let app = Router::new().nest("/foo", service);
```