### PR TITLE
Add accessors to `TypedHeaderRejection` fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
-- None.
+- Add accessors to TypedHeaderRejection fields ([#317])
+
+[#317]: https://github.com/tokio-rs/axum/pull/317
 
 # 0.2.4 (10. September, 2021)
 

--- a/src/extract/rejection.rs
+++ b/src/extract/rejection.rs
@@ -333,4 +333,4 @@ where
 
 #[cfg(feature = "headers")]
 #[cfg_attr(docsrs, doc(cfg(feature = "headers")))]
-pub use super::typed_header::TypedHeaderRejection;
+pub use super::typed_header::{TypedHeaderRejection, TypedHeaderRejectionReason};

--- a/src/extract/typed_header.rs
+++ b/src/extract/typed_header.rs
@@ -48,7 +48,7 @@ where
         } else {
             return Err(TypedHeaderRejection {
                 name: T::name(),
-                reason: Reason::Missing,
+                reason: TypedHeaderRejectionReason::Missing,
             });
         };
 
@@ -56,11 +56,11 @@ where
             Ok(Some(value)) => Ok(Self(value)),
             Ok(None) => Err(TypedHeaderRejection {
                 name: T::name(),
-                reason: Reason::Missing,
+                reason: TypedHeaderRejectionReason::Missing,
             }),
             Err(err) => Err(TypedHeaderRejection {
                 name: T::name(),
-                reason: Reason::Error(err),
+                reason: TypedHeaderRejectionReason::Error(err),
             }),
         }
     }
@@ -78,16 +78,20 @@ impl<T> Deref for TypedHeader<T> {
 #[cfg(feature = "headers")]
 #[cfg_attr(docsrs, doc(cfg(feature = "headers")))]
 #[derive(Debug)]
+#[non_exhaustive]
 pub struct TypedHeaderRejection {
     /// Name of the header that caused the rejection
     pub name: &'static http::header::HeaderName,
     /// Reason why the header extraction has failed
-    pub reason: Reason,
+    pub reason: TypedHeaderRejectionReason,
 }
 
+/// Additional information regarding a [`TypedHeaderRejection`](super::TypedHeaderRejection)
 #[derive(Debug)]
-pub enum Reason {
+pub enum TypedHeaderRejectionReason {
+    /// The header was missing from the HTTP request
     Missing,
+    /// An error occured when parsing the header from the HTTP request
     Error(headers::Error),
 }
 
@@ -105,10 +109,10 @@ impl IntoResponse for TypedHeaderRejection {
 impl std::fmt::Display for TypedHeaderRejection {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match &self.reason {
-            Reason::Missing => {
+            TypedHeaderRejectionReason::Missing => {
                 write!(f, "Header of type `{}` was missing", self.name)
             }
-            Reason::Error(err) => {
+            TypedHeaderRejectionReason::Error(err) => {
                 write!(f, "{} ({})", err, self.name)
             }
         }
@@ -118,8 +122,8 @@ impl std::fmt::Display for TypedHeaderRejection {
 impl std::error::Error for TypedHeaderRejection {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match &self.reason {
-            Reason::Error(err) => Some(err),
-            Reason::Missing => None,
+            TypedHeaderRejectionReason::Error(err) => Some(err),
+            TypedHeaderRejectionReason::Missing => None,
         }
     }
 }

--- a/src/extract/typed_header.rs
+++ b/src/extract/typed_header.rs
@@ -79,12 +79,14 @@ impl<T> Deref for TypedHeader<T> {
 #[cfg_attr(docsrs, doc(cfg(feature = "headers")))]
 #[derive(Debug)]
 pub struct TypedHeaderRejection {
-    name: &'static http::header::HeaderName,
-    reason: Reason,
+    /// Name of the header that caused the rejection
+    pub name: &'static http::header::HeaderName,
+    /// Reason why the header extraction has failed
+    pub reason: Reason,
 }
 
 #[derive(Debug)]
-enum Reason {
+pub enum Reason {
     Missing,
     Error(headers::Error),
 }

--- a/src/extract/typed_header.rs
+++ b/src/extract/typed_header.rs
@@ -78,12 +78,21 @@ impl<T> Deref for TypedHeader<T> {
 #[cfg(feature = "headers")]
 #[cfg_attr(docsrs, doc(cfg(feature = "headers")))]
 #[derive(Debug)]
-#[non_exhaustive]
 pub struct TypedHeaderRejection {
+    name: &'static http::header::HeaderName,
+    reason: TypedHeaderRejectionReason,
+}
+
+impl TypedHeaderRejection {
     /// Name of the header that caused the rejection
-    pub name: &'static http::header::HeaderName,
+    pub fn name(&self) -> &http::header::HeaderName {
+        self.name
+    }
+
     /// Reason why the header extraction has failed
-    pub reason: TypedHeaderRejectionReason,
+    pub fn reason(&self) -> &TypedHeaderRejectionReason {
+        &self.reason
+    }
 }
 
 /// Additional information regarding a [`TypedHeaderRejection`](super::TypedHeaderRejection)


### PR DESCRIPTION
## Motivation

Fixes #316.

Allows to implement a custom extractor that can behave depending on the header rejection's details (name and reason). 
More details in the original issue.

## Solution

* Changes the field visibility from private to public. 
* Adds relevant documentation. 
* Exposes the inner `Reason` type publicly, because this doesn't compile otherwise.   