### PR TITLE
Reduce `NotFound`'s visibility

### DIFF
--- a/axum/src/routing/not_found.rs
+++ b/axum/src/routing/not_found.rs
@@ -12,7 +12,7 @@ use tower_service::Service;
 /// This is used as the bottom service in a method router. You shouldn't have to
 /// use it manually.
 #[derive(Clone, Copy, Debug)]
-pub(crate) struct NotFound;
+pub(super) struct NotFound;
 
 impl<B> Service<Request<B>> for NotFound
 where


### PR DESCRIPTION
It is only used in the crate's `routing` module.