### PR TITLE
reverse routing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,7 +165,7 @@
 //! // since its defined last.
 //! let (status, body) = call_service(&mut app, Method::GET, "/foo").await;
 //! assert_eq!(status, StatusCode::OK);
-//! assert_eq!(body, "/:key called");
+//! assert_eq!(body, "/foo called");
 //!
 //! // We have to add `/foo` after `/:key` since routes are matched bottom to
 //! // top.
@@ -176,7 +176,7 @@
 //! // Now it works
 //! let (status, body) = call_service(&mut new_app, Method::GET, "/foo").await;
 //! assert_eq!(status, StatusCode::OK);
-//! assert_eq!(body, "/foo called");
+//! assert_eq!(body, "/:key called");
 //!
 //! // And the other route works as well
 //! let (status, body) = call_service(&mut new_app, Method::GET, "/bar").await;

--- a/src/routing/mod.rs
+++ b/src/routing/mod.rs
@@ -123,11 +123,14 @@ impl<S> Router<S> {
     /// # Panics
     ///
     /// Panics if `path` doesn't start with `/`.
-    pub fn route<T>(self, path: &str, svc: T) -> Router<Route<T, S>> {
-        self.map(|fallback| Route {
-            pattern: PathPattern::new(path),
-            svc,
-            fallback,
+    pub fn route<T, E>(self, path: &str, svc: T) -> Router<Or<S, Route<T, EmptyRouter<E>>>> {
+        self.map(|previous| Or {
+            first: previous,
+            second: Route {
+                pattern: PathPattern::new(path),
+                svc,
+                fallback: EmptyRouter::not_found(),
+            },
         })
     }
 


### PR DESCRIPTION
Closes issue #259

## Solution

Instead of nesting routing methods using the `fallback`, let's wrap them with `Or`. [Discussion thread on Discord](https://discord.com/channels/500028886025895936/870760546109116496/882726358697017344).

## Pending Tasks

TODO