### PR TITLE
Use named constants for static header values

### DIFF
--- a/axum/Cargo.toml
+++ b/axum/Cargo.toml
@@ -25,7 +25,7 @@ async-trait = "0.1.43"
 bitflags = "1.0"
 bytes = "1.0"
 futures-util = { version = "0.3", default-features = false, features = ["alloc"] }
-http = "0.2"
+http = "0.2.5"
 http-body = "0.4.4"
 hyper = { version = "0.14.14", features = ["server", "tcp", "stream"] }
 matchit = "0.4.4"

--- a/axum/src/json.rs
+++ b/axum/src/json.rs
@@ -176,6 +176,9 @@ where
     type BodyError = Infallible;
 
     fn into_response(self) -> Response<Self::Body> {
+        #[allow(clippy::declare_interior_mutable_const)]
+        const APPLICATION_JSON: HeaderValue = HeaderValue::from_static("application/json");
+
         let bytes = match serde_json::to_vec(&self.0) {
             Ok(res) => res,
             Err(err) => {
@@ -188,10 +191,8 @@ where
         };
 
         let mut res = Response::new(Full::from(bytes));
-        res.headers_mut().insert(
-            header::CONTENT_TYPE,
-            HeaderValue::from_static("application/json"),
-        );
+        res.headers_mut()
+            .insert(header::CONTENT_TYPE, APPLICATION_JSON);
         res
     }
 }

--- a/axum/src/response/mod.rs
+++ b/axum/src/response/mod.rs
@@ -331,12 +331,17 @@ impl IntoResponse for std::borrow::Cow<'static, str> {
     type BodyError = Infallible;
 
     fn into_response(self) -> Response<Self::Body> {
+        #[allow(clippy::declare_interior_mutable_const)]
+        const TEXT_PLAIN: HeaderValue = HeaderValue::from_static("text/plain");
+
         let mut res = Response::new(Full::from(self));
-        res.headers_mut()
-            .insert(header::CONTENT_TYPE, HeaderValue::from_static("text/plain"));
+        res.headers_mut().insert(header::CONTENT_TYPE, TEXT_PLAIN);
         res
     }
 }
+
+#[allow(clippy::declare_interior_mutable_const)]
+const APPLICATION_OCTET_STREAM: HeaderValue = HeaderValue::from_static("application/octet-stream");
 
 impl IntoResponse for Bytes {
     type Body = Full<Bytes>;
@@ -344,10 +349,8 @@ impl IntoResponse for Bytes {
 
     fn into_response(self) -> Response<Self::Body> {
         let mut res = Response::new(Full::from(self));
-        res.headers_mut().insert(
-            header::CONTENT_TYPE,
-            HeaderValue::from_static("application/octet-stream"),
-        );
+        res.headers_mut()
+            .insert(header::CONTENT_TYPE, APPLICATION_OCTET_STREAM);
         res
     }
 }
@@ -358,10 +361,8 @@ impl IntoResponse for &'static [u8] {
 
     fn into_response(self) -> Response<Self::Body> {
         let mut res = Response::new(Full::from(self));
-        res.headers_mut().insert(
-            header::CONTENT_TYPE,
-            HeaderValue::from_static("application/octet-stream"),
-        );
+        res.headers_mut()
+            .insert(header::CONTENT_TYPE, APPLICATION_OCTET_STREAM);
         res
     }
 }
@@ -372,10 +373,8 @@ impl IntoResponse for Vec<u8> {
 
     fn into_response(self) -> Response<Self::Body> {
         let mut res = Response::new(Full::from(self));
-        res.headers_mut().insert(
-            header::CONTENT_TYPE,
-            HeaderValue::from_static("application/octet-stream"),
-        );
+        res.headers_mut()
+            .insert(header::CONTENT_TYPE, APPLICATION_OCTET_STREAM);
         res
     }
 }
@@ -386,10 +385,8 @@ impl IntoResponse for std::borrow::Cow<'static, [u8]> {
 
     fn into_response(self) -> Response<Self::Body> {
         let mut res = Response::new(Full::from(self));
-        res.headers_mut().insert(
-            header::CONTENT_TYPE,
-            HeaderValue::from_static("application/octet-stream"),
-        );
+        res.headers_mut()
+            .insert(header::CONTENT_TYPE, APPLICATION_OCTET_STREAM);
         res
     }
 }
@@ -471,9 +468,11 @@ where
     type BodyError = Infallible;
 
     fn into_response(self) -> Response<Self::Body> {
+        #[allow(clippy::declare_interior_mutable_const)]
+        const TEXT_HTML: HeaderValue = HeaderValue::from_static("text/html");
+
         let mut res = Response::new(self.0.into());
-        res.headers_mut()
-            .insert(header::CONTENT_TYPE, HeaderValue::from_static("text/html"));
+        res.headers_mut().insert(header::CONTENT_TYPE, TEXT_HTML);
         res
     }
 }


### PR DESCRIPTION
Improves performance by moving some computation to compile time.

Resolves #531.