### PR TITLE
axum-debug: Version 0.2.2

### DIFF
--- a/axum-debug/CHANGELOG.md
+++ b/axum-debug/CHANGELOG.md
@@ -7,8 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
+- None.
+
+# 0.2.2 (22. October 2021)
+
 - Fix regression causing errors when `#[debug_handler]` was used on functions with multiple
-  extractors.
+  extractors ([#552])
+
+[#552]: https://github.com/tokio-rs/axum/pull/552
 
 # 0.2.1 (19. October 2021)
 

--- a/axum-debug/Cargo.toml
+++ b/axum-debug/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 name = "axum-debug"
 readme = "README.md"
 repository = "https://github.com/tokio-rs/axum"
-version = "0.2.1"
+version = "0.2.2"
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
- Fix regression causing errors when `#[debug_handler]` was used on functions with multiple
  extractors ([#552])

[#552]: https://github.com/tokio-rs/axum/pull/552