### PR TITLE
Rename `box_body` to `body`

### DIFF
--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     `MethodRouter::route_layer`.
   - Merge method routers with `MethodRouter::merge`
   - Customize response for unsupported methods with `MethodRouter::fallback`
+- **breaking:** The previously deprecated `axum::body::box_body` function has
+  been removed. Use `axum::body::boxed` instead.
 - **fixed:** Adding the same route with different methods now works ie
   `.route("/", get(_)).route("/", post(_))`.
 - **breaking:** `routing::handler_method_router` and

--- a/axum/src/body/mod.rs
+++ b/axum/src/body/mod.rs
@@ -22,7 +22,7 @@ pub use bytes::Bytes;
 pub type BoxBody = http_body::combinators::UnsyncBoxBody<Bytes, Error>;
 
 /// Convert a [`http_body::Body`] into a [`BoxBody`].
-pub fn box_body<B>(body: B) -> BoxBody
+pub fn boxed<B>(body: B) -> BoxBody
 where
     B: http_body::Body<Data = Bytes> + Send + 'static,
     B::Error: Into<BoxError>,
@@ -31,5 +31,5 @@ where
 }
 
 pub(crate) fn empty() -> BoxBody {
-    box_body(http_body::Empty::new())
+    boxed(http_body::Empty::new())
 }

--- a/axum/src/docs/routing/route.md
+++ b/axum/src/docs/routing/route.md
@@ -137,7 +137,7 @@ let app = Router::new()
         // it can be routed to directly.
         service_fn(|req: Request<Body>| async move {
             let body = Body::from(format!("Hi from `{} /foo`", req.method()));
-            let body = axum::body::box_body(body);
+            let body = axum::body::boxed(body);
             let res = Response::new(body);
             Ok::<_, Infallible>(res)
         })

--- a/axum/src/error_handling/mod.rs
+++ b/axum/src/error_handling/mod.rs
@@ -138,7 +138,7 @@ pub mod future {
     //! Future types.
 
     use crate::{
-        body::{box_body, BoxBody},
+        body::{boxed, BoxBody},
         response::IntoResponse,
         BoxError,
     };
@@ -177,11 +177,11 @@ pub mod future {
             let this = self.project();
 
             match ready!(this.inner.poll(cx)) {
-                Ok(res) => Ok(res.map(box_body)).into(),
+                Ok(res) => Ok(res.map(boxed)).into(),
                 Err(err) => {
                     let f = this.f.take().unwrap();
                     let res = f(err);
-                    Ok(res.into_response().map(box_body)).into()
+                    Ok(res.into_response().map(boxed)).into()
                 }
             }
         }

--- a/axum/src/extract/extractor_middleware.rs
+++ b/axum/src/extract/extractor_middleware.rs
@@ -247,7 +247,7 @@ where
                             State::Call { future }
                         }
                         Err(err) => {
-                            let res = err.into_response().map(crate::body::box_body);
+                            let res = err.into_response().map(crate::body::boxed);
                             return Poll::Ready(Ok(res));
                         }
                     }
@@ -255,7 +255,7 @@ where
                 StateProj::Call { future } => {
                     return future
                         .poll(cx)
-                        .map(|result| result.map(|response| response.map(crate::body::box_body)));
+                        .map(|result| result.map(|response| response.map(crate::body::boxed)));
                 }
             };
 

--- a/axum/src/extract/rejection.rs
+++ b/axum/src/extract/rejection.rs
@@ -2,7 +2,7 @@
 
 use super::IntoResponse;
 use crate::{
-    body::{box_body, BoxBody},
+    body::{boxed, BoxBody},
     BoxError, Error,
 };
 use bytes::Bytes;
@@ -325,10 +325,10 @@ where
 
     fn into_response(self) -> http::Response<Self::Body> {
         match self {
-            Self::PayloadTooLarge(inner) => inner.into_response().map(box_body),
-            Self::LengthRequired(inner) => inner.into_response().map(box_body),
-            Self::HeadersAlreadyExtracted(inner) => inner.into_response().map(box_body),
-            Self::Inner(inner) => inner.into_response().map(box_body),
+            Self::PayloadTooLarge(inner) => inner.into_response().map(boxed),
+            Self::LengthRequired(inner) => inner.into_response().map(boxed),
+            Self::HeadersAlreadyExtracted(inner) => inner.into_response().map(boxed),
+            Self::Inner(inner) => inner.into_response().map(boxed),
         }
     }
 }

--- a/axum/src/extract/tuple.rs
+++ b/axum/src/extract/tuple.rs
@@ -1,6 +1,6 @@
 use super::{FromRequest, RequestParts};
 use crate::{
-    body::{box_body, BoxBody},
+    body::{boxed, BoxBody},
     response::IntoResponse,
 };
 use async_trait::async_trait;
@@ -33,7 +33,7 @@ macro_rules! impl_from_request {
             type Rejection = Response<BoxBody>;
 
             async fn from_request(req: &mut RequestParts<B>) -> Result<Self, Self::Rejection> {
-                $( let $ty = $ty::from_request(req).await.map_err(|err| err.into_response().map(box_body))?; )*
+                $( let $ty = $ty::from_request(req).await.map_err(|err| err.into_response().map(boxed))?; )*
                 Ok(($($ty,)*))
             }
         }

--- a/axum/src/handler/mod.rs
+++ b/axum/src/handler/mod.rs
@@ -71,7 +71,7 @@
 //! [axum-debug]: https://docs.rs/axum-debug
 
 use crate::{
-    body::{box_body, Body, BoxBody},
+    body::{boxed, Body, BoxBody},
     extract::{
         connect_info::{Connected, IntoMakeServiceWithConnectInfo},
         FromRequest, RequestParts,
@@ -272,7 +272,7 @@ where
     type Sealed = sealed::Hidden;
 
     async fn call(self, _req: Request<B>) -> Response<BoxBody> {
-        self().await.into_response().map(box_body)
+        self().await.into_response().map(boxed)
     }
 }
 
@@ -296,13 +296,13 @@ macro_rules! impl_handler {
                 $(
                     let $ty = match $ty::from_request(&mut req).await {
                         Ok(value) => value,
-                        Err(rejection) => return rejection.into_response().map(box_body),
+                        Err(rejection) => return rejection.into_response().map(boxed),
                     };
                 )*
 
                 let res = self($($ty,)*).await;
 
-                res.into_response().map(box_body)
+                res.into_response().map(boxed)
             }
         }
     };
@@ -371,8 +371,8 @@ where
             .await
             .map_err(IntoResponse::into_response)
         {
-            Ok(res) => res.map(box_body),
-            Err(res) => res.map(box_body),
+            Ok(res) => res.map(boxed),
+            Err(res) => res.map(boxed),
         }
     }
 }

--- a/axum/src/response/headers.rs
+++ b/axum/src/response/headers.rs
@@ -1,6 +1,6 @@
 use super::IntoResponse;
 use crate::{
-    body::{box_body, BoxBody},
+    body::{boxed, BoxBody},
     BoxError,
 };
 use bytes::Bytes;
@@ -133,10 +133,10 @@ where
     fn into_response(self) -> Response<Self::Body> {
         let headers = match self.0.try_into_header_map() {
             Ok(headers) => headers,
-            Err(res) => return res.map(box_body),
+            Err(res) => return res.map(boxed),
         };
 
-        (headers, self.1).into_response().map(box_body)
+        (headers, self.1).into_response().map(boxed)
     }
 }
 
@@ -157,10 +157,10 @@ where
     fn into_response(self) -> Response<Self::Body> {
         let headers = match self.1.try_into_header_map() {
             Ok(headers) => headers,
-            Err(res) => return res.map(box_body),
+            Err(res) => return res.map(boxed),
         };
 
-        (self.0, headers, self.2).into_response().map(box_body)
+        (self.0, headers, self.2).into_response().map(boxed)
     }
 }
 

--- a/axum/src/response/mod.rs
+++ b/axum/src/response/mod.rs
@@ -1,7 +1,7 @@
 #![doc = include_str!("../docs/response.md")]
 
 use crate::{
-    body::{box_body, BoxBody},
+    body::{boxed, BoxBody},
     BoxError, Error,
 };
 use bytes::Bytes;
@@ -157,7 +157,7 @@ pub trait IntoResponse {
     /// contains exactly one chunk.
     /// - [`axum::body::BoxBody`]: If you need to unify multiple body types into
     /// one, or return a body type that cannot be named. Can be created with
-    /// [`box_body`].
+    /// [`boxed`].
     ///
     /// [`axum::body::Body`]: crate::body::Body
     /// [`axum::body::Empty<Bytes>`]: crate::body::Empty
@@ -209,8 +209,8 @@ where
 
     fn into_response(self) -> Response<Self::Body> {
         match self {
-            Ok(value) => value.into_response().map(box_body),
-            Err(err) => err.into_response().map(box_body),
+            Ok(value) => value.into_response().map(boxed),
+            Err(err) => err.into_response().map(boxed),
         }
     }
 }

--- a/axum/src/routing/method_routing.rs
+++ b/axum/src/routing/method_routing.rs
@@ -1,5 +1,5 @@
 use crate::{
-    body::{box_body, Body, BoxBody, Bytes},
+    body::{boxed, Body, BoxBody, Bytes},
     error_handling::HandleErrorLayer,
     handler::Handler,
     http::{Method, Request, Response, StatusCode},
@@ -508,7 +508,7 @@ impl<B, E> MethodRouter<B, E> {
     /// requests.
     pub fn new() -> Self {
         let fallback = Route::new(service_fn(|_: Request<B>| async {
-            let mut response = Response::new(box_body(Empty::new()));
+            let mut response = Response::new(boxed(Empty::new()));
             *response.status_mut() = StatusCode::METHOD_NOT_ALLOWED;
             Ok(response)
         }));
@@ -609,7 +609,7 @@ impl<ReqBody, E> MethodRouter<ReqBody, E> {
         ResBody: http_body::Body<Data = Bytes> + Send + 'static,
         ResBody::Error: Into<BoxError>,
     {
-        self.on_service_boxed_response_body(filter, svc.map_response(|res| res.map(box_body)))
+        self.on_service_boxed_response_body(filter, svc.map_response(|res| res.map(boxed)))
     }
 
     chained_service_fn!(delete_service, DELETE);
@@ -632,7 +632,7 @@ impl<ReqBody, E> MethodRouter<ReqBody, E> {
         ResBody: http_body::Body<Data = Bytes> + Send + 'static,
         ResBody::Error: Into<BoxError>,
     {
-        self.fallback = Fallback::Custom(Route::new(svc.map_response(|res| res.map(box_body))));
+        self.fallback = Fallback::Custom(Route::new(svc.map_response(|res| res.map(boxed))));
         self
     }
 
@@ -665,7 +665,7 @@ impl<ReqBody, E> MethodRouter<ReqBody, E> {
     {
         let layer = ServiceBuilder::new()
             .layer_fn(Route::new)
-            .layer(MapResponseBodyLayer::new(box_body))
+            .layer(MapResponseBodyLayer::new(boxed))
             .layer(layer)
             .into_inner();
         let layer_fn = |s| layer.layer(s);
@@ -698,7 +698,7 @@ impl<ReqBody, E> MethodRouter<ReqBody, E> {
     {
         let layer = ServiceBuilder::new()
             .layer_fn(Route::new)
-            .layer(MapResponseBodyLayer::new(box_body))
+            .layer(MapResponseBodyLayer::new(boxed))
             .layer(layer)
             .into_inner();
         let layer_fn = |s| layer.layer(s);

--- a/axum/src/routing/mod.rs
+++ b/axum/src/routing/mod.rs
@@ -2,7 +2,7 @@
 
 use self::{future::RouterFuture, not_found::NotFound};
 use crate::{
-    body::{box_body, Body, BoxBody},
+    body::{boxed, Body, BoxBody},
     extract::{
         connect_info::{Connected, IntoMakeServiceWithConnectInfo},
         MatchedPath, OriginalUri,
@@ -274,7 +274,7 @@ where
         NewResBody::Error: Into<BoxError>,
     {
         let layer = ServiceBuilder::new()
-            .layer(MapResponseBodyLayer::new(box_body))
+            .layer(MapResponseBodyLayer::new(boxed))
             .layer(layer)
             .into_inner();
 
@@ -315,7 +315,7 @@ where
         NewResBody::Error: Into<BoxError>,
     {
         let layer = ServiceBuilder::new()
-            .layer(MapResponseBodyLayer::new(box_body))
+            .layer(MapResponseBodyLayer::new(boxed))
             .layer(layer)
             .into_inner();
 

--- a/axum/src/routing/route.rs
+++ b/axum/src/routing/route.rs
@@ -1,5 +1,5 @@
 use crate::{
-    body::{box_body, Body, BoxBody},
+    body::{boxed, Body, BoxBody},
     clone_box_service::CloneBoxService,
 };
 use http::{Request, Response};
@@ -99,7 +99,7 @@ impl<B, E> Future for RouteFuture<B, E> {
         match self.project().future.poll(cx) {
             Poll::Ready(Ok(res)) => {
                 if strip_body {
-                    Poll::Ready(Ok(res.map(|_| box_body(Empty::new()))))
+                    Poll::Ready(Ok(res.map(|_| boxed(Empty::new()))))
                 } else {
                     Poll::Ready(Ok(res))
                 }

--- a/axum/src/routing/tests/nest.rs
+++ b/axum/src/routing/tests/nest.rs
@@ -1,7 +1,7 @@
 use tower_http::services::ServeDir;
 
 use super::*;
-use crate::{body::box_body, extract::Extension};
+use crate::{body::boxed, extract::Extension};
 use std::collections::HashMap;
 
 #[tokio::test]
@@ -151,7 +151,7 @@ async fn nested_service_sees_stripped_uri() {
             Router::new().route(
                 "/baz",
                 service_fn(|req: Request<Body>| async move {
-                    let body = box_body(Body::from(req.uri().to_string()));
+                    let body = boxed(Body::from(req.uri().to_string()));
                     Ok::<_, Infallible>(Response::new(body))
                 }),
             ),

--- a/examples/http-proxy/src/main.rs
+++ b/examples/http-proxy/src/main.rs
@@ -13,7 +13,7 @@
 //! Example is based on <https://github.com/hyperium/hyper/blob/master/examples/http_proxy.rs>
 
 use axum::{
-    body::{box_body, Body},
+    body::{boxed, Body},
     http::{Method, Request, Response, StatusCode},
     routing::get,
     Router,
@@ -37,7 +37,7 @@ async fn main() {
         let router = router.clone();
         async move {
             if req.method() == Method::CONNECT {
-                proxy(req).await.map(|res| res.map(box_body))
+                proxy(req).await.map(|res| res.map(boxed))
             } else {
                 router.oneshot(req).await.map_err(|err| match err {})
             }


### PR DESCRIPTION
Probably would have been easier to merge this change directly into
`main` first and the backport it to `v0.3.x` but here we are 😜

I'm thinking just before shipping 0.4.0 I'll copy the changelog updates
from the `v0.3.x` branch into `main`. Not sure if there is easier way
to manage backports, changelogs, and git without going all our
gitflow with complex tools.

Fixes #528