### PR TITLE
axum-debug: Version 0.2.1

### DIFF
--- a/axum-debug/CHANGELOG.md
+++ b/axum-debug/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
+- None.
+
+# 0.2.1 (19. October 2021)
+
 - Make macro handle more cases such as mutable extractors and handlers taking
   `self` ([#518])
 

--- a/axum-debug/Cargo.toml
+++ b/axum-debug/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 name = "axum-debug"
 readme = "README.md"
 repository = "https://github.com/tokio-rs/axum"
-version = "0.2.0"
+version = "0.2.1"
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
- Make macro handle more cases such as mutable extractors and handlers taking
  `self` ([#518])

[#518]: https://github.com/tokio-rs/axum/pull/518