### PR TITLE
Fix misc warnings from CI

### DIFF
--- a/axum/src/extract/path/de.rs
+++ b/axum/src/extract/path/de.rs
@@ -744,6 +744,7 @@ mod tests {
     #[test]
     fn test_parse_error_at_key_error() {
         #[derive(Debug, Deserialize)]
+        #[allow(dead_code)]
         struct Params {
             a: u32,
         }
@@ -761,6 +762,7 @@ mod tests {
     #[test]
     fn test_parse_error_at_key_error_multiple() {
         #[derive(Debug, Deserialize)]
+        #[allow(dead_code)]
         struct Params {
             a: u32,
             b: u32,

--- a/examples/async-graphql/src/starwars/model.rs
+++ b/examples/async-graphql/src/starwars/model.rs
@@ -122,12 +122,7 @@ impl QueryRoot {
         first: Option<i32>,
         last: Option<i32>,
     ) -> FieldResult<Connection<usize, Human, EmptyFields, EmptyFields>> {
-        let humans = ctx
-            .data_unchecked::<StarWars>()
-            .humans()
-            .iter()
-            .copied()
-            .collect::<Vec<_>>();
+        let humans = ctx.data_unchecked::<StarWars>().humans().to_vec();
         query_characters(after, before, first, last, &humans)
             .await
             .map(|conn| conn.map_node(Human))
@@ -149,12 +144,7 @@ impl QueryRoot {
         first: Option<i32>,
         last: Option<i32>,
     ) -> FieldResult<Connection<usize, Droid, EmptyFields, EmptyFields>> {
-        let droids = ctx
-            .data_unchecked::<StarWars>()
-            .droids()
-            .iter()
-            .copied()
-            .collect::<Vec<_>>();
+        let droids = ctx.data_unchecked::<StarWars>().droids().to_vec();
         query_characters(after, before, first, last, &droids)
             .await
             .map(|conn| conn.map_node(Droid))

--- a/examples/validator/src/main.rs
+++ b/examples/validator/src/main.rs
@@ -86,7 +86,7 @@ impl IntoResponse for ServerError {
     fn into_response(self) -> Response {
         match self {
             ServerError::ValidationError(_) => {
-                let message = format!("Input validation error: [{}]", self).replace("\n", ", ");
+                let message = format!("Input validation error: [{}]", self).replace('\n', ", ");
                 (StatusCode::BAD_REQUEST, message)
             }
             ServerError::AxumFormRejection(_) => (StatusCode::BAD_REQUEST, self.to_string()),


### PR DESCRIPTION
Should fix warnings like

<img width="598" alt="image" src="https://user-images.githubusercontent.com/718941/145720187-c98c3325-f27d-4d8e-8611-3c21478b3f86.png">

Wish there was a way for GH to not report those as they're quite distracting when reviewing. Doesn't seem to be the case however. Not sure why we don't see these warnings locally 🤷 