### PR TITLE
Add constructor to `Sse`

### DIFF
--- a/examples/sse/src/main.rs
+++ b/examples/sse/src/main.rs
@@ -8,7 +8,7 @@ use axum::{
     extract::TypedHeader,
     handler::get,
     http::StatusCode,
-    response::sse::{sse, Event, Sse},
+    response::sse::{Event, Sse},
     Router,
 };
 use futures::stream::{self, Stream};
@@ -59,5 +59,5 @@ async fn sse_handler(
         .map(Ok)
         .throttle(Duration::from_secs(1));
 
-    sse(stream)
+    Sse::new(stream)
 }

--- a/src/response/mod.rs
+++ b/src/response/mod.rs
@@ -21,11 +21,7 @@ pub mod sse;
 pub use crate::Json;
 
 #[doc(inline)]
-pub use self::{
-    headers::Headers,
-    redirect::Redirect,
-    sse::{sse, Sse},
-};
+pub use self::{headers::Headers, redirect::Redirect, sse::Sse};
 
 /// Trait for generating responses.
 ///


### PR DESCRIPTION
I think this is more consistent with the rest of the API.