### PR TITLE
Clarify what `handler::any` and `service::any` accepts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
+- Clarify that `handler::any` and `service::any` only accepts standard HTTP
+  methods ([#337])
 - Add accessors to TypedHeaderRejection fields ([#317])
 
+[#337]: https://github.com/tokio-rs/axum/pull/337
 [#317]: https://github.com/tokio-rs/axum/pull/317
 
 # 0.2.4 (10. September, 2021)

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -28,8 +28,7 @@ mod into_service;
 
 pub use self::into_service::IntoService;
 
-/// Route requests to the given handler regardless of the HTTP method of the
-/// request.
+/// Route requests with any standard HTTP method to the given handler.
 ///
 /// # Example
 ///
@@ -41,8 +40,24 @@ pub use self::into_service::IntoService;
 ///
 /// async fn handler() {}
 ///
-/// // All requests to `/` will go to `handler` regardless of the HTTP method.
 /// let app = Router::new().route("/", any(handler));
+/// # async {
+/// # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
+/// # };
+/// ```
+///
+/// Note that this only accepts the standard HTTP methods. If you need to
+/// support non-standard methods use [`Handler::into_service`]:
+///
+/// ```rust
+/// use axum::{
+///     handler::Handler,
+///     Router,
+/// };
+///
+/// async fn handler() {}
+///
+/// let app = Router::new().route("/", handler.into_service());
 /// # async {
 /// # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
 /// # };

--- a/src/routing/method_filter.rs
+++ b/src/routing/method_filter.rs
@@ -16,7 +16,7 @@ bitflags! {
         const OPTIONS = 0b000010000;
         /// Match `PATCH` requests.
         const PATCH =   0b000100000;
-        /// Match `POSt` requests.
+        /// Match `POST` requests.
         const POST =    0b001000000;
         /// Match `PUT` requests.
         const PUT =     0b010000000;

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -114,9 +114,12 @@ use tower_service::Service;
 
 pub mod future;
 
-/// Route requests to the given service regardless of the HTTP method.
+/// Route requests with any standard HTTP method to the given service.
 ///
 /// See [`get`] for an example.
+///
+/// Note that this only accepts the standard HTTP methods. If you need to
+/// support non-standard methods you can route directly to a [`Service`].
 pub fn any<S, B>(svc: S) -> OnMethod<S, EmptyRouter<S::Error>, B>
 where
     S: Service<Request<B>> + Clone,


### PR DESCRIPTION
They only accept standard HTTP methods and don't think we can fix that
without breaking changes.

I don't think `handler::any` should be deprecated as matching all standard
HTTP methods probably makes sense to supports. Its almost more discoverable
than `Handler::into_service`.

Fixes https://github.com/tokio-rs/axum/issues/289