### PR TITLE
Refactor `sse::Event`

### DIFF
--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
-- None.
+- **breaking:** `sse::Event` is more strict about what field values it supports, disallowing any
+  SSE events that break the specification (such as field values containing carriage returns).
+- **breaking:** `sse::Event` now accepts types implementing `AsRef<str>` instead of `Into<String>`
+  as field values.
+- **fixed:** `sse::Event` will no longer drop the leading space of data values that have it.
 
 # 0.4.2 (06. December, 2021)
 

--- a/axum/Cargo.toml
+++ b/axum/Cargo.toml
@@ -27,9 +27,11 @@ bytes = "1.0"
 futures-util = { version = "0.3", default-features = false, features = ["alloc"] }
 http = "0.2.5"
 http-body = "0.4.4"
-mime = "0.3.16"
 hyper = { version = "0.14.14", features = ["server", "tcp", "stream"] }
+itoa = "0.4.8"
 matchit = "0.4.4"
+memchr = "2.4.1"
+mime = "0.3.16"
 percent-encoding = "2.1"
 pin-project-lite = "0.2.7"
 serde = "1.0"


### PR DESCRIPTION
SSE `Events` are currently somewhat costly to use: each field is a separate allocation and at the end there's two more allocations as it's converted to a `String` then `Bytes`. By instead having the `sse::Event` build a `BytesMut` as it goes along, there will be far fewer allocations overall.

- I added dependencies on `memchr` and `itoa` for the implementation; I judged it to be fine because they're already in the required dependency tree, even several times.
- The SSE event's fields will now be in the order of the methods called on `Event`, instead of a fixed one. This is allowed by the SSE spec AFAICT and it makes more sense.
- To avoid nonsense things like an SSE event with multiple `id` fields, it also keeps track of which fields have been filled in and shouldn't be filled in again via a bitflags.
- I noticed that Axum didn't check that values passed in to the SSE event methods were valid, so I added validation for them (e.g. `data` cannot contain carriage returns, `id` cannot contain null bytes).
- There was a bug that setting `data`/`event`/`id` to a value that began with a space would lead to that space being dropped, because Axum would generate `data: text` from the input `" text"`, which the browser interprets as just `text`. I fixed that and added a test for it.
- I removed the `Display` impl on `Event` since it's no longer used. But I could easily add it back.

Unfortunately these changes are breaking, although they probably won't break any actual code. And it doesn't touch `axum-core` so libraries won't break.