### PR TITLE
Expose TypedHeaderRejection fields

### DIFF
--- a/axum/src/extract/typed_header.rs
+++ b/axum/src/extract/typed_header.rs
@@ -80,8 +80,8 @@ impl<T> Deref for TypedHeader<T> {
 #[cfg_attr(docsrs, doc(cfg(feature = "headers")))]
 #[derive(Debug)]
 pub struct TypedHeaderRejection {
-    name: &'static http::header::HeaderName,
-    reason: TypedHeaderRejectionReason,
+    pub name: &'static http::header::HeaderName,
+    pub reason: TypedHeaderRejectionReason,
 }
 
 impl TypedHeaderRejection {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation

Similar to the `customize-extractor-error` and `customize-path-rejection`, I'm trying to customize the response based on the rejection. I'm unable to do this without these fields being public. 


<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

The solution is to make these fields public so that I can match on `rejection.reason`
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
