### PR TITLE
Version 0.3.4

### DIFF
--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -7,8 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
+- None.
+
+# 0.3.4 (13. November, 2021)
+
 - **change:** `box_body` has been renamed to `boxed`. `box_body` still exists
-  but is deprecated.
+  but is deprecated ([#530])
+
+[#530]: https://github.com/tokio-rs/axum/pull/530
 
 # 0.3.3 (13. November, 2021)
 

--- a/axum/Cargo.toml
+++ b/axum/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axum"
-version = "0.3.3"
+version = "0.3.4"
 authors = ["David Pedersen <david.pdrsn@gmail.com>"]
 categories = ["asynchronous", "network-programming", "web-programming"]
 description = "Web framework that focuses on ergonomics and modularity"


### PR DESCRIPTION
- **change:** `box_body` has been renamed to `boxed`. `box_body` still exists
  but is deprecated ([#530])

[#530]: https://github.com/tokio-rs/axum/pull/530