### PR TITLE
Fix middleware not seeing the full URI for nested routes

### DIFF
--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -684,8 +684,6 @@ async fn middleware_still_run_for_unmatched_requests() {
     assert_eq!(COUNT.load(Ordering::SeqCst), 2);
 }
 
-// TODO(david): middleware still run for empty routers
-
 pub(crate) fn assert_send<T: Send>() {}
 pub(crate) fn assert_sync<T: Sync>() {}
 pub(crate) fn assert_unpin<T: Unpin>() {}


### PR DESCRIPTION
We stripped the prefix before calling any middleware. Instead the prefix
should be stripped just before calling the actual route. This way
middleware still see the full URI, as it used to work in 0.2.

Fixes #419