### PR TITLE
Add very basic validation to the `form` example

### DIFF
--- a/examples/form/Cargo.toml
+++ b/examples/form/Cargo.toml
@@ -10,3 +10,4 @@ tokio = { version = "1.0", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = "0.2"
 serde = { version = "1.0", features = ["derive"] }
+validator = { version = "0.14", features = ["derive"] }

--- a/examples/form/src/main.rs
+++ b/examples/form/src/main.rs
@@ -36,7 +36,7 @@ async fn show_form(errors: Option<String>) -> Html<String> {
         <html>
             <head></head>
             <body>
-                <!-- In a more realistic application we would need to make sure things are properly escaped -->
+                <!-- In a more realistic application we would use a templating language (see templates example) -->
                 <pre>{}</pre>
                 <form action="/" method="post">
                     <label for="name">
@@ -71,7 +71,7 @@ async fn accept_form(Form(input): Form<Input>) -> Html<String> {
     match input.validate() {
         Ok(_) => String::from("Form submitted successfully!").into(),
         // Here the validation errors are presented as-is. In a more realistic
-        // application we would need to customize/process the validation errors to be able to
+        // application we would customize / process the validation errors to be able to
         // show to the user in a way that they could understand it
         Err(e) => show_form(Some(format!("Form error: {}", e))).await,
     }


### PR DESCRIPTION
All HTML forms inevitably have some sort of validation. 

This PR adds very basic form validation for the `form` example using the [validator](https://docs.rs/validator/0.14.0/validator/) crate (validator crate originally suggested by @jplatte at https://github.com/tokio-rs/axum/discussions/295#discussioncomment-1258438 )

Please let me know if this is a useful addition. If things are not done in an idiomatic fashion, please suggest how I can make them better...
