### PR TITLE
Example for defining routes and handlers close together

### DIFF
--- a/examples/routes-and-handlers-close-together/Cargo.toml
+++ b/examples/routes-and-handlers-close-together/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "example-routes-and-handlers-close-together"
+version = "0.1.0"
+edition = "2018"
+publish = false
+
+[dependencies]
+axum = { path = "../../axum" }
+tokio = { version = "1.0", features = ["full"] }

--- a/examples/routes-and-handlers-close-together/src/main.rs
+++ b/examples/routes-and-handlers-close-together/src/main.rs
@@ -1,0 +1,54 @@
+//! Run with
+//!
+//! ```not_rust
+//! cargo run -p example-routes-and-handlers-close-together
+//! ```
+
+use axum::{
+    routing::{get, post, MethodRouter},
+    Router,
+};
+use std::net::SocketAddr;
+
+#[tokio::main]
+async fn main() {
+    let app = Router::new()
+        .merge(root())
+        .merge(get_foo())
+        .merge(post_foo());
+
+    let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
+    println!("listening on {}", addr);
+    axum::Server::bind(&addr)
+        .serve(app.into_make_service())
+        .await
+        .unwrap();
+}
+
+fn root() -> Router {
+    async fn handler() -> &'static str {
+        "Hello, World!"
+    }
+
+    route("/", get(handler))
+}
+
+fn get_foo() -> Router {
+    async fn handler() -> &'static str {
+        "Hi from `GET /foo`"
+    }
+
+    route("/foo", get(handler))
+}
+
+fn post_foo() -> Router {
+    async fn handler() -> &'static str {
+        "Hi from `POST /foo`"
+    }
+
+    route("/foo", post(handler))
+}
+
+fn route(path: &str, method_router: MethodRouter) -> Router {
+    Router::new().route(path, method_router)
+}


### PR DESCRIPTION
Some users have asked if its possible to have routes and handlers close together in the code, so one can easily see what the path is for a given handler. Often this is followed by asking for route macros like `#[get("/")]` which addresses this.

I think a decent, macro free, solution is making functions like this

```rust
fn root() -> Router {
    async fn handler() -> &'static str {
        "Hello, World!"
    }

    route("/", get(handler))
}
```

and then using `Router::merge` to combine things.

I think it makes sense to have an example for this so we have something to link to.