### PR TITLE
migrate all examples to use std::env::var_os instead of std::env::var

### DIFF
--- a/examples/error-handling-and-dependency-injection/src/main.rs
+++ b/examples/error-handling-and-dependency-injection/src/main.rs
@@ -24,7 +24,7 @@ use uuid::Uuid;
 #[tokio::main]
 async fn main() {
     // Set the RUST_LOG, if it hasn't been explicitly defined
-    if std::env::var("RUST_LOG").is_err() {
+    if std::env::var_os("RUST_LOG").is_none() {
         std::env::set_var(
             "RUST_LOG",
             "example_error_handling_and_dependency_injection=debug",

--- a/examples/form/src/main.rs
+++ b/examples/form/src/main.rs
@@ -11,7 +11,7 @@ use std::net::SocketAddr;
 #[tokio::main]
 async fn main() {
     // Set the RUST_LOG, if it hasn't been explicitly defined
-    if std::env::var("RUST_LOG").is_err() {
+    if std::env::var_os("RUST_LOG").is_none() {
         std::env::set_var("RUST_LOG", "example_form=debug")
     }
     tracing_subscriber::fmt::init();

--- a/examples/global-404-handler/src/main.rs
+++ b/examples/global-404-handler/src/main.rs
@@ -15,7 +15,7 @@ use std::net::SocketAddr;
 #[tokio::main]
 async fn main() {
     // Set the RUST_LOG, if it hasn't been explicitly defined
-    if std::env::var("RUST_LOG").is_err() {
+    if std::env::var_os("RUST_LOG").is_none() {
         std::env::set_var("RUST_LOG", "example_global_404_handler=debug")
     }
     tracing_subscriber::fmt::init();

--- a/examples/jwt/src/main.rs
+++ b/examples/jwt/src/main.rs
@@ -56,7 +56,7 @@ static KEYS: Lazy<Keys> = Lazy::new(|| {
 #[tokio::main]
 async fn main() {
     // Set the RUST_LOG, if it hasn't been explicitly defined
-    if std::env::var("RUST_LOG").is_err() {
+    if std::env::var_os("RUST_LOG").is_none() {
         std::env::set_var("RUST_LOG", "example_jwt=debug")
     }
     tracing_subscriber::fmt::init();

--- a/examples/key-value-store/src/main.rs
+++ b/examples/key-value-store/src/main.rs
@@ -32,7 +32,7 @@ use tower_http::{
 #[tokio::main]
 async fn main() {
     // Set the RUST_LOG, if it hasn't been explicitly defined
-    if std::env::var("RUST_LOG").is_err() {
+    if std::env::var_os("RUST_LOG").is_none() {
         std::env::set_var("RUST_LOG", "example_key_value_store=debug,tower_http=debug")
     }
     tracing_subscriber::fmt::init();

--- a/examples/low-level-rustls/src/main.rs
+++ b/examples/low-level-rustls/src/main.rs
@@ -18,7 +18,7 @@ use tokio_rustls::{
 #[tokio::main]
 async fn main() {
     // Set the RUST_LOG, if it hasn't been explicitly defined
-    if std::env::var("RUST_LOG").is_err() {
+    if std::env::var_os("RUST_LOG").is_none() {
         std::env::set_var("RUST_LOG", "example_tls_rustls=debug")
     }
     tracing_subscriber::fmt::init();

--- a/examples/multipart-form/src/main.rs
+++ b/examples/multipart-form/src/main.rs
@@ -15,7 +15,7 @@ use std::net::SocketAddr;
 #[tokio::main]
 async fn main() {
     // Set the RUST_LOG, if it hasn't been explicitly defined
-    if std::env::var("RUST_LOG").is_err() {
+    if std::env::var_os("RUST_LOG").is_none() {
         std::env::set_var("RUST_LOG", "example_multipart_form=debug,tower_http=debug")
     }
     tracing_subscriber::fmt::init();

--- a/examples/oauth/src/main.rs
+++ b/examples/oauth/src/main.rs
@@ -35,7 +35,7 @@ static COOKIE_NAME: &str = "SESSION";
 #[tokio::main]
 async fn main() {
     // Set the RUST_LOG, if it hasn't been explicitly defined
-    if std::env::var("RUST_LOG").is_err() {
+    if std::env::var_os("RUST_LOG").is_none() {
         std::env::set_var("RUST_LOG", "example_oauth=debug")
     }
     tracing_subscriber::fmt::init();

--- a/examples/print-request-response/src/main.rs
+++ b/examples/print-request-response/src/main.rs
@@ -16,7 +16,7 @@ use tower::{filter::AsyncFilterLayer, util::AndThenLayer, BoxError};
 #[tokio::main]
 async fn main() {
     // Set the RUST_LOG, if it hasn't been explicitly defined
-    if std::env::var("RUST_LOG").is_err() {
+    if std::env::var_os("RUST_LOG").is_none() {
         std::env::set_var(
             "RUST_LOG",
             "example_print_request_response=debug,tower_http=debug",

--- a/examples/sessions/src/main.rs
+++ b/examples/sessions/src/main.rs
@@ -24,7 +24,7 @@ use uuid::Uuid;
 #[tokio::main]
 async fn main() {
     // Set the RUST_LOG, if it hasn't been explicitly defined
-    if std::env::var("RUST_LOG").is_err() {
+    if std::env::var_os("RUST_LOG").is_none() {
         std::env::set_var("RUST_LOG", "example_sessions=debug")
     }
     tracing_subscriber::fmt::init();

--- a/examples/sse/src/main.rs
+++ b/examples/sse/src/main.rs
@@ -19,7 +19,7 @@ use tower_http::{services::ServeDir, trace::TraceLayer};
 #[tokio::main]
 async fn main() {
     // Set the RUST_LOG, if it hasn't been explicitly defined
-    if std::env::var("RUST_LOG").is_err() {
+    if std::env::var_os("RUST_LOG").is_none() {
         std::env::set_var("RUST_LOG", "example_sse=debug,tower_http=debug")
     }
     tracing_subscriber::fmt::init();

--- a/examples/static-file-server/src/main.rs
+++ b/examples/static-file-server/src/main.rs
@@ -11,7 +11,7 @@ use tower_http::{services::ServeDir, trace::TraceLayer};
 #[tokio::main]
 async fn main() {
     // Set the RUST_LOG, if it hasn't been explicitly defined
-    if std::env::var("RUST_LOG").is_err() {
+    if std::env::var_os("RUST_LOG").is_none() {
         std::env::set_var(
             "RUST_LOG",
             "example_static_file_server=debug,tower_http=debug",

--- a/examples/templates/src/main.rs
+++ b/examples/templates/src/main.rs
@@ -18,7 +18,7 @@ use std::{convert::Infallible, net::SocketAddr};
 #[tokio::main]
 async fn main() {
     // Set the RUST_LOG, if it hasn't been explicitly defined
-    if std::env::var("RUST_LOG").is_err() {
+    if std::env::var_os("RUST_LOG").is_none() {
         std::env::set_var("RUST_LOG", "example_templates=debug")
     }
     tracing_subscriber::fmt::init();

--- a/examples/testing/src/main.rs
+++ b/examples/testing/src/main.rs
@@ -14,7 +14,7 @@ use tower_http::trace::TraceLayer;
 #[tokio::main]
 async fn main() {
     // Set the RUST_LOG, if it hasn't been explicitly defined
-    if std::env::var("RUST_LOG").is_err() {
+    if std::env::var_os("RUST_LOG").is_none() {
         std::env::set_var("RUST_LOG", "example_testing=debug,tower_http=debug")
     }
     tracing_subscriber::fmt::init();

--- a/examples/tls-rustls/src/main.rs
+++ b/examples/tls-rustls/src/main.rs
@@ -9,7 +9,7 @@ use axum::{handler::get, Router};
 #[tokio::main]
 async fn main() {
     // Set the RUST_LOG, if it hasn't been explicitly defined
-    if std::env::var("RUST_LOG").is_err() {
+    if std::env::var_os("RUST_LOG").is_none() {
         std::env::set_var("RUST_LOG", "example_tls_rustls=debug")
     }
     tracing_subscriber::fmt::init();

--- a/examples/todos/src/main.rs
+++ b/examples/todos/src/main.rs
@@ -35,7 +35,7 @@ use uuid::Uuid;
 #[tokio::main]
 async fn main() {
     // Set the RUST_LOG, if it hasn't been explicitly defined
-    if std::env::var("RUST_LOG").is_err() {
+    if std::env::var_os("RUST_LOG").is_none() {
         std::env::set_var("RUST_LOG", "example_todos=debug,tower_http=debug")
     }
     tracing_subscriber::fmt::init();

--- a/examples/tokio-postgres/src/main.rs
+++ b/examples/tokio-postgres/src/main.rs
@@ -19,7 +19,7 @@ use tokio_postgres::NoTls;
 #[tokio::main]
 async fn main() {
     // Set the RUST_LOG, if it hasn't been explicitly defined
-    if std::env::var("RUST_LOG").is_err() {
+    if std::env::var_os("RUST_LOG").is_none() {
         std::env::set_var("RUST_LOG", "example_tokio_postgres=debug")
     }
     tracing_subscriber::fmt::init();

--- a/examples/tracing-aka-logging/src/main.rs
+++ b/examples/tracing-aka-logging/src/main.rs
@@ -11,7 +11,7 @@ use tower_http::trace::TraceLayer;
 #[tokio::main]
 async fn main() {
     // Set the RUST_LOG, if it hasn't been explicitly defined
-    if std::env::var("RUST_LOG").is_err() {
+    if std::env::var_os("RUST_LOG").is_none() {
         std::env::set_var(
             "RUST_LOG",
             "example_tracing_aka_logging=debug,tower_http=debug",

--- a/examples/unix-domain-socket/src/main.rs
+++ b/examples/unix-domain-socket/src/main.rs
@@ -39,7 +39,7 @@ fn main() {
 #[tokio::main]
 async fn main() {
     // Set the RUST_LOG, if it hasn't been explicitly defined
-    if std::env::var("RUST_LOG").is_err() {
+    if std::env::var_os("RUST_LOG").is_none() {
         std::env::set_var("RUST_LOG", "debug")
     }
     tracing_subscriber::fmt::init();

--- a/examples/versioning/src/main.rs
+++ b/examples/versioning/src/main.rs
@@ -19,7 +19,7 @@ use std::net::SocketAddr;
 #[tokio::main]
 async fn main() {
     // Set the RUST_LOG, if it hasn't been explicitly defined
-    if std::env::var("RUST_LOG").is_err() {
+    if std::env::var_os("RUST_LOG").is_none() {
         std::env::set_var("RUST_LOG", "example_versioning=debug")
     }
     tracing_subscriber::fmt::init();

--- a/examples/websockets/src/main.rs
+++ b/examples/websockets/src/main.rs
@@ -25,7 +25,7 @@ use tower_http::{
 #[tokio::main]
 async fn main() {
     // Set the RUST_LOG, if it hasn't been explicitly defined
-    if std::env::var("RUST_LOG").is_err() {
+    if std::env::var_os("RUST_LOG").is_none() {
         std::env::set_var("RUST_LOG", "example_websockets=debug,tower_http=debug")
     }
     tracing_subscriber::fmt::init();


### PR DESCRIPTION
Fixes #310

