### PR TITLE
Add `StreamBody`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support matching different HTTP methods for the same route that aren't defined
   together. So `Router::new().route("/", get(...)).route("/", post(...))` now
   accepts both `GET` and `POST`. Previously only `POST` would be accepted ([#224](https://github.com/tokio-rs/axum/pull/224))
+- Add `body::StreamBody` for easily responding with a stream of byte chunks
 
 ## Breaking changes
 

--- a/src/body.rs
+++ b/src/body.rs
@@ -3,6 +3,10 @@
 use crate::BoxError;
 use crate::Error;
 
+mod stream_body;
+
+pub use self::stream_body::StreamBody;
+
 #[doc(no_inline)]
 pub use http_body::{Body as HttpBody, Empty, Full};
 

--- a/src/body/stream_body.rs
+++ b/src/body/stream_body.rs
@@ -1,0 +1,102 @@
+use crate::{BoxError, Error};
+use bytes::Bytes;
+use futures_util::stream::{self, Stream, TryStreamExt};
+use http::HeaderMap;
+use http_body::Body;
+use std::convert::Infallible;
+use std::{
+    fmt,
+    pin::Pin,
+    task::{Context, Poll},
+};
+use sync_wrapper::SyncWrapper;
+
+/// An [`http_body::Body`] created from a [`Stream`].
+///
+/// # Example
+///
+/// ```
+/// use axum::{
+///     Router,
+///     handler::get,
+///     body::StreamBody,
+/// };
+/// use futures::stream;
+///
+/// async fn handler() -> StreamBody {
+///     let chunks: Vec<Result<_, std::io::Error>> = vec![
+///         Ok("Hello,"),
+///         Ok(" "),
+///         Ok("world!"),
+///     ];
+///     let stream = stream::iter(chunks);
+///     StreamBody::new(stream)
+/// }
+///
+/// let app = Router::new().route("/", get(handler));
+/// # async {
+/// # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
+/// # };
+/// ```
+///
+/// [`Stream`]: futures_util::stream::Stream
+// this should probably be extracted to `http_body`, eventually...
+pub struct StreamBody {
+    stream: SyncWrapper<Pin<Box<dyn Stream<Item = Result<Bytes, Error>> + Send>>>,
+}
+
+impl StreamBody {
+    /// Create a new `StreamBody` from a [`Stream`].
+    ///
+    /// [`Stream`]: futures_util::stream::Stream
+    pub fn new<S, T, E>(stream: S) -> Self
+    where
+        S: Stream<Item = Result<T, E>> + Send + 'static,
+        T: Into<Bytes> + 'static,
+        E: Into<BoxError> + 'static,
+    {
+        let stream = stream
+            .map_ok(Into::into)
+            .map_err(|err| Error::new(err.into()));
+        Self {
+            stream: SyncWrapper::new(Box::pin(stream)),
+        }
+    }
+}
+
+impl Default for StreamBody {
+    fn default() -> Self {
+        Self::new(stream::empty::<Result<Bytes, Infallible>>())
+    }
+}
+
+impl fmt::Debug for StreamBody {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("StreamBody").finish()
+    }
+}
+
+impl Body for StreamBody {
+    type Data = Bytes;
+    type Error = Error;
+
+    fn poll_data(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Self::Data, Self::Error>>> {
+        Pin::new(self.stream.get_mut()).poll_next(cx)
+    }
+
+    fn poll_trailers(
+        self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+    ) -> Poll<Result<Option<HeaderMap>, Self::Error>> {
+        Poll::Ready(Ok(None))
+    }
+}
+
+#[test]
+fn stream_body_traits() {
+    crate::tests::assert_send::<StreamBody>();
+    crate::tests::assert_sync::<StreamBody>();
+}

--- a/src/body/stream_body.rs
+++ b/src/body/stream_body.rs
@@ -99,4 +99,5 @@ impl Body for StreamBody {
 fn stream_body_traits() {
     crate::tests::assert_send::<StreamBody>();
     crate::tests::assert_sync::<StreamBody>();
+    crate::tests::assert_unpin::<StreamBody>();
 }

--- a/src/response/mod.rs
+++ b/src/response/mod.rs
@@ -198,6 +198,7 @@ macro_rules! impl_into_response_for_body {
 impl_into_response_for_body!(hyper::Body);
 impl_into_response_for_body!(Full<Bytes>);
 impl_into_response_for_body!(Empty<Bytes>);
+impl_into_response_for_body!(crate::body::StreamBody);
 
 impl<E> IntoResponse for http_body::combinators::BoxBody<Bytes, E>
 where

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -701,3 +701,4 @@ where
 
 pub(crate) fn assert_send<T: Send>() {}
 pub(crate) fn assert_sync<T: Sync>() {}
+pub(crate) fn assert_unpin<T: Unpin>() {}


### PR DESCRIPTION
This adds `StreamBody` which converts a `Stream` of `Bytes` into a `http_body::Body`.

---

As suggested by @Kestrer on Discord it would make sense for axum to provide different kinds of body types other than `Empty`, `Full`, and `hyper::Body`. There is also some talk about [splitting up `hyper::Body`](https://github.com/hyperium/hyper/issues/2345) so this can be seen as getting started on that effort. axum's body types could be moved to hyper or http-body if thats the direction we decide on.

The types I'm thinking about adding are:

- `StreamBody`-  added in this PR
- `AsyncReadBody` - similar to [http-body#41](https://github.com/hyperium/http-body/pull/41/files)
- `ChannelBody` - similar to `hyper::Body::channel`