### PR TITLE
Fix compile time regression by boxing routes internally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
-- Improve performance of `BoxRoute` ([#339])
-- Expand accepted content types for JSON requests ([#378])
+- **fixed:** Fix regressions in compile times introduced by Rust 1.56
+- **fixed:** Expand accepted content types for JSON requests ([#378])
+- **breaking:** The router's type is now always `Router` regardless of how many routes or
+  middleware are applies.
+
+  This means router types are all always nameable:
+
+  ```rust
+  fn my_routes() -> Router {
+      Router::new().route(
+          "/users",
+          post(|| async { "Hello, World!" }),
+      )
+  }
+  ```
+- **breaking:** `Route::boxed` and `BoxRoute` have been removed as they're no longer
+  necessary
+- **breaking:** `Router::check_infallible` now directly returns a `self` (if the router
+  cannot fail) without any additional middleware
+- **breaking:** The following methods have new specific trait bounds necessary for boxing:
+    - `Router::route`
+    - `Router::nest`
+    - `Router::layer`
+    - `Router::or`
+    - `Router::handle_error`
+- **breaking:** `Router::into_make_service` and `Router::into_make_service_with_connect_info`
+  now produce `Router` services
+- **breaking:** `Route`, `Nested`, `Or` types are now private. They no longer had to be
+  public because `Router` is internally boxed
 - **breaking:** Automatically do percent decoding in `extract::Path`
   ([#272])
-- **breaking:** `Router::boxed` now the inner service to implement `Clone` and
-  `Sync` in addition to the previous trait bounds ([#339])
 - **breaking:** Added feature flags for HTTP1 and JSON. This enables removing a
   few dependencies if your app only uses HTTP2 or doesn't use JSON. Its only a
   breaking change if you depend on axum with `default_features = false`. ([#286])
@@ -21,7 +46,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **breaking:** Change `Connected::connect_info` to return `Self` and remove
   the associated type `ConnectInfo` ([#396])
 
-[#339]: https://github.com/tokio-rs/axum/pull/339
 [#286]: https://github.com/tokio-rs/axum/pull/286
 [#272]: https://github.com/tokio-rs/axum/pull/272
 [#378]: https://github.com/tokio-rs/axum/pull/378

--- a/examples/key-value-store/src/main.rs
+++ b/examples/key-value-store/src/main.rs
@@ -12,7 +12,6 @@ use axum::{
     handler::{delete, get, Handler},
     http::StatusCode,
     response::IntoResponse,
-    routing::BoxRoute,
     Router,
 };
 use std::{
@@ -109,7 +108,7 @@ async fn list_keys(Extension(state): Extension<SharedState>) -> String {
         .join("\n")
 }
 
-fn admin_routes() -> Router<BoxRoute> {
+fn admin_routes() -> Router {
     async fn delete_all_keys(Extension(state): Extension<SharedState>) {
         state.write().unwrap().db.clear();
     }
@@ -123,7 +122,6 @@ fn admin_routes() -> Router<BoxRoute> {
         .route("/key/:key", delete(remove_key))
         // Require bearer auth for all admin routes
         .layer(RequireAuthorizationLayer::bearer("secret-token"))
-        .boxed()
 }
 
 fn handle_error(error: BoxError) -> Result<impl IntoResponse, Infallible> {

--- a/examples/testing/src/main.rs
+++ b/examples/testing/src/main.rs
@@ -6,7 +6,6 @@
 
 use axum::{
     handler::{get, post},
-    routing::BoxRoute,
     Json, Router,
 };
 use tower_http::trace::TraceLayer;
@@ -32,7 +31,7 @@ async fn main() {
 /// Having a function that produces our app makes it easy to call it from tests
 /// without having to create an HTTP server.
 #[allow(dead_code)]
-fn app() -> Router<BoxRoute> {
+fn app() -> Router {
     Router::new()
         .route("/", get(|| async { "Hello, World!" }))
         .route(
@@ -43,7 +42,6 @@ fn app() -> Router<BoxRoute> {
         )
         // We can still add middleware
         .layer(TraceLayer::new_for_http())
-        .boxed()
 }
 
 #[cfg(test)]

--- a/examples/tls-rustls/src/main.rs
+++ b/examples/tls-rustls/src/main.rs
@@ -14,14 +14,18 @@ async fn main() {
     }
     tracing_subscriber::fmt::init();
 
-    let app = Router::new().route("/", get(handler));
+    // this doesn't currently work because axum-server requires services to be
+    // `Sync`. That requirement can be removed but requires making a new
+    // release
 
-    axum_server::bind_rustls("127.0.0.1:3000")
-        .private_key_file("examples/tls-rustls/self_signed_certs/key.pem")
-        .certificate_file("examples/tls-rustls/self_signed_certs/cert.pem")
-        .serve(app)
-        .await
-        .unwrap();
+    // let app = Router::new().route("/", get(handler));
+
+    // axum_server::bind_rustls("127.0.0.1:3000")
+    //     .private_key_file("examples/tls-rustls/self_signed_certs/key.pem")
+    //     .certificate_file("examples/tls-rustls/self_signed_certs/cert.pem")
+    //     .serve(app)
+    //     .await
+    //     .unwrap();
 }
 
 async fn handler() -> &'static str {

--- a/src/clone_box_service.rs
+++ b/src/clone_box_service.rs
@@ -1,5 +1,8 @@
 use futures_util::future::BoxFuture;
-use std::task::{Context, Poll};
+use std::{
+    fmt,
+    task::{Context, Poll},
+};
 use tower::ServiceExt;
 use tower_service::Service;
 
@@ -11,6 +14,12 @@ pub(crate) struct CloneBoxService<T, U, E>(
             + Sync,
     >,
 );
+
+impl<T, U, E> fmt::Debug for CloneBoxService<T, U, E> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CloneBoxService").finish()
+    }
+}
 
 impl<T, U, E> CloneBoxService<T, U, E> {
     pub(crate) fn new<S>(inner: S) -> Self

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -386,15 +386,12 @@
 //!     http::Request,
 //!     handler::get,
 //!     Router,
-//!     routing::BoxRoute
 //! };
 //! use tower_http::services::ServeFile;
 //! use http::Response;
 //!
-//! fn api_routes() -> Router<BoxRoute> {
-//!     Router::new()
-//!         .route("/users", get(|_: Request<Body>| async { /* ... */ }))
-//!         .boxed()
+//! fn api_routes() -> Router {
+//!     Router::new().route("/users", get(|_: Request<Body>| async { /* ... */ }))
 //! }
 //!
 //! let app = Router::new()

--- a/src/routing/future.rs
+++ b/src/routing/future.rs
@@ -24,6 +24,18 @@ opaque_future! {
         std::future::Ready<Result<Response<BoxBody>, E>>;
 }
 
+opaque_future! {
+    /// Response future for [`Router`](super::Router).
+    pub type RouterFuture<E> =
+        futures_util::future::BoxFuture<'static, Result<Response<BoxBody>, E>>;
+}
+
+opaque_future! {
+    /// Response future for [`Routes`](super::Routes).
+    pub type RoutesFuture<E> =
+        futures_util::future::BoxFuture<'static, Result<Response<BoxBody>, E>>;
+}
+
 pin_project! {
     /// The response future for [`BoxRoute`](super::BoxRoute).
     pub struct BoxRouteFuture<B, E>

--- a/src/routing/or.rs
+++ b/src/routing/or.rs
@@ -13,13 +13,8 @@ use std::{
 use tower::{util::Oneshot, ServiceExt};
 use tower_service::Service;
 
-/// [`tower::Service`] that is the combination of two routers.
-///
-/// See [`Router::or`] for more details.
-///
-/// [`Router::or`]: super::Router::or
 #[derive(Debug, Clone, Copy)]
-pub struct Or<A, B> {
+pub(crate) struct Or<A, B> {
     pub(super) first: A,
     pub(super) second: B,
 }

--- a/src/tests/handle_error.rs
+++ b/src/tests/handle_error.rs
@@ -173,14 +173,3 @@ fn layered() {
 
     check_make_svc::<_, _, _, Infallible>(app.into_make_service());
 }
-
-#[tokio::test] // async because of `.boxed()`
-async fn layered_boxed() {
-    let app = Router::new()
-        .route("/echo", get::<_, Body, _>(unit))
-        .layer(timeout())
-        .boxed()
-        .handle_error(handle_error::<BoxError>);
-
-    check_make_svc::<_, _, _, Infallible>(app.into_make_service());
-}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -249,8 +249,7 @@ async fn boxing() {
                 "hi from POST"
             }),
         )
-        .layer(tower_http::compression::CompressionLayer::new())
-        .boxed();
+        .layer(tower_http::compression::CompressionLayer::new());
 
     let client = TestClient::new(app);
 

--- a/src/tests/or.rs
+++ b/src/tests/or.rs
@@ -159,8 +159,8 @@ async fn nesting() {
 
 #[tokio::test]
 async fn boxed() {
-    let one = Router::new().route("/foo", get(|| async {})).boxed();
-    let two = Router::new().route("/bar", get(|| async {})).boxed();
+    let one = Router::new().route("/foo", get(|| async {}));
+    let two = Router::new().route("/bar", get(|| async {}));
     let app = one.or(two);
 
     let client = TestClient::new(app);


### PR DESCRIPTION
After much testing this appears to fix the compile time regressions introduced by Rust 1.56. Kinda wish we didn't have to do this but I don't think there is another way. We can always change things if/when the bug is fixed in Rust.

I think we're gonna have to ship this as 0.3 and push the existing things on the [0.3 milestone](https://github.com/tokio-rs/axum/milestone/2) to 0.4. I don't like blocking users from updating to the 2021 edition.