### PR TITLE
Implement `FromRequest` for `http::request::Parts`

### DIFF
--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
-- None
+- Implement `FromRequest` for [`http::request::Parts`] so it can be used an
+  extractor ([#489])
+
+[#489]: https://github.com/tokio-rs/axum/pull/489
+[`http::request::Parts`]: https://docs.rs/http/latest/http/request/struct.Parts.html
 
 # 0.3.2 (08. November, 2021)
 

--- a/axum/src/extract/rejection.rs
+++ b/axum/src/extract/rejection.rs
@@ -272,6 +272,16 @@ composite_rejection! {
     }
 }
 
+composite_rejection! {
+    /// Rejection used for [`http::request::Parts`].
+    ///
+    /// Contains one variant for each way the [`http::request::Parts`] extractor can fail.
+    pub enum RequestPartsAlreadyExtracted {
+        HeadersAlreadyExtracted,
+        ExtensionsAlreadyExtracted,
+    }
+}
+
 define_rejection! {
     #[status = INTERNAL_SERVER_ERROR]
     #[body = "No matched path found"]


### PR DESCRIPTION
Its a convenient way to extract everything from the request except the
body. Also makes sense for axum to provide this since other crates
can't.