### PR TITLE
Change return type to be able use html tag

### DIFF
--- a/examples/hello-world/src/main.rs
+++ b/examples/hello-world/src/main.rs
@@ -4,7 +4,7 @@
 //! cargo run -p example-hello-world
 //! ```
 
-use axum::{handler::get, Router};
+use axum::{handler::get, response::Html, Router};
 use std::net::SocketAddr;
 
 #[tokio::main]
@@ -21,6 +21,6 @@ async fn main() {
         .unwrap();
 }
 
-async fn handler() -> &'static str {
-    "<h1>Hello, World!</h1>"
+async fn handler() -> Html<&'static str> {
+    Html("<h1>Hello, World!</h1>")
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation
Seeing documents (https://docs.rs/axum/0.2.3/axum/#building-responses), It looks like we should return `Html<&'static str>` instead of `&'static str`, if we would like to use html tag.

Function returning "\<h1\>Hello, World!\</h1\>" with return type `&'static str` displays contents like as follows. I think this is not expected behavior.
![Screenshot from 2021-08-27 02-29-43](https://user-images.githubusercontent.com/10243002/131009810-f33b4bbd-8cad-4d3c-b426-783deab2e01a.png)

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution
Change return type to be able use html tag

I'm not familiar with OSS contribution. Please let me know if I took a mistake or something rude on Pull Request creating.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
