### PR TITLE
[Docs] add datafuse as community showcase

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -6,3 +6,4 @@ setup as its own crate so its dependencies are clear.
 ## Community showcase
 
 - [Houseflow](https://github.com/gbaranski/houseflow): House automation platform written in Rust.
+- [Datafuse](https://github.com/datafuselabs/datafuse): Cloud native data warehouse written in Rust.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->
Datafuse currently migrated from warp to axum for http services and prometheus metrics services, we think it could be added as another community showcase
Related PR:
https://github.com/datafuselabs/datafuse/pull/1654
https://github.com/datafuselabs/datafuse/pull/1702

