### PR TITLE
Add `ExtensionsAlreadyExtracted` to `PathRejection`

### DIFF
--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -11,9 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **fixed:** Make `Path` fail with `ExtensionsAlreadyExtracted` if another extractor (such as
   `Request`) has previously taken the request extensions. Thus `PathRejection` now contains a
   variant with `ExtensionsAlreadyExtracted`. This is not a breaking change since `PathRejection` is
-  marked as `#[non_exhaustive]`
+  marked as `#[non_exhaustive]` ([#619])
 
 [#607]: https://github.com/tokio-rs/axum/pull/607
+[#619]: https://github.com/tokio-rs/axum/pull/619
 
 # 0.4.2 (06. December, 2021)
 

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # Unreleased
 
 - **added:** `axum::AddExtension::layer` ([#607])
+- **fixed:** Make `Path` fail with `ExtensionsAlreadyExtracted` if another extractor (such as
+  `Request`) has previously taken the request extensions. Thus `PathRejection` now contains a
+  variant with `ExtensionsAlreadyExtracted`. This is not a breaking change since `PathRejection` is
+  marked as `#[non_exhaustive]`
 
 [#607]: https://github.com/tokio-rs/axum/pull/607
 

--- a/axum/src/extract/path/mod.rs
+++ b/axum/src/extract/path/mod.rs
@@ -3,6 +3,7 @@
 
 mod de;
 
+use super::rejection::ExtensionsAlreadyExtracted;
 use crate::{
     body::{boxed, Full},
     extract::{rejection::*, FromRequest, RequestParts},
@@ -17,8 +18,6 @@ use std::{
     fmt,
     ops::{Deref, DerefMut},
 };
-
-use super::rejection::ExtensionsAlreadyExtracted;
 
 /// Extractor that will get captures from the URL and parse them using
 /// [`serde`].

--- a/axum/src/extract/rejection.rs
+++ b/axum/src/extract/rejection.rs
@@ -163,6 +163,7 @@ composite_rejection! {
     pub enum PathRejection {
         FailedToDeserializePathParams,
         MissingPathParams,
+        ExtensionsAlreadyExtracted,
     }
 }
 


### PR DESCRIPTION
Fixes https://github.com/tokio-rs/axum/issues/618

If the request extensions had previously been extracted `Path` would fail with [`MissingPathParams`](https://docs.rs/axum/latest/axum/extract/rejection/struct.MissingPathParams.html) which said there was a bug in axum, however it was actually a user error.

This is fixed by adding a variant for `ExtensionsAlreadyExtracted` to `PathRejection`. This is not a breaking change since `PathRejection` is `#[non_exhaustive]`.