### PR TITLE
Remove dependency on `tower-http`'s `add-extension` feature

### DIFF
--- a/axum/Cargo.toml
+++ b/axum/Cargo.toml
@@ -37,7 +37,7 @@ sync_wrapper = "0.1.1"
 tokio = { version = "1", features = ["time"] }
 tokio-util = "0.6"
 tower = { version = "0.4.11", default-features = false, features = ["util", "buffer", "make"] }
-tower-http = { version = "0.1", features = ["add-extension", "map-response-body"] }
+tower-http = { version = "0.1", features = ["map-response-body"] }
 tower-layer = "0.3"
 tower-service = "0.3"
 


### PR DESCRIPTION
It is not currently being used, since `axum/src/add_extension.rs` "is
vendored from `tower-http` to reduce public dependencies".