### PR TITLE
Fix URI captures matching empty segments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
+Just me testing auto-merge
+
 - **fixed:** Fix URI captures matching empty segments. This means requests with
   URI `/` will no longer be matched by `/:key` ([#264](https://github.com/tokio-rs/axum/pull/264))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
-- **fixed:** Fix URI captures matching empty segments. This mean requests with
-  URI `/` will no longer be matched by `/:key`
+- **fixed:** Fix URI captures matching empty segments. This means requests with
+  URI `/` will no longer be matched by `/:key` ([#264](https://github.com/tokio-rs/axum/pull/264))
 
 # 0.2.1 (24. August, 2021)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
-- 👀
+- **fixed:** Fix URI captures matching empty segments. This mean requests with
+  URI `/` will no longer be matched by `/:key`
 
 # 0.2.1 (24. August, 2021)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
-Just me testing auto-merge
-
 - **fixed:** Fix URI captures matching empty segments. This means requests with
   URI `/` will no longer be matched by `/:key` ([#264](https://github.com/tokio-rs/axum/pull/264))
 

--- a/src/routing/mod.rs
+++ b/src/routing/mod.rs
@@ -765,7 +765,7 @@ impl PathPattern {
                 if let Some(key) = part.strip_prefix(':') {
                     capture_group_names.push(Bytes::copy_from_slice(key.as_bytes()));
 
-                    Cow::Owned(format!("(?P<{}>[^/]*)", key))
+                    Cow::Owned(format!("(?P<{}>[^/]+)", key))
                 } else {
                     Cow::Borrowed(part)
                 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -672,6 +672,25 @@ async fn when_multiple_routes_match() {
     assert_eq!(res.status(), StatusCode::OK);
 }
 
+#[tokio::test]
+async fn captures_dont_match_empty_segments() {
+    let app = Router::new().route("/:key", get(|| async {}));
+
+    let addr = run_in_background(app).await;
+
+    let client = reqwest::Client::new();
+
+    let res = client.get(format!("http://{}", addr)).send().await.unwrap();
+    assert_eq!(res.status(), StatusCode::NOT_FOUND);
+
+    let res = client
+        .get(format!("http://{}/foo", addr))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+}
+
 /// Run a `tower::Service` in the background and get a URI for it.
 pub(crate) async fn run_in_background<S, ResBody>(svc: S) -> SocketAddr
 where


### PR DESCRIPTION
It was never the intention that `/:key` should match `/`. This fixes that.

Part of https://github.com/tokio-rs/axum/issues/259