### PR TITLE
Use `AtomicU32` in `RouteId`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -146,3 +146,21 @@ jobs:
         with:
           command: check ${{ matrix.checks }}
           arguments: --all-features --manifest-path axum/Cargo.toml
+
+  armv5te-unknown-linux-musleabi:
+    needs: check
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        target: armv5te-unknown-linux-musleabi
+        override: true
+        profile: minimal
+    - uses: Swatinem/rust-cache@v1
+    - name: Check
+      uses: actions-rs/cargo@v1
+      with:
+        command: check
+        args: --all --all-targets --all-features --target armv5te-unknown-linux-musleabi

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -161,6 +161,9 @@ jobs:
     - uses: Swatinem/rust-cache@v1
     - name: Check
       uses: actions-rs/cargo@v1
+      env:
+        # Clang has native cross-compilation support
+        CC: clang
       with:
         command: check
         args: --all --all-targets --all-features --target armv5te-unknown-linux-musleabi

--- a/axum/Cargo.toml
+++ b/axum/Cargo.toml
@@ -52,7 +52,7 @@ tokio-tungstenite = { optional = true, version = "0.16" }
 
 [dev-dependencies]
 futures = "0.3"
-reqwest = { version = "0.11", features = ["json", "stream"] }
+reqwest = { version = "0.11", default-features = false, features = ["json", "stream"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1.6.1", features = ["macros", "rt", "rt-multi-thread", "net"] }

--- a/axum/src/routing/mod.rs
+++ b/axum/src/routing/mod.rs
@@ -48,13 +48,18 @@ pub use self::method_routing::{
 };
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
-struct RouteId(u64);
+struct RouteId(u32);
 
 impl RouteId {
     fn next() -> Self {
-        use std::sync::atomic::{AtomicU64, Ordering};
-        static ID: AtomicU64 = AtomicU64::new(0);
-        Self(ID.fetch_add(1, Ordering::SeqCst))
+        use std::sync::atomic::{AtomicU32, Ordering};
+        // `AtomicU64` isn't supported on all platforms
+        static ID: AtomicU32 = AtomicU32::new(0);
+        let id = ID.fetch_add(1, Ordering::Relaxed);
+        if id == u32::MAX {
+            panic!("Over `u32::MAX` routes created. If you need this, please file an issue.");
+        }
+        Self(id)
     }
 }
 

--- a/examples/jwt/src/main.rs
+++ b/examples/jwt/src/main.rs
@@ -93,7 +93,7 @@ async fn authorize(Json(payload): Json<AuthPayload>) -> Result<Json<AuthBody>, A
     let claims = Claims {
         sub: "b@b.com".to_owned(),
         company: "ACME".to_owned(),
-        exp: 10000000000,
+        exp: 100000,
     };
     // Create the authorization token
     let token = encode(&Header::default(), &claims, &KEYS.encoding)

--- a/examples/oauth/Cargo.toml
+++ b/examples/oauth/Cargo.toml
@@ -12,5 +12,6 @@ tracing-subscriber = { version="0.3", features = ["env-filter"] }
 oauth2 = "4.1"
 async-session = "3.0.0"
 serde = { version = "1.0", features = ["derive"] }
-reqwest = { version = "0.11", features = ["json"] }
+# Use Rustls because it makes it easier to cross-compile on CI
+reqwest = { version = "0.11", default-features = false, features = ["rustls-tls", "json"] }
 headers = "0.3"


### PR DESCRIPTION
I don't think anyone is going to be creating >`u32::MAX` routes anyway so it should be fine, but I added a panic branch just in case, so silent bugs are never introduced. Also, there's no need to use `SeqCst`, it's not like there are any data dependencies associated with that atomic so `Relaxed` will do.

Fixes: #596.