### PR TITLE
Add `Handler::{into_make_service, into_make_service_with_connect_info}`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     is because bodies are streams and requiring streams to be `Sync` is
     unnecessary.
   - **added:** Implement `IntoResponse` for `http_body::combinators::UnsyncBoxBody`.
+  - **added:** Add `Handler::into_make_service` for serving a handler without a
+    `Router`.
+  - **added:** Add `Handler::into_make_service_with_connect_info` for serving a
+    handler without a `Router`, and storing info about the incoming connection.
 - Routing:
   - Big internal refactoring of routing leading to several improvements ([#363])
     - **added:** Wildcard routes like `.route("/api/users/*rest", service)` are now supported.

--- a/src/routing/into_make_service.rs
+++ b/src/routing/into_make_service.rs
@@ -14,7 +14,7 @@ pub struct IntoMakeService<S> {
 }
 
 impl<S> IntoMakeService<S> {
-    pub(super) fn new(svc: S) -> Self {
+    pub(crate) fn new(svc: S) -> Self {
         Self { svc }
     }
 }

--- a/src/routing/mod.rs
+++ b/src/routing/mod.rs
@@ -302,14 +302,14 @@ where
     /// ```
     ///
     /// [`MakeService`]: tower::make::MakeService
-    pub fn into_make_service(self) -> IntoMakeService<B> {
+    pub fn into_make_service(self) -> IntoMakeService<Self> {
         IntoMakeService::new(self)
     }
 
     #[doc = include_str!("../docs/routing/into_make_service_with_connect_info.md")]
     pub fn into_make_service_with_connect_info<C, Target>(
         self,
-    ) -> IntoMakeServiceWithConnectInfo<B, C>
+    ) -> IntoMakeServiceWithConnectInfo<Self, C>
     where
         C: Connected<Target>,
     {


### PR DESCRIPTION
These are useful if you want to run a handler without a `Router`, for
example to make a proxy.