### PR TITLE
Remove the associated `Body` type on `IntoResponse`

### DIFF
--- a/axum-debug/tests/pass/returns_self.rs
+++ b/axum-debug/tests/pass/returns_self.rs
@@ -1,5 +1,5 @@
 use axum::{
-    body::{Bytes, Full},
+    body::BoxBody,
     http::Response,
     response::IntoResponse,
 };
@@ -16,10 +16,7 @@ impl A {
 }
 
 impl IntoResponse for A {
-    type Body = Full<Bytes>;
-    type BodyError = Infallible;
-
-    fn into_response(self) -> Response<Self::Body> {
+    fn into_response(self) -> Response<BoxBody> {
         todo!()
     }
 }

--- a/axum-extra/src/extract/cached.rs
+++ b/axum-extra/src/extract/cached.rs
@@ -1,6 +1,6 @@
 use axum::{
     async_trait,
-    body::{boxed, BoxBody},
+    body::BoxBody,
     extract::{
         rejection::{ExtensionRejection, ExtensionsAlreadyExtracted},
         Extension, FromRequest, RequestParts,
@@ -30,7 +30,7 @@ use std::{
 /// use axum::{
 ///     async_trait,
 ///     extract::{FromRequest, RequestParts},
-///     body::{self, BoxBody},
+///     body::BoxBody,
 ///     response::IntoResponse,
 ///     http::{StatusCode, Response},
 /// };
@@ -67,7 +67,7 @@ use std::{
 ///         // once, in case other extractors for the same request also loads the session
 ///         let session: Session = Cached::<Session>::from_request(req)
 ///             .await
-///             .map_err(|err| err.into_response().map(body::boxed))?
+///             .map_err(|err| err.into_response())?
 ///             .0;
 ///
 ///         // load user from session...
@@ -157,13 +157,10 @@ impl<R> IntoResponse for CachedRejection<R>
 where
     R: IntoResponse,
 {
-    type Body = BoxBody;
-    type BodyError = <Self::Body as axum::body::HttpBody>::Error;
-
-    fn into_response(self) -> Response<Self::Body> {
+    fn into_response(self) -> Response<BoxBody> {
         match self {
-            Self::ExtensionsAlreadyExtracted(inner) => inner.into_response().map(boxed),
-            Self::Inner(inner) => inner.into_response().map(boxed),
+            Self::ExtensionsAlreadyExtracted(inner) => inner.into_response(),
+            Self::Inner(inner) => inner.into_response(),
         }
     }
 }

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -34,12 +34,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Previously it would be silently discarded ([#529])
 - Update WebSockets to use tokio-tungstenite 0.16 ([#525])
 - **added:** Default to return `charset=utf-8` for text content type. ([#554])
+- **breaking:** The `Body` and `BodyError` associated types on the
+  `IntoResponse` trait have been removed - instead, `.into_response()` will now
+  always return `Response<BoxBody>` ([#571])
 
 [#525]: https://github.com/tokio-rs/axum/pull/525
 [#527]: https://github.com/tokio-rs/axum/pull/527
 [#529]: https://github.com/tokio-rs/axum/pull/529
 [#534]: https://github.com/tokio-rs/axum/pull/534
 [#554]: https://github.com/tokio-rs/axum/pull/554
+[#571]: https://github.com/tokio-rs/axum/pull/571
 
 # 0.3.3 (13. November, 2021)
 

--- a/axum/src/body/stream_body.rs
+++ b/axum/src/body/stream_body.rs
@@ -1,4 +1,8 @@
-use crate::{response::IntoResponse, BoxError, Error};
+use crate::{
+    body::{self, BoxBody},
+    response::IntoResponse,
+    BoxError, Error,
+};
 use bytes::Bytes;
 use futures_util::{
     ready,
@@ -77,11 +81,8 @@ where
     S::Ok: Into<Bytes>,
     S::Error: Into<BoxError>,
 {
-    type Body = Self;
-    type BodyError = Error;
-
-    fn into_response(self) -> Response<Self> {
-        Response::new(self)
+    fn into_response(self) -> Response<BoxBody> {
+        Response::new(body::boxed(self))
     }
 }
 

--- a/axum/src/error_handling/mod.rs
+++ b/axum/src/error_handling/mod.rs
@@ -143,7 +143,7 @@ where
         let future = Box::pin(async move {
             match inner.oneshot(req).await {
                 Ok(res) => Ok(res.map(boxed)),
-                Err(err) => Ok(f(err).await.into_response().map(boxed)),
+                Err(err) => Ok(f(err).await.into_response()),
             }
         });
 

--- a/axum/src/extract/extractor_middleware.rs
+++ b/axum/src/extract/extractor_middleware.rs
@@ -247,7 +247,7 @@ where
                             State::Call { future }
                         }
                         Err(err) => {
-                            let res = err.into_response().map(crate::body::boxed);
+                            let res = err.into_response();
                             return Poll::Ready(Ok(res));
                         }
                     }

--- a/axum/src/extract/tuple.rs
+++ b/axum/src/extract/tuple.rs
@@ -1,8 +1,5 @@
 use super::{FromRequest, RequestParts};
-use crate::{
-    body::{boxed, BoxBody},
-    response::IntoResponse,
-};
+use crate::{body::BoxBody, response::IntoResponse};
 use async_trait::async_trait;
 use http::Response;
 use std::convert::Infallible;
@@ -33,7 +30,7 @@ macro_rules! impl_from_request {
             type Rejection = Response<BoxBody>;
 
             async fn from_request(req: &mut RequestParts<B>) -> Result<Self, Self::Rejection> {
-                $( let $ty = $ty::from_request(req).await.map_err(|err| err.into_response().map(boxed))?; )*
+                $( let $ty = $ty::from_request(req).await.map_err(|err| err.into_response())?; )*
                 Ok(($($ty,)*))
             }
         }

--- a/axum/src/extract/typed_header.rs
+++ b/axum/src/extract/typed_header.rs
@@ -1,10 +1,8 @@
 use super::{FromRequest, RequestParts};
-use crate::response::IntoResponse;
+use crate::{body::BoxBody, response::IntoResponse};
 use async_trait::async_trait;
-use bytes::Bytes;
 use headers::HeaderMapExt;
-use http_body::Full;
-use std::{convert::Infallible, ops::Deref};
+use std::ops::Deref;
 
 /// Extractor that extracts a typed header value from [`headers`].
 ///
@@ -108,10 +106,7 @@ pub enum TypedHeaderRejectionReason {
 }
 
 impl IntoResponse for TypedHeaderRejection {
-    type Body = Full<Bytes>;
-    type BodyError = Infallible;
-
-    fn into_response(self) -> http::Response<Self::Body> {
+    fn into_response(self) -> http::Response<BoxBody> {
         let mut res = self.to_string().into_response();
         *res.status_mut() = http::StatusCode::BAD_REQUEST;
         res

--- a/axum/src/extract/ws.rs
+++ b/axum/src/extract/ws.rs
@@ -65,7 +65,11 @@
 
 use self::rejection::*;
 use super::{rejection::*, FromRequest, RequestParts};
-use crate::{response::IntoResponse, Error};
+use crate::{
+    body::{self, BoxBody},
+    response::IntoResponse,
+    Error,
+};
 use async_trait::async_trait;
 use bytes::Bytes;
 use futures_util::{
@@ -76,7 +80,6 @@ use http::{
     header::{self, HeaderName, HeaderValue},
     Method, Response, StatusCode,
 };
-use http_body::Full;
 use hyper::upgrade::{OnUpgrade, Upgraded};
 use sha1::{Digest, Sha1};
 use std::{
@@ -285,10 +288,7 @@ where
     F: FnOnce(WebSocket) -> Fut + Send + 'static,
     Fut: Future + Send + 'static,
 {
-    type Body = Full<Bytes>;
-    type BodyError = <Self::Body as http_body::Body>::Error;
-
-    fn into_response(self) -> Response<Self::Body> {
+    fn into_response(self) -> Response<BoxBody> {
         // check requested protocols
         let protocol = self
             .extractor
@@ -347,7 +347,7 @@ where
             builder = builder.header(header::SEC_WEBSOCKET_PROTOCOL, protocol);
         }
 
-        builder.body(Full::default()).unwrap()
+        builder.body(body::boxed(body::Empty::new())).unwrap()
     }
 }
 

--- a/axum/src/handler/mod.rs
+++ b/axum/src/handler/mod.rs
@@ -272,7 +272,7 @@ where
     type Sealed = sealed::Hidden;
 
     async fn call(self, _req: Request<B>) -> Response<BoxBody> {
-        self().await.into_response().map(boxed)
+        self().await.into_response()
     }
 }
 
@@ -296,13 +296,13 @@ macro_rules! impl_handler {
                 $(
                     let $ty = match $ty::from_request(&mut req).await {
                         Ok(value) => value,
-                        Err(rejection) => return rejection.into_response().map(boxed),
+                        Err(rejection) => return rejection.into_response(),
                     };
                 )*
 
                 let res = self($($ty,)*).await;
 
-                res.into_response().map(boxed)
+                res.into_response()
             }
         }
     };
@@ -350,14 +350,9 @@ where
     type Sealed = sealed::Hidden;
 
     async fn call(self, req: Request<ReqBody>) -> Response<BoxBody> {
-        match self
-            .svc
-            .oneshot(req)
-            .await
-            .map_err(IntoResponse::into_response)
-        {
+        match self.svc.oneshot(req).await {
             Ok(res) => res.map(boxed),
-            Err(res) => res.map(boxed),
+            Err(res) => res.into_response(),
         }
     }
 }

--- a/axum/src/macros.rs
+++ b/axum/src/macros.rs
@@ -59,11 +59,8 @@ macro_rules! define_rejection {
 
         #[allow(deprecated)]
         impl $crate::response::IntoResponse for $name {
-            type Body = http_body::Full<bytes::Bytes>;
-            type BodyError = std::convert::Infallible;
-
-            fn into_response(self) -> http::Response<Self::Body> {
-                let mut res = http::Response::new(http_body::Full::from($body));
+            fn into_response(self) -> http::Response<$crate::body::BoxBody> {
+                let mut res = http::Response::new($crate::body::boxed(http_body::Full::from($body)));
                 *res.status_mut() = http::StatusCode::$status;
                 res
             }
@@ -104,12 +101,9 @@ macro_rules! define_rejection {
         }
 
         impl IntoResponse for $name {
-            type Body = http_body::Full<bytes::Bytes>;
-            type BodyError = std::convert::Infallible;
-
-            fn into_response(self) -> http::Response<Self::Body> {
+            fn into_response(self) -> http::Response<$crate::body::BoxBody> {
                 let mut res =
-                    http::Response::new(http_body::Full::from(format!(concat!($body, ": {}"), self.0)));
+                    http::Response::new($crate::body::boxed(http_body::Full::from(format!(concat!($body, ": {}"), self.0))));
                 *res.status_mut() = http::StatusCode::$status;
                 res
             }
@@ -148,10 +142,7 @@ macro_rules! composite_rejection {
         }
 
         impl $crate::response::IntoResponse for $name {
-            type Body = http_body::Full<bytes::Bytes>;
-            type BodyError = std::convert::Infallible;
-
-            fn into_response(self) -> http::Response<Self::Body> {
+            fn into_response(self) -> http::Response<$crate::body::BoxBody> {
                 match self {
                     $(
                         Self::$variant(inner) => inner.into_response(),

--- a/axum/src/response/headers.rs
+++ b/axum/src/response/headers.rs
@@ -1,14 +1,11 @@
 use super::IntoResponse;
-use crate::{
-    body::{boxed, BoxBody},
-    BoxError,
-};
+use crate::body::{boxed, BoxBody};
 use bytes::Bytes;
 use http::{
     header::{HeaderMap, HeaderName, HeaderValue},
     Response, StatusCode,
 };
-use http_body::{Body, Full};
+use http_body::{Empty, Full};
 use std::{convert::TryInto, fmt};
 use tower::util::Either;
 
@@ -59,7 +56,7 @@ use tower::util::Either;
 pub struct Headers<H>(pub H);
 
 impl<H> Headers<H> {
-    fn try_into_header_map<K, V>(self) -> Result<HeaderMap, Response<Full<Bytes>>>
+    fn try_into_header_map<K, V>(self) -> Result<HeaderMap, Response<BoxBody>>
     where
         H: IntoIterator<Item = (K, V)>,
         K: TryInto<HeaderName>,
@@ -81,7 +78,7 @@ impl<H> Headers<H> {
                     Either::B(err) => err.to_string(),
                 };
 
-                let body = Full::new(Bytes::copy_from_slice(err.as_bytes()));
+                let body = boxed(Full::new(Bytes::copy_from_slice(err.as_bytes())));
                 let mut res = Response::new(body);
                 *res.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
                 res
@@ -97,15 +94,12 @@ where
     V: TryInto<HeaderValue>,
     V::Error: fmt::Display,
 {
-    type Body = Full<Bytes>;
-    type BodyError = <Self::Body as Body>::Error;
-
-    fn into_response(self) -> http::Response<Self::Body> {
+    fn into_response(self) -> http::Response<BoxBody> {
         let headers = self.try_into_header_map();
 
         match headers {
             Ok(headers) => {
-                let mut res = Response::new(Full::new(Bytes::new()));
+                let mut res = Response::new(boxed(Empty::new()));
                 *res.headers_mut() = headers;
                 res
             }
@@ -117,50 +111,38 @@ where
 impl<H, T, K, V> IntoResponse for (Headers<H>, T)
 where
     T: IntoResponse,
-    T::Body: Body<Data = Bytes> + Send + 'static,
-    <T::Body as Body>::Error: Into<BoxError>,
     H: IntoIterator<Item = (K, V)>,
     K: TryInto<HeaderName>,
     K::Error: fmt::Display,
     V: TryInto<HeaderValue>,
     V::Error: fmt::Display,
 {
-    type Body = BoxBody;
-    type BodyError = <Self::Body as Body>::Error;
-
-    // this boxing could be improved with a EitherBody but thats
-    // an issue for another time
-    fn into_response(self) -> Response<Self::Body> {
+    fn into_response(self) -> Response<BoxBody> {
         let headers = match self.0.try_into_header_map() {
             Ok(headers) => headers,
-            Err(res) => return res.map(boxed),
+            Err(res) => return res,
         };
 
-        (headers, self.1).into_response().map(boxed)
+        (headers, self.1).into_response()
     }
 }
 
 impl<H, T, K, V> IntoResponse for (StatusCode, Headers<H>, T)
 where
     T: IntoResponse,
-    T::Body: Body<Data = Bytes> + Send + 'static,
-    <T::Body as Body>::Error: Into<BoxError>,
     H: IntoIterator<Item = (K, V)>,
     K: TryInto<HeaderName>,
     K::Error: fmt::Display,
     V: TryInto<HeaderValue>,
     V::Error: fmt::Display,
 {
-    type Body = BoxBody;
-    type BodyError = <Self::Body as Body>::Error;
-
-    fn into_response(self) -> Response<Self::Body> {
+    fn into_response(self) -> Response<BoxBody> {
         let headers = match self.1.try_into_header_map() {
             Ok(headers) => headers,
-            Err(res) => return res.map(boxed),
+            Err(res) => return res,
         };
 
-        (self.0, headers, self.2).into_response().map(boxed)
+        (self.0, headers, self.2).into_response()
     }
 }
 

--- a/axum/src/response/mod.rs
+++ b/axum/src/response/mod.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     body::{boxed, BoxBody},
-    BoxError, Error,
+    BoxError,
 };
 use bytes::Bytes;
 use http::{header, HeaderMap, HeaderValue, Response, StatusCode};
@@ -39,7 +39,7 @@ pub use self::{headers::Headers, redirect::Redirect, sse::Sse};
 /// ```rust
 /// use axum::{
 ///     Router,
-///     body::Body,
+///     body::{self, BoxBody, Bytes},
 ///     routing::get,
 ///     http::{Response, StatusCode},
 ///     response::IntoResponse,
@@ -51,16 +51,13 @@ pub use self::{headers::Headers, redirect::Redirect, sse::Sse};
 /// }
 ///
 /// impl IntoResponse for MyError {
-///     type Body = Body;
-///     type BodyError = <Self::Body as axum::body::HttpBody>::Error;
-///
-///     fn into_response(self) -> Response<Self::Body> {
+///     fn into_response(self) -> Response<BoxBody> {
 ///         let body = match self {
 ///             MyError::SomethingWentWrong => {
-///                 Body::from("something went wrong")
+///                 body::boxed(body::Full::from("something went wrong"))
 ///             },
 ///             MyError::SomethingElseWentWrong => {
-///                 Body::from("something else went wrong")
+///                 body::boxed(body::Full::from("something else went wrong"))
 ///             },
 ///         };
 ///
@@ -87,6 +84,7 @@ pub use self::{headers::Headers, redirect::Redirect, sse::Sse};
 ///
 /// ```rust
 /// use axum::{
+///     body::{self, BoxBody},
 ///     routing::get,
 ///     response::IntoResponse,
 ///     Router,
@@ -127,11 +125,8 @@ pub use self::{headers::Headers, redirect::Redirect, sse::Sse};
 ///
 /// // Now we can implement `IntoResponse` directly for `MyBody`
 /// impl IntoResponse for MyBody {
-///     type Body = Self;
-///     type BodyError = <Self as Body>::Error;
-///
-///     fn into_response(self) -> Response<Self::Body> {
-///         Response::new(self)
+///     fn into_response(self) -> Response<BoxBody> {
+///         Response::new(body::boxed(self))
 ///     }
 /// }
 ///
@@ -145,56 +140,18 @@ pub use self::{headers::Headers, redirect::Redirect, sse::Sse};
 /// # };
 /// ```
 pub trait IntoResponse {
-    /// The body type of the response.
-    ///
-    /// Unless you're implementing this trait for a custom body type, these are
-    /// some common types you can use:
-    ///
-    /// - [`axum::body::Body`]: A good default that supports most use cases.
-    /// - [`axum::body::Empty<Bytes>`]: When you know your response is always
-    /// empty.
-    /// - [`axum::body::Full<Bytes>`]: When you know your response always
-    /// contains exactly one chunk.
-    /// - [`axum::body::BoxBody`]: If you need to unify multiple body types into
-    /// one, or return a body type that cannot be named. Can be created with
-    /// [`boxed`].
-    ///
-    /// [`axum::body::Body`]: crate::body::Body
-    /// [`axum::body::Empty<Bytes>`]: crate::body::Empty
-    /// [`axum::body::Full<Bytes>`]: crate::body::Full
-    /// [`axum::body::BoxBody`]: crate::body::BoxBody
-    type Body: http_body::Body<Data = Bytes, Error = Self::BodyError> + Send + 'static;
-
-    /// The error type `Self::Body` might generate.
-    ///
-    /// Generally it should be possible to set this to:
-    ///
-    /// ```rust,ignore
-    /// type BodyError = <Self::Body as axum::body::HttpBody>::Error;
-    /// ```
-    ///
-    /// This associated type exists mainly to make returning `impl IntoResponse`
-    /// possible and to simplify trait bounds internally in axum.
-    type BodyError: Into<BoxError>;
-
     /// Create a response.
-    fn into_response(self) -> Response<Self::Body>;
+    fn into_response(self) -> Response<BoxBody>;
 }
 
 impl IntoResponse for () {
-    type Body = Empty<Bytes>;
-    type BodyError = Infallible;
-
-    fn into_response(self) -> Response<Self::Body> {
-        Response::new(Empty::new())
+    fn into_response(self) -> Response<BoxBody> {
+        Response::new(boxed(Empty::new()))
     }
 }
 
 impl IntoResponse for Infallible {
-    type Body = Empty<Bytes>;
-    type BodyError = Infallible;
-
-    fn into_response(self) -> Response<Self::Body> {
+    fn into_response(self) -> Response<BoxBody> {
         match self {}
     }
 }
@@ -204,13 +161,10 @@ where
     T: IntoResponse,
     E: IntoResponse,
 {
-    type Body = BoxBody;
-    type BodyError = Error;
-
-    fn into_response(self) -> Response<Self::Body> {
+    fn into_response(self) -> Response<BoxBody> {
         match self {
-            Ok(value) => value.into_response().map(boxed),
-            Err(err) => err.into_response().map(boxed),
+            Ok(value) => value.into_response(),
+            Err(err) => err.into_response(),
         }
     }
 }
@@ -220,22 +174,16 @@ where
     B: http_body::Body<Data = Bytes> + Send + 'static,
     B::Error: Into<BoxError>,
 {
-    type Body = B;
-    type BodyError = <B as http_body::Body>::Error;
-
-    fn into_response(self) -> Self {
-        self
+    fn into_response(self) -> Response<BoxBody> {
+        self.map(boxed)
     }
 }
 
 macro_rules! impl_into_response_for_body {
     ($body:ty) => {
         impl IntoResponse for $body {
-            type Body = $body;
-            type BodyError = <$body as http_body::Body>::Error;
-
-            fn into_response(self) -> Response<Self> {
-                Response::new(self)
+            fn into_response(self) -> Response<BoxBody> {
+                Response::new(boxed(self))
             }
         }
     };
@@ -246,11 +194,8 @@ impl_into_response_for_body!(Full<Bytes>);
 impl_into_response_for_body!(Empty<Bytes>);
 
 impl IntoResponse for http::response::Parts {
-    type Body = Empty<Bytes>;
-    type BodyError = Infallible;
-
-    fn into_response(self) -> Response<Self::Body> {
-        Response::from_parts(self, Empty::new())
+    fn into_response(self) -> Response<BoxBody> {
+        Response::from_parts(self, boxed(Empty::new()))
     }
 }
 
@@ -258,11 +203,8 @@ impl<E> IntoResponse for http_body::combinators::BoxBody<Bytes, E>
 where
     E: Into<BoxError> + 'static,
 {
-    type Body = Self;
-    type BodyError = E;
-
-    fn into_response(self) -> Response<Self> {
-        Response::new(self)
+    fn into_response(self) -> Response<BoxBody> {
+        Response::new(boxed(self))
     }
 }
 
@@ -270,11 +212,8 @@ impl<E> IntoResponse for http_body::combinators::UnsyncBoxBody<Bytes, E>
 where
     E: Into<BoxError> + 'static,
 {
-    type Body = Self;
-    type BodyError = E;
-
-    fn into_response(self) -> Response<Self> {
-        Response::new(self)
+    fn into_response(self) -> Response<BoxBody> {
+        Response::new(boxed(self))
     }
 }
 
@@ -284,11 +223,8 @@ where
     F: FnMut(B::Data) -> Bytes + Send + 'static,
     B::Error: Into<BoxError>,
 {
-    type Body = Self;
-    type BodyError = <B as http_body::Body>::Error;
-
-    fn into_response(self) -> Response<Self::Body> {
-        Response::new(self)
+    fn into_response(self) -> Response<BoxBody> {
+        Response::new(boxed(self))
     }
 }
 
@@ -298,40 +234,28 @@ where
     F: FnMut(B::Error) -> E + Send + 'static,
     E: Into<BoxError>,
 {
-    type Body = Self;
-    type BodyError = E;
-
-    fn into_response(self) -> Response<Self::Body> {
-        Response::new(self)
+    fn into_response(self) -> Response<BoxBody> {
+        Response::new(boxed(self))
     }
 }
 
 impl IntoResponse for &'static str {
-    type Body = Full<Bytes>;
-    type BodyError = Infallible;
-
     #[inline]
-    fn into_response(self) -> Response<Self::Body> {
+    fn into_response(self) -> Response<BoxBody> {
         Cow::Borrowed(self).into_response()
     }
 }
 
 impl IntoResponse for String {
-    type Body = Full<Bytes>;
-    type BodyError = Infallible;
-
     #[inline]
-    fn into_response(self) -> Response<Self::Body> {
+    fn into_response(self) -> Response<BoxBody> {
         Cow::<'static, str>::Owned(self).into_response()
     }
 }
 
-impl IntoResponse for std::borrow::Cow<'static, str> {
-    type Body = Full<Bytes>;
-    type BodyError = Infallible;
-
-    fn into_response(self) -> Response<Self::Body> {
-        let mut res = Response::new(Full::from(self));
+impl IntoResponse for Cow<'static, str> {
+    fn into_response(self) -> Response<BoxBody> {
+        let mut res = Response::new(boxed(Full::from(self)));
         res.headers_mut().insert(
             header::CONTENT_TYPE,
             HeaderValue::from_static(mime::TEXT_PLAIN_UTF_8.as_ref()),
@@ -341,11 +265,8 @@ impl IntoResponse for std::borrow::Cow<'static, str> {
 }
 
 impl IntoResponse for Bytes {
-    type Body = Full<Bytes>;
-    type BodyError = Infallible;
-
-    fn into_response(self) -> Response<Self::Body> {
-        let mut res = Response::new(Full::from(self));
+    fn into_response(self) -> Response<BoxBody> {
+        let mut res = Response::new(boxed(Full::from(self)));
         res.headers_mut().insert(
             header::CONTENT_TYPE,
             HeaderValue::from_static(mime::APPLICATION_OCTET_STREAM.as_ref()),
@@ -355,11 +276,8 @@ impl IntoResponse for Bytes {
 }
 
 impl IntoResponse for &'static [u8] {
-    type Body = Full<Bytes>;
-    type BodyError = Infallible;
-
-    fn into_response(self) -> Response<Self::Body> {
-        let mut res = Response::new(Full::from(self));
+    fn into_response(self) -> Response<BoxBody> {
+        let mut res = Response::new(boxed(Full::from(self)));
         res.headers_mut().insert(
             header::CONTENT_TYPE,
             HeaderValue::from_static(mime::APPLICATION_OCTET_STREAM.as_ref()),
@@ -369,11 +287,8 @@ impl IntoResponse for &'static [u8] {
 }
 
 impl IntoResponse for Vec<u8> {
-    type Body = Full<Bytes>;
-    type BodyError = Infallible;
-
-    fn into_response(self) -> Response<Self::Body> {
-        let mut res = Response::new(Full::from(self));
+    fn into_response(self) -> Response<BoxBody> {
+        let mut res = Response::new(boxed(Full::from(self)));
         res.headers_mut().insert(
             header::CONTENT_TYPE,
             HeaderValue::from_static(mime::APPLICATION_OCTET_STREAM.as_ref()),
@@ -382,12 +297,9 @@ impl IntoResponse for Vec<u8> {
     }
 }
 
-impl IntoResponse for std::borrow::Cow<'static, [u8]> {
-    type Body = Full<Bytes>;
-    type BodyError = Infallible;
-
-    fn into_response(self) -> Response<Self::Body> {
-        let mut res = Response::new(Full::from(self));
+impl IntoResponse for Cow<'static, [u8]> {
+    fn into_response(self) -> Response<BoxBody> {
+        let mut res = Response::new(boxed(Full::from(self)));
         res.headers_mut().insert(
             header::CONTENT_TYPE,
             HeaderValue::from_static(mime::APPLICATION_OCTET_STREAM.as_ref()),
@@ -397,11 +309,11 @@ impl IntoResponse for std::borrow::Cow<'static, [u8]> {
 }
 
 impl IntoResponse for StatusCode {
-    type Body = Empty<Bytes>;
-    type BodyError = Infallible;
-
-    fn into_response(self) -> Response<Self::Body> {
-        Response::builder().status(self).body(Empty::new()).unwrap()
+    fn into_response(self) -> Response<BoxBody> {
+        Response::builder()
+            .status(self)
+            .body(boxed(Empty::new()))
+            .unwrap()
     }
 }
 
@@ -409,10 +321,7 @@ impl<T> IntoResponse for (StatusCode, T)
 where
     T: IntoResponse,
 {
-    type Body = T::Body;
-    type BodyError = T::BodyError;
-
-    fn into_response(self) -> Response<T::Body> {
+    fn into_response(self) -> Response<BoxBody> {
         let mut res = self.1.into_response();
         *res.status_mut() = self.0;
         res
@@ -423,10 +332,7 @@ impl<T> IntoResponse for (HeaderMap, T)
 where
     T: IntoResponse,
 {
-    type Body = T::Body;
-    type BodyError = T::BodyError;
-
-    fn into_response(self) -> Response<T::Body> {
+    fn into_response(self) -> Response<BoxBody> {
         let mut res = self.1.into_response();
         res.headers_mut().extend(self.0);
         res
@@ -437,10 +343,7 @@ impl<T> IntoResponse for (StatusCode, HeaderMap, T)
 where
     T: IntoResponse,
 {
-    type Body = T::Body;
-    type BodyError = T::BodyError;
-
-    fn into_response(self) -> Response<T::Body> {
+    fn into_response(self) -> Response<BoxBody> {
         let mut res = self.2.into_response();
         *res.status_mut() = self.0;
         res.headers_mut().extend(self.1);
@@ -449,11 +352,8 @@ where
 }
 
 impl IntoResponse for HeaderMap {
-    type Body = Empty<Bytes>;
-    type BodyError = Infallible;
-
-    fn into_response(self) -> Response<Self::Body> {
-        let mut res = Response::new(Empty::new());
+    fn into_response(self) -> Response<BoxBody> {
+        let mut res = Response::new(boxed(Empty::new()));
         *res.headers_mut() = self;
         res
     }
@@ -469,11 +369,8 @@ impl<T> IntoResponse for Html<T>
 where
     T: Into<Full<Bytes>>,
 {
-    type Body = Full<Bytes>;
-    type BodyError = Infallible;
-
-    fn into_response(self) -> Response<Self::Body> {
-        let mut res = Response::new(self.0.into());
+    fn into_response(self) -> Response<BoxBody> {
+        let mut res = Response::new(boxed(self.0.into()));
         res.headers_mut().insert(
             header::CONTENT_TYPE,
             HeaderValue::from_static(mime::TEXT_HTML_UTF_8.as_ref()),
@@ -491,7 +388,6 @@ impl<T> From<T> for Html<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::body::Body;
     use http::header::{HeaderMap, HeaderName};
 
     #[test]
@@ -499,11 +395,8 @@ mod tests {
         struct MyResponse;
 
         impl IntoResponse for MyResponse {
-            type Body = Body;
-            type BodyError = <Self::Body as http_body::Body>::Error;
-
-            fn into_response(self) -> Response<Body> {
-                let mut resp = Response::new(String::new().into());
+            fn into_response(self) -> Response<BoxBody> {
+                let mut resp = Response::new(boxed(Empty::new()));
                 resp.headers_mut()
                     .insert(HeaderName::from_static("a"), HeaderValue::from_static("1"));
                 resp

--- a/axum/src/response/redirect.rs
+++ b/axum/src/response/redirect.rs
@@ -1,7 +1,7 @@
 use super::IntoResponse;
-use bytes::Bytes;
+use crate::body::{boxed, BoxBody};
 use http::{header::LOCATION, HeaderValue, Response, StatusCode, Uri};
-use http_body::{Body, Empty};
+use http_body::Empty;
 use std::convert::TryFrom;
 
 /// Response that redirects the request to another location.
@@ -105,11 +105,8 @@ impl Redirect {
 }
 
 impl IntoResponse for Redirect {
-    type Body = Empty<Bytes>;
-    type BodyError = <Self::Body as Body>::Error;
-
-    fn into_response(self) -> Response<Self::Body> {
-        let mut res = Response::new(Empty::new());
+    fn into_response(self) -> Response<BoxBody> {
+        let mut res = Response::new(boxed(Empty::new()));
         *res.status_mut() = self.status_code;
         res.headers_mut().insert(LOCATION, self.location);
         res

--- a/examples/error-handling-and-dependency-injection/src/main.rs
+++ b/examples/error-handling-and-dependency-injection/src/main.rs
@@ -9,7 +9,7 @@
 
 use axum::{
     async_trait,
-    body::{Bytes, Full},
+    body::BoxBody,
     extract::{Extension, Path},
     http::{Response, StatusCode},
     response::IntoResponse,
@@ -18,7 +18,7 @@ use axum::{
 };
 use serde::{Deserialize, Serialize};
 use serde_json::json;
-use std::{convert::Infallible, net::SocketAddr, sync::Arc};
+use std::{net::SocketAddr, sync::Arc};
 use uuid::Uuid;
 
 #[tokio::main]
@@ -92,10 +92,7 @@ impl From<UserRepoError> for AppError {
 }
 
 impl IntoResponse for AppError {
-    type Body = Full<Bytes>;
-    type BodyError = Infallible;
-
-    fn into_response(self) -> Response<Self::Body> {
+    fn into_response(self) -> Response<BoxBody> {
         let (status, error_message) = match self {
             AppError::UserRepo(UserRepoError::NotFound) => {
                 (StatusCode::NOT_FOUND, "User not found")

--- a/examples/jwt/src/main.rs
+++ b/examples/jwt/src/main.rs
@@ -8,7 +8,7 @@
 
 use axum::{
     async_trait,
-    body::{Bytes, Full},
+    body::BoxBody,
     extract::{FromRequest, RequestParts, TypedHeader},
     http::{Response, StatusCode},
     response::IntoResponse,
@@ -20,7 +20,7 @@ use jsonwebtoken::{decode, encode, DecodingKey, EncodingKey, Header, Validation}
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
-use std::{convert::Infallible, fmt::Display, net::SocketAddr};
+use std::{fmt::Display, net::SocketAddr};
 
 // Quick instructions
 //
@@ -141,10 +141,7 @@ where
 }
 
 impl IntoResponse for AuthError {
-    type Body = Full<Bytes>;
-    type BodyError = Infallible;
-
-    fn into_response(self) -> Response<Self::Body> {
+    fn into_response(self) -> Response<BoxBody> {
         let (status, error_message) = match self {
             AuthError::WrongCredentials => (StatusCode::UNAUTHORIZED, "Wrong credentials"),
             AuthError::MissingCredentials => (StatusCode::BAD_REQUEST, "Missing credentials"),

--- a/examples/oauth/src/main.rs
+++ b/examples/oauth/src/main.rs
@@ -9,7 +9,7 @@
 use async_session::{MemoryStore, Session, SessionStore};
 use axum::{
     async_trait,
-    body::{Bytes, Empty},
+    body::BoxBody,
     extract::{Extension, FromRequest, Query, RequestParts, TypedHeader},
     http::{header::SET_COOKIE, HeaderMap, Response},
     response::{IntoResponse, Redirect},
@@ -199,10 +199,7 @@ async fn login_authorized(
 struct AuthRedirect;
 
 impl IntoResponse for AuthRedirect {
-    type Body = Empty<Bytes>;
-    type BodyError = <Self::Body as axum::body::HttpBody>::Error;
-
-    fn into_response(self) -> Response<Self::Body> {
+    fn into_response(self) -> Response<BoxBody> {
         Redirect::found("/auth/discord".parse().unwrap()).into_response()
     }
 }

--- a/examples/templates/src/main.rs
+++ b/examples/templates/src/main.rs
@@ -6,14 +6,14 @@
 
 use askama::Template;
 use axum::{
-    body::{Bytes, Full},
+    body::{self, BoxBody, Full},
     extract,
     http::{Response, StatusCode},
     response::{Html, IntoResponse},
     routing::get,
     Router,
 };
-use std::{convert::Infallible, net::SocketAddr};
+use std::net::SocketAddr;
 
 #[tokio::main]
 async fn main() {
@@ -52,18 +52,15 @@ impl<T> IntoResponse for HtmlTemplate<T>
 where
     T: Template,
 {
-    type Body = Full<Bytes>;
-    type BodyError = Infallible;
-
-    fn into_response(self) -> Response<Self::Body> {
+    fn into_response(self) -> Response<BoxBody> {
         match self.0.render() {
             Ok(html) => Html(html).into_response(),
             Err(err) => Response::builder()
                 .status(StatusCode::INTERNAL_SERVER_ERROR)
-                .body(Full::from(format!(
+                .body(body::boxed(Full::from(format!(
                     "Failed to render template. Error: {}",
                     err
-                )))
+                ))))
                 .unwrap(),
         }
     }

--- a/examples/validator/src/main.rs
+++ b/examples/validator/src/main.rs
@@ -12,7 +12,7 @@
 
 use async_trait::async_trait;
 use axum::{
-    body::{Bytes, Full},
+    body::BoxBody,
     extract::{Form, FromRequest, RequestParts},
     http::{Response, StatusCode},
     response::{Html, IntoResponse},
@@ -20,7 +20,7 @@ use axum::{
     BoxError, Router,
 };
 use serde::{de::DeserializeOwned, Deserialize};
-use std::{convert::Infallible, net::SocketAddr};
+use std::net::SocketAddr;
 use thiserror::Error;
 use validator::Validate;
 
@@ -84,10 +84,7 @@ pub enum ServerError {
 }
 
 impl IntoResponse for ServerError {
-    type Body = Full<Bytes>;
-    type BodyError = Infallible;
-
-    fn into_response(self) -> Response<Self::Body> {
+    fn into_response(self) -> Response<BoxBody> {
         match self {
             ServerError::ValidationError(_) => {
                 let message = format!("Input validation error: [{}]", self).replace("\n", ", ");

--- a/examples/versioning/src/main.rs
+++ b/examples/versioning/src/main.rs
@@ -6,7 +6,7 @@
 
 use axum::{
     async_trait,
-    body::{Bytes, Full},
+    body::BoxBody,
     extract::{FromRequest, Path, RequestParts},
     http::{Response, StatusCode},
     response::IntoResponse,
@@ -51,7 +51,7 @@ impl<B> FromRequest<B> for Version
 where
     B: Send,
 {
-    type Rejection = Response<Full<Bytes>>;
+    type Rejection = Response<BoxBody>;
 
     async fn from_request(req: &mut RequestParts<B>) -> Result<Self, Self::Rejection> {
         let params = Path::<HashMap<String, String>>::from_request(req)


### PR DESCRIPTION
Fixes: #570

I did not include the `Response` type definition for now.