### PR TITLE
Simplify internal macros for implementing `Handler` and `FromRequest`

### DIFF
--- a/src/extract/tuple.rs
+++ b/src/extract/tuple.rs
@@ -20,29 +20,39 @@ where
 }
 
 macro_rules! impl_from_request {
-    () => {
-    };
+    () => {};
 
-    ( $head:ident, $($tail:ident),* $(,)? ) => {
+    ( $($ty:ident),* $(,)? ) => {
         #[async_trait]
         #[allow(non_snake_case)]
-        impl<B, $head, $($tail,)*> FromRequest<B> for ($head, $($tail,)*)
+        impl<B, $($ty,)*> FromRequest<B> for ($($ty,)*)
         where
-            $head: FromRequest<B> + Send,
-            $( $tail: FromRequest<B> + Send, )*
+            $( $ty: FromRequest<B> + Send, )*
             B: Send,
         {
             type Rejection = Response<BoxBody>;
 
             async fn from_request(req: &mut RequestParts<B>) -> Result<Self, Self::Rejection> {
-                let $head = $head::from_request(req).await.map_err(|err| err.into_response().map(box_body))?;
-                $( let $tail = $tail::from_request(req).await.map_err(|err| err.into_response().map(box_body))?; )*
-                Ok(($head, $($tail,)*))
+                $( let $ty = $ty::from_request(req).await.map_err(|err| err.into_response().map(box_body))?; )*
+                Ok(($($ty,)*))
             }
         }
-
-        impl_from_request!($($tail,)*);
     };
 }
 
+impl_from_request!(T1);
+impl_from_request!(T1, T2);
+impl_from_request!(T1, T2, T3);
+impl_from_request!(T1, T2, T3, T4);
+impl_from_request!(T1, T2, T3, T4, T5);
+impl_from_request!(T1, T2, T3, T4, T5, T6);
+impl_from_request!(T1, T2, T3, T4, T5, T6, T7);
+impl_from_request!(T1, T2, T3, T4, T5, T6, T7, T8);
+impl_from_request!(T1, T2, T3, T4, T5, T6, T7, T8, T9);
+impl_from_request!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10);
+impl_from_request!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11);
+impl_from_request!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12);
+impl_from_request!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13);
+impl_from_request!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14);
+impl_from_request!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15);
 impl_from_request!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16);


### PR DESCRIPTION
Makes the generated docs nicer and avoids having a recursive macro.