### PR TITLE
Remove needless traits bounds from `Router::boxed`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **fixed:** Fix URI captures matching empty segments. This means requests with
   URI `/` will no longer be matched by `/:key` ([#264](https://github.com/tokio-rs/axum/pull/264))
+- **fixed:** Remove needless trait bounds from `Router::boxed` ([#264](https://github.com/tokio-rs/axum/pull/264))
 
 # 0.2.1 (24. August, 2021)
 

--- a/src/routing/mod.rs
+++ b/src/routing/mod.rs
@@ -257,12 +257,11 @@ impl<S> Router<S> {
     pub fn boxed<ReqBody, ResBody>(self) -> Router<BoxRoute<ReqBody, S::Error>>
     where
         S: Service<Request<ReqBody>, Response = Response<ResBody>> + Send + 'static,
-        S::Error: Into<BoxError> + Send + Sync,
+        S::Error: Into<BoxError> + Send,
         S::Future: Send,
-        ReqBody: http_body::Body<Data = Bytes> + Send + Sync + 'static,
-        ReqBody::Error: Into<BoxError> + Send + Sync + 'static,
+        ReqBody: Send + 'static,
         ResBody: http_body::Body<Data = Bytes> + Send + Sync + 'static,
-        ResBody::Error: Into<BoxError> + Send + Sync + 'static,
+        ResBody::Error: Into<BoxError>,
     {
         self.map(|svc| {
             ServiceBuilder::new()


### PR DESCRIPTION
Turns out these bounds weren't actually needed.

I was hoping it would speed up compile times but that isn't the case.

I don't suppose removing trait bounds is a breaking change :thinking: