### PR TITLE
Remove tower from axum's public API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Convert `RequestAlreadyExtracted` to an enum with each possible error variant ([#167](https://github.com/tokio-rs/axum/pull/167))
 - `Router::check_infallible` now returns a `CheckInfallible` service. This
   is to improve compile times.
+- `Router::into_make_service` now returns `routing::IntoMakeService` rather than
+  `tower::make::Shared` ([#229](https://github.com/tokio-rs/axum/pull/229))
 - These future types have been moved
     - `extract::extractor_middleware::ExtractorMiddlewareResponseFuture` moved
       to `extract::extractor_middleware::future::ResponseFuture` ([#133](https://github.com/tokio-rs/axum/pull/133))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   is to improve compile times.
 - `Router::into_make_service` now returns `routing::IntoMakeService` rather than
   `tower::make::Shared` ([#229](https://github.com/tokio-rs/axum/pull/229))
+- All usage of `tower::BoxError` has been replaced with `axum::BoxError` ([#229](https://github.com/tokio-rs/axum/pull/229))
+- `tower::util::Either` no longer implements `IntoResponse` ([#229](https://github.com/tokio-rs/axum/pull/229))
 - These future types have been moved
     - `extract::extractor_middleware::ExtractorMiddlewareResponseFuture` moved
       to `extract::extractor_middleware::future::ResponseFuture` ([#133](https://github.com/tokio-rs/axum/pull/133))

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,8 @@ members = ["examples/*"]
 default = ["tower-log"]
 ws = ["tokio-tungstenite", "sha-1", "base64"]
 multipart = ["multer", "mime"]
-tower-log = ["tower/log"]
+# tower-log = ["tower/log"]
+tower-log = []
 
 [dependencies]
 async-trait = "0.1"
@@ -36,6 +37,8 @@ serde_urlencoded = "0.7"
 tokio = { version = "1", features = ["time"] }
 tokio-util = "0.6"
 tower = { version = "0.4", default-features = false, features = ["util", "buffer", "make"] }
+tower-service = "0.3"
+tower-layer = "0.3"
 tower-http = { version = "0.1", features = ["add-extension", "map-response-body"] }
 sync_wrapper = "0.1.1"
 
@@ -56,6 +59,7 @@ uuid = { version = "0.8", features = ["serde", "v4"] }
 tokio-stream = "0.1"
 
 [dev-dependencies.tower]
+package = "tower"
 version = "0.4"
 features = [
     "util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,7 @@ members = ["examples/*"]
 default = ["tower-log"]
 ws = ["tokio-tungstenite", "sha-1", "base64"]
 multipart = ["multer", "mime"]
-# tower-log = ["tower/log"]
-tower-log = []
+tower-log = ["tower/log"]
 
 [dependencies]
 async-trait = "0.1"

--- a/src/body.rs
+++ b/src/body.rs
@@ -1,7 +1,7 @@
 //! HTTP body utilities.
 
+use crate::BoxError;
 use crate::Error;
-use tower::BoxError;
 
 #[doc(no_inline)]
 pub use http_body::{Body as HttpBody, Empty, Full};

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -8,7 +8,8 @@ use std::{
 };
 use tokio::sync::{mpsc, oneshot, OwnedSemaphorePermit, Semaphore};
 use tokio_util::sync::PollSemaphore;
-use tower::{Service, ServiceExt};
+use tower::ServiceExt;
+use tower_service::Service;
 
 /// A version of [`tower::buffer::Buffer`] which panicks on channel related errors, thus keeping
 /// the error type of the service.

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,5 @@
+use crate::BoxError;
 use std::{error::Error as StdError, fmt};
-use tower::BoxError;
 
 /// Errors that can happen when using axum.
 #[derive(Debug)]

--- a/src/extract/connect_info.rs
+++ b/src/extract/connect_info.rs
@@ -14,8 +14,8 @@ use std::{
     net::SocketAddr,
     task::{Context, Poll},
 };
-use tower::Service;
 use tower_http::add_extension::AddExtension;
+use tower_service::Service;
 
 /// A [`MakeService`] created from a router.
 ///

--- a/src/extract/extractor_middleware.rs
+++ b/src/extract/extractor_middleware.rs
@@ -3,6 +3,7 @@
 //! See [`extractor_middleware`] for more details.
 
 use super::{FromRequest, RequestParts};
+use crate::BoxError;
 use crate::{body::BoxBody, response::IntoResponse};
 use bytes::Bytes;
 use futures_util::{future::BoxFuture, ready};
@@ -15,7 +16,8 @@ use std::{
     pin::Pin,
     task::{Context, Poll},
 };
-use tower::{BoxError, Layer, Service};
+use tower_layer::Layer;
+use tower_service::Service;
 
 /// Convert an extractor into a middleware.
 ///

--- a/src/extract/form.rs
+++ b/src/extract/form.rs
@@ -1,10 +1,10 @@
 use super::{has_content_type, rejection::*, take_body, FromRequest, RequestParts};
+use crate::BoxError;
 use async_trait::async_trait;
 use bytes::Buf;
 use http::Method;
 use serde::de::DeserializeOwned;
 use std::ops::Deref;
-use tower::BoxError;
 
 /// Extractor that deserializes `application/x-www-form-urlencoded` requests
 /// into some type.

--- a/src/extract/multipart.rs
+++ b/src/extract/multipart.rs
@@ -3,6 +3,7 @@
 //! See [`Multipart`] for more details.
 
 use super::{rejection::*, BodyStream, FromRequest, RequestParts};
+use crate::BoxError;
 use async_trait::async_trait;
 use bytes::Bytes;
 use futures_util::stream::Stream;
@@ -13,7 +14,6 @@ use std::{
     pin::Pin,
     task::{Context, Poll},
 };
-use tower::BoxError;
 
 /// Extractor that parses `multipart/form-data` requests commonly used with file uploads.
 ///

--- a/src/extract/rejection.rs
+++ b/src/extract/rejection.rs
@@ -1,6 +1,7 @@
 //! Rejection response types.
 
 use super::IntoResponse;
+use crate::BoxError;
 use crate::{
     body::{box_body, BoxBody},
     Error,
@@ -8,7 +9,6 @@ use crate::{
 use bytes::Bytes;
 use http_body::Full;
 use std::convert::Infallible;
-use tower::BoxError;
 
 define_rejection! {
     #[status = INTERNAL_SERVER_ERROR]

--- a/src/extract/request_parts.rs
+++ b/src/extract/request_parts.rs
@@ -1,4 +1,5 @@
 use super::{rejection::*, take_body, Extension, FromRequest, RequestParts};
+use crate::BoxError;
 use async_trait::async_trait;
 use bytes::Bytes;
 use futures_util::stream::Stream;
@@ -8,7 +9,6 @@ use std::{
     pin::Pin,
     task::{Context, Poll},
 };
-use tower::BoxError;
 
 #[async_trait]
 impl<B> FromRequest<B> for Request<B>

--- a/src/handler/future.rs
+++ b/src/handler/future.rs
@@ -16,7 +16,8 @@ use std::{
     pin::Pin,
     task::{Context, Poll},
 };
-use tower::{util::Oneshot, Service};
+use tower::util::Oneshot;
+use tower_service::Service;
 
 pin_project! {
     /// The response future for [`OnMethod`](super::OnMethod).

--- a/src/handler/into_service.rs
+++ b/src/handler/into_service.rs
@@ -7,7 +7,7 @@ use std::{
     marker::PhantomData,
     task::{Context, Poll},
 };
-use tower::Service;
+use tower_service::Service;
 
 /// An adapter that makes a [`Handler`] into a [`Service`].
 ///

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -7,6 +7,7 @@ use crate::{
     routing::{EmptyRouter, MethodFilter},
     service::HandleError,
     util::Either,
+    BoxError,
 };
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -18,7 +19,9 @@ use std::{
     marker::PhantomData,
     task::{Context, Poll},
 };
-use tower::{BoxError, Layer, Service, ServiceExt};
+use tower::ServiceExt;
+use tower_layer::Layer;
+use tower_service::Service;
 
 pub mod future;
 mod into_service;

--- a/src/json.rs
+++ b/src/json.rs
@@ -1,3 +1,4 @@
+use crate::BoxError;
 use crate::{
     extract::{has_content_type, rejection::*, take_body, FromRequest, RequestParts},
     response::IntoResponse,
@@ -15,7 +16,6 @@ use std::{
     convert::Infallible,
     ops::{Deref, DerefMut},
 };
-use tower::BoxError;
 
 /// JSON Extractor/Response
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -832,3 +832,6 @@ pub use tower_http::add_extension::{AddExtension, AddExtensionLayer};
 
 #[doc(inline)]
 pub use self::{error::Error, json::Json, routing::Router};
+
+/// Alias for a type-erased error type.
+pub type BoxError = Box<dyn std::error::Error + Send + Sync>;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -81,7 +81,7 @@ macro_rules! define_rejection {
         impl $name {
             pub(crate) fn from_err<E>(err: E) -> Self
             where
-                E: Into<tower::BoxError>,
+                E: Into<crate::BoxError>,
             {
                 Self(crate::Error::new(err))
             }

--- a/src/response/headers.rs
+++ b/src/response/headers.rs
@@ -1,11 +1,14 @@
 use super::IntoResponse;
-use crate::body::{box_body, BoxBody};
+use crate::{
+    body::{box_body, BoxBody},
+    BoxError,
+};
 use bytes::Bytes;
 use http::header::{HeaderMap, HeaderName, HeaderValue};
 use http::{Response, StatusCode};
 use http_body::{Body, Full};
 use std::{convert::TryInto, fmt};
-use tower::{util::Either, BoxError};
+use tower::util::Either;
 
 /// A response with headers.
 ///

--- a/src/response/mod.rs
+++ b/src/response/mod.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     body::{box_body, BoxBody},
-    Error,
+    BoxError, Error,
 };
 use bytes::Bytes;
 use http::{header, HeaderMap, HeaderValue, Response, StatusCode};
@@ -11,7 +11,6 @@ use http_body::{
     Empty, Full,
 };
 use std::{borrow::Cow, convert::Infallible};
-use tower::{util::Either, BoxError};
 
 mod headers;
 mod redirect;
@@ -151,22 +150,6 @@ impl IntoResponse for Infallible {
 
     fn into_response(self) -> Response<Self::Body> {
         match self {}
-    }
-}
-
-impl<T, K> IntoResponse for Either<T, K>
-where
-    T: IntoResponse,
-    K: IntoResponse,
-{
-    type Body = BoxBody;
-    type BodyError = Error;
-
-    fn into_response(self) -> Response<Self::Body> {
-        match self {
-            Either::A(inner) => inner.into_response().map(box_body),
-            Either::B(inner) => inner.into_response().map(box_body),
-        }
     }
 }
 

--- a/src/response/sse.rs
+++ b/src/response/sse.rs
@@ -28,6 +28,7 @@
 //! ```
 
 use crate::response::IntoResponse;
+use crate::BoxError;
 use bytes::Bytes;
 use futures_util::{
     ready,
@@ -48,7 +49,6 @@ use std::{
 };
 use sync_wrapper::SyncWrapper;
 use tokio::time::Sleep;
-use tower::BoxError;
 
 /// Create a new [`Sse`] response that will respond with the given stream of
 /// [`Event`]s.

--- a/src/routing/future.rs
+++ b/src/routing/future.rs
@@ -1,10 +1,11 @@
 //! Future types.
 
-use crate::{body::BoxBody, buffer::MpscBuffer, routing::FromEmptyRouter};
+use crate::{body::BoxBody, buffer::MpscBuffer, routing::FromEmptyRouter, BoxError};
 use futures_util::ready;
 use http::{Request, Response};
 use pin_project_lite::pin_project;
 use std::{
+    convert::Infallible,
     fmt,
     future::Future,
     pin::Pin,
@@ -12,8 +13,9 @@ use std::{
 };
 use tower::{
     util::{BoxService, Oneshot},
-    BoxError, Service, ServiceExt,
+    ServiceExt,
 };
+use tower_service::Service;
 
 pub use super::or::ResponseFuture as OrResponseFuture;
 
@@ -178,4 +180,10 @@ where
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         self.project().inner.poll(cx)
     }
+}
+
+opaque_future! {
+    /// Response future from [`MakeRouteService`] services.
+    pub type MakeRouteServiceFuture<S> =
+        futures_util::future::Ready<Result<S, Infallible>>;
 }

--- a/src/routing/or.rs
+++ b/src/routing/or.rs
@@ -10,7 +10,8 @@ use std::{
     pin::Pin,
     task::{Context, Poll},
 };
-use tower::{util::Oneshot, Service, ServiceExt};
+use tower::{util::Oneshot, ServiceExt};
+use tower_service::Service;
 
 /// [`tower::Service`] that is the combination of two routers.
 ///

--- a/src/service/future.rs
+++ b/src/service/future.rs
@@ -4,6 +4,7 @@ use crate::{
     body::{box_body, BoxBody},
     response::IntoResponse,
     util::{Either, EitherProj},
+    BoxError,
 };
 use bytes::Bytes;
 use futures_util::ready;
@@ -15,7 +16,8 @@ use std::{
     pin::Pin,
     task::{Context, Poll},
 };
-use tower::{util::Oneshot, BoxError, Service};
+use tower::util::Oneshot;
+use tower_service::Service;
 
 pin_project! {
     /// Response future for [`HandleError`](super::HandleError).

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -96,6 +96,7 @@
 //! [`Redirect`]: tower_http::services::Redirect
 //! [load shed]: tower::load_shed
 
+use crate::BoxError;
 use crate::{
     body::BoxBody,
     response::IntoResponse,
@@ -108,7 +109,8 @@ use std::{
     marker::PhantomData,
     task::{Context, Poll},
 };
-use tower::{util::Oneshot, BoxError, Service, ServiceExt as _};
+use tower::{util::Oneshot, ServiceExt as _};
+use tower_service::Service;
 
 pub mod future;
 

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::blacklisted_name)]
 
+use crate::BoxError;
 use crate::{
     extract,
     handler::{any, delete, get, on, patch, post, Handler},
@@ -23,7 +24,8 @@ use std::{
     task::{Context, Poll},
     time::Duration,
 };
-use tower::{make::Shared, service_fn, BoxError, Service};
+use tower::{make::Shared, service_fn};
+use tower_service::Service;
 
 mod get_to_head;
 mod handle_error;

--- a/src/tests/or.rs
+++ b/src/tests/or.rs
@@ -1,9 +1,7 @@
+use super::*;
+use crate::{extract::OriginalUri, response::IntoResponse, Json};
 use serde_json::{json, Value};
 use tower::{limit::ConcurrencyLimitLayer, timeout::TimeoutLayer};
-
-use crate::{extract::OriginalUri, response::IntoResponse, Json};
-
-use super::*;
 
 #[tokio::test]
 async fn basic() {


### PR DESCRIPTION
Instead rely on `tower-service` and `tower-layer`. `tower` itself is
only used internally.

Fixes https://github.com/tokio-rs/axum/issues/186