### PR TITLE
axum-debug: Version 0.3.2

### DIFF
--- a/axum-debug/CHANGELOG.md
+++ b/axum-debug/CHANGELOG.md
@@ -7,9 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
+- None.
+
+# 0.3.2 (09. December 2021)
+
 - Support checking `FromRequest` bounds for extractors whose request body is something else than
   `axum::body::Body`. Use `#[debug_handler(body = YourBodyType)]` to use a different request body
-  type.
+  type ([#595])
+
+[#595]: https://github.com/tokio-rs/axum/pull/595
 
 # 0.3.1 (06. December 2021)
 

--- a/axum-debug/Cargo.toml
+++ b/axum-debug/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 name = "axum-debug"
 readme = "README.md"
 repository = "https://github.com/tokio-rs/axum"
-version = "0.3.1"
+version = "0.3.2"
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
- Support checking `FromRequest` bounds for extractors whose request body is something else than
  `axum::body::Body`. Use `#[debug_handler(body = YourBodyType)]` to use a different request body
  type ([#595])

[#595]: https://github.com/tokio-rs/axum/pull/595