### PR TITLE
Make `.nest("/", service)` work again (with a warning)

### DIFF
--- a/axum/Cargo.toml
+++ b/axum/Cargo.toml
@@ -40,6 +40,7 @@ tower = { version = "0.4.10", default-features = false, features = ["util", "buf
 tower-http = { version = "0.1", features = ["add-extension", "map-response-body"] }
 tower-layer = "0.3"
 tower-service = "0.3"
+tracing = "0.1"
 
 # optional dependencies
 base64 = { optional = true, version = "0.13" }
@@ -57,7 +58,6 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1.6.1", features = ["macros", "rt", "rt-multi-thread", "net"] }
 tokio-stream = "0.1"
-tracing = "0.1"
 uuid = { version = "0.8", features = ["serde", "v4"] }
 anyhow = "1.0"
 

--- a/axum/src/routing/mod.rs
+++ b/axum/src/routing/mod.rs
@@ -24,6 +24,7 @@ use tower::{util::ServiceExt, ServiceBuilder};
 use tower_http::map_response_body::MapResponseBodyLayer;
 use tower_layer::Layer;
 use tower_service::Service;
+use tracing::warn;
 
 pub mod future;
 pub mod handler_method_routing;
@@ -148,6 +149,13 @@ where
     {
         if path.is_empty() {
             panic!("Invalid route: empty path");
+        }
+
+        if path == "/" {
+            warn!(
+                r#"Using `.nest("/", service)` is discouraged, use `.fallback(service)` instead."#
+            );
+            return self.fallback(svc);
         }
 
         if path.contains('*') {


### PR DESCRIPTION
## Motivation

Lots of people don't read the changelog or miss what it says about `.nest("/", svc)`.

## Solution

Make it work again by forwarding to `.fallback`, but raising a warning because `.fallback` is more explicit and panic messages if you do both are not going to be great.