### PR TITLE
axum: Version 0.3.3

### DIFF
--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
+- None.
+
+# 0.3.3 (13. November, 2021)
+
 - Implement `FromRequest` for [`http::request::Parts`] so it can be used an
   extractor ([#489])
 - Implement `IntoResponse` for `http::response::Parts` ([#490])

--- a/axum/Cargo.toml
+++ b/axum/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axum"
-version = "0.3.2"
+version = "0.3.3"
 authors = ["David Pedersen <david.pdrsn@gmail.com>"]
 categories = ["asynchronous", "network-programming", "web-programming"]
 description = "Web framework that focuses on ergonomics and modularity"


### PR DESCRIPTION
- Implement `FromRequest` for [`http::request::Parts`] so it can be used an
  extractor ([#489])
- Implement `IntoResponse` for `http::response::Parts` ([#490])

[#489]: https://github.com/tokio-rs/axum/pull/489
[#490]: https://github.com/tokio-rs/axum/pull/490
[`http::request::Parts`]: https://docs.rs/http/latest/http/request/struct.Parts.html