### PR TITLE
axum-debug: Use proc-macro-crate for referencing axum in generated code

### DIFF
--- a/axum-debug/Cargo.toml
+++ b/axum-debug/Cargo.toml
@@ -15,6 +15,7 @@ version = "0.1.0"
 proc-macro = true
 
 [dependencies]
+proc-macro-crate = "1.1.0"
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = { version = "1.0", features = ["full"] }


### PR DESCRIPTION
Allows users to rename `axum` (say to `axum03`) in `Cargo.toml` and still have `axum-debug` work.

Would also allow usage of `axum-debug` in axum itself (possibly relevant for in-crate tests) if https://github.com/bkchr/proc-macro-crate/issues/11 were fixed (for this specific case there is a workaround though).