### PR TITLE
Bump minimum version of async-trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ tower-log = ["tower/log"]
 ws = ["tokio-tungstenite", "sha-1", "base64"]
 
 [dependencies]
-async-trait = "0.1"
+async-trait = "0.1.43"
 bitflags = "1.0"
 bytes = "1.0"
 futures-util = { version = "0.3", default-features = false, features = ["alloc"] }


### PR DESCRIPTION
A backport of https://github.com/tokio-rs/axum/pull/369 to 0.2