### PR TITLE
Make JSON and HTTP1 support optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,8 @@ version = "0.2.3"
 members = ["examples/*"]
 
 [features]
-default = ["json", "tower-log"]
+default = ["http1", "json", "tower-log"]
+http1 = ["hyper/http1"]
 http2 = ["hyper/http2"]
 json = ["serde_json"]
 multipart = ["multer", "mime"]
@@ -29,7 +30,7 @@ bytes = "1.0"
 futures-util = { version = "0.3", default-features = false, features = ["alloc"] }
 http = "0.2"
 http-body = "0.4.3"
-hyper = { version = "0.14", features = ["server", "tcp", "http1", "stream"] }
+hyper = { version = "0.14", features = ["server", "tcp", "stream"] }
 pin-project-lite = "0.2.7"
 regex = "1.5"
 serde = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,9 @@ version = "0.2.3"
 members = ["examples/*"]
 
 [features]
-default = ["tower-log"]
+default = ["json", "tower-log"]
 http2 = ["hyper/http2"]
+json = ["serde_json"]
 multipart = ["multer", "mime"]
 tower-log = ["tower/log"]
 ws = ["tokio-tungstenite", "sha-1", "base64"]
@@ -32,7 +33,7 @@ hyper = { version = "0.14", features = ["server", "tcp", "http1", "stream"] }
 pin-project-lite = "0.2.7"
 regex = "1.5"
 serde = "1.0"
-serde_json = "1.0"
+serde_json = { version = "1.0", optional = true }
 serde_urlencoded = "0.7"
 tokio = { version = "1", features = ["time"] }
 tokio-util = "0.6"
@@ -54,6 +55,7 @@ mime = { optional = true, version = "0.3" }
 futures = "0.3"
 reqwest = { version = "0.11", features = ["json", "stream"] }
 serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 tokio = { version = "1.6.1", features = ["macros", "rt", "rt-multi-thread", "net"] }
 uuid = { version = "0.8", features = ["serde", "v4"] }
 tokio-stream = "0.1"

--- a/src/extract/mod.rs
+++ b/src/extract/mod.rs
@@ -313,6 +313,7 @@ pub use self::{
     request_parts::{BodyStream, RawBody},
 };
 #[doc(no_inline)]
+#[cfg(feature = "json")]
 pub use crate::Json;
 
 #[cfg(feature = "multipart")]

--- a/src/extract/rejection.rs
+++ b/src/extract/rejection.rs
@@ -25,9 +25,11 @@ define_rejection! {
     pub struct HeadersAlreadyExtracted;
 }
 
+#[cfg(feature = "json")]
 define_rejection! {
     #[status = BAD_REQUEST]
     #[body = "Failed to parse the request body as JSON"]
+    #[cfg_attr(docsrs, doc(cfg(feature = "json")))]
     /// Rejection type for [`Json`](super::Json).
     pub struct InvalidJsonBody(Error);
 }
@@ -199,11 +201,13 @@ composite_rejection! {
     }
 }
 
+#[cfg(feature = "json")]
 composite_rejection! {
     /// Rejection used for [`Json`](super::Json).
     ///
     /// Contains one variant for each way the [`Json`](super::Json) extractor
     /// can fail.
+    #[cfg_attr(docsrs, doc(cfg(feature = "json")))]
     pub enum JsonRejection {
         InvalidJsonBody,
         MissingJsonContentType,

--- a/src/json.rs
+++ b/src/json.rs
@@ -17,10 +17,10 @@ use std::{
     ops::{Deref, DerefMut},
 };
 
-/// JSON Extractor/Response
+/// JSON Extractor / Response.
 ///
 /// When used as an extractor, it can deserialize request bodies into some type that
-/// implements [`serde::Serialize`]. If the request body cannot be parsed, or it does not contain
+/// implements [`serde::Deserialize`]. If the request body cannot be parsed, or it does not contain
 /// the `Content-Type: application/json` header, it will reject the request and return a
 /// `400 Bad Request` response.
 ///

--- a/src/json.rs
+++ b/src/json.rs
@@ -87,6 +87,7 @@ use std::{
 /// # };
 /// ```
 #[derive(Debug, Clone, Copy, Default)]
+#[cfg_attr(docsrs, doc(cfg(feature = "json")))]
 pub struct Json<T>(pub T);
 
 #[async_trait]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -940,6 +940,8 @@
 //!
 //! - `headers`: Enables extracting typed headers via [`extract::TypedHeader`].
 //! - `http2`: Enables hyper's `http2` feature.
+//! - `json`: Enables the [`Json`] type and some similar convenience functionality.
+//!   Enabled by default.
 //! - `multipart`: Enables parsing `multipart/form-data` requests with [`extract::Multipart`].
 //! - `tower-log`: Enables `tower`'s `log` feature. Enabled by default.
 //! - `ws`: Enables WebSockets support via [`extract::ws`].
@@ -1007,6 +1009,7 @@ pub(crate) mod macros;
 
 mod buffer;
 mod error;
+#[cfg(feature = "json")]
 mod json;
 mod util;
 
@@ -1030,7 +1033,10 @@ pub use hyper::Server;
 pub use tower_http::add_extension::{AddExtension, AddExtensionLayer};
 
 #[doc(inline)]
-pub use self::{error::Error, json::Json, routing::Router};
+#[cfg(feature = "json")]
+pub use self::json::Json;
+#[doc(inline)]
+pub use self::{error::Error, routing::Router};
 
 /// Alias for a type-erased error type.
 pub type BoxError = Box<dyn std::error::Error + Send + Sync>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -939,6 +939,7 @@
 //! The following optional features are available:
 //!
 //! - `headers`: Enables extracting typed headers via [`extract::TypedHeader`].
+//! - `http1`: Enables hyper's `http1` feature. Enabled by default.
 //! - `http2`: Enables hyper's `http2` feature.
 //! - `json`: Enables the [`Json`] type and some similar convenience functionality.
 //!   Enabled by default.

--- a/src/response/mod.rs
+++ b/src/response/mod.rs
@@ -18,6 +18,7 @@ mod redirect;
 pub mod sse;
 
 #[doc(no_inline)]
+#[cfg(feature = "json")]
 pub use crate::Json;
 
 #[doc(inline)]

--- a/src/response/sse.rs
+++ b/src/response/sse.rs
@@ -37,7 +37,6 @@ use futures_util::{
 use http::Response;
 use http_body::Body as HttpBody;
 use pin_project_lite::pin_project;
-use serde::Serialize;
 use std::{
     borrow::Cow,
     fmt,
@@ -181,6 +180,7 @@ pub struct Event {
 #[derive(Debug)]
 enum DataType {
     Text(String),
+    #[cfg(feature = "json")]
     Json(String),
 }
 
@@ -197,9 +197,11 @@ impl Event {
 
     /// Set Server-sent event data
     /// data field(s) ("data:<content>")
+    #[cfg(feature = "json")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "json")))]
     pub fn json_data<T>(mut self, data: T) -> Result<Event, serde_json::Error>
     where
-        T: Serialize,
+        T: serde::Serialize,
     {
         self.data = Some(DataType::Json(serde_json::to_string(&data)?));
         Ok(self)
@@ -265,6 +267,7 @@ impl fmt::Display for Event {
                     f.write_char('\n')?;
                 }
             }
+            #[cfg(feature = "json")]
             Some(DataType::Json(data)) => {
                 "data:".fmt(f)?;
                 data.fmt(f)?;


### PR DESCRIPTION
This is a breaking change because it changes the API surface for users who use `default-features = false`.