### PR TITLE
Add `axum-openapi` crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
     "axum",
+    "axum-openapi",
     "examples/*",
 ]

--- a/axum-openapi/Cargo.toml
+++ b/axum-openapi/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "axum-openapi"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+axum = { path = "../axum" }
+openapiv3 = "0.5.0"
+tower-service = "0.3"
+tower-layer = "0.3"
+serde_yaml = "0.8"
+serde_json = "1.0"
+serde = "1.0"
+
+[dev-dependencies]
+tokio = { version = "1.13", features = ["full"] }

--- a/axum-openapi/Cargo.toml
+++ b/axum-openapi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "axum-openapi"
 version = "0.1.0"
-edition = "2021"
+edition = "2018"
 publish = false
 
 [dependencies]

--- a/axum-openapi/Cargo.toml
+++ b/axum-openapi/Cargo.toml
@@ -6,12 +6,15 @@ publish = false
 
 [dependencies]
 axum = { path = "../axum" }
-openapiv3 = "0.5.0"
+# openapiv3 = "0.5.0"
+okapi = { version = "0.7.0-rc.1", features = ["impl_json_schema", "preserve_order"] }
 tower-service = "0.3"
 tower-layer = "0.3"
 serde_yaml = "0.8"
 serde_json = "1.0"
 serde = "1.0"
+assert-json-diff = "2.0"
+schemars = "0.8"
 
 [dev-dependencies]
 tokio = { version = "1.13", features = ["full"] }

--- a/axum-openapi/README.md
+++ b/axum-openapi/README.md
@@ -1,0 +1,4 @@
+# axum-openapi
+
+This experimental openapi generation for axum. Still work-in-progress and
+nothing is released to crates.io yet.

--- a/axum-openapi/src/handler_method_routing.rs
+++ b/axum-openapi/src/handler_method_routing.rs
@@ -13,7 +13,7 @@ use axum::{
     http::{Request, Response},
     routing::MethodNotAllowed,
 };
-use okapi::openapi3::{Operation, PathItem};
+use okapi::openapi3::{Components, Operation, PathItem};
 use tower_service::Service;
 
 // NOTE: could we make axum main method routers work like this? Its more generics but conceptually
@@ -21,47 +21,53 @@ use tower_service::Service;
 // Might be worth it to consider a redesign of axum's method router such that we wouldn't have to
 // write all this and could instead wrap it, similarly to how we're wrapping `Router`
 // TODO(david): impl fmt::Debug
-pub struct MethodRouter<Delete, Get, Head, On, Options, Patch, Post, Put, Trace, B = Body> {
-    delete: Option<WithOperation<Delete>>,
-    get: Option<WithOperation<Get>>,
-    head: Option<WithOperation<Head>>,
-    on: Option<WithOperation<On>>,
-    options: Option<WithOperation<Options>>,
-    patch: Option<WithOperation<Patch>>,
-    post: Option<WithOperation<Post>>,
-    put: Option<WithOperation<Put>>,
-    trace: Option<WithOperation<Trace>>,
-    _marker: PhantomData<fn() -> B>,
+pub struct MethodRouter<Delete, Get, Head, Options, Patch, Post, Put, Trace, B = Body> {
+    pub(crate) delete: Option<WithOperation<Delete>>,
+    pub(crate) get: Option<WithOperation<Get>>,
+    pub(crate) head: Option<WithOperation<Head>>,
+    pub(crate) options: Option<WithOperation<Options>>,
+    pub(crate) patch: Option<WithOperation<Patch>>,
+    pub(crate) post: Option<WithOperation<Post>>,
+    pub(crate) put: Option<WithOperation<Put>>,
+    pub(crate) trace: Option<WithOperation<Trace>>,
+    pub(crate) _marker: PhantomData<fn() -> B>,
 }
 
 #[derive(Clone, Default)]
-struct WithOperation<T> {
-    svc: T,
+pub(crate) struct WithOperation<S> {
+    svc: S,
     operation: Operation,
+    components: Components,
 }
 
-impl<T> WithOperation<T> {
-    fn get_operation(&self) -> Operation {
-        self.operation.clone()
+impl<H, B, T> WithOperation<IntoService<H, B, T>> {
+    fn new(handler: H, id: impl Into<String>) -> Self
+    where
+        H: Handler<B, T> + ToOperation<T>,
+    {
+        let mut components = Default::default();
+        let mut operation = handler.to_operation(&mut components);
+        operation.operation_id = Some(id.into());
+        Self {
+            svc: handler.into_service(),
+            operation,
+            components,
+        }
     }
 }
 
-fn operation_with_id<H, T>(id: impl Into<String>, handler: &H) -> Operation
-where
-    H: ToOperation<T>,
-{
-    let mut op = handler.to_operation();
-    op.operation_id = Some(id.into());
-    op
+impl<T> WithOperation<T> {
+    pub(crate) fn to_inner(&self) -> (Operation, Components) {
+        (self.operation.clone(), self.components.clone())
+    }
 }
 
-impl<Delete, Get, Head, On, Options, Patch, Post, Put, Trace, B> Clone
-    for MethodRouter<Delete, Get, Head, On, Options, Patch, Post, Put, Trace, B>
+impl<Delete, Get, Head, Options, Patch, Post, Put, Trace, B> Clone
+    for MethodRouter<Delete, Get, Head, Options, Patch, Post, Put, Trace, B>
 where
     Delete: Clone,
     Get: Clone,
     Head: Clone,
-    On: Clone,
     Options: Clone,
     Patch: Clone,
     Post: Clone,
@@ -73,7 +79,6 @@ where
             delete: self.delete.clone(),
             get: self.get.clone(),
             head: self.head.clone(),
-            on: self.on.clone(),
             options: self.options.clone(),
             patch: self.patch.clone(),
             post: self.post.clone(),
@@ -96,7 +101,6 @@ pub fn get<H, B, T>(
     MethodNotAllowed,
     MethodNotAllowed,
     MethodNotAllowed,
-    MethodNotAllowed,
     B,
 >
 where
@@ -104,12 +108,8 @@ where
 {
     MethodRouter {
         delete: Default::default(),
-        get: Some(WithOperation {
-            operation: operation_with_id(id, &handler),
-            svc: handler.into_service(),
-        }),
+        get: Some(WithOperation::new(handler, id)),
         head: Default::default(),
-        on: Default::default(),
         options: Default::default(),
         patch: Default::default(),
         post: Default::default(),
@@ -119,14 +119,14 @@ where
     }
 }
 
-impl<Delete, Get, Head, On, Options, Patch, Post, Put, Trace, B>
-    MethodRouter<Delete, Get, Head, On, Options, Patch, Post, Put, Trace, B>
+impl<Delete, Get, Head, Options, Patch, Post, Put, Trace, B>
+    MethodRouter<Delete, Get, Head, Options, Patch, Post, Put, Trace, B>
 {
     pub fn post<H, T>(
         self,
         id: impl Into<String>,
         handler: H,
-    ) -> MethodRouter<Delete, Get, Head, On, Options, Patch, IntoService<H, B, T>, Put, Trace, B>
+    ) -> MethodRouter<Delete, Get, Head, Options, Patch, IntoService<H, B, T>, Put, Trace, B>
     where
         H: Handler<B, T> + ToOperation<T>,
     {
@@ -134,13 +134,9 @@ impl<Delete, Get, Head, On, Options, Patch, Post, Put, Trace, B>
             delete: self.delete,
             get: self.get,
             head: self.head,
-            on: self.on,
             options: self.options,
             patch: self.patch,
-            post: Some(WithOperation {
-                operation: operation_with_id(id, &handler),
-                svc: handler.into_service(),
-            }),
+            post: Some(WithOperation::new(handler, id)),
             put: self.put,
             trace: self.trace,
             _marker: PhantomData,
@@ -148,8 +144,8 @@ impl<Delete, Get, Head, On, Options, Patch, Post, Put, Trace, B>
     }
 }
 
-impl<Delete, Get, Head, On, Options, Patch, Post, Put, Trace, B> Service<Request<B>>
-    for MethodRouter<Delete, Get, Head, On, Options, Patch, Post, Put, Trace, B>
+impl<Delete, Get, Head, Options, Patch, Post, Put, Trace, B> Service<Request<B>>
+    for MethodRouter<Delete, Get, Head, Options, Patch, Post, Put, Trace, B>
 where
     B: Send + 'static,
 {
@@ -168,23 +164,5 @@ where
         // TODO(david): implement this, will require a future with tons of generics and we just
         // care about things type checking so far
         todo!()
-    }
-}
-
-impl<Delete, Get, Head, On, Options, Patch, Post, Put, Trace, B> ToPathItem
-    for MethodRouter<Delete, Get, Head, On, Options, Patch, Post, Put, Trace, B>
-{
-    fn to_path_item(&self) -> PathItem {
-        PathItem {
-            get: self.get.as_ref().map(WithOperation::get_operation),
-            put: self.put.as_ref().map(WithOperation::get_operation),
-            post: self.post.as_ref().map(WithOperation::get_operation),
-            delete: self.delete.as_ref().map(WithOperation::get_operation),
-            options: self.options.as_ref().map(WithOperation::get_operation),
-            head: self.head.as_ref().map(WithOperation::get_operation),
-            patch: self.patch.as_ref().map(WithOperation::get_operation),
-            trace: self.trace.as_ref().map(WithOperation::get_operation),
-            ..Default::default()
-        }
     }
 }

--- a/axum-openapi/src/handler_method_routing.rs
+++ b/axum-openapi/src/handler_method_routing.rs
@@ -1,0 +1,199 @@
+use std::{
+    convert::Infallible,
+    future::Future,
+    marker::PhantomData,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use crate::{ToOperation, ToPathItem};
+use axum::{
+    body::{Body, BoxBody},
+    handler::{Handler, IntoService},
+    http::{Request, Response},
+    routing::MethodNotAllowed,
+};
+use openapiv3::{Operation, PathItem};
+use tower_service::Service;
+
+// NOTE: could we make axum main method routers work like this? Its more generics but conceptually
+// simpler imo
+// Might be worth it to consider a redesign of axum's method router such that we wouldn't have to
+// write all this and could instead wrap it, similarly to how we're wrapping `Router`
+// TODO(david): impl fmt::Debug
+pub struct MethodRouter<Delete, Get, Head, On, Options, Patch, Post, Put, Trace, B = Body> {
+    delete: Delete,
+    delete_operation: Option<Operation>,
+    get: Get,
+    get_operation: Option<Operation>,
+    head: Head,
+    head_operation: Option<Operation>,
+    on: On,
+    on_operation: Option<Operation>,
+    options: Options,
+    options_operation: Option<Operation>,
+    patch: Patch,
+    patch_operation: Option<Operation>,
+    post: Post,
+    post_operation: Option<Operation>,
+    put: Put,
+    put_operation: Option<Operation>,
+    trace: Trace,
+    trace_operation: Option<Operation>,
+    _marker: PhantomData<fn() -> B>,
+}
+
+impl<Delete, Get, Head, On, Options, Patch, Post, Put, Trace, B> Clone
+    for MethodRouter<Delete, Get, Head, On, Options, Patch, Post, Put, Trace, B>
+where
+    Delete: Clone,
+    Get: Clone,
+    Head: Clone,
+    On: Clone,
+    Options: Clone,
+    Patch: Clone,
+    Post: Clone,
+    Put: Clone,
+    Trace: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            delete: self.delete.clone(),
+            delete_operation: self.delete_operation.clone(),
+            get: self.get.clone(),
+            get_operation: self.get_operation.clone(),
+            head: self.head.clone(),
+            head_operation: self.head_operation.clone(),
+            on: self.on.clone(),
+            on_operation: self.on_operation.clone(),
+            options: self.options.clone(),
+            options_operation: self.options_operation.clone(),
+            patch: self.patch.clone(),
+            patch_operation: self.patch_operation.clone(),
+            post: self.post.clone(),
+            post_operation: self.post_operation.clone(),
+            put: self.put.clone(),
+            put_operation: self.put_operation.clone(),
+            trace: self.trace.clone(),
+            trace_operation: self.trace_operation.clone(),
+            _marker: PhantomData,
+        }
+    }
+}
+
+pub fn get<H, B, T>(
+    handler: H,
+) -> MethodRouter<
+    MethodNotAllowed,
+    IntoService<H, B, T>,
+    MethodNotAllowed,
+    MethodNotAllowed,
+    MethodNotAllowed,
+    MethodNotAllowed,
+    MethodNotAllowed,
+    MethodNotAllowed,
+    MethodNotAllowed,
+    B,
+>
+where
+    H: Handler<B, T> + ToOperation<T>,
+{
+    MethodRouter {
+        delete: Default::default(),
+        delete_operation: Default::default(),
+        get_operation: Some(handler.to_operation()),
+        get: handler.into_service(),
+        head: Default::default(),
+        head_operation: Default::default(),
+        on: Default::default(),
+        on_operation: Default::default(),
+        options: Default::default(),
+        options_operation: Default::default(),
+        patch: Default::default(),
+        patch_operation: Default::default(),
+        post: Default::default(),
+        post_operation: Default::default(),
+        put: Default::default(),
+        put_operation: Default::default(),
+        trace: Default::default(),
+        trace_operation: Default::default(),
+        _marker: PhantomData,
+    }
+}
+
+impl<Delete, Get, Head, On, Options, Patch, Post, Put, Trace, B>
+    MethodRouter<Delete, Get, Head, On, Options, Patch, Post, Put, Trace, B>
+{
+    pub fn post<H, T>(
+        self,
+        handler: H,
+    ) -> MethodRouter<Delete, Get, Head, On, Options, Patch, IntoService<H, B, T>, Put, Trace, B>
+    where
+        H: Handler<B, T> + ToOperation<T>,
+    {
+        MethodRouter {
+            delete: self.delete,
+            delete_operation: self.delete_operation,
+            get: self.get,
+            get_operation: self.get_operation,
+            head: self.head,
+            head_operation: self.head_operation,
+            on: self.on,
+            on_operation: self.on_operation,
+            options: self.options,
+            options_operation: self.options_operation,
+            patch: self.patch,
+            patch_operation: self.patch_operation,
+            post_operation: Some(handler.to_operation()),
+            post: handler.into_service(),
+            put: self.put,
+            put_operation: self.put_operation,
+            trace: self.trace,
+            trace_operation: self.trace_operation,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<Delete, Get, Head, On, Options, Patch, Post, Put, Trace, B> Service<Request<B>>
+    for MethodRouter<Delete, Get, Head, On, Options, Patch, Post, Put, Trace, B>
+where
+    B: Send + 'static,
+{
+    type Response = Response<BoxBody>;
+    // TODO(david): error should be generic
+    type Error = Infallible;
+    type Future =
+        Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send + 'static>>;
+
+    #[inline]
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, _req: Request<B>) -> Self::Future {
+        // TODO(david): implement this, will require a future with tons of generics and we just
+        // care about things type checking so far
+        todo!()
+    }
+}
+
+impl<Delete, Get, Head, On, Options, Patch, Post, Put, Trace, B> ToPathItem
+    for MethodRouter<Delete, Get, Head, On, Options, Patch, Post, Put, Trace, B>
+{
+    fn to_path_item(&self) -> PathItem {
+        PathItem {
+            get: self.get_operation.clone(),
+            put: self.put_operation.clone(),
+            post: self.post_operation.clone(),
+            delete: self.delete_operation.clone(),
+            options: self.options_operation.clone(),
+            head: self.head_operation.clone(),
+            patch: self.patch_operation.clone(),
+            trace: self.trace_operation.clone(),
+            servers: Default::default(),
+            parameters: Default::default(),
+            extensions: Default::default(),
+        }
+    }
+}

--- a/axum-openapi/src/lib.rs
+++ b/axum-openapi/src/lib.rs
@@ -1,0 +1,291 @@
+#![allow(
+    clippy::field_reassign_with_default,
+    clippy::new_without_default,
+    clippy::type_complexity,
+    dead_code,
+    unreachable_code,
+    unused_imports,
+    unused_mut,
+    unused_variables
+)]
+
+use axum::{
+    body::{Body, BoxBody, Bytes, Full, HttpBody},
+    http::{header, HeaderValue, Request, Response, StatusCode},
+    response::IntoResponse,
+    routing::Route,
+    BoxError, Json, Router,
+};
+use openapiv3::{HeaderStyle, MediaType, OpenAPI, Operation, PathItem, ReferenceOr, Responses};
+use std::{borrow::Cow, convert::Infallible, future::Future};
+use tower_layer::Layer;
+use tower_service::Service;
+
+pub mod handler_method_routing;
+
+pub struct OpenApiRouter<B = Body> {
+    router: Router<B>,
+    schema: OpenAPI,
+}
+
+impl<B> OpenApiRouter<B>
+where
+    B: Send + 'static,
+{
+    pub fn new() -> Self {
+        Self::with_openapi(Default::default())
+    }
+
+    pub fn with_openapi(openapi: OpenAPI) -> Self {
+        Self {
+            router: Default::default(),
+            schema: openapi,
+        }
+    }
+
+    pub fn route<T>(mut self, path: &str, service: T) -> Self
+    where
+        T: Service<Request<B>, Response = Response<BoxBody>, Error = Infallible>
+            + ToPathItem
+            + Clone
+            + Send
+            + 'static,
+        T::Future: Send + 'static,
+    {
+        // TODO(david): correct path templating with `{key}` instead of `:key`
+        // TODO(david): does openapi have wildcards?
+
+        self.schema
+            .paths
+            .insert(path.to_string(), ReferenceOr::Item(service.to_path_item()));
+
+        self.router = self.router.route(path, service);
+        self
+    }
+
+    pub fn nest<T>(mut self, path: &str, service: T) -> Self
+    where
+        T: Service<Request<B>, Response = Response<BoxBody>, Error = Infallible>
+            + Clone
+            + Send
+            + 'static,
+        T::Future: Send + 'static,
+    {
+        self.router = self.router.nest(path, service);
+        self
+    }
+
+    pub fn merge(mut self, other: Router<B>) -> Self {
+        self.router = self.router.merge(other);
+        self
+    }
+
+    pub fn layer<L, LayeredReqBody, LayeredResBody>(self, layer: L) -> OpenApiRouter<LayeredReqBody>
+    where
+        L: Layer<Route<B>>,
+        L::Service: Service<
+                Request<LayeredReqBody>,
+                Response = Response<LayeredResBody>,
+                Error = Infallible,
+            > + Clone
+            + Send
+            + 'static,
+        <L::Service as Service<Request<LayeredReqBody>>>::Future: Send + 'static,
+        LayeredResBody: HttpBody<Data = Bytes> + Send + 'static,
+        LayeredResBody::Error: Into<BoxError>,
+    {
+        OpenApiRouter {
+            router: self.router.layer(layer),
+            schema: self.schema,
+        }
+    }
+
+    pub fn fallback<T>(mut self, service: T) -> Self
+    where
+        T: Service<Request<B>, Response = Response<BoxBody>, Error = Infallible>
+            + Clone
+            + Send
+            + 'static,
+        T::Future: Send + 'static,
+    {
+        self.router = self.router.fallback(service);
+        self
+    }
+
+    pub fn into_parts(self) -> (Router<B>, OpenAPI) {
+        (self.router, self.schema)
+    }
+}
+
+pub fn schema_routes(schema: OpenAPI) -> SchemaRoutes {
+    SchemaRoutes {
+        schema,
+        json: true,
+        yaml: true,
+        path: "openapi".into(),
+    }
+}
+
+pub struct SchemaRoutes {
+    schema: OpenAPI,
+    json: bool,
+    yaml: bool,
+    path: Cow<'static, str>,
+}
+
+impl SchemaRoutes {
+    pub fn json(mut self, enabled: bool) -> Self {
+        self.json = enabled;
+        self
+    }
+
+    pub fn yaml(mut self, enabled: bool) -> Self {
+        self.yaml = enabled;
+        self
+    }
+
+    pub fn path(mut self, path: &str) -> Self {
+        self.path = path.to_string().into();
+        self
+    }
+
+    pub fn into_router(self) -> Router {
+        use crate::handler_method_routing::get;
+        use axum::{
+            extract::Extension,
+            http::{header::CONTENT_TYPE, StatusCode},
+            response::Headers,
+            AddExtensionLayer, Json,
+        };
+        use std::sync::Arc;
+
+        let mut router = Router::new();
+
+        if self.yaml {
+            router = router.route(
+                &format!("/{}.yaml", self.path),
+                axum::routing::get(|Extension(schema): Extension<Arc<OpenAPI>>| async move {
+                    Yaml((&*schema).clone())
+                }),
+            );
+        }
+
+        if self.json {
+            router = router.route(
+                &format!("/{}.yaml", self.path),
+                axum::routing::get(|Extension(schema): Extension<Arc<OpenAPI>>| async move {
+                    Json((&*schema).clone())
+                }),
+            )
+        }
+
+        router.layer(AddExtensionLayer::new(Arc::new(self.schema)))
+    }
+}
+
+struct Yaml<T>(T);
+
+impl<T> IntoResponse for Yaml<T>
+where
+    T: serde::Serialize,
+{
+    type Body = Full<Bytes>;
+    type BodyError = <Self::Body as HttpBody>::Error;
+
+    fn into_response(self) -> Response<Self::Body> {
+        let bytes = match serde_yaml::to_vec(&self.0) {
+            Ok(bytes) => bytes,
+            Err(err) => {
+                return Response::builder()
+                    .status(StatusCode::INTERNAL_SERVER_ERROR)
+                    .header(header::CONTENT_TYPE, "text/plain")
+                    .body(Full::from(err.to_string()))
+                    .unwrap();
+            }
+        };
+
+        let mut res = Response::new(Full::from(bytes));
+        res.headers_mut().insert(
+            header::CONTENT_TYPE,
+            HeaderValue::from_static("application/x-yaml"),
+        );
+        res
+    }
+}
+
+pub trait ToPathItem {
+    fn to_path_item(&self) -> PathItem;
+}
+
+pub trait ToOperation<T> {
+    fn to_operation(&self) -> Operation;
+}
+
+pub trait ToResponses {
+    fn to_responses() -> Responses;
+}
+
+impl<F, Fut, Res> ToOperation<()> for F
+where
+    F: FnOnce() -> Fut,
+    Fut: Future<Output = Res> + Send,
+    Res: ToResponses,
+{
+    fn to_operation(&self) -> Operation {
+        let mut op = Operation::default();
+        op.responses = Res::to_responses();
+        op
+    }
+}
+
+impl ToResponses for () {
+    fn to_responses() -> Responses {
+        Responses::default()
+    }
+}
+
+impl<T> ToResponses for Json<T> {
+    fn to_responses() -> Responses {
+        let response = openapiv3::Response {
+            content: vec![("application/json".to_string(), MediaType::default())]
+                .into_iter()
+                .collect(),
+            ..Default::default()
+        };
+
+        // TODO(david): how to handle `response.content.schema`? Would be cool if we could say
+        // something else than "its JSON"
+
+        Responses {
+            default: Some(ReferenceOr::Item(response)),
+            responses: Default::default(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::handler_method_routing::get;
+    use axum::{
+        extract::Extension,
+        http::{header::CONTENT_TYPE, StatusCode},
+        response::Headers,
+        AddExtensionLayer, Json,
+    };
+    use serde_json::json;
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn test_openapi() {
+        let app = OpenApiRouter::new()
+            .route("/", get(|| async { Json(json!({ "foo": "bar" })) }))
+            .route("/foo", get(|| async {}).post(|| async {}));
+
+        let (router, openapi) = app.into_parts();
+
+        println!("{}", serde_yaml::to_string(&openapi).unwrap());
+
+        let router_with_openapi_schema = router.merge(schema_routes(openapi).into_router());
+    }
+}

--- a/axum-openapi/src/lib.rs
+++ b/axum-openapi/src/lib.rs
@@ -172,7 +172,7 @@ impl SchemaRoutes {
 
         if self.json {
             router = router.route(
-                &format!("/{}.yaml", self.path),
+                &format!("/{}.json", self.path),
                 axum::routing::get(|Extension(schema): Extension<Arc<OpenAPI>>| async move {
                     Json((&*schema).clone())
                 }),

--- a/axum-openapi/src/to_operation.rs
+++ b/axum-openapi/src/to_operation.rs
@@ -1,0 +1,5 @@
+use okapi::openapi3::Operation;
+
+pub trait ToOperation<T> {
+    fn to_operation(&self) -> Operation;
+}

--- a/axum-openapi/src/to_operation.rs
+++ b/axum-openapi/src/to_operation.rs
@@ -1,5 +1,45 @@
-use okapi::openapi3::Operation;
+use std::future::Future;
+
+use axum::routing::MethodNotAllowed;
+use okapi::openapi3::{Components, Operation};
+
+use crate::ToResponses;
 
 pub trait ToOperation<T> {
-    fn to_operation(&self) -> Operation;
+    fn to_operation(&self, components: &mut Components) -> Operation;
+}
+
+impl<T> ToOperation<T> for MethodNotAllowed {
+    fn to_operation(&self, components: &mut Components) -> Operation {
+        unreachable!()
+    }
+}
+
+impl<F, Fut, Res> ToOperation<()> for F
+where
+    F: FnOnce() -> Fut,
+    Fut: Future<Output = Res> + Send,
+    Res: ToResponses,
+{
+    fn to_operation(&self, components: &mut Components) -> Operation {
+        let mut op = Operation::default();
+        op.responses = Res::to_responses(components);
+        op
+    }
+}
+
+impl<F, Fut, Res, T1> ToOperation<(T1,)> for F
+where
+    F: FnOnce(T1) -> Fut,
+    Fut: Future<Output = Res> + Send,
+    Res: ToResponses,
+{
+    fn to_operation(&self, components: &mut Components) -> Operation {
+        // TODO(david): next step: ToParameter
+        todo!()
+
+        // let mut op = Operation::default();
+        // op.responses = Res::to_responses(components);
+        // op
+    }
 }

--- a/axum-openapi/src/to_path_item.rs
+++ b/axum-openapi/src/to_path_item.rs
@@ -1,0 +1,5 @@
+use okapi::openapi3::PathItem;
+
+pub trait ToPathItem {
+    fn to_path_item(&self) -> PathItem;
+}

--- a/axum-openapi/src/to_path_item.rs
+++ b/axum-openapi/src/to_path_item.rs
@@ -1,5 +1,54 @@
-use okapi::openapi3::PathItem;
+use crate::{
+    handler_method_routing::{MethodRouter, WithOperation},
+    ToOperation,
+};
+use axum::routing::MethodNotAllowed;
+use okapi::openapi3::{Components, Operation, PathItem};
 
 pub trait ToPathItem {
-    fn to_path_item(&self) -> PathItem;
+    fn to_path_item(&self, components: &mut Components) -> PathItem;
+}
+
+impl<Delete, Get, Head, Options, Patch, Post, Put, Trace, B> ToPathItem
+    for MethodRouter<Delete, Get, Head, Options, Patch, Post, Put, Trace, B>
+{
+    fn to_path_item(&self, components_out: &mut Components) -> PathItem {
+        let mut components = Some(std::mem::take(components_out));
+
+        let delete = self.delete.as_ref().map(|op| op.to_inner());
+        let get = self.get.as_ref().map(|op| op.to_inner());
+        let head = self.head.as_ref().map(|op| op.to_inner());
+        let options = self.options.as_ref().map(|op| op.to_inner());
+        let patch = self.patch.as_ref().map(|op| op.to_inner());
+        let post = self.post.as_ref().map(|op| op.to_inner());
+        let put = self.put.as_ref().map(|op| op.to_inner());
+        let trace = self.trace.as_ref().map(|op| op.to_inner());
+
+        fn get_operation_and_merge_components(
+            op_and_comp: Option<(Operation, Components)>,
+            comp_out: &mut Option<Components>,
+        ) -> Option<Operation> {
+            op_and_comp.map(|(op, comp)| {
+                okapi::merge::merge_components(comp_out, &Some(comp))
+                    .expect("failed to merge components");
+                op
+            })
+        }
+
+        let item = PathItem {
+            get: get_operation_and_merge_components(get, &mut components),
+            delete: get_operation_and_merge_components(delete, &mut components),
+            head: get_operation_and_merge_components(head, &mut components),
+            options: get_operation_and_merge_components(options, &mut components),
+            patch: get_operation_and_merge_components(patch, &mut components),
+            put: get_operation_and_merge_components(put, &mut components),
+            post: get_operation_and_merge_components(post, &mut components),
+            trace: get_operation_and_merge_components(trace, &mut components),
+            ..Default::default()
+        };
+
+        *components_out = components.expect("components None after merge");
+
+        item
+    }
 }

--- a/axum-openapi/src/to_responses.rs
+++ b/axum-openapi/src/to_responses.rs
@@ -1,0 +1,119 @@
+use std::{future::Future, marker::PhantomData};
+
+use axum::{http::Response, response::IntoResponse, Json};
+use okapi::openapi3::{self, MediaType, Operation, RefOr, Responses};
+use schemars::JsonSchema;
+
+use crate::ToOperation;
+
+pub trait ToResponses {
+    fn to_responses() -> Responses;
+}
+
+// `const S: &'static str` is gonna be great
+pub trait ResponseDescription {
+    const DESCRIPTION: &'static str;
+}
+
+pub trait IntoOpenApiResponse: ToResponses + IntoResponse {}
+
+impl<T> IntoOpenApiResponse for T where T: ToResponses + IntoResponse {}
+
+impl<F, Fut, Res> ToOperation<()> for F
+where
+    F: FnOnce() -> Fut,
+    Fut: Future<Output = Res> + Send,
+    Res: ToResponses,
+{
+    fn to_operation(&self) -> Operation {
+        let mut op = Operation::default();
+        op.responses = Res::to_responses();
+        op
+    }
+}
+
+pub struct WithDescription<T, K> {
+    response: K,
+    _marker: PhantomData<fn() -> T>,
+}
+
+#[macro_export]
+macro_rules! describe {
+    (
+        $description:literal,
+        $res:expr $(,)?
+    ) => {{
+        struct __ResponseDescription;
+        impl $crate::ResponseDescription for __ResponseDescription {
+            const DESCRIPTION: &'static str = $description;
+        }
+        $crate::describe::<__ResponseDescription, _>($res)
+    }};
+}
+
+pub fn describe<T, K>(response: K) -> WithDescription<T, K>
+where
+    T: ResponseDescription,
+    K: IntoResponse,
+{
+    WithDescription {
+        response,
+        _marker: PhantomData,
+    }
+}
+
+impl<T, K> IntoResponse for WithDescription<T, K>
+where
+    K: IntoResponse,
+{
+    type Body = K::Body;
+    type BodyError = K::BodyError;
+
+    fn into_response(self) -> Response<Self::Body> {
+        self.response.into_response()
+    }
+}
+
+impl<T, K> ToResponses for WithDescription<T, K>
+where
+    T: ResponseDescription,
+    K: ToResponses,
+{
+    fn to_responses() -> Responses {
+        let mut res = K::to_responses();
+        if let Some(RefOr::Object(default)) = &mut res.default {
+            default.description = T::DESCRIPTION.to_string();
+        }
+        res
+    }
+}
+
+impl ToResponses for () {
+    fn to_responses() -> Responses {
+        Responses::default()
+    }
+}
+
+impl<T> ToResponses for Json<T>
+where
+    T: JsonSchema,
+{
+    fn to_responses() -> Responses {
+        let schema = schemars::schema_for!(T).schema;
+        let mut media_type = MediaType::default();
+        media_type.schema = Some(schema);
+
+        let response = openapi3::Response {
+            content: vec![("application/json".to_string(), media_type)]
+                .into_iter()
+                .collect(),
+            ..Default::default()
+        };
+
+        Responses {
+            default: Some(RefOr::Object(response)),
+            responses: Default::default(),
+            extensions: Default::default(),
+        }
+    }
+}

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
-- None
+- **added:** `MethodNotAllowed`'s constructor is now public.
 
 # 0.3.0 (02. November, 2021)
 

--- a/axum/src/routing/method_not_allowed.rs
+++ b/axum/src/routing/method_not_allowed.rs
@@ -11,17 +11,23 @@ use tower_service::Service;
 
 /// A [`Service`] that responds with `405 Method not allowed` to all requests.
 ///
-/// This is used as the bottom service in a method router. You shouldn't have to
-/// use it manually.
+/// This is used as the bottom service in a method router.
 pub struct MethodNotAllowed<E = Infallible> {
     _marker: PhantomData<fn() -> E>,
 }
 
 impl<E> MethodNotAllowed<E> {
-    pub(crate) fn new() -> Self {
+    /// Create a new `MethodNotAllowed`.
+    pub fn new() -> Self {
         Self {
             _marker: PhantomData,
         }
+    }
+}
+
+impl<E> Default for MethodNotAllowed<E> {
+    fn default() -> Self {
+        Self::new()
     }
 }
 


### PR DESCRIPTION
This is a proof of concept implementation of OpenAPI generation for axum.

I've been thinking that it would be nice if we could iterate on openapi stuff in a separate crate, so we wouldn't have to ship breaking versions of axum itself all the time. When we've found an API we're happy with and its been tested by users, we can move it into axum itself.

So this introduces a new crate called `axum-openapi` (nothing on crates.io yet). The basic idea is creating types that wrap those in axum, provide an identical API, but also support generating openapi schemas for your routes. I think this is a decent way to experiment with it without changing a lot in axum.

Example:

```rust
let app = OpenApiRouter::new()
    .route("/", get(|| async { Json(json!({ "foo": "bar" })) }))
    .route("/foo", get(|| async {}).post(|| async {}));

let (router, openapi) = app.into_parts();

// we serialize our schema and print it
println!("{}", serde_yaml::to_string(&openapi).unwrap());

// or generate some routes to serve it to clients
let router_with_openapi_schema = router.merge(schema_routes(openapi).into_router());
```

Calling `GET /openapi.yaml` returns

```yaml
---
openapi: ""
info:
  title: ""
  version: ""
paths:
  /:
    get:
      responses:
        default:
          description: ""
          content:
            application/json: {}
  /foo:
    get:
      responses: {}
    post:
      responses: {}
```

There is still lots to do but hopefully this illustrates one possible path forward.

---

Notes to self:
- https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md
- https://docs.rs/okapi/0.7.0-rc.1/okapi/openapi3/struct.OpenApi.html
- https://docs.rs/schemars/0.8.6/schemars/gen/struct.SchemaSettings.html#method.openapi3