### PR TITLE
Version 0.3.2

### DIFF
--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -7,8 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
+- None
+
+# 0.3.2 (08. November, 2021)
+
 - **added:** Add `Router::route_layer` for applying middleware that
-  will only run on requests that match a route ([#474])
+  will only run on requests that match a route. This is useful for middleware
+  that return early, such as authorization ([#474])
 
 [#474]: https://github.com/tokio-rs/axum/pull/474
 

--- a/axum/Cargo.toml
+++ b/axum/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axum"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["David Pedersen <david.pdrsn@gmail.com>"]
 categories = ["asynchronous", "network-programming", "web-programming"]
 description = "Web framework that focuses on ergonomics and modularity"


### PR DESCRIPTION
- **added:** Add `Router::route_layer` for applying middleware that
  will only run on requests that match a route. This is useful for middleware
  that return early, such as authorization ([#474])

[#474]: https://github.com/tokio-rs/axum/pull/474