### PR TITLE
Change `Connected::connect_info` to return `Self`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,11 +18,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   breaking change if you depend on axum with `default_features = false`. ([#286])
 - **breaking:** Remove `routing::Layered` as it didn't actually do anything and
   thus wasn't necessary
+- **breaking:** Change `Connected::connect_info` to return `Self` and remove
+  the associated type `ConnectInfo` ([#396])
 
 [#339]: https://github.com/tokio-rs/axum/pull/339
 [#286]: https://github.com/tokio-rs/axum/pull/286
 [#272]: https://github.com/tokio-rs/axum/pull/272
 [#378]: https://github.com/tokio-rs/axum/pull/378
+[#396]: https://github.com/tokio-rs/axum/pull/396
 
 # 0.2.8 (07. October, 2021)
 

--- a/examples/unix-domain-socket/src/main.rs
+++ b/examples/unix-domain-socket/src/main.rs
@@ -156,9 +156,7 @@ struct UdsConnectInfo {
 }
 
 impl connect_info::Connected<&UnixStream> for UdsConnectInfo {
-    type ConnectInfo = Self;
-
-    fn connect_info(target: &UnixStream) -> Self::ConnectInfo {
+    fn connect_info(target: &UnixStream) -> Self {
         let peer_addr = target.peer_addr().unwrap();
         let peer_cred = target.peer_cred().unwrap();
 

--- a/src/extract/connect_info.rs
+++ b/src/extract/connect_info.rs
@@ -65,18 +65,13 @@ where
 /// See [`Router::into_make_service_with_connect_info`] for more details.
 ///
 /// [`Router::into_make_service_with_connect_info`]: crate::routing::Router::into_make_service_with_connect_info
-pub trait Connected<T> {
-    /// The connection information type the IO resources generates.
-    type ConnectInfo: Clone + Send + Sync + 'static;
-
+pub trait Connected<T>: Clone + Send + Sync + 'static {
     /// Create type holding information about the connection.
-    fn connect_info(target: T) -> Self::ConnectInfo;
+    fn connect_info(target: T) -> Self;
 }
 
 impl Connected<&AddrStream> for SocketAddr {
-    type ConnectInfo = SocketAddr;
-
-    fn connect_info(target: &AddrStream) -> Self::ConnectInfo {
+    fn connect_info(target: &AddrStream) -> Self {
         target.remote_addr()
     }
 }
@@ -86,7 +81,7 @@ where
     S: Clone,
     C: Connected<T>,
 {
-    type Response = AddExtension<S, ConnectInfo<C::ConnectInfo>>;
+    type Response = AddExtension<S, ConnectInfo<C>>;
     type Error = Infallible;
     type Future = ResponseFuture<Self::Response>;
 
@@ -177,9 +172,7 @@ mod tests {
         }
 
         impl Connected<&AddrStream> for MyConnectInfo {
-            type ConnectInfo = Self;
-
-            fn connect_info(_target: &AddrStream) -> Self::ConnectInfo {
+            fn connect_info(_target: &AddrStream) -> Self {
                 Self {
                     value: "it worked!",
                 }

--- a/src/routing/mod.rs
+++ b/src/routing/mod.rs
@@ -429,9 +429,7 @@ impl<S> Router<S> {
     /// }
     ///
     /// impl Connected<&AddrStream> for MyConnectInfo {
-    ///     type ConnectInfo = MyConnectInfo;
-    ///
-    ///     fn connect_info(target: &AddrStream) -> Self::ConnectInfo {
+    ///     fn connect_info(target: &AddrStream) -> Self {
     ///         MyConnectInfo {
     ///             // ...
     ///         }


### PR DESCRIPTION
I've been thinking that having an associated type probably isn't
necessary. I imagine most users are either using `SocketAddr` to the
remote connection IP, or writing their own connection struct.