### PR TITLE
Bump minimum version of async-trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ tower-log = ["tower/log"]
 ws = ["tokio-tungstenite", "sha-1", "base64"]
 
 [dependencies]
-async-trait = "0.1"
+async-trait = "0.1.43"
 bitflags = "1.0"
 bytes = "1.0"
 dyn-clone = "1.0"


### PR DESCRIPTION
Older versions generate invalid code for Handler impls.

Fixes #324.