### PR TITLE
Implement `IntoResponse` for `http::response::Parts`

### DIFF
--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
-- None
+- Implement `IntoResponse` for `http::response::Parts` ([#490])
+
+[#490]: https://github.com/tokio-rs/axum/pull/490
 
 # 0.3.2 (08. November, 2021)
 

--- a/axum/src/response/mod.rs
+++ b/axum/src/response/mod.rs
@@ -250,20 +250,7 @@ impl IntoResponse for http::response::Parts {
     type BodyError = Infallible;
 
     fn into_response(self) -> Response<Self::Body> {
-        let Self {
-            status,
-            version,
-            headers,
-            extensions,
-            ..
-        } = self;
-
-        let mut res = Response::new(Empty::new());
-        *res.status_mut() = status;
-        *res.version_mut() = version;
-        *res.headers_mut() = headers;
-        *res.extensions_mut() = extensions;
-        res
+        Response::from_parts(self, Empty::new())
     }
 }
 

--- a/axum/src/response/mod.rs
+++ b/axum/src/response/mod.rs
@@ -245,6 +245,28 @@ impl_into_response_for_body!(hyper::Body);
 impl_into_response_for_body!(Full<Bytes>);
 impl_into_response_for_body!(Empty<Bytes>);
 
+impl IntoResponse for http::response::Parts {
+    type Body = Empty<Bytes>;
+    type BodyError = Infallible;
+
+    fn into_response(self) -> Response<Self::Body> {
+        let Self {
+            status,
+            version,
+            headers,
+            extensions,
+            ..
+        } = self;
+
+        let mut res = Response::new(Empty::new());
+        *res.status_mut() = status;
+        *res.version_mut() = version;
+        *res.headers_mut() = headers;
+        *res.extensions_mut() = extensions;
+        res
+    }
+}
+
 impl<E> IntoResponse for http_body::combinators::BoxBody<Bytes, E>
 where
     E: Into<BoxError> + 'static,


### PR DESCRIPTION
Not sure there are many use cases for this but still thinks it makes to
provide since other crates can't.