### PR TITLE
Rename `extract::Body` to `extract::RawBody`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `tower::make::Shared` ([#229](https://github.com/tokio-rs/axum/pull/229))
 - All usage of `tower::BoxError` has been replaced with `axum::BoxError` ([#229](https://github.com/tokio-rs/axum/pull/229))
 - `tower::util::Either` no longer implements `IntoResponse` ([#229](https://github.com/tokio-rs/axum/pull/229))
+- `extract::Body` has been renamed to `extract::RawBody` to avoid conflicting
+  with `body::Body`
 - These future types have been moved
     - `extract::extractor_middleware::ExtractorMiddlewareResponseFuture` moved
       to `extract::extractor_middleware::future::ResponseFuture` ([#133](https://github.com/tokio-rs/axum/pull/133))

--- a/src/extract/mod.rs
+++ b/src/extract/mod.rs
@@ -254,7 +254,7 @@
 //!         "/body",
 //!         // `extract::Body` defaults to `axum::body::Body`
 //!         // but can be customized
-//!         get(|_: extract::Body<MyBody<Body>>| async {})
+//!         get(|_: extract::RawBody<MyBody<Body>>| async {})
 //!     )
 //!     .route(
 //!         "/body-stream",
@@ -310,7 +310,7 @@ pub use self::{
     query::Query,
     raw_query::RawQuery,
     request_parts::OriginalUri,
-    request_parts::{Body, BodyStream},
+    request_parts::{BodyStream, RawBody},
 };
 #[doc(no_inline)]
 pub use crate::Json;

--- a/src/extract/request_parts.rs
+++ b/src/extract/request_parts.rs
@@ -46,7 +46,7 @@ where
 }
 
 #[async_trait]
-impl<B> FromRequest<B> for Body<B>
+impl<B> FromRequest<B> for RawBody<B>
 where
     B: Send,
 {
@@ -219,19 +219,19 @@ where
     }
 }
 
-/// Extractor that extracts the request body.
+/// Extractor that extracts the raw request body.
 ///
 /// # Example
 ///
 /// ```rust,no_run
 /// use axum::{
-///     extract::Body,
+///     extract::RawBody,
 ///     handler::get,
 ///     Router,
 /// };
 /// use futures::StreamExt;
 ///
-/// async fn handler(Body(body): Body) {
+/// async fn handler(RawBody(body): RawBody) {
 ///     // ...
 /// }
 ///
@@ -241,7 +241,7 @@ where
 /// # };
 /// ```
 #[derive(Debug, Default, Clone)]
-pub struct Body<B = crate::body::Body>(pub B);
+pub struct RawBody<B = crate::body::Body>(pub B);
 
 #[async_trait]
 impl<B> FromRequest<B> for Bytes


### PR DESCRIPTION
To avoid conflicts with `axum::body::Body`.