### PR TITLE
Version 0.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
-- Add accessors to TypedHeaderRejection fields ([#317])
+- None.
+
+# 0.2.5 (18. September, 2021)
+
+- Add accessors for `TypedHeaderRejection` fields ([#317])
+- Improve docs for extractors ([#327])
 
 [#317]: https://github.com/tokio-rs/axum/pull/317
+[#327]: https://github.com/tokio-rs/axum/pull/327
 
 # 0.2.4 (10. September, 2021)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axum"
-version = "0.2.4"
+version = "0.2.5"
 authors = ["David Pedersen <david.pdrsn@gmail.com>"]
 categories = ["asynchronous", "network-programming", "web-programming"]
 description = "Web framework that focuses on ergonomics and modularity"


### PR DESCRIPTION
- Add accessors for `TypedHeaderRejection` fields ([#317])
- Improve docs for extractors ([#327])

[#317]: https://github.com/tokio-rs/axum/pull/317
[#327]: https://github.com/tokio-rs/axum/pull/327