### PR TITLE
Use `std::future::ready`

### DIFF
--- a/src/extract/connect_info.rs
+++ b/src/extract/connect_info.rs
@@ -7,6 +7,7 @@
 use super::{Extension, FromRequest, RequestParts};
 use async_trait::async_trait;
 use hyper::server::conn::AddrStream;
+use std::future::ready;
 use std::{
     convert::Infallible,
     fmt,
@@ -90,7 +91,7 @@ where
         let connect_info = ConnectInfo(C::connect_info(target));
         let svc = AddExtension::new(self.svc.clone(), connect_info);
         ResponseFuture {
-            future: futures_util::future::ok(svc),
+            future: ready(Ok(svc)),
         }
     }
 }
@@ -98,7 +99,7 @@ where
 opaque_future! {
     /// Response future for [`IntoMakeServiceWithConnectInfo`].
     pub type ResponseFuture<T> =
-        futures_util::future::Ready<Result<T, Infallible>>;
+        std::future::Ready<Result<T, Infallible>>;
 }
 
 /// Extractor for getting connection information produced by a [`Connected`].

--- a/src/routing/future.rs
+++ b/src/routing/future.rs
@@ -22,7 +22,7 @@ pub use super::or::ResponseFuture as OrResponseFuture;
 opaque_future! {
     /// Response future for [`EmptyRouter`](super::EmptyRouter).
     pub type EmptyRouterFuture<E> =
-        futures_util::future::Ready<Result<Response<BoxBody>, E>>;
+        std::future::Ready<Result<Response<BoxBody>, E>>;
 }
 
 pin_project! {
@@ -185,5 +185,5 @@ where
 opaque_future! {
     /// Response future from [`MakeRouteService`] services.
     pub type MakeRouteServiceFuture<S> =
-        futures_util::future::Ready<Result<S, Infallible>>;
+        std::future::Ready<Result<S, Infallible>>;
 }

--- a/src/routing/mod.rs
+++ b/src/routing/mod.rs
@@ -19,6 +19,7 @@ use std::{
     borrow::Cow,
     convert::Infallible,
     fmt,
+    future::ready,
     marker::PhantomData,
     sync::Arc,
     task::{Context, Poll},
@@ -713,7 +714,7 @@ where
 
         *res.status_mut() = self.status;
         EmptyRouterFuture {
-            future: futures_util::future::ok(res),
+            future: ready(Ok(res)),
         }
     }
 }
@@ -1050,7 +1051,7 @@ where
 
     fn call(&mut self, _target: T) -> Self::Future {
         future::MakeRouteServiceFuture {
-            future: futures_util::future::ready(Ok(self.service.clone())),
+            future: ready(Ok(self.service.clone())),
         }
     }
 }

--- a/src/tests/handle_error.rs
+++ b/src/tests/handle_error.rs
@@ -1,5 +1,5 @@
 use super::*;
-use futures_util::future::{pending, ready};
+use std::future::{pending, ready};
 use tower::{timeout::TimeoutLayer, MakeService};
 
 async fn unit() {}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -9,7 +9,6 @@ use crate::{
     service, Router,
 };
 use bytes::Bytes;
-use futures_util::future::Ready;
 use http::{
     header::{HeaderMap, AUTHORIZATION},
     Request, Response, StatusCode, Uri,
@@ -17,9 +16,11 @@ use http::{
 use hyper::{Body, Server};
 use serde::Deserialize;
 use serde_json::json;
+use std::future::Ready;
 use std::{
     collections::HashMap,
     convert::Infallible,
+    future::ready,
     net::{SocketAddr, TcpListener},
     task::{Context, Poll},
     time::Duration,
@@ -550,7 +551,7 @@ async fn wrong_method_service() {
         }
 
         fn call(&mut self, _req: R) -> Self::Future {
-            futures_util::future::ok(Response::new(http_body::Empty::new()))
+            ready(Ok(Response::new(http_body::Empty::new())))
         }
     }
 


### PR DESCRIPTION
`std::future::ready` has been stable since 1.48 so since axum's MSRV is
1.51 we can use this rather the one from `futures_util`.