### PR TITLE
Allow duplicate itoa dependency

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -40,6 +40,8 @@ skip = [
     # rustls uses old version (dev dep)
     { name = "spin", version = "=0.5.2" },
     { name = "webpki", version = "=0.21.4" },
+    # pulled in by hyper, http, and serde_urlencoded
+    { name = "itoa", version = "=0.4.8" },
 ]
 
 [sources]


### PR DESCRIPTION
Once the community has updated to itoa 1.0 we can remove this.