### PR TITLE
`axum-debug`: fix UI tests' failures when using rustc 1.54

### DIFF
--- a/axum-debug/tests/fail/argument_not_extractor.stderr
+++ b/axum-debug/tests/fail/argument_not_extractor.stderr
@@ -2,10 +2,7 @@ error[E0277]: the trait bound `bool: FromRequest` is not satisfied
  --> tests/fail/argument_not_extractor.rs:4:23
   |
 4 | async fn handler(foo: bool) {}
-  |                       ^^^^ the trait `FromRequest` is not implemented for `bool`
-  |
-note: required by a bound in `handler::{closure#0}::debug_handler`
- --> tests/fail/argument_not_extractor.rs:4:23
-  |
-4 | async fn handler(foo: bool) {}
-  |                       ^^^^ required by this bound in `handler::{closure#0}::debug_handler`
+  |                       ^^^^
+  |                       |
+  |                       the trait `FromRequest` is not implemented for `bool`
+  |                       required by this bound in `handler::{closure#0}::debug_handler`

--- a/axum-debug/tests/fail/not_send.stderr
+++ b/axum-debug/tests/fail/not_send.stderr
@@ -2,7 +2,10 @@ error: future cannot be sent between threads safely
  --> tests/fail/not_send.rs:4:10
   |
 4 | async fn handler() {
-  |          ^^^^^^^ future returned by `handler` is not `Send`
+  |          ^^^^^^^
+  |          |
+  |          future returned by `handler` is not `Send`
+  |          required by this bound in `handler::{closure#0}::debug_handler`
   |
   = help: within `impl Future`, the trait `Send` is not implemented for `Rc<()>`
 note: future is not `Send` as this value is used across an await
@@ -14,8 +17,3 @@ note: future is not `Send` as this value is used across an await
   |     ^^^^^^^^^^^^^^ await occurs here, with `rc` maybe used later
 7 | }
   | - `rc` is later dropped here
-note: required by a bound in `handler::{closure#0}::debug_handler`
- --> tests/fail/not_send.rs:4:10
-  |
-4 | async fn handler() {
-  |          ^^^^^^^ required by this bound in `handler::{closure#0}::debug_handler`

--- a/axum-debug/tests/fail/wrong_return_type.stderr
+++ b/axum-debug/tests/fail/wrong_return_type.stderr
@@ -2,10 +2,7 @@ error[E0277]: the trait bound `bool: IntoResponse` is not satisfied
  --> tests/fail/wrong_return_type.rs:4:23
   |
 4 | async fn handler() -> bool {
-  |                       ^^^^ the trait `IntoResponse` is not implemented for `bool`
-  |
-note: required by a bound in `handler::{closure#0}::debug_handler`
- --> tests/fail/wrong_return_type.rs:4:23
-  |
-4 | async fn handler() -> bool {
-  |                       ^^^^ required by this bound in `handler::{closure#0}::debug_handler`
+  |                       ^^^^
+  |                       |
+  |                       the trait `IntoResponse` is not implemented for `bool`
+  |                       required by this bound in `handler::{closure#0}::debug_handler`


### PR DESCRIPTION
The MSRV is 1.54. However, `rustc`'s messages in the tests use 1.56.
This commit is the result of running `TRY_BUILD=overwrite cargo test` on
the `axum-debug` crate with 1.54.
