### PR TITLE
Version 0.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - None.
 
+# 0.2.4 (10. September, 2021)
+
+- Document using `StreamExt::split` with `WebSocket` ([#291])
+- Document adding middleware to multiple groups of routes ([#293])
+
+[#291]: https://github.com/tokio-rs/axum/pull/291
+[#293]: https://github.com/tokio-rs/axum/pull/293
+
 # 0.2.3 (26. August, 2021)
 
 - **fixed:** Fix accidental breaking change introduced by internal refactor.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,6 @@
 [package]
+name = "axum"
+version = "0.2.4"
 authors = ["David Pedersen <david.pdrsn@gmail.com>"]
 categories = ["asynchronous", "network-programming", "web-programming"]
 description = "Web framework that focuses on ergonomics and modularity"
@@ -6,10 +8,8 @@ edition = "2018"
 homepage = "https://github.com/tokio-rs/axum"
 keywords = ["http", "web", "framework"]
 license = "MIT"
-name = "axum"
 readme = "README.md"
 repository = "https://github.com/tokio-rs/axum"
-version = "0.2.3"
 
 [workspace]
 members = ["examples/*"]


### PR DESCRIPTION
Contains some documentation improvements:

- Document using `StreamExt::split` with `WebSocket` ([#291])
- Document adding middleware to multiple groups of routes ([#293])

[#291]: https://github.com/tokio-rs/axum/pull/291
[#293]: https://github.com/tokio-rs/axum/pull/293