### PR TITLE
Refactor internal testing setup

### DIFF
--- a/src/extract/request_parts.rs
+++ b/src/extract/request_parts.rs
@@ -335,19 +335,12 @@ mod tests {
 
         let app = Router::new().route("/", post(handler));
 
-        let addr = run_in_background(app).await;
+        let client = TestClient::new(app);
 
-        let client = reqwest::Client::new();
-
-        let res = client
-            .post(format!("http://{}", addr))
-            .body("hi there")
-            .send()
-            .await
-            .unwrap();
+        let res = client.post("/").body("hi there").send().await;
         assert_eq!(res.status(), StatusCode::INTERNAL_SERVER_ERROR);
         assert_eq!(
-            res.text().await.unwrap(),
+            res.text().await,
             "Cannot have two request body extractors for a single handler"
         );
     }

--- a/src/extract/typed_header.rs
+++ b/src/extract/typed_header.rs
@@ -152,21 +152,14 @@ mod tests {
 
         let app = Router::new().route("/", get(handle));
 
-        let addr = run_in_background(app).await;
+        let client = TestClient::new(app);
 
-        let client = reqwest::Client::new();
-
-        let res = client
-            .get(format!("http://{}", addr))
-            .header("user-agent", "foobar")
-            .send()
-            .await
-            .unwrap();
-        let body = res.text().await.unwrap();
+        let res = client.get("/").header("user-agent", "foobar").send().await;
+        let body = res.text().await;
         assert_eq!(body, "foobar");
 
-        let res = client.get(format!("http://{}", addr)).send().await.unwrap();
-        let body = res.text().await.unwrap();
+        let res = client.get("/").send().await;
+        let body = res.text().await;
         assert_eq!(body, "Header of type `user-agent` was missing");
     }
 }

--- a/src/tests/handle_error.rs
+++ b/src/tests/handle_error.rs
@@ -48,15 +48,9 @@ async fn handler() {
             .handle_error(|_: BoxError| Ok::<_, Infallible>(StatusCode::REQUEST_TIMEOUT))),
     );
 
-    let addr = run_in_background(app).await;
+    let client = TestClient::new(app);
 
-    let client = reqwest::Client::new();
-
-    let res = client
-        .get(format!("http://{}/", addr))
-        .send()
-        .await
-        .unwrap();
+    let res = client.get("/").send().await;
     assert_eq!(res.status(), StatusCode::REQUEST_TIMEOUT);
 }
 
@@ -70,15 +64,9 @@ async fn handler_multiple_methods_first() {
         .post(unit),
     );
 
-    let addr = run_in_background(app).await;
+    let client = TestClient::new(app);
 
-    let client = reqwest::Client::new();
-
-    let res = client
-        .get(format!("http://{}/", addr))
-        .send()
-        .await
-        .unwrap();
+    let res = client.get("/").send().await;
     assert_eq!(res.status(), StatusCode::REQUEST_TIMEOUT);
 }
 
@@ -95,15 +83,9 @@ async fn handler_multiple_methods_middle() {
             .post(unit),
     );
 
-    let addr = run_in_background(app).await;
+    let client = TestClient::new(app);
 
-    let client = reqwest::Client::new();
-
-    let res = client
-        .get(format!("http://{}/", addr))
-        .send()
-        .await
-        .unwrap();
+    let res = client.get("/").send().await;
     assert_eq!(res.status(), StatusCode::REQUEST_TIMEOUT);
 }
 
@@ -118,15 +100,9 @@ async fn handler_multiple_methods_last() {
         ),
     );
 
-    let addr = run_in_background(app).await;
+    let client = TestClient::new(app);
 
-    let client = reqwest::Client::new();
-
-    let res = client
-        .get(format!("http://{}/", addr))
-        .send()
-        .await
-        .unwrap();
+    let res = client.get("/").send().await;
     assert_eq!(res.status(), StatusCode::REQUEST_TIMEOUT);
 }
 

--- a/src/tests/helpers.rs
+++ b/src/tests/helpers.rs
@@ -1,0 +1,140 @@
+#![allow(unused_imports, dead_code)]
+
+use crate::BoxError;
+use crate::{
+    extract,
+    handler::{any, delete, get, on, patch, post, Handler},
+    response::IntoResponse,
+    routing::MethodFilter,
+    service, Router,
+};
+use bytes::Bytes;
+use http::{
+    header::{HeaderMap, HeaderName, HeaderValue, AUTHORIZATION},
+    Method, Request, StatusCode, Uri,
+};
+use hyper::{Body, Server};
+use serde::Deserialize;
+use serde_json::json;
+use std::future::Ready;
+use std::{
+    collections::HashMap,
+    convert::{Infallible, TryFrom},
+    future::ready,
+    net::{SocketAddr, TcpListener},
+    task::{Context, Poll},
+    time::Duration,
+};
+use tower::{make::Shared, service_fn};
+use tower_service::Service;
+
+pub(crate) struct TestClient {
+    client: reqwest::Client,
+    addr: SocketAddr,
+}
+
+impl TestClient {
+    pub(crate) fn new<S, ResBody>(svc: S) -> Self
+    where
+        S: Service<Request<Body>, Response = http::Response<ResBody>> + Clone + Send + 'static,
+        ResBody: http_body::Body + Send + 'static,
+        ResBody::Data: Send,
+        ResBody::Error: Into<BoxError>,
+        S::Future: Send,
+        S::Error: Into<BoxError>,
+    {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("Could not bind ephemeral socket");
+        let addr = listener.local_addr().unwrap();
+        println!("Listening on {}", addr);
+
+        tokio::spawn(async move {
+            let server = Server::from_tcp(listener).unwrap().serve(Shared::new(svc));
+            server.await.expect("server error");
+        });
+
+        TestClient {
+            client: reqwest::Client::new(),
+            addr,
+        }
+    }
+
+    pub(crate) fn get(&self, url: &str) -> RequestBuilder {
+        RequestBuilder {
+            builder: self.client.get(format!("http://{}{}", self.addr, url)),
+        }
+    }
+
+    pub(crate) fn post(&self, url: &str) -> RequestBuilder {
+        RequestBuilder {
+            builder: self.client.post(format!("http://{}{}", self.addr, url)),
+        }
+    }
+
+    pub(crate) fn put(&self, url: &str) -> RequestBuilder {
+        RequestBuilder {
+            builder: self.client.put(format!("http://{}{}", self.addr, url)),
+        }
+    }
+
+    pub(crate) fn patch(&self, url: &str) -> RequestBuilder {
+        RequestBuilder {
+            builder: self.client.patch(format!("http://{}{}", self.addr, url)),
+        }
+    }
+}
+
+pub(crate) struct RequestBuilder {
+    builder: reqwest::RequestBuilder,
+}
+
+impl RequestBuilder {
+    pub(crate) async fn send(self) -> Response {
+        Response {
+            response: self.builder.send().await.unwrap(),
+        }
+    }
+
+    pub(crate) fn body(mut self, body: impl Into<reqwest::Body>) -> Self {
+        self.builder = self.builder.body(body);
+        self
+    }
+
+    pub(crate) fn json<T>(mut self, json: &T) -> Self
+    where
+        T: serde::Serialize,
+    {
+        self.builder = self.builder.json(json);
+        self
+    }
+    pub(crate) fn header<K, V>(mut self, key: K, value: V) -> Self
+    where
+        HeaderName: TryFrom<K>,
+        <HeaderName as TryFrom<K>>::Error: Into<http::Error>,
+        HeaderValue: TryFrom<V>,
+        <HeaderValue as TryFrom<V>>::Error: Into<http::Error>,
+    {
+        self.builder = self.builder.header(key, value);
+        self
+    }
+}
+
+pub(crate) struct Response {
+    response: reqwest::Response,
+}
+
+impl Response {
+    pub(crate) async fn text(self) -> String {
+        self.response.text().await.unwrap()
+    }
+
+    pub(crate) async fn json<T>(self) -> T
+    where
+        T: serde::de::DeserializeOwned,
+    {
+        self.response.json().await.unwrap()
+    }
+
+    pub(crate) fn status(&self) -> StatusCode {
+        self.response.status()
+    }
+}


### PR DESCRIPTION
This changes the test setup to use our own client rather than using
reqwest directly. Allows us to add several quality of life features like
always unwrapping results.