### PR TITLE
Use `HttpBody` type alias internally

### DIFF
--- a/axum/src/body/mod.rs
+++ b/axum/src/body/mod.rs
@@ -17,5 +17,5 @@ pub use bytes::Bytes;
 pub use axum_core::body::{boxed, BoxBody};
 
 pub(crate) fn empty() -> BoxBody {
-    boxed(http_body::Empty::new())
+    boxed(Empty::new())
 }

--- a/axum/src/body/stream_body.rs
+++ b/axum/src/body/stream_body.rs
@@ -1,9 +1,8 @@
 use crate::{
-    body::{self, HttpBody},
+    body::{self, HttpBody, Bytes},
     response::{IntoResponse, Response},
     BoxError, Error,
 };
-use bytes::Bytes;
 use futures_util::{
     ready,
     stream::{self, TryStream},

--- a/axum/src/body/stream_body.rs
+++ b/axum/src/body/stream_body.rs
@@ -1,5 +1,5 @@
 use crate::{
-    body::{self, HttpBody, Bytes},
+    body::{self, Bytes, HttpBody},
     response::{IntoResponse, Response},
     BoxError, Error,
 };

--- a/axum/src/body/stream_body.rs
+++ b/axum/src/body/stream_body.rs
@@ -1,5 +1,5 @@
 use crate::{
-    body,
+    body::{self, HttpBody},
     response::{IntoResponse, Response},
     BoxError, Error,
 };
@@ -9,7 +9,6 @@ use futures_util::{
     stream::{self, TryStream},
 };
 use http::HeaderMap;
-use http_body::Body;
 use pin_project_lite::pin_project;
 use std::{
     fmt,
@@ -98,7 +97,7 @@ impl<S> fmt::Debug for StreamBody<S> {
     }
 }
 
-impl<S> Body for StreamBody<S>
+impl<S> HttpBody for StreamBody<S>
 where
     S: TryStream,
     S::Ok: Into<Bytes>,

--- a/axum/src/docs/extract.md
+++ b/axum/src/docs/extract.md
@@ -413,7 +413,7 @@ use std::{
 use tower_http::map_request_body::MapRequestBodyLayer;
 use axum::{
     extract::{self, BodyStream},
-    body::Body,
+    body::{Body, HttpBody},
     routing::get,
     http::{header::HeaderMap, Request},
     Router,
@@ -421,9 +421,9 @@ use axum::{
 
 struct MyBody<B>(B);
 
-impl<B> http_body::Body for MyBody<B>
+impl<B> HttpBody for MyBody<B>
 where
-    B: http_body::Body + Unpin,
+    B: HttpBody + Unpin,
 {
     type Data = B::Data;
     type Error = B::Error;

--- a/axum/src/extract/content_length_limit.rs
+++ b/axum/src/extract/content_length_limit.rs
@@ -80,8 +80,7 @@ impl<T, const N: u64> Deref for ContentLengthLimit<T, N> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{routing::post, test_helpers::*, Router};
-    use bytes::Bytes;
+    use crate::{body::Bytes, routing::post, test_helpers::*, Router};
     use http::StatusCode;
     use serde::Deserialize;
 
@@ -127,7 +126,7 @@ mod tests {
         let res = client
             .post("/")
             .body(reqwest::Body::wrap_stream(futures_util::stream::iter(
-                vec![Ok::<_, std::io::Error>(bytes::Bytes::new())],
+                vec![Ok::<_, std::io::Error>(Bytes::new())],
             )))
             .send()
             .await;

--- a/axum/src/extract/extractor_middleware.rs
+++ b/axum/src/extract/extractor_middleware.rs
@@ -4,6 +4,7 @@
 
 use super::{FromRequest, RequestParts};
 use crate::{
+    body::HttpBody,
     response::{IntoResponse, Response},
     BoxError,
 };
@@ -170,7 +171,7 @@ where
     E: FromRequest<ReqBody> + 'static,
     ReqBody: Default + Send + 'static,
     S: Service<Request<ReqBody>, Response = Response<ResBody>> + Clone,
-    ResBody: http_body::Body<Data = Bytes> + Send + 'static,
+    ResBody: HttpBody<Data = Bytes> + Send + 'static,
     ResBody::Error: Into<BoxError>,
 {
     type Response = Response;
@@ -229,7 +230,7 @@ where
     E: FromRequest<ReqBody>,
     S: Service<Request<ReqBody>, Response = Response<ResBody>>,
     ReqBody: Default,
-    ResBody: http_body::Body<Data = Bytes> + Send + 'static,
+    ResBody: HttpBody<Data = Bytes> + Send + 'static,
     ResBody::Error: Into<BoxError>,
 {
     type Output = Result<Response, S::Error>;

--- a/axum/src/extract/extractor_middleware.rs
+++ b/axum/src/extract/extractor_middleware.rs
@@ -4,11 +4,10 @@
 
 use super::{FromRequest, RequestParts};
 use crate::{
-    body::HttpBody,
+    body::{HttpBody, Bytes},
     response::{IntoResponse, Response},
     BoxError,
 };
-use bytes::Bytes;
 use futures_util::{future::BoxFuture, ready};
 use http::Request;
 use pin_project_lite::pin_project;

--- a/axum/src/extract/extractor_middleware.rs
+++ b/axum/src/extract/extractor_middleware.rs
@@ -4,7 +4,7 @@
 
 use super::{FromRequest, RequestParts};
 use crate::{
-    body::{HttpBody, Bytes},
+    body::{Bytes, HttpBody},
     response::{IntoResponse, Response},
     BoxError,
 };

--- a/axum/src/extract/form.rs
+++ b/axum/src/extract/form.rs
@@ -1,4 +1,5 @@
 use super::{has_content_type, rejection::*, FromRequest, RequestParts};
+use crate::body::{HttpBody, Empty, Full};
 use crate::BoxError;
 use async_trait::async_trait;
 use http::Method;
@@ -46,7 +47,7 @@ pub struct Form<T>(pub T);
 impl<T, B> FromRequest<B> for Form<T>
 where
     T: DeserializeOwned,
-    B: http_body::Body + Send,
+    B: HttpBody + Send,
     B::Data: Send,
     B::Error: Into<BoxError>,
 {
@@ -98,7 +99,7 @@ mod tests {
         let mut req = RequestParts::new(
             Request::builder()
                 .uri(uri.as_ref())
-                .body(http_body::Empty::<bytes::Bytes>::new())
+                .body(Empty::<bytes::Bytes>::new())
                 .unwrap(),
         );
         assert_eq!(Form::<T>::from_request(&mut req).await.unwrap().0, value);
@@ -113,7 +114,7 @@ mod tests {
                     http::header::CONTENT_TYPE,
                     mime::APPLICATION_WWW_FORM_URLENCODED.as_ref(),
                 )
-                .body(http_body::Full::<bytes::Bytes>::new(
+                .body(Full::<bytes::Bytes>::new(
                     serde_urlencoded::to_string(&value).unwrap().into(),
                 ))
                 .unwrap(),
@@ -179,7 +180,7 @@ mod tests {
                 .uri("http://example.com/test")
                 .method(Method::POST)
                 .header(http::header::CONTENT_TYPE, mime::APPLICATION_JSON.as_ref())
-                .body(http_body::Full::<bytes::Bytes>::new(
+                .body(Full::<bytes::Bytes>::new(
                     serde_urlencoded::to_string(&Pagination {
                         size: Some(10),
                         page: None,

--- a/axum/src/extract/form.rs
+++ b/axum/src/extract/form.rs
@@ -1,5 +1,5 @@
 use super::{has_content_type, rejection::*, FromRequest, RequestParts};
-use crate::body::{Bytes, Empty, Full, HttpBody};
+use crate::body::{Bytes, HttpBody};
 use crate::BoxError;
 use async_trait::async_trait;
 use http::Method;
@@ -84,6 +84,7 @@ impl<T> Deref for Form<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::body::{Empty, Full};
     use crate::extract::RequestParts;
     use http::Request;
     use serde::{Deserialize, Serialize};

--- a/axum/src/extract/form.rs
+++ b/axum/src/extract/form.rs
@@ -1,5 +1,5 @@
 use super::{has_content_type, rejection::*, FromRequest, RequestParts};
-use crate::body::{HttpBody, Empty, Full};
+use crate::body::{HttpBody, Empty, Full, Bytes};
 use crate::BoxError;
 use async_trait::async_trait;
 use http::Method;
@@ -64,7 +64,7 @@ where
                 return Err(InvalidFormContentType.into());
             }
 
-            let bytes = bytes::Bytes::from_request(req).await?;
+            let bytes = Bytes::from_request(req).await?;
             let value = serde_urlencoded::from_bytes(&bytes)
                 .map_err(FailedToDeserializeQueryString::new::<T, _>)?;
 
@@ -99,7 +99,7 @@ mod tests {
         let mut req = RequestParts::new(
             Request::builder()
                 .uri(uri.as_ref())
-                .body(Empty::<bytes::Bytes>::new())
+                .body(Empty::<Bytes>::new())
                 .unwrap(),
         );
         assert_eq!(Form::<T>::from_request(&mut req).await.unwrap().0, value);
@@ -114,7 +114,7 @@ mod tests {
                     http::header::CONTENT_TYPE,
                     mime::APPLICATION_WWW_FORM_URLENCODED.as_ref(),
                 )
-                .body(Full::<bytes::Bytes>::new(
+                .body(Full::<Bytes>::new(
                     serde_urlencoded::to_string(&value).unwrap().into(),
                 ))
                 .unwrap(),
@@ -180,7 +180,7 @@ mod tests {
                 .uri("http://example.com/test")
                 .method(Method::POST)
                 .header(http::header::CONTENT_TYPE, mime::APPLICATION_JSON.as_ref())
-                .body(Full::<bytes::Bytes>::new(
+                .body(Full::<Bytes>::new(
                     serde_urlencoded::to_string(&Pagination {
                         size: Some(10),
                         page: None,

--- a/axum/src/extract/form.rs
+++ b/axum/src/extract/form.rs
@@ -1,5 +1,5 @@
 use super::{has_content_type, rejection::*, FromRequest, RequestParts};
-use crate::body::{HttpBody, Empty, Full, Bytes};
+use crate::body::{Bytes, Empty, Full, HttpBody};
 use crate::BoxError;
 use async_trait::async_trait;
 use http::Method;

--- a/axum/src/extract/multipart.rs
+++ b/axum/src/extract/multipart.rs
@@ -3,10 +3,9 @@
 //! See [`Multipart`] for more details.
 
 use super::{rejection::*, BodyStream, FromRequest, RequestParts};
-use crate::body::HttpBody;
+use crate::body::{HttpBody, Bytes};
 use crate::BoxError;
 use async_trait::async_trait;
-use bytes::Bytes;
 use futures_util::stream::Stream;
 use http::header::{HeaderMap, CONTENT_TYPE};
 use mime::Mime;

--- a/axum/src/extract/multipart.rs
+++ b/axum/src/extract/multipart.rs
@@ -3,7 +3,7 @@
 //! See [`Multipart`] for more details.
 
 use super::{rejection::*, BodyStream, FromRequest, RequestParts};
-use crate::body::{HttpBody, Bytes};
+use crate::body::{Bytes, HttpBody};
 use crate::BoxError;
 use async_trait::async_trait;
 use futures_util::stream::Stream;

--- a/axum/src/extract/multipart.rs
+++ b/axum/src/extract/multipart.rs
@@ -3,6 +3,7 @@
 //! See [`Multipart`] for more details.
 
 use super::{rejection::*, BodyStream, FromRequest, RequestParts};
+use crate::body::HttpBody;
 use crate::BoxError;
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -52,7 +53,7 @@ pub struct Multipart {
 #[async_trait]
 impl<B> FromRequest<B> for Multipart
 where
-    B: http_body::Body<Data = Bytes> + Default + Unpin + Send + 'static,
+    B: HttpBody<Data = Bytes> + Default + Unpin + Send + 'static,
     B::Error: Into<BoxError>,
 {
     type Rejection = MultipartRejection;

--- a/axum/src/extract/rejection.rs
+++ b/axum/src/extract/rejection.rs
@@ -1,11 +1,10 @@
 //! Rejection response types.
 
 use crate::{
-    body::boxed,
+    body::{boxed, Full},
     response::{IntoResponse, Response},
     BoxError, Error,
 };
-use http_body::Full;
 
 pub use crate::extract::path::FailedToDeserializePathParams;
 pub use axum_core::extract::rejection::*;

--- a/axum/src/extract/request_parts.rs
+++ b/axum/src/extract/request_parts.rs
@@ -1,5 +1,8 @@
 use super::{rejection::*, take_body, Extension, FromRequest, RequestParts};
-use crate::{body::{Body, HttpBody, Bytes}, BoxError, Error};
+use crate::{
+    body::{Body, Bytes, HttpBody},
+    BoxError, Error,
+};
 use async_trait::async_trait;
 use futures_util::stream::Stream;
 use http::Uri;

--- a/axum/src/extract/request_parts.rs
+++ b/axum/src/extract/request_parts.rs
@@ -1,7 +1,6 @@
 use super::{rejection::*, take_body, Extension, FromRequest, RequestParts};
-use crate::{body::{Body, HttpBody}, BoxError, Error};
+use crate::{body::{Body, HttpBody, Bytes}, BoxError, Error};
 use async_trait::async_trait;
-use bytes::Bytes;
 use futures_util::stream::Stream;
 use http::Uri;
 use std::{

--- a/axum/src/extract/request_parts.rs
+++ b/axum/src/extract/request_parts.rs
@@ -1,10 +1,9 @@
 use super::{rejection::*, take_body, Extension, FromRequest, RequestParts};
-use crate::{body::Body, BoxError, Error};
+use crate::{body::{Body, HttpBody}, BoxError, Error};
 use async_trait::async_trait;
 use bytes::Bytes;
 use futures_util::stream::Stream;
 use http::Uri;
-use http_body::Body as HttpBody;
 use std::{
     convert::Infallible,
     fmt,
@@ -93,7 +92,7 @@ where
 /// [`Stream`]: https://docs.rs/futures/latest/futures/stream/trait.Stream.html
 /// [`body::Body`]: crate::body::Body
 pub struct BodyStream(
-    SyncWrapper<Pin<Box<dyn http_body::Body<Data = Bytes, Error = Error> + Send + 'static>>>,
+    SyncWrapper<Pin<Box<dyn HttpBody<Data = Bytes, Error = Error> + Send + 'static>>>,
 );
 
 impl Stream for BodyStream {

--- a/axum/src/extract/ws.rs
+++ b/axum/src/extract/ws.rs
@@ -65,7 +65,11 @@
 
 use self::rejection::*;
 use super::{rejection::*, FromRequest, RequestParts};
-use crate::{body::{self, Bytes}, response::Response, Error};
+use crate::{
+    body::{self, Bytes},
+    response::Response,
+    Error,
+};
 use async_trait::async_trait;
 use futures_util::{
     sink::{Sink, SinkExt},

--- a/axum/src/extract/ws.rs
+++ b/axum/src/extract/ws.rs
@@ -65,9 +65,8 @@
 
 use self::rejection::*;
 use super::{rejection::*, FromRequest, RequestParts};
-use crate::{body, response::Response, Error};
+use crate::{body::{self, Bytes}, response::Response, Error};
 use async_trait::async_trait;
-use bytes::Bytes;
 use futures_util::{
     sink::{Sink, SinkExt},
     stream::{Stream, StreamExt},

--- a/axum/src/handler/mod.rs
+++ b/axum/src/handler/mod.rs
@@ -5,7 +5,7 @@
 //! Some examples of handlers:
 //!
 //! ```rust
-//! use bytes::Bytes;
+//! use axum::body::Bytes;
 //! use http::StatusCode;
 //!
 //! // Handler that immediately returns an empty `200 OK` response.
@@ -71,7 +71,7 @@
 //! [axum-debug]: https://docs.rs/axum-debug
 
 use crate::{
-    body::{boxed, Body, HttpBody},
+    body::{boxed, Body, HttpBody, Bytes},
     extract::{
         connect_info::{Connected, IntoMakeServiceWithConnectInfo},
         FromRequest, RequestParts,
@@ -81,7 +81,6 @@ use crate::{
     BoxError,
 };
 use async_trait::async_trait;
-use bytes::Bytes;
 use http::Request;
 use std::{fmt, future::Future, marker::PhantomData};
 use tower::ServiceExt;

--- a/axum/src/handler/mod.rs
+++ b/axum/src/handler/mod.rs
@@ -71,7 +71,7 @@
 //! [axum-debug]: https://docs.rs/axum-debug
 
 use crate::{
-    body::{boxed, Body, HttpBody, Bytes},
+    body::{boxed, Body, Bytes, HttpBody},
     extract::{
         connect_info::{Connected, IntoMakeServiceWithConnectInfo},
         FromRequest, RequestParts,

--- a/axum/src/handler/mod.rs
+++ b/axum/src/handler/mod.rs
@@ -71,7 +71,7 @@
 //! [axum-debug]: https://docs.rs/axum-debug
 
 use crate::{
-    body::{boxed, Body},
+    body::{boxed, Body, HttpBody},
     extract::{
         connect_info::{Connected, IntoMakeServiceWithConnectInfo},
         FromRequest, RequestParts,
@@ -344,7 +344,7 @@ where
     S::Future: Send,
     T: 'static,
     ReqBody: Send + 'static,
-    ResBody: http_body::Body<Data = Bytes> + Send + 'static,
+    ResBody: HttpBody<Data = Bytes> + Send + 'static,
     ResBody::Error: Into<BoxError>,
 {
     type Sealed = sealed::Hidden;

--- a/axum/src/json.rs
+++ b/axum/src/json.rs
@@ -1,5 +1,5 @@
 use crate::{
-    body::{self, HttpBody, Full},
+    body::{self, HttpBody, Full, Bytes},
     extract::{rejection::*, FromRequest, RequestParts},
     response::{IntoResponse, Response},
     BoxError,
@@ -97,7 +97,7 @@ where
 
     async fn from_request(req: &mut RequestParts<B>) -> Result<Self, Self::Rejection> {
         if json_content_type(req)? {
-            let bytes = bytes::Bytes::from_request(req).await?;
+            let bytes = Bytes::from_request(req).await?;
 
             let value = serde_json::from_slice(&bytes).map_err(InvalidJsonBody::from_err)?;
 

--- a/axum/src/json.rs
+++ b/axum/src/json.rs
@@ -1,5 +1,5 @@
 use crate::{
-    body,
+    body::{self, HttpBody, Full},
     extract::{rejection::*, FromRequest, RequestParts},
     response::{IntoResponse, Response},
     BoxError,
@@ -9,7 +9,6 @@ use http::{
     header::{self, HeaderValue},
     StatusCode,
 };
-use http_body::Full;
 use serde::{de::DeserializeOwned, Serialize};
 use std::ops::{Deref, DerefMut};
 
@@ -90,7 +89,7 @@ pub struct Json<T>(pub T);
 impl<T, B> FromRequest<B> for Json<T>
 where
     T: DeserializeOwned,
-    B: http_body::Body + Send,
+    B: HttpBody + Send,
     B::Data: Send,
     B::Error: Into<BoxError>,
 {

--- a/axum/src/json.rs
+++ b/axum/src/json.rs
@@ -1,5 +1,5 @@
 use crate::{
-    body::{self, HttpBody, Full, Bytes},
+    body::{self, Bytes, Full, HttpBody},
     extract::{rejection::*, FromRequest, RequestParts},
     response::{IntoResponse, Response},
     BoxError,

--- a/axum/src/macros.rs
+++ b/axum/src/macros.rs
@@ -60,7 +60,7 @@ macro_rules! define_rejection {
         #[allow(deprecated)]
         impl $crate::response::IntoResponse for $name {
             fn into_response(self) -> $crate::response::Response {
-                let mut res = http::Response::new($crate::body::boxed(http_body::Full::from($body)));
+                let mut res = http::Response::new($crate::body::boxed(crate::body::Full::from($body)));
                 *res.status_mut() = http::StatusCode::$status;
                 res
             }
@@ -103,7 +103,7 @@ macro_rules! define_rejection {
         impl IntoResponse for $name {
             fn into_response(self) -> $crate::response::Response {
                 let mut res =
-                    http::Response::new($crate::body::boxed(http_body::Full::from(format!(concat!($body, ": {}"), self.0))));
+                    http::Response::new($crate::body::boxed(crate::body::Full::from(format!(concat!($body, ": {}"), self.0))));
                 *res.status_mut() = http::StatusCode::$status;
                 res
             }

--- a/axum/src/response/mod.rs
+++ b/axum/src/response/mod.rs
@@ -1,9 +1,9 @@
 #![doc = include_str!("../docs/response.md")]
 
+use crate::body::Full;
 use axum_core::body::boxed;
 use bytes::Bytes;
 use http::{header, HeaderValue};
-use http_body::Full;
 
 mod redirect;
 
@@ -48,11 +48,11 @@ impl<T> From<T> for Html<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::body::Empty;
     use http::{
         header::{HeaderMap, HeaderName},
         StatusCode,
     };
-    use http_body::Empty;
 
     #[test]
     fn test_merge_headers() {

--- a/axum/src/response/mod.rs
+++ b/axum/src/response/mod.rs
@@ -1,6 +1,6 @@
 #![doc = include_str!("../docs/response.md")]
 
-use crate::body::{Full, Bytes};
+use crate::body::{Bytes, Full};
 use axum_core::body::boxed;
 use http::{header, HeaderValue};
 

--- a/axum/src/response/mod.rs
+++ b/axum/src/response/mod.rs
@@ -1,8 +1,7 @@
 #![doc = include_str!("../docs/response.md")]
 
-use crate::body::Full;
+use crate::body::{Full, Bytes};
 use axum_core::body::boxed;
-use bytes::Bytes;
 use http::{header, HeaderValue};
 
 mod redirect;

--- a/axum/src/response/redirect.rs
+++ b/axum/src/response/redirect.rs
@@ -1,7 +1,6 @@
 use super::{IntoResponse, Response};
-use crate::body::boxed;
+use crate::body::{boxed, Empty};
 use http::{header::LOCATION, HeaderValue, StatusCode, Uri};
-use http_body::Empty;
 use std::convert::TryFrom;
 
 /// Response that redirects the request to another location.

--- a/axum/src/response/sse.rs
+++ b/axum/src/response/sse.rs
@@ -28,11 +28,10 @@
 //! ```
 
 use crate::{
-    body::{self, HttpBody},
+    body::{self, HttpBody, Bytes},
     response::{IntoResponse, Response},
     BoxError,
 };
-use bytes::Bytes;
 use futures_util::{
     ready,
     stream::{Stream, TryStream},

--- a/axum/src/response/sse.rs
+++ b/axum/src/response/sse.rs
@@ -28,7 +28,7 @@
 //! ```
 
 use crate::{
-    body,
+    body::{self, HttpBody},
     response::{IntoResponse, Response},
     BoxError,
 };
@@ -37,7 +37,6 @@ use futures_util::{
     ready,
     stream::{Stream, TryStream},
 };
-use http_body::Body as HttpBody;
 use pin_project_lite::pin_project;
 use std::{
     borrow::Cow,

--- a/axum/src/response/sse.rs
+++ b/axum/src/response/sse.rs
@@ -28,7 +28,7 @@
 //! ```
 
 use crate::{
-    body::{self, HttpBody, Bytes},
+    body::{self, Bytes, HttpBody},
     response::{IntoResponse, Response},
     BoxError,
 };

--- a/axum/src/routing/method_routing.rs
+++ b/axum/src/routing/method_routing.rs
@@ -77,7 +77,7 @@ macro_rules! top_level_service_fn {
         where
             S: Service<Request<ReqBody>, Response = Response<ResBody>> + Clone + Send + 'static,
             S::Future: Send + 'static,
-            ResBody: crate::body::HttpBody<Data = Bytes> + Send + 'static,
+            ResBody: HttpBody<Data = Bytes> + Send + 'static,
             ResBody::Error: Into<BoxError>,
         {
             on_service(MethodFilter::$method, svc)

--- a/axum/src/routing/method_routing.rs
+++ b/axum/src/routing/method_routing.rs
@@ -212,7 +212,7 @@ macro_rules! chained_service_fn {
                 + Send
                 + 'static,
             S::Future: Send + 'static,
-            ResBody: crate::body::HttpBody<Data = Bytes> + Send + 'static,
+            ResBody: HttpBody<Data = Bytes> + Send + 'static,
             ResBody::Error: Into<BoxError>,
         {
             self.on_service(MethodFilter::$method, svc)

--- a/axum/src/routing/method_routing.rs
+++ b/axum/src/routing/method_routing.rs
@@ -1,5 +1,5 @@
 use crate::{
-    body::{boxed, Body, Bytes},
+    body::{boxed, Body, Bytes, Empty, HttpBody},
     error_handling::{HandleError, HandleErrorLayer},
     handler::Handler,
     http::{Method, Request, StatusCode},
@@ -7,7 +7,6 @@ use crate::{
     routing::{Fallback, MethodFilter, Route},
     BoxError,
 };
-use http_body::Empty;
 use std::{
     convert::Infallible,
     fmt,
@@ -78,7 +77,7 @@ macro_rules! top_level_service_fn {
         where
             S: Service<Request<ReqBody>, Response = Response<ResBody>> + Clone + Send + 'static,
             S::Future: Send + 'static,
-            ResBody: http_body::Body<Data = Bytes> + Send + 'static,
+            ResBody: crate::body::HttpBody<Data = Bytes> + Send + 'static,
             ResBody::Error: Into<BoxError>,
         {
             on_service(MethodFilter::$method, svc)
@@ -213,7 +212,7 @@ macro_rules! chained_service_fn {
                 + Send
                 + 'static,
             S::Future: Send + 'static,
-            ResBody: http_body::Body<Data = Bytes> + Send + 'static,
+            ResBody: crate::body::HttpBody<Data = Bytes> + Send + 'static,
             ResBody::Error: Into<BoxError>,
         {
             self.on_service(MethodFilter::$method, svc)
@@ -321,7 +320,7 @@ pub fn on_service<S, ReqBody, ResBody>(
 where
     S: Service<Request<ReqBody>, Response = Response<ResBody>> + Clone + Send + 'static,
     S::Future: Send + 'static,
-    ResBody: http_body::Body<Data = Bytes> + Send + 'static,
+    ResBody: HttpBody<Data = Bytes> + Send + 'static,
     ResBody::Error: Into<BoxError>,
 {
     MethodRouter::new().on_service(filter, svc)
@@ -384,7 +383,7 @@ pub fn any_service<S, ReqBody, ResBody>(svc: S) -> MethodRouter<ReqBody, S::Erro
 where
     S: Service<Request<ReqBody>, Response = Response<ResBody>> + Clone + Send + 'static,
     S::Future: Send + 'static,
-    ResBody: http_body::Body<Data = Bytes> + Send + 'static,
+    ResBody: HttpBody<Data = Bytes> + Send + 'static,
     ResBody::Error: Into<BoxError>,
 {
     MethodRouter::new().fallback(svc)
@@ -607,7 +606,7 @@ impl<ReqBody, E> MethodRouter<ReqBody, E> {
             + Send
             + 'static,
         S::Future: Send + 'static,
-        ResBody: http_body::Body<Data = Bytes> + Send + 'static,
+        ResBody: HttpBody<Data = Bytes> + Send + 'static,
         ResBody::Error: Into<BoxError>,
     {
         self.on_service_boxed_response_body(filter, svc.map_response(|res| res.map(boxed)))
@@ -630,7 +629,7 @@ impl<ReqBody, E> MethodRouter<ReqBody, E> {
             + Send
             + 'static,
         S::Future: Send + 'static,
-        ResBody: http_body::Body<Data = Bytes> + Send + 'static,
+        ResBody: HttpBody<Data = Bytes> + Send + 'static,
         ResBody::Error: Into<BoxError>,
     {
         self.fallback = Fallback::Custom(Route::new(svc.map_response(|res| res.map(boxed))));
@@ -658,7 +657,7 @@ impl<ReqBody, E> MethodRouter<ReqBody, E> {
             + Send
             + 'static,
         <L::Service as Service<Request<NewReqBody>>>::Future: Send + 'static,
-        NewResBody: http_body::Body<Data = Bytes> + Send + 'static,
+        NewResBody: HttpBody<Data = Bytes> + Send + 'static,
         NewResBody::Error: Into<BoxError>,
     {
         let layer = ServiceBuilder::new()
@@ -691,7 +690,7 @@ impl<ReqBody, E> MethodRouter<ReqBody, E> {
             + Send
             + 'static,
         <L::Service as Service<Request<ReqBody>>>::Future: Send + 'static,
-        NewResBody: http_body::Body<Data = Bytes> + Send + 'static,
+        NewResBody: HttpBody<Data = Bytes> + Send + 'static,
         NewResBody::Error: Into<BoxError>,
     {
         let layer = ServiceBuilder::new()

--- a/axum/src/routing/mod.rs
+++ b/axum/src/routing/mod.rs
@@ -2,7 +2,7 @@
 
 use self::{future::RouterFuture, not_found::NotFound};
 use crate::{
-    body::{boxed, Body, HttpBody},
+    body::{boxed, Body, HttpBody, Bytes},
     extract::{
         connect_info::{Connected, IntoMakeServiceWithConnectInfo},
         MatchedPath, OriginalUri,
@@ -12,7 +12,6 @@ use crate::{
     util::{try_downcast, ByteStr, PercentDecodedByteStr},
     BoxError,
 };
-use bytes::Bytes;
 use http::{Request, StatusCode, Uri};
 use std::{
     borrow::Cow,

--- a/axum/src/routing/mod.rs
+++ b/axum/src/routing/mod.rs
@@ -2,7 +2,7 @@
 
 use self::{future::RouterFuture, not_found::NotFound};
 use crate::{
-    body::{boxed, Body, HttpBody, Bytes},
+    body::{boxed, Body, Bytes, HttpBody},
     extract::{
         connect_info::{Connected, IntoMakeServiceWithConnectInfo},
         MatchedPath, OriginalUri,

--- a/axum/src/routing/mod.rs
+++ b/axum/src/routing/mod.rs
@@ -2,7 +2,7 @@
 
 use self::{future::RouterFuture, not_found::NotFound};
 use crate::{
-    body::{boxed, Body},
+    body::{boxed, Body, HttpBody},
     extract::{
         connect_info::{Connected, IntoMakeServiceWithConnectInfo},
         MatchedPath, OriginalUri,
@@ -278,7 +278,7 @@ where
             + Send
             + 'static,
         <L::Service as Service<Request<NewReqBody>>>::Future: Send + 'static,
-        NewResBody: http_body::Body<Data = Bytes> + Send + 'static,
+        NewResBody: HttpBody<Data = Bytes> + Send + 'static,
         NewResBody::Error: Into<BoxError>,
     {
         let layer = ServiceBuilder::new()
@@ -319,7 +319,7 @@ where
             + Send
             + 'static,
         <L::Service as Service<Request<B>>>::Future: Send + 'static,
-        NewResBody: http_body::Body<Data = Bytes> + Send + 'static,
+        NewResBody: HttpBody<Data = Bytes> + Send + 'static,
         NewResBody::Error: Into<BoxError>,
     {
         let layer = ServiceBuilder::new()

--- a/axum/src/routing/route.rs
+++ b/axum/src/routing/route.rs
@@ -1,9 +1,8 @@
 use crate::{
-    body::{boxed, Body},
+    body::{boxed, Body, Empty},
     response::Response,
 };
 use http::Request;
-use http_body::Empty;
 use pin_project_lite::pin_project;
 use std::{
     convert::Infallible,

--- a/axum/src/routing/tests/merge.rs
+++ b/axum/src/routing/tests/merge.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::{error_handling::HandleErrorLayer, extract::OriginalUri, response::IntoResponse, Json};
+use crate::{body::HttpBody, error_handling::HandleErrorLayer, extract::OriginalUri, response::IntoResponse, Json};
 use serde_json::{json, Value};
 use tower::{limit::ConcurrencyLimitLayer, timeout::TimeoutLayer};
 
@@ -62,7 +62,7 @@ async fn multiple_ors_balanced_differently() {
     async fn test<S, ResBody>(name: &str, app: S)
     where
         S: Service<Request<Body>, Response = Response<ResBody>> + Clone + Send + 'static,
-        ResBody: http_body::Body + Send + 'static,
+        ResBody: HttpBody + Send + 'static,
         ResBody::Data: Send,
         ResBody::Error: Into<BoxError>,
         S::Future: Send,

--- a/axum/src/routing/tests/merge.rs
+++ b/axum/src/routing/tests/merge.rs
@@ -1,5 +1,8 @@
 use super::*;
-use crate::{body::HttpBody, error_handling::HandleErrorLayer, extract::OriginalUri, response::IntoResponse, Json};
+use crate::{
+    body::HttpBody, error_handling::HandleErrorLayer, extract::OriginalUri, response::IntoResponse,
+    Json,
+};
 use serde_json::{json, Value};
 use tower::{limit::ConcurrencyLimitLayer, timeout::TimeoutLayer};
 

--- a/axum/src/routing/tests/mod.rs
+++ b/axum/src/routing/tests/mod.rs
@@ -1,4 +1,5 @@
 use crate::{
+    body::Empty,
     error_handling::HandleErrorLayer,
     extract::{self, Path},
     handler::Handler,
@@ -234,7 +235,7 @@ async fn wrong_method_service() {
     struct Svc;
 
     impl<R> Service<R> for Svc {
-        type Response = Response<http_body::Empty<Bytes>>;
+        type Response = Response<Empty<Bytes>>;
         type Error = Infallible;
         type Future = Ready<Result<Self::Response, Self::Error>>;
 
@@ -243,7 +244,7 @@ async fn wrong_method_service() {
         }
 
         fn call(&mut self, _req: R) -> Self::Future {
-            ready(Ok(Response::new(http_body::Empty::new())))
+            ready(Ok(Response::new(Empty::new())))
         }
     }
 

--- a/axum/src/routing/tests/mod.rs
+++ b/axum/src/routing/tests/mod.rs
@@ -1,5 +1,5 @@
 use crate::{
-    body::{Empty, Bytes},
+    body::{Bytes, Empty},
     error_handling::HandleErrorLayer,
     extract::{self, Path},
     handler::Handler,

--- a/axum/src/routing/tests/mod.rs
+++ b/axum/src/routing/tests/mod.rs
@@ -1,5 +1,5 @@
 use crate::{
-    body::Empty,
+    body::{Empty, Bytes},
     error_handling::HandleErrorLayer,
     extract::{self, Path},
     handler::Handler,
@@ -8,7 +8,6 @@ use crate::{
     test_helpers::*,
     BoxError, Json, Router,
 };
-use bytes::Bytes;
 use http::{Method, Request, Response, StatusCode, Uri};
 use hyper::Body;
 use serde::Deserialize;

--- a/axum/src/test_helpers.rs
+++ b/axum/src/test_helpers.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::blacklisted_name)]
 
 use crate::BoxError;
+use crate::body::HttpBody;
 use http::{
     header::{HeaderName, HeaderValue},
     Request, StatusCode,
@@ -28,7 +29,7 @@ impl TestClient {
     pub(crate) fn new<S, ResBody>(svc: S) -> Self
     where
         S: Service<Request<Body>, Response = http::Response<ResBody>> + Clone + Send + 'static,
-        ResBody: http_body::Body + Send + 'static,
+        ResBody: HttpBody + Send + 'static,
         ResBody::Data: Send,
         ResBody::Error: Into<BoxError>,
         S::Future: Send,

--- a/axum/src/test_helpers.rs
+++ b/axum/src/test_helpers.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::blacklisted_name)]
 
-use crate::BoxError;
 use crate::body::HttpBody;
+use crate::BoxError;
 use http::{
     header::{HeaderName, HeaderValue},
     Request, StatusCode,

--- a/axum/src/util.rs
+++ b/axum/src/util.rs
@@ -1,4 +1,4 @@
-use bytes::Bytes;
+use crate::body::Bytes;
 use pin_project_lite::pin_project;
 use std::fmt;
 use std::ops::Deref;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation
Replace `http_body::{Body, Empty, Full}` with `crate::body::{HttpBody, Empty, Full}`

Replace `bytes::Bytes` with `crate::body::Bytes`

Then developers can copy code from axum and make their own changes without declaring `http_body` and `bytes` in their Cargo.toml

https://github.com/tokio-rs/axum/discussions/623

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution
replace
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
