### PR TITLE
Fix `#[debug_handler]` for multiple extractors

### DIFF
--- a/axum-debug/CHANGELOG.md
+++ b/axum-debug/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
-- None.
+- Fix regression causing errors when `#[debug_handler]` was used on functions with multiple
+  extractors.
 
 # 0.2.1 (19. October 2021)
 

--- a/axum-debug/Cargo.toml
+++ b/axum-debug/Cargo.toml
@@ -16,7 +16,7 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0"
 quote = "1.0"
-syn = { version = "1.0", features = ["full"] }
+syn = { version = "1.0", features = ["full", "visit"] }
 
 [dev-dependencies]
 axum = { path = "../axum", version = "0.3" }

--- a/axum-debug/Cargo.toml
+++ b/axum-debug/Cargo.toml
@@ -16,7 +16,7 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0"
 quote = "1.0"
-syn = { version = "1.0", features = ["full", "visit"] }
+syn = { version = "1.0", features = ["full"] }
 
 [dev-dependencies]
 axum = { path = "../axum", version = "0.3" }

--- a/axum-debug/tests/pass/multiple_extractors.rs
+++ b/axum-debug/tests/pass/multiple_extractors.rs
@@ -1,0 +1,6 @@
+use axum_debug::debug_handler;
+
+#[debug_handler]
+async fn handler(_one: String, _two: String, _three: String) {}
+
+fn main() {}


### PR DESCRIPTION
It generated a function for each extractor to check the type but those
functions didn't have unique names.

Fixed by including all idents in the `arg: Extractor` token tree in the
name of the function generated. Not sure there is a simpler way to fix
it.

Fixes https://github.com/tokio-rs/axum/issues/551