### PR TITLE
Idea: Box services internally _and_ store the complete type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   breaking change if you depend on axum with `default_features = false`. ([#286])
 - **breaking:** Remove `routing::Layered` as it didn't actually do anything and
   thus wasn't necessary
+- **breaking:** Replace `Router::boxed` with `routing::BoxRoute::layer`. This
+  fixes compile time issues with `Router::boxed`. Routes are now boxed with
+  `.layer(BoxRoute::<Body>::layer())`.
 
 [#339]: https://github.com/tokio-rs/axum/pull/339
 [#286]: https://github.com/tokio-rs/axum/pull/286

--- a/examples/key-value-store/src/main.rs
+++ b/examples/key-value-store/src/main.rs
@@ -7,7 +7,7 @@
 //! ```
 
 use axum::{
-    body::Bytes,
+    body::{Body, Bytes},
     extract::{ContentLengthLimit, Extension, Path},
     handler::{delete, get, Handler},
     http::StatusCode,
@@ -121,9 +121,13 @@ fn admin_routes() -> Router<BoxRoute> {
     Router::new()
         .route("/keys", delete(delete_all_keys))
         .route("/key/:key", delete(remove_key))
-        // Require bearer auth for all admin routes
-        .layer(RequireAuthorizationLayer::bearer("secret-token"))
-        .boxed()
+        .layer(
+            ServiceBuilder::new()
+                // Box the router so we can name the type
+                .layer(BoxRoute::<Body>::layer())
+                // Require bearer auth for all admin routes
+                .layer(RequireAuthorizationLayer::bearer("secret-token")),
+        )
 }
 
 fn handle_error(error: BoxError) -> Result<impl IntoResponse, Infallible> {

--- a/examples/testing/Cargo.toml
+++ b/examples/testing/Cargo.toml
@@ -12,6 +12,7 @@ tracing-subscriber = "0.2"
 tower-http = { version = "0.1", features = ["trace"] }
 serde_json = "1.0"
 hyper = { version = "0.14", features = ["full"] }
+tower = "0.4"
 
 [dev-dependencies]
 tower = { version = "0.4", features = ["util"] }

--- a/examples/testing/src/main.rs
+++ b/examples/testing/src/main.rs
@@ -5,10 +5,12 @@
 //! ```
 
 use axum::{
+    body::Body,
     handler::{get, post},
     routing::BoxRoute,
     Json, Router,
 };
+use tower::ServiceBuilder;
 use tower_http::trace::TraceLayer;
 
 #[tokio::main]
@@ -42,8 +44,11 @@ fn app() -> Router<BoxRoute> {
             }),
         )
         // We can still add middleware
-        .layer(TraceLayer::new_for_http())
-        .boxed()
+        .layer(
+            ServiceBuilder::new()
+                .layer(BoxRoute::<Body>::layer())
+                .layer(TraceLayer::new_for_http()),
+        )
 }
 
 #[cfg(test)]

--- a/src/clone_box_service.rs
+++ b/src/clone_box_service.rs
@@ -1,5 +1,8 @@
 use futures_util::future::BoxFuture;
-use std::task::{Context, Poll};
+use std::{
+    fmt,
+    task::{Context, Poll},
+};
 use tower::ServiceExt;
 use tower_service::Service;
 
@@ -40,6 +43,12 @@ impl<T, U, E> Service<T> for CloneBoxService<T, U, E> {
 impl<T, U, E> Clone for CloneBoxService<T, U, E> {
     fn clone(&self) -> Self {
         Self(self.0.clone_box())
+    }
+}
+
+impl<T, U, E> fmt::Debug for CloneBoxService<T, U, E> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("CloneBoxService").finish()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -394,7 +394,7 @@
 //! fn api_routes() -> Router<BoxRoute> {
 //!     Router::new()
 //!         .route("/users", get(|_: Request<Body>| async { /* ... */ }))
-//!         .boxed()
+//!         .layer(BoxRoute::<Body>::layer())
 //! }
 //!
 //! let app = Router::new()

--- a/src/routing/box_route.rs
+++ b/src/routing/box_route.rs
@@ -1,0 +1,163 @@
+use crate::{
+    body::{box_body, Body, BoxBody},
+    clone_box_service::CloneBoxService,
+    BoxError,
+};
+use bytes::Bytes;
+use http::{Request, Response};
+use pin_project_lite::pin_project;
+use std::{
+    convert::Infallible,
+    fmt,
+    future::Future,
+    marker::PhantomData,
+    pin::Pin,
+    task::{Context, Poll},
+};
+use tower::{util::Oneshot, ServiceBuilder, ServiceExt};
+use tower_http::map_response_body::MapResponseBodyLayer;
+use tower_layer::Layer;
+use tower_service::Service;
+
+/// [`Layer`] that applies the [`BoxRoute`] middleware.
+///
+/// Created with [`BoxRoute::layer`]. See [`BoxRoute`] for more details.
+pub struct BoxRouteLayer<B = Body, E = Infallible>(PhantomData<fn() -> (B, E)>);
+
+impl<B, E> fmt::Debug for BoxRouteLayer<B, E> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("BoxRouteLayer").finish()
+    }
+}
+
+impl<B, E> Clone for BoxRouteLayer<B, E> {
+    fn clone(&self) -> Self {
+        Self(self.0)
+    }
+}
+
+impl<S, ReqBody, ResBody> Layer<S> for BoxRouteLayer<ReqBody, S::Error>
+where
+    S: Service<Request<ReqBody>, Response = Response<ResBody>> + Clone + Send + Sync + 'static,
+    S::Error: Into<BoxError> + Send,
+    S::Future: Send,
+    ReqBody: Send + 'static,
+    ResBody: http_body::Body<Data = Bytes> + Send + Sync + 'static,
+    ResBody::Error: Into<BoxError>,
+{
+    type Service = BoxRoute<ReqBody, S::Error>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        ServiceBuilder::new()
+            .layer_fn(BoxRoute)
+            .layer_fn(CloneBoxService::new)
+            .layer(MapResponseBodyLayer::new(box_body))
+            .service(inner)
+    }
+}
+
+/// A boxed route trait object.
+///
+/// This makes it easier to name the types of routers to, for example, return
+/// them from functions. Applied with `.layer(BoxRoute::<Body>::layer())`:
+///
+/// ```rust
+/// use axum::{
+///     body::Body,
+///     handler::get,
+///     routing::BoxRoute,
+///     Router,
+/// };
+///
+/// async fn first_handler() { /* ... */ }
+///
+/// async fn second_handler() { /* ... */ }
+///
+/// async fn third_handler() { /* ... */ }
+///
+/// fn app() -> Router<BoxRoute> {
+///     Router::new()
+///         .route("/", get(first_handler).post(second_handler))
+///         .route("/foo", get(third_handler))
+///         .layer(BoxRoute::<Body>::layer())
+/// }
+/// ```
+///
+/// Note that its important to specify the request body type with
+/// `BoxRoute::<Body>::layer()` as this improves compile times.
+pub struct BoxRoute<B = Body, E = Infallible>(CloneBoxService<Request<B>, Response<BoxBody>, E>);
+
+impl<B, E> BoxRoute<B, E> {
+    /// Get a [`BoxRouteLayer`] which is a [`Layer`] that applies the
+    /// [`BoxRoute`] middleware.
+    pub fn layer() -> BoxRouteLayer<B, E> {
+        BoxRouteLayer(PhantomData)
+    }
+}
+
+impl<B, E> Clone for BoxRoute<B, E> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+impl<B, E> fmt::Debug for BoxRoute<B, E> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("BoxRoute").finish()
+    }
+}
+
+impl<B, E> Service<Request<B>> for BoxRoute<B, E>
+where
+    E: Into<BoxError>,
+{
+    type Response = Response<BoxBody>;
+    type Error = E;
+    type Future = BoxRouteFuture<B, E>;
+
+    #[inline]
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    #[inline]
+    fn call(&mut self, req: Request<B>) -> Self::Future {
+        BoxRouteFuture {
+            inner: self.0.clone().oneshot(req),
+        }
+    }
+}
+
+pin_project! {
+    /// The response future for [`BoxRoute`].
+    pub struct BoxRouteFuture<B, E>
+    where
+        E: Into<BoxError>,
+    {
+        #[pin]
+        pub(super) inner: Oneshot<
+            CloneBoxService<Request<B>, Response<BoxBody>, E>,
+            Request<B>,
+        >,
+    }
+}
+
+impl<B, E> Future for BoxRouteFuture<B, E>
+where
+    E: Into<BoxError>,
+{
+    type Output = Result<Response<BoxBody>, E>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        self.project().inner.poll(cx)
+    }
+}
+
+impl<B, E> fmt::Debug for BoxRouteFuture<B, E>
+where
+    E: Into<BoxError>,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("BoxRouteFuture").finish()
+    }
+}

--- a/src/routing/future.rs
+++ b/src/routing/future.rs
@@ -1,14 +1,11 @@
 //! Future types.
 
-use crate::{
-    body::BoxBody, clone_box_service::CloneBoxService, routing::FromEmptyRouter, BoxError,
-};
+use crate::{body::BoxBody, routing::FromEmptyRouter};
 use futures_util::ready;
 use http::{Request, Response};
 use pin_project_lite::pin_project;
 use std::{
     convert::Infallible,
-    fmt,
     future::Future,
     pin::Pin,
     task::{Context, Poll},
@@ -16,46 +13,12 @@ use std::{
 use tower::{util::Oneshot, ServiceExt};
 use tower_service::Service;
 
-pub use super::or::ResponseFuture as OrResponseFuture;
+pub use super::{box_route::BoxRouteFuture, or::ResponseFuture as OrResponseFuture};
 
 opaque_future! {
     /// Response future for [`EmptyRouter`](super::EmptyRouter).
     pub type EmptyRouterFuture<E> =
         std::future::Ready<Result<Response<BoxBody>, E>>;
-}
-
-pin_project! {
-    /// The response future for [`BoxRoute`](super::BoxRoute).
-    pub struct BoxRouteFuture<B, E>
-    where
-        E: Into<BoxError>,
-    {
-        #[pin]
-        pub(super) inner: Oneshot<
-            CloneBoxService<Request<B>, Response<BoxBody>, E>,
-            Request<B>,
-        >,
-    }
-}
-
-impl<B, E> Future for BoxRouteFuture<B, E>
-where
-    E: Into<BoxError>,
-{
-    type Output = Result<Response<BoxBody>, E>;
-
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        self.project().inner.poll(cx)
-    }
-}
-
-impl<B, E> fmt::Debug for BoxRouteFuture<B, E>
-where
-    E: Into<BoxError>,
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("BoxRouteFuture").finish()
-    }
 }
 
 pin_project! {

--- a/src/routing/mod.rs
+++ b/src/routing/mod.rs
@@ -9,7 +9,6 @@ use crate::{
     },
     service::HandleError,
     util::{ByteStr, PercentDecodedByteStr},
-    BoxError,
 };
 use bytes::Bytes;
 use http::{Request, Response, StatusCode, Uri};

--- a/src/routing/mod.rs
+++ b/src/routing/mod.rs
@@ -550,6 +550,19 @@ impl<S> Router<S> {
         self.map(CheckInfallible)
     }
 
+    /// TODO: docs
+    pub fn boxed<ReqBody, ResBody>(self) -> Router<BoxRoute<ReqBody, S::Error>>
+    where
+        S: Service<Request<ReqBody>, Response = Response<ResBody>> + Clone + Send + Sync + 'static,
+        S::Error: Into<crate::BoxError> + Send,
+        S::Future: Send,
+        ReqBody: Send + 'static,
+        ResBody: http_body::Body<Data = Bytes> + Send + Sync + 'static,
+        ResBody::Error: Into<crate::BoxError>,
+    {
+        self.layer(BoxRoute::<ReqBody, S::Error>::layer())
+    }
+
     fn map<F, S2>(self, f: F) -> Router<S2>
     where
         F: FnOnce(S) -> S2,

--- a/src/tests/handle_error.rs
+++ b/src/tests/handle_error.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::routing::BoxRoute;
 use std::future::{pending, ready};
 use tower::{timeout::TimeoutLayer, MakeService};
 
@@ -174,12 +175,12 @@ fn layered() {
     check_make_svc::<_, _, _, Infallible>(app.into_make_service());
 }
 
-#[tokio::test] // async because of `.boxed()`
-async fn layered_boxed() {
+#[test]
+fn layered_boxed() {
     let app = Router::new()
         .route("/echo", get::<_, Body, _>(unit))
         .layer(timeout())
-        .boxed()
+        .layer(BoxRoute::<Body, BoxError>::layer())
         .handle_error(handle_error::<BoxError>);
 
     check_make_svc::<_, _, _, Infallible>(app.into_make_service());

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,12 +1,11 @@
 #![allow(clippy::blacklisted_name)]
 
-use crate::BoxError;
 use crate::{
     extract::{self, Path},
     handler::{any, delete, get, on, patch, post, Handler},
     response::IntoResponse,
-    routing::MethodFilter,
-    service, Json, Router,
+    routing::{BoxRoute, MethodFilter},
+    service, BoxError, Json, Router,
 };
 use bytes::Bytes;
 use http::{
@@ -250,7 +249,7 @@ async fn boxing() {
             }),
         )
         .layer(tower_http::compression::CompressionLayer::new())
-        .boxed();
+        .layer(BoxRoute::<Body>::layer());
 
     let client = TestClient::new(app);
 

--- a/src/tests/or.rs
+++ b/src/tests/or.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::{extract::OriginalUri, response::IntoResponse, Json};
+use crate::{extract::OriginalUri, response::IntoResponse, routing::BoxRoute, Json};
 use serde_json::{json, Value};
 use tower::{limit::ConcurrencyLimitLayer, timeout::TimeoutLayer};
 
@@ -159,8 +159,14 @@ async fn nesting() {
 
 #[tokio::test]
 async fn boxed() {
-    let one = Router::new().route("/foo", get(|| async {})).boxed();
-    let two = Router::new().route("/bar", get(|| async {})).boxed();
+    let one = Router::new()
+        .route("/foo", get(|| async {}))
+        .layer(BoxRoute::<Body>::layer());
+
+    let two = Router::new()
+        .route("/bar", get(|| async {}))
+        .layer(BoxRoute::<Body>::layer());
+
     let app = one.or(two);
 
     let client = TestClient::new(app);


### PR DESCRIPTION
All compile issues we've had comes from building very large types and rust not being very good at evaluating trait bounds on them. A common workaround is to use boxing to erase the types. People have suggested that axum internally box _all_ routes. I've been reluctant to do that because I wanted to keep as much type information as possible so we could use it to do cool stuff, like generating OpenAPI specs purely based on the types.

Today I had an idea though, what if we both boxed all services _and_ kept the type information? For example `Route` could be defined as:

```rust
pub struct Route<S, ReqBody, E, F> {
    // the route's path (this branch is using the pre matchit router)
    pub(crate) pattern: PathPattern,
    // the boxed service behind this route
    pub(crate) svc: CloneBoxService<Request<ReqBody>, Response<BoxBody>, E>,
    // keep the type of the original service so we can use it in trait bounds
    pub(crate) svc_ty: PhantomData<fn() -> S>,
    // the fallback route if this doesn't match
    pub(crate) fallback: F,
}
```

`Service` can then be implemented from these trait bounds:

```rust
impl<S, F, B, E> Service<Request<B>> for Route<S, B, E, F>
where
    F: Service<Request<B>, Response = Response<BoxBody>, Error = E> + Clone,
    B: Send + Sync + 'static,
{
    // ...
}
```

Notice here that there is no bounds on `S`. Thats because `Route.svc` is already a `Service`. No new bounds necessary.

`Router::boxed` can be defined like it used to be:

```rust
pub fn boxed<ReqBody, ResBody>(self) -> Router<BoxRoute<ReqBody, S::Error>>
where
    S: Service<Request<ReqBody>, Response = Response<ResBody>> + Clone + Send + Sync + 'static,
    S::Error: Into<crate::BoxError> + Send,
    S::Future: Send,
    ReqBody: Send + 'static,
    ResBody: http_body::Body<Data = Bytes> + Send + Sync + 'static,
    ResBody::Error: Into<crate::BoxError>,
{
    self.layer(BoxRoute::<ReqBody, S::Error>::layer())
}
```

With these changes code like this:

```rust
let app: Router<BoxRoute> = Router::new()
    .route("/list", get(handle))
    .route("/home", get(handle))
    .route("/create", post(handle))
    .route("/update/:id", post(handle))
    .route("/delete", post(handle))
    .route("/detail", get(handle))
    .route("/earnings/create", post(handle))
    .route("/earnings/delete", post(handle))
    .route("/earnings/find", get(handle))
    .boxed();
```

compiles quickly. Previously it would take ages.

I think this approach is quite interesting and definitely something I'll look more into. Some todos

- [ ] Benchmark it
- [ ] Consider if this is really worth doing now it seems https://github.com/tokio-rs/axum/pull/385 fixes issues with `Router::boxed`. Does this solve other problems that https://github.com/tokio-rs/axum/pull/385 doesn't solve?
- [ ] Do a POC for OpenAPI generation and make sure its still possible from this setup.