### PR TITLE
feat: expose tower log feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,10 @@ version = "0.1.3"
 members = ["examples/*"]
 
 [features]
-default = []
+default = ["tower-log"]
 ws = ["tokio-tungstenite", "sha-1", "base64"]
 multipart = ["multer", "mime"]
+tower-log = ["tower/log"]
 
 [dependencies]
 async-trait = "0.1"
@@ -34,7 +35,7 @@ serde_json = "1.0"
 serde_urlencoded = "0.7"
 tokio = { version = "1", features = ["time"] }
 tokio-util = "0.6"
-tower = { version = "0.4", features = ["util", "buffer", "make"] }
+tower = { version = "0.4", default-features = false, features = ["util", "buffer", "make"] }
 tower-http = { version = "0.1", features = ["add-extension", "map-response-body"] }
 sync_wrapper = "0.1.1"
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation

`tower` has as [only `default` feature `log`](https://github.com/tower-rs/tower/blob/ee131aaf467d2f1dcf9e60086823cf540ee94a0d/tower/Cargo.toml#L27), which toggles `tracing/log`. That's problematic in code relying on `Send+Sync`. This has been done in warp and hyper as well:

- https://github.com/seanmonstar/warp/pull/861
- https://github.com/hyperium/hyper/issues/2326

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

We don't enable `tower`'s default features and expose the `log` feature instead. I guess this should be considered a breaking change.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
