### PR TITLE
Split first sentence into its own paragraph in TypedHeader docs

### DIFF
--- a/axum/src/extract/typed_header.rs
+++ b/axum/src/extract/typed_header.rs
@@ -6,9 +6,10 @@ use headers::HeaderMapExt;
 use http_body::Full;
 use std::{convert::Infallible, ops::Deref};
 
-/// Extractor that extracts a typed header value from [`headers`]. In general, it's
-/// recommended to extract only the needed headers via `TypedHeader` rather than removing all
-/// headers with the `HeaderMap` extractor.
+/// Extractor that extracts a typed header value from [`headers`].
+///
+/// In general, it's recommended to extract only the needed headers via `TypedHeader` rather than
+/// removing all headers with the `HeaderMap` extractor.
 ///
 /// # Example
 ///


### PR DESCRIPTION
It's pretty uncommon to have a big first paragraph. I think it's also the breaking point to tell rustdoc what to show in a module overview.