### PR TITLE
Remove generic parameter from `BodyStream`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `tower::make::Shared` ([#229](https://github.com/tokio-rs/axum/pull/229))
 - All usage of `tower::BoxError` has been replaced with `axum::BoxError` ([#229](https://github.com/tokio-rs/axum/pull/229))
 - `tower::util::Either` no longer implements `IntoResponse` ([#229](https://github.com/tokio-rs/axum/pull/229))
+- `extract::BodyStream` is no longer generic over the request body ([#234](https://github.com/tokio-rs/axum/pull/234))
 - These future types have been moved
     - `extract::extractor_middleware::ExtractorMiddlewareResponseFuture` moved
       to `extract::extractor_middleware::future::ResponseFuture` ([#133](https://github.com/tokio-rs/axum/pull/133))

--- a/src/extract/mod.rs
+++ b/src/extract/mod.rs
@@ -259,7 +259,7 @@
 //!     .route(
 //!         "/body-stream",
 //!         // same for `extract::BodyStream`
-//!         get(|_: extract::BodyStream<MyBody<Body>>| async {}),
+//!         get(|_: extract::BodyStream| async {}),
 //!     )
 //!     .route(
 //!         // and `Request<_>`

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -698,3 +698,6 @@ where
 
     addr
 }
+
+pub(crate) fn assert_send<T: Send>() {}
+pub(crate) fn assert_sync<T: Sync>() {}


### PR DESCRIPTION
I think `BodyStream` is more useful without being generic over the
request body.

I'm also looking into adding a response body from a stream called
`StreamBody` which will work pretty much opposite to this.