### PR TITLE
Update to tower 0.4.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ serde_urlencoded = "0.7"
 sync_wrapper = "0.1.1"
 tokio = { version = "1", features = ["time"] }
 tokio-util = "0.6"
-tower = { version = "0.4", default-features = false, features = ["util", "buffer", "make"] }
+tower = { version = "0.4.9", default-features = false, features = ["util", "buffer", "make"] }
 tower-http = { version = "0.1", features = ["add-extension", "map-response-body"] }
 tower-layer = "0.3"
 tower-service = "0.3"
@@ -65,7 +65,7 @@ tokio-stream = "0.1"
 
 [dev-dependencies.tower]
 package = "tower"
-version = "0.4"
+version = "0.4.9"
 features = [
     "util",
     "timeout",

--- a/examples/key-value-store/src/main.rs
+++ b/examples/key-value-store/src/main.rs
@@ -56,8 +56,7 @@ async fn main() {
                 .concurrency_limit(1024)
                 .timeout(Duration::from_secs(10))
                 .layer(TraceLayer::new_for_http())
-                .layer(AddExtensionLayer::new(SharedState::default()))
-                .into_inner(),
+                .layer(AddExtensionLayer::new(SharedState::default())),
         )
         // Handle errors from middleware
         .handle_error(handle_error)

--- a/examples/todos/src/main.rs
+++ b/examples/todos/src/main.rs
@@ -51,8 +51,7 @@ async fn main() {
             ServiceBuilder::new()
                 .timeout(Duration::from_secs(10))
                 .layer(TraceLayer::new_for_http())
-                .layer(AddExtensionLayer::new(db))
-                .into_inner(),
+                .layer(AddExtensionLayer::new(db)),
         )
         .handle_error(|error: BoxError| {
             let result = if error.is::<tower::timeout::error::Elapsed>() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -963,8 +963,7 @@
 //!     // Process at most 100 requests concurrently
 //!     .concurrency_limit(100)
 //!     // Compress response bodies
-//!     .layer(CompressionLayer::new())
-//!     .into_inner();
+//!     .layer(CompressionLayer::new());
 //!
 //! let app = Router::new()
 //!     .route("/", get(|_: Request<Body>| async { /* ... */ }))
@@ -1000,8 +999,7 @@
 //!     // `AsyncFilterLayer` lets you asynchronously transform the request
 //!     .layer(AsyncFilterLayer::new(map_request))
 //!     // `AndThenLayer` lets you asynchronously transform the response
-//!     .layer(AndThenLayer::new(map_response))
-//!     .into_inner();
+//!     .layer(AndThenLayer::new(map_response));
 //!
 //! async fn map_request(req: Request<Body>) -> Result<Request<Body>, Infallible> {
 //!     Ok(req)

--- a/src/routing/mod.rs
+++ b/src/routing/mod.rs
@@ -264,8 +264,7 @@ impl<S> Router<S> {
             ServiceBuilder::new()
                 .layer_fn(BoxRoute)
                 .layer_fn(CloneBoxService::new)
-                .layer(MapResponseBodyLayer::new(box_body))
-                .into_inner(),
+                .layer(MapResponseBodyLayer::new(box_body)),
         )
     }
 

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -323,8 +323,7 @@ async fn middleware_on_single_route() {
         get(handle.layer(
             ServiceBuilder::new()
                 .layer(TraceLayer::new_for_http())
-                .layer(CompressionLayer::new())
-                .into_inner(),
+                .layer(CompressionLayer::new()),
         )),
     );
 


### PR DESCRIPTION
`ServiceBuilder` now directly implements `Layer` so you don't have to
call `into_inner` all the time.