### PR TITLE
Update routing layer documentation

### DIFF
--- a/axum/src/docs/routing/layer.md
+++ b/axum/src/docs/routing/layer.md
@@ -27,7 +27,7 @@ async fn second_handler() {}
 
 async fn third_handler() {}
 
-// All requests to `handler` and `other_handler` will be sent through
+// All requests to `first_handler` and `second_handler` will be sent through
 // `ConcurrencyLimit`
 let app = Router::new().route("/", get(first_handler))
     .route("/foo", get(second_handler))


### PR DESCRIPTION
## Motivation

The handler names in the routing layer documentation don't match the example code.

## Solution

I changed the names in the comments to match those in the code.