### PR TITLE
Expose hyper's http2 feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = ["examples/*"]
 
 [features]
 default = ["tower-log"]
+http2 = ["hyper/http2"]
 multipart = ["multer", "mime"]
 tower-log = ["tower/log"]
 ws = ["tokio-tungstenite", "sha-1", "base64"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -939,6 +939,7 @@
 //! The following optional features are available:
 //!
 //! - `headers`: Enables extracting typed headers via [`extract::TypedHeader`].
+//! - `http2`: Enables hyper's `http2` feature.
 //! - `multipart`: Enables parsing `multipart/form-data` requests with [`extract::Multipart`].
 //! - `tower-log`: Enables `tower`'s `log` feature. Enabled by default.
 //! - `ws`: Enables WebSockets support via [`extract::ws`].


### PR DESCRIPTION
## Motivation

So you don't have to depend on hyper explicitly to enable this feature.

## Solution

What the title says.

## Notes

I think the the http1 feature on hyper should be made optional in axum 0.3.0, but be part of the `default` feature set, so users can opt into http2-only operation.