### PR TITLE
Rename `EmptyRouter` to `MethodNotAllowed`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
       with a trailing slash is received.
     - This can be overridden by explicitly defining two routes: One with and one
       without trailing a slash.
+- **breaking:** `EmptyRouter` has been renamed to `MethodNotAllowed` as its only
+  used in method routers and not in path routers (`Router`)
 
 [#339]: https://github.com/tokio-rs/axum/pull/339
 [#286]: https://github.com/tokio-rs/axum/pull/286

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -4,7 +4,7 @@ use crate::{
     body::{box_body, BoxBody},
     extract::{FromRequest, RequestParts},
     response::IntoResponse,
-    routing::{EmptyRouter, MethodRouter},
+    routing::{MethodNotAllowed, MethodRouter},
     BoxError,
 };
 use async_trait::async_trait;
@@ -78,7 +78,7 @@ pub trait Handler<B, T>: Clone + Send + Sized + 'static {
     /// ```
     fn layer<L>(self, layer: L) -> Layered<L::Service, T>
     where
-        L: Layer<MethodRouter<Self, B, T, EmptyRouter>>,
+        L: Layer<MethodRouter<Self, B, T, MethodNotAllowed>>,
     {
         Layered::new(layer.layer(crate::routing::any(self)))
     }

--- a/src/routing/future.rs
+++ b/src/routing/future.rs
@@ -42,8 +42,8 @@ opaque_future! {
 }
 
 opaque_future! {
-    /// Response future for [`EmptyRouter`](super::EmptyRouter).
-    pub type EmptyRouterFuture<E> =
+    /// Response future for [`MethodNotAllowed`](super::MethodNotAllowed).
+    pub type MethodNotAllowedFuture<E> =
         std::future::Ready<Result<Response<BoxBody>, E>>;
 }
 

--- a/src/routing/handler_method_router.rs
+++ b/src/routing/handler_method_router.rs
@@ -3,7 +3,7 @@
 use crate::{
     body::{box_body, BoxBody},
     handler::Handler,
-    routing::{EmptyRouter, MethodFilter},
+    routing::{MethodFilter, MethodNotAllowed},
     util::{Either, EitherProj},
 };
 use futures_util::{future::BoxFuture, ready};
@@ -57,7 +57,7 @@ use tower_service::Service;
 /// # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
 /// # };
 /// ```
-pub fn any<H, B, T>(handler: H) -> MethodRouter<H, B, T, EmptyRouter>
+pub fn any<H, B, T>(handler: H) -> MethodRouter<H, B, T, MethodNotAllowed>
 where
     H: Handler<B, T>,
 {
@@ -67,7 +67,7 @@ where
 /// Route `CONNECT` requests to the given handler.
 ///
 /// See [`get`] for an example.
-pub fn connect<H, B, T>(handler: H) -> MethodRouter<H, B, T, EmptyRouter>
+pub fn connect<H, B, T>(handler: H) -> MethodRouter<H, B, T, MethodNotAllowed>
 where
     H: Handler<B, T>,
 {
@@ -77,7 +77,7 @@ where
 /// Route `DELETE` requests to the given handler.
 ///
 /// See [`get`] for an example.
-pub fn delete<H, B, T>(handler: H) -> MethodRouter<H, B, T, EmptyRouter>
+pub fn delete<H, B, T>(handler: H) -> MethodRouter<H, B, T, MethodNotAllowed>
 where
     H: Handler<B, T>,
 {
@@ -106,7 +106,7 @@ where
 /// Note that `get` routes will also be called for `HEAD` requests but will have
 /// the response body removed. Make sure to add explicit `HEAD` routes
 /// afterwards.
-pub fn get<H, B, T>(handler: H) -> MethodRouter<H, B, T, EmptyRouter>
+pub fn get<H, B, T>(handler: H) -> MethodRouter<H, B, T, MethodNotAllowed>
 where
     H: Handler<B, T>,
 {
@@ -116,7 +116,7 @@ where
 /// Route `HEAD` requests to the given handler.
 ///
 /// See [`get`] for an example.
-pub fn head<H, B, T>(handler: H) -> MethodRouter<H, B, T, EmptyRouter>
+pub fn head<H, B, T>(handler: H) -> MethodRouter<H, B, T, MethodNotAllowed>
 where
     H: Handler<B, T>,
 {
@@ -126,7 +126,7 @@ where
 /// Route `OPTIONS` requests to the given handler.
 ///
 /// See [`get`] for an example.
-pub fn options<H, B, T>(handler: H) -> MethodRouter<H, B, T, EmptyRouter>
+pub fn options<H, B, T>(handler: H) -> MethodRouter<H, B, T, MethodNotAllowed>
 where
     H: Handler<B, T>,
 {
@@ -136,7 +136,7 @@ where
 /// Route `PATCH` requests to the given handler.
 ///
 /// See [`get`] for an example.
-pub fn patch<H, B, T>(handler: H) -> MethodRouter<H, B, T, EmptyRouter>
+pub fn patch<H, B, T>(handler: H) -> MethodRouter<H, B, T, MethodNotAllowed>
 where
     H: Handler<B, T>,
 {
@@ -146,7 +146,7 @@ where
 /// Route `POST` requests to the given handler.
 ///
 /// See [`get`] for an example.
-pub fn post<H, B, T>(handler: H) -> MethodRouter<H, B, T, EmptyRouter>
+pub fn post<H, B, T>(handler: H) -> MethodRouter<H, B, T, MethodNotAllowed>
 where
     H: Handler<B, T>,
 {
@@ -156,7 +156,7 @@ where
 /// Route `PUT` requests to the given handler.
 ///
 /// See [`get`] for an example.
-pub fn put<H, B, T>(handler: H) -> MethodRouter<H, B, T, EmptyRouter>
+pub fn put<H, B, T>(handler: H) -> MethodRouter<H, B, T, MethodNotAllowed>
 where
     H: Handler<B, T>,
 {
@@ -166,7 +166,7 @@ where
 /// Route `TRACE` requests to the given handler.
 ///
 /// See [`get`] for an example.
-pub fn trace<H, B, T>(handler: H) -> MethodRouter<H, B, T, EmptyRouter>
+pub fn trace<H, B, T>(handler: H) -> MethodRouter<H, B, T, MethodNotAllowed>
 where
     H: Handler<B, T>,
 {
@@ -192,14 +192,14 @@ where
 /// # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
 /// # };
 /// ```
-pub fn on<H, B, T>(method: MethodFilter, handler: H) -> MethodRouter<H, B, T, EmptyRouter>
+pub fn on<H, B, T>(method: MethodFilter, handler: H) -> MethodRouter<H, B, T, MethodNotAllowed>
 where
     H: Handler<B, T>,
 {
     MethodRouter {
         method,
         handler,
-        fallback: EmptyRouter::method_not_allowed(),
+        fallback: MethodNotAllowed::new(),
         _marker: PhantomData,
     }
 }

--- a/src/routing/service_method_router.rs
+++ b/src/routing/service_method_router.rs
@@ -98,7 +98,7 @@
 
 use crate::{
     body::{box_body, BoxBody},
-    routing::{EmptyRouter, MethodFilter},
+    routing::{MethodFilter, MethodNotAllowed},
     util::{Either, EitherProj},
     BoxError,
 };
@@ -123,7 +123,7 @@ use tower_service::Service;
 ///
 /// Note that this only accepts the standard HTTP methods. If you need to
 /// support non-standard methods you can route directly to a [`Service`].
-pub fn any<S, B>(svc: S) -> MethodRouter<S, EmptyRouter<S::Error>, B>
+pub fn any<S, B>(svc: S) -> MethodRouter<S, MethodNotAllowed<S::Error>, B>
 where
     S: Service<Request<B>> + Clone,
 {
@@ -133,7 +133,7 @@ where
 /// Route `CONNECT` requests to the given service.
 ///
 /// See [`get`] for an example.
-pub fn connect<S, B>(svc: S) -> MethodRouter<S, EmptyRouter<S::Error>, B>
+pub fn connect<S, B>(svc: S) -> MethodRouter<S, MethodNotAllowed<S::Error>, B>
 where
     S: Service<Request<B>> + Clone,
 {
@@ -143,7 +143,7 @@ where
 /// Route `DELETE` requests to the given service.
 ///
 /// See [`get`] for an example.
-pub fn delete<S, B>(svc: S) -> MethodRouter<S, EmptyRouter<S::Error>, B>
+pub fn delete<S, B>(svc: S) -> MethodRouter<S, MethodNotAllowed<S::Error>, B>
 where
     S: Service<Request<B>> + Clone,
 {
@@ -178,7 +178,7 @@ where
 /// Note that `get` routes will also be called for `HEAD` requests but will have
 /// the response body removed. Make sure to add explicit `HEAD` routes
 /// afterwards.
-pub fn get<S, B>(svc: S) -> MethodRouter<S, EmptyRouter<S::Error>, B>
+pub fn get<S, B>(svc: S) -> MethodRouter<S, MethodNotAllowed<S::Error>, B>
 where
     S: Service<Request<B>> + Clone,
 {
@@ -188,7 +188,7 @@ where
 /// Route `HEAD` requests to the given service.
 ///
 /// See [`get`] for an example.
-pub fn head<S, B>(svc: S) -> MethodRouter<S, EmptyRouter<S::Error>, B>
+pub fn head<S, B>(svc: S) -> MethodRouter<S, MethodNotAllowed<S::Error>, B>
 where
     S: Service<Request<B>> + Clone,
 {
@@ -198,7 +198,7 @@ where
 /// Route `OPTIONS` requests to the given service.
 ///
 /// See [`get`] for an example.
-pub fn options<S, B>(svc: S) -> MethodRouter<S, EmptyRouter<S::Error>, B>
+pub fn options<S, B>(svc: S) -> MethodRouter<S, MethodNotAllowed<S::Error>, B>
 where
     S: Service<Request<B>> + Clone,
 {
@@ -208,7 +208,7 @@ where
 /// Route `PATCH` requests to the given service.
 ///
 /// See [`get`] for an example.
-pub fn patch<S, B>(svc: S) -> MethodRouter<S, EmptyRouter<S::Error>, B>
+pub fn patch<S, B>(svc: S) -> MethodRouter<S, MethodNotAllowed<S::Error>, B>
 where
     S: Service<Request<B>> + Clone,
 {
@@ -218,7 +218,7 @@ where
 /// Route `POST` requests to the given service.
 ///
 /// See [`get`] for an example.
-pub fn post<S, B>(svc: S) -> MethodRouter<S, EmptyRouter<S::Error>, B>
+pub fn post<S, B>(svc: S) -> MethodRouter<S, MethodNotAllowed<S::Error>, B>
 where
     S: Service<Request<B>> + Clone,
 {
@@ -228,7 +228,7 @@ where
 /// Route `PUT` requests to the given service.
 ///
 /// See [`get`] for an example.
-pub fn put<S, B>(svc: S) -> MethodRouter<S, EmptyRouter<S::Error>, B>
+pub fn put<S, B>(svc: S) -> MethodRouter<S, MethodNotAllowed<S::Error>, B>
 where
     S: Service<Request<B>> + Clone,
 {
@@ -238,7 +238,7 @@ where
 /// Route `TRACE` requests to the given service.
 ///
 /// See [`get`] for an example.
-pub fn trace<S, B>(svc: S) -> MethodRouter<S, EmptyRouter<S::Error>, B>
+pub fn trace<S, B>(svc: S) -> MethodRouter<S, MethodNotAllowed<S::Error>, B>
 where
     S: Service<Request<B>> + Clone,
 {
@@ -270,14 +270,14 @@ where
 /// # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
 /// # };
 /// ```
-pub fn on<S, B>(method: MethodFilter, svc: S) -> MethodRouter<S, EmptyRouter<S::Error>, B>
+pub fn on<S, B>(method: MethodFilter, svc: S) -> MethodRouter<S, MethodNotAllowed<S::Error>, B>
 where
     S: Service<Request<B>> + Clone,
 {
     MethodRouter {
         method,
         svc,
-        fallback: EmptyRouter::method_not_allowed(),
+        fallback: MethodNotAllowed::new(),
         _request_body: PhantomData,
     }
 }


### PR DESCRIPTION
It is no longer needed in `Router` so can be changed to always return
`403 Method Not Allowed`.