### PR TITLE
Allow extractor resources to be used external to axum

### DIFF
--- a/axum/src/macros.rs
+++ b/axum/src/macros.rs
@@ -86,10 +86,10 @@ macro_rules! define_rejection {
     ) => {
         $(#[$m])*
         #[derive(Debug)]
-        pub struct $name(pub(crate) crate::Error);
+        pub struct $name(pub crate::Error);
 
         impl $name {
-            pub(crate) fn from_err<E>(err: E) -> Self
+            pub fn from_err<E>(err: E) -> Self
             where
                 E: Into<crate::BoxError>,
             {


### PR DESCRIPTION
 Hello, the current extractors only allow use within the crate itself, even though custom extractors would want to be able to reuse this logic.

## Motivation

in making a custom extractor, wanted to reuse the existing MissingExtension/ExtensionAlreadyExtracted

## Solution

just remove the (crate) part of from err