### PR TITLE
Introduce `Response` type alias as a shorthand for `Response<BoxBody>`

### DIFF
--- a/axum-core/src/extract/tuple.rs
+++ b/axum-core/src/extract/tuple.rs
@@ -1,7 +1,6 @@
 use super::{FromRequest, RequestParts};
-use crate::{body::BoxBody, response::IntoResponse};
+use crate::response::{IntoResponse, Response};
 use async_trait::async_trait;
-use http::Response;
 use std::convert::Infallible;
 
 #[async_trait]
@@ -27,7 +26,7 @@ macro_rules! impl_from_request {
             $( $ty: FromRequest<B> + Send, )*
             B: Send,
         {
-            type Rejection = Response<BoxBody>;
+            type Rejection = Response;
 
             async fn from_request(req: &mut RequestParts<B>) -> Result<Self, Self::Rejection> {
                 $( let $ty = $ty::from_request(req).await.map_err(|err| err.into_response())?; )*

--- a/axum-core/src/lib.rs
+++ b/axum-core/src/lib.rs
@@ -59,8 +59,5 @@ pub mod body;
 pub mod extract;
 pub mod response;
 
-#[doc(no_inline)]
-pub use self::response::Response;
-
 /// Alias for a type-erased error type.
 pub type BoxError = Box<dyn std::error::Error + Send + Sync>;

--- a/axum-core/src/lib.rs
+++ b/axum-core/src/lib.rs
@@ -59,5 +59,8 @@ pub mod body;
 pub mod extract;
 pub mod response;
 
+#[doc(no_inline)]
+pub use self::response::Response;
+
 /// Alias for a type-erased error type.
 pub type BoxError = Box<dyn std::error::Error + Send + Sync>;

--- a/axum-core/src/macros.rs
+++ b/axum-core/src/macros.rs
@@ -12,7 +12,7 @@ macro_rules! define_rejection {
 
         #[allow(deprecated)]
         impl $crate::response::IntoResponse for $name {
-            fn into_response(self) -> http::Response<$crate::body::BoxBody> {
+            fn into_response(self) -> $crate::Response {
                 let mut res = http::Response::new($crate::body::boxed(http_body::Full::from($body)));
                 *res.status_mut() = http::StatusCode::$status;
                 res
@@ -54,7 +54,7 @@ macro_rules! define_rejection {
         }
 
         impl crate::response::IntoResponse for $name {
-            fn into_response(self) -> http::Response<$crate::body::BoxBody> {
+            fn into_response(self) -> $crate::Response {
                 let body = http_body::Full::from(format!(concat!($body, ": {}"), self.0));
                 let body = $crate::body::boxed(body);
                 let mut res =
@@ -97,7 +97,7 @@ macro_rules! composite_rejection {
         }
 
         impl $crate::response::IntoResponse for $name {
-            fn into_response(self) -> http::Response<$crate::body::BoxBody> {
+            fn into_response(self) -> $crate::Response {
                 match self {
                     $(
                         Self::$variant(inner) => inner.into_response(),

--- a/axum-core/src/macros.rs
+++ b/axum-core/src/macros.rs
@@ -12,7 +12,7 @@ macro_rules! define_rejection {
 
         #[allow(deprecated)]
         impl $crate::response::IntoResponse for $name {
-            fn into_response(self) -> $crate::Response {
+            fn into_response(self) -> $crate::response::Response {
                 let mut res = http::Response::new($crate::body::boxed(http_body::Full::from($body)));
                 *res.status_mut() = http::StatusCode::$status;
                 res
@@ -54,7 +54,7 @@ macro_rules! define_rejection {
         }
 
         impl crate::response::IntoResponse for $name {
-            fn into_response(self) -> $crate::Response {
+            fn into_response(self) -> $crate::response::Response {
                 let body = http_body::Full::from(format!(concat!($body, ": {}"), self.0));
                 let body = $crate::body::boxed(body);
                 let mut res =
@@ -97,7 +97,7 @@ macro_rules! composite_rejection {
         }
 
         impl $crate::response::IntoResponse for $name {
-            fn into_response(self) -> $crate::Response {
+            fn into_response(self) -> $crate::response::Response {
                 match self {
                     $(
                         Self::$variant(inner) => inner.into_response(),

--- a/axum-core/src/response/headers.rs
+++ b/axum-core/src/response/headers.rs
@@ -1,9 +1,9 @@
-use super::IntoResponse;
-use crate::body::{boxed, BoxBody};
+use super::{IntoResponse, Response};
+use crate::body::boxed;
 use bytes::Bytes;
 use http::{
     header::{HeaderMap, HeaderName, HeaderValue},
-    Response, StatusCode,
+    StatusCode,
 };
 use http_body::{Empty, Full};
 use std::{convert::TryInto, fmt};
@@ -55,7 +55,7 @@ use std::{convert::TryInto, fmt};
 pub struct Headers<H>(pub H);
 
 impl<H> Headers<H> {
-    fn try_into_header_map<K, V>(self) -> Result<HeaderMap, Response<BoxBody>>
+    fn try_into_header_map<K, V>(self) -> Result<HeaderMap, Response>
     where
         H: IntoIterator<Item = (K, V)>,
         K: TryInto<HeaderName>,
@@ -93,7 +93,7 @@ where
     V: TryInto<HeaderValue>,
     V::Error: fmt::Display,
 {
-    fn into_response(self) -> http::Response<BoxBody> {
+    fn into_response(self) -> Response {
         let headers = self.try_into_header_map();
 
         match headers {
@@ -116,7 +116,7 @@ where
     V: TryInto<HeaderValue>,
     V::Error: fmt::Display,
 {
-    fn into_response(self) -> Response<BoxBody> {
+    fn into_response(self) -> Response {
         let headers = match self.0.try_into_header_map() {
             Ok(headers) => headers,
             Err(res) => return res,
@@ -135,7 +135,7 @@ where
     V: TryInto<HeaderValue>,
     V::Error: fmt::Display,
 {
-    fn into_response(self) -> Response<BoxBody> {
+    fn into_response(self) -> Response {
         let headers = match self.1.try_into_header_map() {
             Ok(headers) => headers,
             Err(res) => return res,

--- a/axum-debug/tests/pass/returns_self.rs
+++ b/axum-debug/tests/pass/returns_self.rs
@@ -1,7 +1,6 @@
 use axum::{
     body::BoxBody,
-    http::Response,
-    response::IntoResponse,
+    response::{IntoResponse, Response},
 };
 use axum_debug::debug_handler;
 
@@ -15,7 +14,7 @@ impl A {
 }
 
 impl IntoResponse for A {
-    fn into_response(self) -> Response<BoxBody> {
+    fn into_response(self) -> Response {
         todo!()
     }
 }

--- a/axum-extra/src/extract/cached.rs
+++ b/axum-extra/src/extract/cached.rs
@@ -1,12 +1,10 @@
 use axum::{
     async_trait,
-    body::BoxBody,
     extract::{
         rejection::{ExtensionRejection, ExtensionsAlreadyExtracted},
         Extension, FromRequest, RequestParts,
     },
-    http::Response,
-    response::IntoResponse,
+    response::{IntoResponse, Response},
 };
 use std::{
     fmt,
@@ -31,8 +29,8 @@ use std::{
 ///     async_trait,
 ///     extract::{FromRequest, RequestParts},
 ///     body::BoxBody,
-///     response::IntoResponse,
-///     http::{StatusCode, Response},
+///     response::{IntoResponse, Response},
+///     http::StatusCode,
 /// };
 ///
 /// #[derive(Clone)]
@@ -58,7 +56,7 @@ use std::{
 /// where
 ///     B: Send,
 /// {
-///     type Rejection = Response<BoxBody>;
+///     type Rejection = Response;
 ///
 ///     async fn from_request(req: &mut RequestParts<B>) -> Result<Self, Self::Rejection> {
 ///         // loading a `CurrentUser` requires first loading the `Session`
@@ -157,7 +155,7 @@ impl<R> IntoResponse for CachedRejection<R>
 where
     R: IntoResponse,
 {
-    fn into_response(self) -> Response<BoxBody> {
+    fn into_response(self) -> Response {
         match self {
             Self::ExtensionsAlreadyExtracted(inner) => inner.into_response(),
             Self::Inner(inner) => inner.into_response(),

--- a/axum-extra/src/response/erased_json.rs
+++ b/axum-extra/src/response/erased_json.rs
@@ -1,7 +1,7 @@
 use axum::{
-    body::{self, BoxBody, Full},
-    http::{header, HeaderValue, Response, StatusCode},
-    response::IntoResponse,
+    body::{self, Full},
+    http::{header, HeaderValue, StatusCode},
+    response::{IntoResponse, Response},
 };
 use serde::Serialize;
 
@@ -39,7 +39,7 @@ impl ErasedJson {
 }
 
 impl IntoResponse for ErasedJson {
-    fn into_response(self) -> Response<BoxBody> {
+    fn into_response(self) -> Response {
         let bytes = match self.0 {
             Ok(res) => res,
             Err(err) => {

--- a/axum-extra/src/routing/resource.rs
+++ b/axum-extra/src/routing/resource.rs
@@ -1,8 +1,9 @@
 use super::HasRoutes;
 use axum::{
-    body::{Body, BoxBody},
+    body::Body,
     handler::Handler,
-    http::{Request, Response},
+    http::Request,
+    response::Response,
     routing::{delete, get, on, post, MethodFilter},
     Router,
 };
@@ -139,10 +140,7 @@ impl<B: Send + 'static> Resource<B> {
     /// The routes will be nested at `/{resource_name}/:{resource_name}_id`.
     pub fn nest<T>(mut self, svc: T) -> Self
     where
-        T: Service<Request<B>, Response = Response<BoxBody>, Error = Infallible>
-            + Clone
-            + Send
-            + 'static,
+        T: Service<Request<B>, Response = Response, Error = Infallible> + Clone + Send + 'static,
         T::Future: Send + 'static,
     {
         let path = self.show_update_destroy_path();
@@ -155,10 +153,7 @@ impl<B: Send + 'static> Resource<B> {
     /// The routes will be nested at `/{resource_name}`.
     pub fn nest_collection<T>(mut self, svc: T) -> Self
     where
-        T: Service<Request<B>, Response = Response<BoxBody>, Error = Infallible>
-            + Clone
-            + Send
-            + 'static,
+        T: Service<Request<B>, Response = Response, Error = Infallible> + Clone + Send + 'static,
         T::Future: Send + 'static,
     {
         let path = self.index_create_path();
@@ -176,10 +171,7 @@ impl<B: Send + 'static> Resource<B> {
 
     fn route<T>(mut self, path: &str, svc: T) -> Self
     where
-        T: Service<Request<B>, Response = Response<BoxBody>, Error = Infallible>
-            + Clone
-            + Send
-            + 'static,
+        T: Service<Request<B>, Response = Response, Error = Infallible> + Clone + Send + 'static,
         T::Future: Send + 'static,
     {
         self.router = self.router.route(path, svc);

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -7,8 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
-- **added:** `axum::Response`/`axum::response::Response` now exist as a shorthand for writing
-`Response<BoxBody>`.
+- **added:** `axum::response::Response` now exists as a shorthand for writing `Response<BoxBody>`.
 
 # 0.4.0 (02. December, 2021)
 

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
-- None.
+- **added:** `axum::Response`/`axum::response::Response` now exist as a shorthand for writing
+`Response<BoxBody>`.
 
 # 0.4.0 (02. December, 2021)
 

--- a/axum/src/body/stream_body.rs
+++ b/axum/src/body/stream_body.rs
@@ -1,6 +1,6 @@
 use crate::{
-    body::{self, BoxBody},
-    response::IntoResponse,
+    body,
+    response::{IntoResponse, Response},
     BoxError, Error,
 };
 use bytes::Bytes;
@@ -8,7 +8,7 @@ use futures_util::{
     ready,
     stream::{self, TryStream},
 };
-use http::{HeaderMap, Response};
+use http::HeaderMap;
 use http_body::Body;
 use pin_project_lite::pin_project;
 use std::{
@@ -81,7 +81,7 @@ where
     S::Ok: Into<Bytes>,
     S::Error: Into<BoxError>,
 {
-    fn into_response(self) -> Response<BoxBody> {
+    fn into_response(self) -> Response {
         Response::new(body::boxed(self))
     }
 }

--- a/axum/src/docs/error_handling.md
+++ b/axum/src/docs/error_handling.md
@@ -24,7 +24,7 @@ async fn handler() -> Result<String, StatusCode> {
 
 While it looks like it might fail with a `StatusCode` this actually isn't an
 "error". If this handler returns `Err(some_status_code)` that will still be
-converted into a [`Response<_>`] and sent back to the client. This is done
+converted into a [`Response`] and sent back to the client. This is done
 through `StatusCode`'s [`IntoResponse`] implementation.
 
 It doesn't matter whether you return `Err(StatusCode::NOT_FOUND)` or
@@ -171,5 +171,5 @@ async fn handle_timeout_error(
 
 [`tower::Service`]: `tower::Service`
 [`Infallible`]: std::convert::Infallible
-[`Response<_>`]: http::Response
+[`Response`]: crate::response::Response
 [`IntoResponse`]: crate::response::IntoResponse

--- a/axum/src/docs/middleware.md
+++ b/axum/src/docs/middleware.md
@@ -55,11 +55,12 @@ compatible with axum. Some commonly used middleware are:
 
 ```rust,no_run
 use axum::{
-    body::{Body, BoxBody},
-    routing::get,
-    http::{Request, Response},
-    error_handling::HandleErrorLayer,
+	response::Response,
     Router,
+    body::{Body, BoxBody},
+    error_handling::HandleErrorLayer,
+    http::Request,
+    routing::get,
 };
 use tower::{
     filter::AsyncFilterLayer,
@@ -90,7 +91,7 @@ async fn map_request(req: Request<Body>) -> Result<Request<Body>, Infallible> {
     Ok(req)
 }
 
-async fn map_response(res: Response<BoxBody>) -> Result<Response<BoxBody>, Infallible> {
+async fn map_response(res: Response) -> Result<Response, Infallible> {
     Ok(res)
 }
 
@@ -112,10 +113,11 @@ You can also write you own middleware by implementing [`tower::Service`]:
 
 ```rust
 use axum::{
-    body::{Body, BoxBody},
-    routing::get,
-    http::{Request, Response},
+	response::Response,
     Router,
+    body::{Body, BoxBody},
+    http::Request,
+    routing::get,
 };
 use futures::future::BoxFuture;
 use tower::{Service, layer::layer_fn};
@@ -128,7 +130,7 @@ struct MyMiddleware<S> {
 
 impl<S> Service<Request<Body>> for MyMiddleware<S>
 where
-    S: Service<Request<Body>, Response = Response<BoxBody>> + Clone + Send + 'static,
+    S: Service<Request<Body>, Response = Response> + Clone + Send + 'static,
     S::Future: Send + 'static,
 {
     type Response = S::Response;
@@ -148,7 +150,7 @@ where
         let mut inner = std::mem::replace(&mut self.inner, clone);
 
         Box::pin(async move {
-            let res: Response<BoxBody> = inner.call(req).await?;
+            let res: Response = inner.call(req).await?;
 
             println!("`MyMiddleware` received the response");
 

--- a/axum/src/error_handling/mod.rs
+++ b/axum/src/error_handling/mod.rs
@@ -1,10 +1,10 @@
 #![doc = include_str!("../docs/error_handling.md")]
 
 use crate::{
-    body::{boxed, BoxBody, Bytes, Full, HttpBody},
+    body::{boxed, Bytes, Full, HttpBody},
     extract::{FromRequest, RequestParts},
-    http::{Request, Response, StatusCode},
-    response::IntoResponse,
+    http::{Request, StatusCode},
+    response::{IntoResponse, Response},
     BoxError,
 };
 use std::{
@@ -126,7 +126,7 @@ where
     ResBody: HttpBody<Data = Bytes> + Send + 'static,
     ResBody::Error: Into<BoxError>,
 {
-    type Response = Response<BoxBody>;
+    type Response = Response;
     type Error = Infallible;
     type Future = future::HandleErrorFuture;
 
@@ -168,7 +168,7 @@ macro_rules! impl_service {
             ResBody: HttpBody<Data = Bytes> + Send + 'static,
             ResBody::Error: Into<BoxError>,
         {
-            type Response = Response<BoxBody>;
+            type Response = Response;
             type Error = Infallible;
 
             type Future = future::HandleErrorFuture;
@@ -221,8 +221,7 @@ all_the_tuples!(impl_service);
 pub mod future {
     //! Future types.
 
-    use crate::body::BoxBody;
-    use http::Response;
+    use crate::response::Response;
     use pin_project_lite::pin_project;
     use std::{
         convert::Infallible,
@@ -235,7 +234,7 @@ pub mod future {
         /// Response future for [`HandleError`].
         pub struct HandleErrorFuture {
             #[pin]
-            pub(super) future: Pin<Box<dyn Future<Output = Result<Response<BoxBody>, Infallible>>
+            pub(super) future: Pin<Box<dyn Future<Output = Result<Response, Infallible>>
                 + Send
                 + 'static
             >>,
@@ -243,7 +242,7 @@ pub mod future {
     }
 
     impl Future for HandleErrorFuture {
-        type Output = Result<Response<BoxBody>, Infallible>;
+        type Output = Result<Response, Infallible>;
 
         fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
             self.project().future.poll(cx)

--- a/axum/src/extract/extractor_middleware.rs
+++ b/axum/src/extract/extractor_middleware.rs
@@ -3,10 +3,13 @@
 //! See [`extractor_middleware`] for more details.
 
 use super::{FromRequest, RequestParts};
-use crate::{body::BoxBody, response::IntoResponse, BoxError};
+use crate::{
+    response::{IntoResponse, Response},
+    BoxError,
+};
 use bytes::Bytes;
 use futures_util::{future::BoxFuture, ready};
-use http::{Request, Response};
+use http::Request;
 use pin_project_lite::pin_project;
 use std::{
     fmt,
@@ -170,7 +173,7 @@ where
     ResBody: http_body::Body<Data = Bytes> + Send + 'static,
     ResBody::Error: Into<BoxError>,
 {
-    type Response = Response<BoxBody>;
+    type Response = Response;
     type Error = S::Error;
     type Future = ResponseFuture<ReqBody, S, E>;
 
@@ -229,7 +232,7 @@ where
     ResBody: http_body::Body<Data = Bytes> + Send + 'static,
     ResBody::Error: Into<BoxError>,
 {
-    type Output = Result<Response<BoxBody>, S::Error>;
+    type Output = Result<Response, S::Error>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         loop {

--- a/axum/src/extract/mod.rs
+++ b/axum/src/extract/mod.rs
@@ -1,6 +1,5 @@
 #![doc = include_str!("../docs/extract.md")]
 
-use crate::response::IntoResponse;
 use http::header;
 use rejection::*;
 

--- a/axum/src/extract/path/mod.rs
+++ b/axum/src/extract/path/mod.rs
@@ -4,9 +4,9 @@
 mod de;
 
 use crate::{
-    body::{boxed, BoxBody, Full},
+    body::{boxed, Full},
     extract::{rejection::*, FromRequest, RequestParts},
-    response::IntoResponse,
+    response::{IntoResponse, Response},
     routing::{InvalidUtf8InPathParam, UrlParams},
 };
 use async_trait::async_trait;
@@ -370,7 +370,7 @@ impl FailedToDeserializePathParams {
 }
 
 impl IntoResponse for FailedToDeserializePathParams {
-    fn into_response(self) -> http::Response<BoxBody> {
+    fn into_response(self) -> Response {
         let (status, body) = match self.0.kind {
             ErrorKind::Message(_)
             | ErrorKind::InvalidUtf8InPathParam { .. }
@@ -385,7 +385,7 @@ impl IntoResponse for FailedToDeserializePathParams {
                 (StatusCode::INTERNAL_SERVER_ERROR, self.0.kind.to_string())
             }
         };
-        let mut res = http::Response::new(boxed(Full::from(body)));
+        let mut res = Response::new(boxed(Full::from(body)));
         *res.status_mut() = status;
         res
     }

--- a/axum/src/extract/rejection.rs
+++ b/axum/src/extract/rejection.rs
@@ -1,8 +1,8 @@
 //! Rejection response types.
 
-use super::IntoResponse;
 use crate::{
-    body::{boxed, BoxBody},
+    body::boxed,
+    response::{IntoResponse, Response},
     BoxError, Error,
 };
 use http_body::Full;
@@ -87,8 +87,8 @@ impl FailedToDeserializeQueryString {
 }
 
 impl IntoResponse for FailedToDeserializeQueryString {
-    fn into_response(self) -> http::Response<BoxBody> {
-        let mut res = http::Response::new(boxed(Full::from(self.to_string())));
+    fn into_response(self) -> Response {
+        let mut res = Response::new(boxed(Full::from(self.to_string())));
         *res.status_mut() = http::StatusCode::BAD_REQUEST;
         res
     }
@@ -204,7 +204,7 @@ impl<T> IntoResponse for ContentLengthLimitRejection<T>
 where
     T: IntoResponse,
 {
-    fn into_response(self) -> http::Response<BoxBody> {
+    fn into_response(self) -> Response {
         match self {
             Self::PayloadTooLarge(inner) => inner.into_response(),
             Self::LengthRequired(inner) => inner.into_response(),

--- a/axum/src/extract/typed_header.rs
+++ b/axum/src/extract/typed_header.rs
@@ -1,5 +1,5 @@
 use super::{FromRequest, RequestParts};
-use crate::{body::BoxBody, response::IntoResponse};
+use crate::response::{IntoResponse, Response};
 use async_trait::async_trait;
 use headers::HeaderMapExt;
 use std::ops::Deref;
@@ -106,7 +106,7 @@ pub enum TypedHeaderRejectionReason {
 }
 
 impl IntoResponse for TypedHeaderRejection {
-    fn into_response(self) -> http::Response<BoxBody> {
+    fn into_response(self) -> Response {
         let mut res = self.to_string().into_response();
         *res.status_mut() = http::StatusCode::BAD_REQUEST;
         res

--- a/axum/src/extract/ws.rs
+++ b/axum/src/extract/ws.rs
@@ -66,8 +66,8 @@
 use self::rejection::*;
 use super::{rejection::*, FromRequest, RequestParts};
 use crate::{
-    body::{self, BoxBody},
-    response::IntoResponse,
+    body,
+    response::{IntoResponse, Response},
     Error,
 };
 use async_trait::async_trait;
@@ -78,7 +78,7 @@ use futures_util::{
 };
 use http::{
     header::{self, HeaderName, HeaderValue},
-    Method, Response, StatusCode,
+    Method, StatusCode,
 };
 use hyper::upgrade::{OnUpgrade, Upgraded};
 use sha1::{Digest, Sha1};
@@ -296,7 +296,7 @@ where
     F: FnOnce(WebSocket) -> Fut + Send + 'static,
     Fut: Future + Send + 'static,
 {
-    fn into_response(self) -> Response<BoxBody> {
+    fn into_response(self) -> Response {
         // check requested protocols
         let protocol = self
             .extractor

--- a/axum/src/handler/future.rs
+++ b/axum/src/handler/future.rs
@@ -1,15 +1,14 @@
 //! Handler future types.
 
-use crate::body::BoxBody;
+use crate::response::Response;
 use futures_util::future::{BoxFuture, Map};
-use http::Response;
 use std::convert::Infallible;
 
 opaque_future! {
     /// The response future for [`IntoService`](super::IntoService).
     pub type IntoServiceFuture =
         Map<
-            BoxFuture<'static, Response<BoxBody>>,
-            fn(Response<BoxBody>) -> Result<Response<BoxBody>, Infallible>,
+            BoxFuture<'static, Response>,
+            fn(Response) -> Result<Response, Infallible>,
         >;
 }

--- a/axum/src/handler/into_service.rs
+++ b/axum/src/handler/into_service.rs
@@ -1,6 +1,6 @@
 use super::Handler;
-use crate::body::BoxBody;
-use http::{Request, Response};
+use crate::response::Response;
+use http::Request;
 use std::{
     convert::Infallible,
     fmt,
@@ -58,7 +58,7 @@ where
     H: Handler<T, B> + Clone + Send + 'static,
     B: Send + 'static,
 {
-    type Response = Response<BoxBody>;
+    type Response = Response;
     type Error = Infallible;
     type Future = super::future::IntoServiceFuture;
 

--- a/axum/src/json.rs
+++ b/axum/src/json.rs
@@ -1,7 +1,7 @@
 use crate::{
-    body::{self, BoxBody},
+    body,
     extract::{rejection::*, FromRequest, RequestParts},
-    response::IntoResponse,
+    response::{IntoResponse, Response},
     BoxError,
 };
 use async_trait::async_trait;
@@ -10,7 +10,6 @@ use http::{
     StatusCode,
 };
 use http_body::Full;
-use hyper::Response;
 use serde::{de::DeserializeOwned, Serialize};
 use std::ops::{Deref, DerefMut};
 
@@ -163,7 +162,7 @@ impl<T> IntoResponse for Json<T>
 where
     T: Serialize,
 {
-    fn into_response(self) -> Response<BoxBody> {
+    fn into_response(self) -> Response {
         let bytes = match serde_json::to_vec(&self.0) {
             Ok(res) => res,
             Err(err) => {

--- a/axum/src/lib.rs
+++ b/axum/src/lib.rs
@@ -410,6 +410,8 @@ pub use hyper::Server;
 #[doc(inline)]
 #[cfg(feature = "json")]
 pub use self::json::Json;
+#[doc(no_inline)]
+pub use self::response::Response;
 #[doc(inline)]
 pub use self::routing::Router;
 

--- a/axum/src/lib.rs
+++ b/axum/src/lib.rs
@@ -410,8 +410,6 @@ pub use hyper::Server;
 #[doc(inline)]
 #[cfg(feature = "json")]
 pub use self::json::Json;
-#[doc(no_inline)]
-pub use self::response::Response;
 #[doc(inline)]
 pub use self::routing::Router;
 

--- a/axum/src/macros.rs
+++ b/axum/src/macros.rs
@@ -59,7 +59,7 @@ macro_rules! define_rejection {
 
         #[allow(deprecated)]
         impl $crate::response::IntoResponse for $name {
-            fn into_response(self) -> http::Response<$crate::body::BoxBody> {
+            fn into_response(self) -> $crate::Response {
                 let mut res = http::Response::new($crate::body::boxed(http_body::Full::from($body)));
                 *res.status_mut() = http::StatusCode::$status;
                 res
@@ -101,7 +101,7 @@ macro_rules! define_rejection {
         }
 
         impl IntoResponse for $name {
-            fn into_response(self) -> http::Response<$crate::body::BoxBody> {
+            fn into_response(self) -> $crate::Response {
                 let mut res =
                     http::Response::new($crate::body::boxed(http_body::Full::from(format!(concat!($body, ": {}"), self.0))));
                 *res.status_mut() = http::StatusCode::$status;
@@ -142,7 +142,7 @@ macro_rules! composite_rejection {
         }
 
         impl $crate::response::IntoResponse for $name {
-            fn into_response(self) -> http::Response<$crate::body::BoxBody> {
+            fn into_response(self) -> $crate::Response {
                 match self {
                     $(
                         Self::$variant(inner) => inner.into_response(),

--- a/axum/src/macros.rs
+++ b/axum/src/macros.rs
@@ -59,7 +59,7 @@ macro_rules! define_rejection {
 
         #[allow(deprecated)]
         impl $crate::response::IntoResponse for $name {
-            fn into_response(self) -> $crate::Response {
+            fn into_response(self) -> $crate::response::Response {
                 let mut res = http::Response::new($crate::body::boxed(http_body::Full::from($body)));
                 *res.status_mut() = http::StatusCode::$status;
                 res
@@ -101,7 +101,7 @@ macro_rules! define_rejection {
         }
 
         impl IntoResponse for $name {
-            fn into_response(self) -> $crate::Response {
+            fn into_response(self) -> $crate::response::Response {
                 let mut res =
                     http::Response::new($crate::body::boxed(http_body::Full::from(format!(concat!($body, ": {}"), self.0))));
                 *res.status_mut() = http::StatusCode::$status;
@@ -142,7 +142,7 @@ macro_rules! composite_rejection {
         }
 
         impl $crate::response::IntoResponse for $name {
-            fn into_response(self) -> $crate::Response {
+            fn into_response(self) -> $crate::response::Response {
                 match self {
                     $(
                         Self::$variant(inner) => inner.into_response(),

--- a/axum/src/response/mod.rs
+++ b/axum/src/response/mod.rs
@@ -1,8 +1,8 @@
 #![doc = include_str!("../docs/response.md")]
 
-use axum_core::body::{boxed, BoxBody};
+use axum_core::body::boxed;
 use bytes::Bytes;
-use http::{header, HeaderValue, Response};
+use http::{header, HeaderValue};
 use http_body::Full;
 
 mod redirect;
@@ -14,7 +14,7 @@ pub mod sse;
 pub use crate::Json;
 
 #[doc(inline)]
-pub use axum_core::response::{Headers, IntoResponse};
+pub use axum_core::response::{Headers, IntoResponse, Response};
 
 #[doc(inline)]
 pub use self::{redirect::Redirect, sse::Sse};
@@ -29,7 +29,7 @@ impl<T> IntoResponse for Html<T>
 where
     T: Into<Full<Bytes>>,
 {
-    fn into_response(self) -> Response<BoxBody> {
+    fn into_response(self) -> Response {
         let mut res = Response::new(boxed(self.0.into()));
         res.headers_mut().insert(
             header::CONTENT_TYPE,
@@ -59,7 +59,7 @@ mod tests {
         struct MyResponse;
 
         impl IntoResponse for MyResponse {
-            fn into_response(self) -> Response<BoxBody> {
+            fn into_response(self) -> Response {
                 let mut resp = Response::new(boxed(Empty::new()));
                 resp.headers_mut()
                     .insert(HeaderName::from_static("a"), HeaderValue::from_static("1"));

--- a/axum/src/response/redirect.rs
+++ b/axum/src/response/redirect.rs
@@ -1,6 +1,6 @@
-use super::IntoResponse;
-use crate::body::{boxed, BoxBody};
-use http::{header::LOCATION, HeaderValue, Response, StatusCode, Uri};
+use super::{IntoResponse, Response};
+use crate::body::boxed;
+use http::{header::LOCATION, HeaderValue, StatusCode, Uri};
 use http_body::Empty;
 use std::convert::TryFrom;
 
@@ -105,7 +105,7 @@ impl Redirect {
 }
 
 impl IntoResponse for Redirect {
-    fn into_response(self) -> Response<BoxBody> {
+    fn into_response(self) -> Response {
         let mut res = Response::new(boxed(Empty::new()));
         *res.status_mut() = self.status_code;
         res.headers_mut().insert(LOCATION, self.location);

--- a/axum/src/response/sse.rs
+++ b/axum/src/response/sse.rs
@@ -28,8 +28,8 @@
 //! ```
 
 use crate::{
-    body::{self, BoxBody},
-    response::IntoResponse,
+    body,
+    response::{IntoResponse, Response},
     BoxError,
 };
 use bytes::Bytes;
@@ -37,7 +37,6 @@ use futures_util::{
     ready,
     stream::{Stream, TryStream},
 };
-use http::Response;
 use http_body::Body as HttpBody;
 use pin_project_lite::pin_project;
 use std::{
@@ -98,7 +97,7 @@ where
     S: Stream<Item = Result<Event, E>> + Send + 'static,
     E: Into<BoxError>,
 {
-    fn into_response(self) -> Response<BoxBody> {
+    fn into_response(self) -> Response {
         let body = body::boxed(Body {
             event_stream: SyncWrapper::new(self.stream),
             keep_alive: self.keep_alive.map(KeepAliveStream::new),

--- a/axum/src/routing/future.rs
+++ b/axum/src/routing/future.rs
@@ -1,8 +1,7 @@
 //! Future types.
 
-use crate::body::BoxBody;
+use crate::response::Response;
 use futures_util::future::Either;
-use http::Response;
 use std::{convert::Infallible, future::ready};
 
 pub use super::{into_make_service::IntoMakeServiceFuture, route::RouteFuture};
@@ -12,7 +11,7 @@ opaque_future! {
     pub type RouterFuture<B> =
         futures_util::future::Either<
             RouteFuture<B, Infallible>,
-            std::future::Ready<Result<Response<BoxBody>, Infallible>>,
+            std::future::Ready<Result<Response, Infallible>>,
         >;
 }
 
@@ -21,7 +20,7 @@ impl<B> RouterFuture<B> {
         Self::new(Either::Left(future))
     }
 
-    pub(super) fn from_response(response: Response<BoxBody>) -> Self {
+    pub(super) fn from_response(response: Response) -> Self {
         Self::new(Either::Right(ready(Ok(response))))
     }
 }

--- a/axum/src/routing/mod.rs
+++ b/axum/src/routing/mod.rs
@@ -2,17 +2,18 @@
 
 use self::{future::RouterFuture, not_found::NotFound};
 use crate::{
-    body::{boxed, Body, BoxBody},
+    body::{boxed, Body},
     extract::{
         connect_info::{Connected, IntoMakeServiceWithConnectInfo},
         MatchedPath, OriginalUri,
     },
+    response::Response,
     routing::strip_prefix::StripPrefix,
     util::{try_downcast, ByteStr, PercentDecodedByteStr},
     BoxError,
 };
 use bytes::Bytes;
-use http::{Request, Response, StatusCode, Uri};
+use http::{Request, StatusCode, Uri};
 use std::{
     borrow::Cow,
     collections::HashMap,
@@ -109,10 +110,7 @@ where
     #[doc = include_str!("../docs/routing/route.md")]
     pub fn route<T>(mut self, path: &str, service: T) -> Self
     where
-        T: Service<Request<B>, Response = Response<BoxBody>, Error = Infallible>
-            + Clone
-            + Send
-            + 'static,
+        T: Service<Request<B>, Response = Response, Error = Infallible> + Clone + Send + 'static,
         T::Future: Send + 'static,
     {
         if path.is_empty() {
@@ -161,10 +159,7 @@ where
     #[doc = include_str!("../docs/routing/nest.md")]
     pub fn nest<T>(mut self, path: &str, svc: T) -> Self
     where
-        T: Service<Request<B>, Response = Response<BoxBody>, Error = Infallible>
-            + Clone
-            + Send
-            + 'static,
+        T: Service<Request<B>, Response = Response, Error = Infallible> + Clone + Send + 'static,
         T::Future: Send + 'static,
     {
         if path.is_empty() {
@@ -352,10 +347,7 @@ where
     #[doc = include_str!("../docs/routing/fallback.md")]
     pub fn fallback<T>(mut self, svc: T) -> Self
     where
-        T: Service<Request<B>, Response = Response<BoxBody>, Error = Infallible>
-            + Clone
-            + Send
-            + 'static,
+        T: Service<Request<B>, Response = Response, Error = Infallible> + Clone + Send + 'static,
         T::Future: Send + 'static,
     {
         self.fallback = Fallback::Custom(Route::new(svc));
@@ -461,7 +453,7 @@ impl<B> Service<Request<B>> for Router<B>
 where
     B: Send + 'static,
 {
-    type Response = Response<BoxBody>;
+    type Response = Response;
     type Error = Infallible;
     type Future = RouterFuture<B>;
 

--- a/axum/src/routing/not_found.rs
+++ b/axum/src/routing/not_found.rs
@@ -1,5 +1,5 @@
-use crate::body::BoxBody;
-use http::{Request, Response, StatusCode};
+use crate::response::Response;
+use http::{Request, StatusCode};
 use std::{
     convert::Infallible,
     future::ready,
@@ -18,9 +18,9 @@ impl<B> Service<Request<B>> for NotFound
 where
     B: Send + 'static,
 {
-    type Response = Response<BoxBody>;
+    type Response = Response;
     type Error = Infallible;
-    type Future = std::future::Ready<Result<Response<BoxBody>, Self::Error>>;
+    type Future = std::future::Ready<Result<Response, Self::Error>>;
 
     #[inline]
     fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {

--- a/examples/error-handling-and-dependency-injection/src/main.rs
+++ b/examples/error-handling-and-dependency-injection/src/main.rs
@@ -9,10 +9,9 @@
 
 use axum::{
     async_trait,
-    body::BoxBody,
     extract::{Extension, Path},
-    http::{Response, StatusCode},
-    response::IntoResponse,
+    http::StatusCode,
+    response::{IntoResponse, Response},
     routing::{get, post},
     AddExtensionLayer, Json, Router,
 };
@@ -92,7 +91,7 @@ impl From<UserRepoError> for AppError {
 }
 
 impl IntoResponse for AppError {
-    fn into_response(self) -> Response<BoxBody> {
+    fn into_response(self) -> Response {
         let (status, error_message) = match self {
             AppError::UserRepo(UserRepoError::NotFound) => {
                 (StatusCode::NOT_FOUND, "User not found")

--- a/examples/http-proxy/src/main.rs
+++ b/examples/http-proxy/src/main.rs
@@ -13,9 +13,9 @@
 //! Example is based on <https://github.com/hyperium/hyper/blob/master/examples/http_proxy.rs>
 
 use axum::{
-    body::{self, Body, BoxBody},
-    http::{Method, Request, Response, StatusCode},
-    response::IntoResponse,
+    body::{self, Body},
+    http::{Method, Request, StatusCode},
+    response::{IntoResponse, Response},
     routing::get,
     Router,
 };
@@ -55,7 +55,7 @@ async fn main() {
         .unwrap();
 }
 
-async fn proxy(req: Request<Body>) -> Result<Response<BoxBody>, hyper::Error> {
+async fn proxy(req: Request<Body>) -> Result<Response, hyper::Error> {
     tracing::trace!(?req);
 
     if let Some(host_addr) = req.uri().authority().map(|auth| auth.to_string()) {

--- a/examples/jwt/src/main.rs
+++ b/examples/jwt/src/main.rs
@@ -8,10 +8,9 @@
 
 use axum::{
     async_trait,
-    body::BoxBody,
     extract::{FromRequest, RequestParts, TypedHeader},
-    http::{Response, StatusCode},
-    response::IntoResponse,
+    http::StatusCode,
+    response::{IntoResponse, Response},
     routing::{get, post},
     Json, Router,
 };
@@ -141,7 +140,7 @@ where
 }
 
 impl IntoResponse for AuthError {
-    fn into_response(self) -> Response<BoxBody> {
+    fn into_response(self) -> Response {
         let (status, error_message) = match self {
             AuthError::WrongCredentials => (StatusCode::UNAUTHORIZED, "Wrong credentials"),
             AuthError::MissingCredentials => (StatusCode::BAD_REQUEST, "Missing credentials"),

--- a/examples/oauth/src/main.rs
+++ b/examples/oauth/src/main.rs
@@ -9,10 +9,9 @@
 use async_session::{MemoryStore, Session, SessionStore};
 use axum::{
     async_trait,
-    body::BoxBody,
     extract::{Extension, FromRequest, Query, RequestParts, TypedHeader},
-    http::{header::SET_COOKIE, HeaderMap, Response},
-    response::{IntoResponse, Redirect},
+    http::{header::SET_COOKIE, HeaderMap},
+    response::{IntoResponse, Redirect, Response},
     routing::get,
     AddExtensionLayer, Router,
 };
@@ -199,7 +198,7 @@ async fn login_authorized(
 struct AuthRedirect;
 
 impl IntoResponse for AuthRedirect {
-    fn into_response(self) -> Response<BoxBody> {
+    fn into_response(self) -> Response {
         Redirect::found("/auth/discord".parse().unwrap()).into_response()
     }
 }

--- a/examples/print-request-response/src/main.rs
+++ b/examples/print-request-response/src/main.rs
@@ -5,9 +5,10 @@
 //! ```
 
 use axum::{
-    body::{Body, BoxBody, Bytes},
+    body::{Body, Bytes},
     error_handling::HandleErrorLayer,
-    http::{Request, Response, StatusCode},
+    http::{Request, StatusCode},
+    response::Response,
     routing::post,
     Router,
 };
@@ -54,7 +55,7 @@ async fn map_request(req: Request<Body>) -> Result<Request<Body>, BoxError> {
     Ok(req)
 }
 
-async fn map_response(res: Response<BoxBody>) -> Result<Response<Body>, BoxError> {
+async fn map_response(res: Response) -> Result<Response<Body>, BoxError> {
     let (parts, body) = res.into_parts();
     let bytes = buffer_and_print("response", body).await?;
     let res = Response::from_parts(parts, Body::from(bytes));

--- a/examples/templates/src/main.rs
+++ b/examples/templates/src/main.rs
@@ -6,10 +6,10 @@
 
 use askama::Template;
 use axum::{
-    body::{self, BoxBody, Full},
+    body::{self, Full},
     extract,
-    http::{Response, StatusCode},
-    response::{Html, IntoResponse},
+    http::StatusCode,
+    response::{Html, IntoResponse, Response},
     routing::get,
     Router,
 };
@@ -52,7 +52,7 @@ impl<T> IntoResponse for HtmlTemplate<T>
 where
     T: Template,
 {
-    fn into_response(self) -> Response<BoxBody> {
+    fn into_response(self) -> Response {
         match self.0.render() {
             Ok(html) => Html(html).into_response(),
             Err(err) => Response::builder()

--- a/examples/tracing-aka-logging/src/main.rs
+++ b/examples/tracing-aka-logging/src/main.rs
@@ -6,8 +6,8 @@
 
 use axum::{
     body::Bytes,
-    http::{HeaderMap, Request, Response},
-    response::Html,
+    http::{HeaderMap, Request},
+    response::{Html, Response},
     routing::get,
     Router,
 };
@@ -42,11 +42,9 @@ async fn main() {
                 .on_request(|_request: &Request<_>, _span: &Span| {
                     // ...
                 })
-                .on_response(
-                    |_response: &Response<_>, _latency: Duration, _span: &Span| {
-                        // ...
-                    },
-                )
+                .on_response(|_response: &Response, _latency: Duration, _span: &Span| {
+                    // ...
+                })
                 .on_body_chunk(|_chunk: &Bytes, _latency: Duration, _span: &Span| {
                     // ..
                 })

--- a/examples/validator/src/main.rs
+++ b/examples/validator/src/main.rs
@@ -12,10 +12,9 @@
 
 use async_trait::async_trait;
 use axum::{
-    body::BoxBody,
     extract::{Form, FromRequest, RequestParts},
-    http::{Response, StatusCode},
-    response::{Html, IntoResponse},
+    http::StatusCode,
+    response::{Html, IntoResponse, Response},
     routing::get,
     BoxError, Router,
 };
@@ -84,7 +83,7 @@ pub enum ServerError {
 }
 
 impl IntoResponse for ServerError {
-    fn into_response(self) -> Response<BoxBody> {
+    fn into_response(self) -> Response {
         match self {
             ServerError::ValidationError(_) => {
                 let message = format!("Input validation error: [{}]", self).replace("\n", ", ");

--- a/examples/versioning/src/main.rs
+++ b/examples/versioning/src/main.rs
@@ -6,10 +6,9 @@
 
 use axum::{
     async_trait,
-    body::BoxBody,
     extract::{FromRequest, Path, RequestParts},
-    http::{Response, StatusCode},
-    response::IntoResponse,
+    http::StatusCode,
+    response::{IntoResponse, Response},
     routing::get,
     Router,
 };
@@ -51,7 +50,7 @@ impl<B> FromRequest<B> for Version
 where
     B: Send,
 {
-    type Rejection = Response<BoxBody>;
+    type Rejection = Response;
 
     async fn from_request(req: &mut RequestParts<B>) -> Result<Self, Self::Rejection> {
         let params = Path::<HashMap<String, String>>::from_request(req)


### PR DESCRIPTION
## Motivation

Nowadays `Response` is pretty much only used with `BoxBody` as its body type, but it becomes tedious to type out `Response<BoxBody>` every time and have to import them both.

## Solution

Provide a new type alias to allow writing `Response` instead of the full `Response<BoxBody>`:

```rust
pub type Response<T = BoxBody> = http::Response<T>;
```

This type is defined in `axum_core::response` but is re-exported in ~~`axum`, `axum_core`, `axum::response` and `axum_core::response`~~ `axum::response`. The "default type parameter" trick is used to not lose any functionality over `http::Response`.

Prior art: [Warp does this](https://docs.rs/warp/latest/warp/reply/type.Response.html).