### PR TITLE
Add Json::erased constructor

### DIFF
--- a/axum/Cargo.toml
+++ b/axum/Cargo.toml
@@ -46,7 +46,7 @@ base64 = { optional = true, version = "0.13" }
 headers = { optional = true, version = "0.3" }
 mime = { optional = true, version = "0.3" }
 multer = { optional = true, version = "2.0.0" }
-serde_json = { version = "1.0", optional = true }
+serde_json = { version = "1.0", optional = true, features = ["raw_value"] }
 sha-1 = { optional = true, version = "0.9.6" }
 tokio-tungstenite = { optional = true, version = "0.15" }
 

--- a/axum/src/response/mod.rs
+++ b/axum/src/response/mod.rs
@@ -17,6 +17,8 @@ mod redirect;
 
 pub mod sse;
 
+#[cfg(feature = "json")]
+pub use crate::json::JsonSerializationError;
 #[doc(no_inline)]
 #[cfg(feature = "json")]
 pub use crate::Json;


### PR DESCRIPTION
So I couldn't actually do the copy-free hack I wanted because `Box<RawValue>` can't be converted to `Box<str>` with `serde_json`s current API (though the impl would be easy to add there). The idea there way to use the [castaway](https://github.com/sagebind/castaway) crate or implement the same logic manually, to "specialize" the `Box<RawValue>` body in the `IntoResponse` impl.

Might still be worth having this.

To do:

* [x] Improve documentation
* [x] Create an error type to wrap the `serde_json::Error` in that implements `IntoResponse`? This would allow returning `Json::Erased` from a handler, letting `IntoResponse` "handle" the error the same way as serialization errors in `Json<OwnType>` are handled.