### PR TITLE
axum-debug: Version 0.2.0

### DIFF
--- a/axum-debug/CHANGELOG.md
+++ b/axum-debug/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
+# 0.2.0 (13. October 2021)
+
 - **breaking:** Removed `debug_router` macro.
 - **breaking:** Removed `check_service` function.
 - **breaking:** Removed `debug_service` function.

--- a/axum-debug/Cargo.toml
+++ b/axum-debug/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 name = "axum-debug"
 readme = "README.md"
 repository = "https://github.com/tokio-rs/axum"
-version = "0.1.0"
+version = "0.2.0"
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
- **breaking:** Removed `debug_router` macro.
- **breaking:** Removed `check_service` function.
- **breaking:** Removed `debug_service` function.