### PR TITLE
fix markdown links in Readme

### DIFF
--- a/axum/README.md
+++ b/axum/README.md
@@ -125,7 +125,7 @@ channel][chat] or open an [issue] with your question.
 
 ## Community projects
 
-See [here](ecosystem) for a list of community maintained crates and projects
+See [here][ecosystem] for a list of community maintained crates and projects
 built with axum.
 
 ## Contributing
@@ -136,7 +136,7 @@ you! We have a [contributing guide][contributing] to help you get involved in th
 
 ## License
 
-This project is licensed under the [MIT license](license).
+This project is licensed under the [MIT license][license].
 
 ### Contribution
 
@@ -151,9 +151,9 @@ additional terms or conditions.
 [`hyper`]: https://crates.io/crates/hyper
 [`tower-http`]: https://crates.io/crates/tower-http
 [`tonic`]: https://crates.io/crates/tonic
-[contributing]: https://github.com/tokio-rs/axum/blob/main/CONTRIBUTING.md
+[contributing]: /CONTRIBUTING.md
 [chat]: https://discord.gg/tokio
 [issue]: https://github.com/tokio-rs/axum/issues/new
 [`tower::Service`]: https://docs.rs/tower/latest/tower/trait.Service.html
-[ecosystem]: https://github.com/tokio-rs/axum/blob/main/ECOSYSTEM.md
-[license]: https://github.com/tokio-rs/axum/blob/main/LICENSE
+[ecosystem]: /ECOSYSTEM.md
+[license]: /axum/LICENSE


### PR DESCRIPTION
markdown links in readmes: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-readmes#relative-links-and-image-paths-in-readme-files

square brackets: https://www.markdownguide.org/basic-syntax/#reference-style-links

Supersedes  #460