### PR TITLE
Use `Self` in `RouterFuture`'s `impl` block

### DIFF
--- a/axum/src/routing/future.rs
+++ b/axum/src/routing/future.rs
@@ -22,6 +22,6 @@ impl<B> RouterFuture<B> {
     }
 
     pub(super) fn from_response(response: Response<BoxBody>) -> Self {
-        RouterFuture::new(Either::Right(ready(Ok(response))))
+        Self::new(Either::Right(ready(Ok(response))))
     }
 }


### PR DESCRIPTION
For consistency with the other method and the rest of the codebase.
