### PR TITLE
Run middleware for requests with no matching route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,9 +41,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - **fixed:** Adding a conflicting route will now cause a panic instead of silently making
       a route unreachable.
     - **fixed:** Route matching is faster as number of routes increase.
-  - **fixed:** Middleware that return early (such as `tower_http::auth::RequireAuthorization`)
-    now no longer catch requests that would otherwise be 404s. They also work
-    correctly with `Router::merge` (previously called `or`) ([#408])
   - **fixed:** Correctly handle trailing slashes in routes:
     - If a route with a trailing slash exists and a request without a trailing
       slash is received, axum will send a 301 redirection to the route with the

--- a/src/routing/future.rs
+++ b/src/routing/future.rs
@@ -13,6 +13,8 @@ use std::{
 use tower::util::Oneshot;
 use tower_service::Service;
 
+pub use super::method_not_allowed::MethodNotAllowedFuture;
+
 opaque_future! {
     /// Response future for [`Router`](super::Router).
     pub type RouterFuture<B> =
@@ -58,12 +60,6 @@ impl<B> Future for RouteFuture<B> {
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         self.project().future.poll(cx)
     }
-}
-
-opaque_future! {
-    /// Response future for [`MethodNotAllowed`](super::MethodNotAllowed).
-    pub type MethodNotAllowedFuture<E> =
-        std::future::Ready<Result<Response<BoxBody>, E>>;
 }
 
 pin_project! {

--- a/src/routing/method_not_allowed.rs
+++ b/src/routing/method_not_allowed.rs
@@ -1,0 +1,69 @@
+use crate::body::BoxBody;
+use http::{Request, Response, StatusCode};
+use std::{
+    convert::Infallible,
+    fmt,
+    future::ready,
+    marker::PhantomData,
+    task::{Context, Poll},
+};
+use tower_service::Service;
+
+/// A [`Service`] that responds with `405 Method not allowed` to all requests.
+///
+/// This is used as the bottom service in a method router. You shouldn't have to
+/// use it manually.
+pub struct MethodNotAllowed<E = Infallible> {
+    _marker: PhantomData<fn() -> E>,
+}
+
+impl<E> MethodNotAllowed<E> {
+    pub(crate) fn new() -> Self {
+        Self {
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<E> Clone for MethodNotAllowed<E> {
+    fn clone(&self) -> Self {
+        Self {
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<E> fmt::Debug for MethodNotAllowed<E> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("MethodNotAllowed").finish()
+    }
+}
+
+impl<B, E> Service<Request<B>> for MethodNotAllowed<E>
+where
+    B: Send + Sync + 'static,
+{
+    type Response = Response<BoxBody>;
+    type Error = E;
+    type Future = MethodNotAllowedFuture<E>;
+
+    #[inline]
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, _req: Request<B>) -> Self::Future {
+        let res = Response::builder()
+            .status(StatusCode::METHOD_NOT_ALLOWED)
+            .body(crate::body::empty())
+            .unwrap();
+
+        MethodNotAllowedFuture::new(ready(Ok(res)))
+    }
+}
+
+opaque_future! {
+    /// Response future for [`MethodNotAllowed`](super::MethodNotAllowed).
+    pub type MethodNotAllowedFuture<E> =
+        std::future::Ready<Result<Response<BoxBody>, E>>;
+}

--- a/src/routing/not_found.rs
+++ b/src/routing/not_found.rs
@@ -1,0 +1,38 @@
+use crate::body::BoxBody;
+use http::{Request, Response, StatusCode};
+use std::{
+    convert::Infallible,
+    future::ready,
+    task::{Context, Poll},
+};
+use tower_service::Service;
+
+/// A [`Service`] that responds with `405 Method not allowed` to all requests.
+///
+/// This is used as the bottom service in a method router. You shouldn't have to
+/// use it manually.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct NotFound;
+
+impl<B> Service<Request<B>> for NotFound
+where
+    B: Send + Sync + 'static,
+{
+    type Response = Response<BoxBody>;
+    type Error = Infallible;
+    type Future = std::future::Ready<Result<Response<BoxBody>, Self::Error>>;
+
+    #[inline]
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, _req: Request<B>) -> Self::Future {
+        let res = Response::builder()
+            .status(StatusCode::NOT_FOUND)
+            .body(crate::body::empty())
+            .unwrap();
+
+        ready(Ok(res))
+    }
+}


### PR DESCRIPTION
While thinking about #419 I realized that `main` had a bug where
middleware wouldn't be called if no route matched the incoming request.
`Router` would just directly return a 404 without calling any
middleware.

This fixes by making the fallback default to a service that always
returns 404 and always calling that if no route matches.

Layers applied to the router is then also applied to the fallback.

Unfortunately this breaks #380 but I don't currently see a way to
support both. Auth middleware need to run _after_ routing because you
don't care about auth for unknown paths, but logging middleware need to
run _before_ routing because they do care about seeing requests for
unknown paths so they can log them...

We could intro methods for adding middleware before or after routing
but that feels like something users shouldn't have to worry about 🤷 

Part of #419