### PR TITLE
Avoid double-boxing bodies where possible

### DIFF
--- a/axum/src/body/mod.rs
+++ b/axum/src/body/mod.rs
@@ -1,7 +1,6 @@
 //! HTTP body utilities.
 
-use crate::{BoxError, Error};
-use std::any::Any;
+use crate::{util::try_downcast, BoxError, Error};
 
 mod stream_body;
 
@@ -23,31 +22,12 @@ pub use bytes::Bytes;
 pub type BoxBody = http_body::combinators::UnsyncBoxBody<Bytes, Error>;
 
 /// Convert a [`http_body::Body`] into a [`BoxBody`].
-///
-/// If the given body is already a [`BoxBody`], this function will not box the body again.
 pub fn boxed<B>(body: B) -> BoxBody
 where
     B: http_body::Body<Data = Bytes> + Send + 'static,
     B::Error: Into<BoxError>,
 {
-    downcast_box_body(body).unwrap_or_else(|body| body.map_err(Error::new).boxed_unsync())
-}
-
-fn downcast_box_body<B: 'static>(body: B) -> Result<BoxBody, B> {
-    let mut body = Some(body);
-    if let Some(body) = <dyn Any>::downcast_mut::<Option<BoxBody>>(&mut body) {
-        Ok(body.take().unwrap())
-    } else {
-        Err(body.unwrap())
-    }
-}
-
-#[test]
-fn body_not_double_boxed() {
-    let body = Full::new(Bytes::from("hello world"));
-    assert!(downcast_box_body(body.clone()).is_err());
-    assert!(downcast_box_body(boxed(body.clone())).is_ok());
-    assert!(downcast_box_body(boxed(boxed(body.clone()))).is_ok());
+    try_downcast(body).unwrap_or_else(|body| body.map_err(Error::new).boxed_unsync())
 }
 
 pub(crate) fn empty() -> BoxBody {

--- a/axum/src/body/mod.rs
+++ b/axum/src/body/mod.rs
@@ -1,6 +1,7 @@
 //! HTTP body utilities.
 
 use crate::{BoxError, Error};
+use std::any::Any;
 
 mod stream_body;
 
@@ -22,12 +23,31 @@ pub use bytes::Bytes;
 pub type BoxBody = http_body::combinators::UnsyncBoxBody<Bytes, Error>;
 
 /// Convert a [`http_body::Body`] into a [`BoxBody`].
+///
+/// If the given body is already a [`BoxBody`], this function will not box the body again.
 pub fn boxed<B>(body: B) -> BoxBody
 where
     B: http_body::Body<Data = Bytes> + Send + 'static,
     B::Error: Into<BoxError>,
 {
-    body.map_err(Error::new).boxed_unsync()
+    downcast_box_body(body).unwrap_or_else(|body| body.map_err(Error::new).boxed_unsync())
+}
+
+fn downcast_box_body<B: 'static>(body: B) -> Result<BoxBody, B> {
+    let mut body = Some(body);
+    if let Some(body) = <dyn Any>::downcast_mut::<Option<BoxBody>>(&mut body) {
+        Ok(body.take().unwrap())
+    } else {
+        Err(body.unwrap())
+    }
+}
+
+#[test]
+fn body_not_double_boxed() {
+    let body = Full::new(Bytes::from("hello world"));
+    assert!(downcast_box_body(body.clone()).is_err());
+    assert!(downcast_box_body(boxed(body.clone())).is_ok());
+    assert!(downcast_box_body(boxed(boxed(body.clone()))).is_ok());
 }
 
 pub(crate) fn empty() -> BoxBody {

--- a/axum/src/routing/mod.rs
+++ b/axum/src/routing/mod.rs
@@ -8,7 +8,7 @@ use crate::{
         MatchedPath, OriginalUri,
     },
     routing::strip_prefix::StripPrefix,
-    util::{ByteStr, PercentDecodedByteStr},
+    util::{try_downcast, ByteStr, PercentDecodedByteStr},
     BoxError,
 };
 use bytes::Bytes;
@@ -654,20 +654,6 @@ impl<B, E> Fallback<B, E> {
             Fallback::Default(inner) => Fallback::Default(f(inner)),
             Fallback::Custom(inner) => Fallback::Custom(f(inner)),
         }
-    }
-}
-
-fn try_downcast<T, K>(k: K) -> Result<T, K>
-where
-    T: 'static,
-    K: Send + 'static,
-{
-    use std::any::Any;
-
-    let k = Box::new(k) as Box<dyn Any + Send + 'static>;
-    match k.downcast() {
-        Ok(t) => Ok(*t),
-        Err(other) => Err(*other.downcast().unwrap()),
     }
 }
 

--- a/axum/src/util.rs
+++ b/axum/src/util.rs
@@ -65,3 +65,22 @@ pin_project! {
         B { #[pin] inner: B },
     }
 }
+
+pub(crate) fn try_downcast<T, K>(k: K) -> Result<T, K>
+where
+    T: 'static,
+    K: Send + 'static,
+{
+    let mut k = Some(k);
+    if let Some(k) = <dyn std::any::Any>::downcast_mut::<Option<T>>(&mut k) {
+        Ok(k.take().unwrap())
+    } else {
+        Err(k.unwrap())
+    }
+}
+
+#[test]
+fn test_try_downcast() {
+    assert_eq!(try_downcast::<i32, _>(5_u32), Err(5_u32));
+    assert_eq!(try_downcast::<i32, _>(5_i32), Ok(5_i32));
+}


### PR DESCRIPTION
## Motivation

It can be inefficient if bodies are accidentally boxed twice - for example a handler might return a `Response<BoxBody>`, which `MethodRouter` would then box again.

## Solution

Ensure that bodies don't get boxed twice, by checking if they are already boxed and if so not doing anything.
