### PR TITLE
axum-debug: Move axum dependency to dev-dependencies

### DIFF
--- a/axum-debug/Cargo.toml
+++ b/axum-debug/Cargo.toml
@@ -18,7 +18,7 @@ proc-macro = true
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = { version = "1.0", features = ["full"] }
-axum = { path = "../axum", version = "0.3" }
 
 [dev-dependencies]
+axum = { path = "../axum", version = "0.3" }
 trybuild = "1.0"

--- a/axum-debug/src/lib.rs
+++ b/axum-debug/src/lib.rs
@@ -77,8 +77,8 @@
 //!
 //! Macros in this crate have no effect when using release profile. (eg. `cargo build --release`)
 //!
-//! [`axum`]: axum
-//! [`Handler`]: axum::handler::Handler
+//! [`axum`]: https://docs.rs/axum/0.3
+//! [`Handler`]: https://docs.rs/axum/0.3/axum/handler/trait.Handler.html
 //! [`debug_handler`]: macro@debug_handler
 
 #![warn(


### PR DESCRIPTION
There is no reason for axum-debug to depend on axum, it's more of a sibling dependency (the code *generated by* axum-debug needs `axum` to be in scope, not axum-debug itself).

For the doc tests, it needs to be available though.