### PR TITLE
Derive `Debug` for `Router` instead of implementing manually

### DIFF
--- a/axum/src/routing/mod.rs
+++ b/axum/src/routing/mod.rs
@@ -62,6 +62,7 @@ impl RouteId {
 }
 
 /// The router type for composing handlers and services.
+#[derive(Debug)]
 pub struct Router<B = Body> {
     routes: HashMap<RouteId, Route<B>>,
     node: Node,
@@ -84,16 +85,6 @@ where
 {
     fn default() -> Self {
         Self::new()
-    }
-}
-
-impl<B> fmt::Debug for Router<B> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Router")
-            .field("routes", &self.routes)
-            .field("node", &self.node)
-            .field("fallback", &self.fallback)
-            .finish()
     }
 }
 


### PR DESCRIPTION
I believe `derive` produces the same implementation.