### PR TITLE
Fix `Router::merge` for overlapping routes same different methods

### DIFF
--- a/axum/src/routing/tests/mod.rs
+++ b/axum/src/routing/tests/mod.rs
@@ -584,3 +584,19 @@ async fn nesting_router_with_fallbacks_panics() {
     let app = Router::new().nest("/", one);
     TestClient::new(app);
 }
+
+#[tokio::test]
+async fn merging_routers_with_same_paths_but_different_methods() {
+    let one = Router::new().route("/", get(|| async { "GET" }));
+    let two = Router::new().route("/", post(|| async { "POST" }));
+
+    let client = TestClient::new(one.merge(two));
+
+    let res = client.get("/").send().await;
+    let body = res.text().await;
+    assert_eq!(body, "GET");
+
+    let res = client.post("/").send().await;
+    let body = res.text().await;
+    assert_eq!(body, "POST");
+}


### PR DESCRIPTION
Discovered while working on [something else](https://twitter.com/DavidPdrsn/status/1461777694098604036) that we didn't properly
handle this:

```rust
let one = Router::new().route("/", get(|| async {}));
let two = Router::new().route("/", post(|| async {}));

let app = one.merge(two);
```

It would panic and complain about overlapping routes.