### PR TITLE
Depend on tower 0.4.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ serde_urlencoded = "0.7"
 sync_wrapper = "0.1.1"
 tokio = { version = "1", features = ["time"] }
 tokio-util = "0.6"
-tower = { version = "0.4", default-features = false, features = ["util", "buffer", "make"] }
+tower = { version = "0.4.10", default-features = false, features = ["util", "buffer", "make"] }
 tower-http = { version = "0.1", features = ["add-extension", "map-response-body"] }
 tower-layer = "0.3"
 tower-service = "0.3"
@@ -65,7 +65,7 @@ uuid = { version = "0.8", features = ["serde", "v4"] }
 
 [dev-dependencies.tower]
 package = "tower"
-version = "0.4"
+version = "0.4.10"
 features = [
     "util",
     "timeout",


### PR DESCRIPTION
axum uses `impl Layer for ServiceBuilder` internally which requires
tower 0.4.10. Making that explicit should help users updating to axum
0.3 without also having to manually bump their tower dependency.