### PR TITLE
Re-export the headers crate when the headers feature is active

### DIFF
--- a/axum/src/lib.rs
+++ b/axum/src/lib.rs
@@ -402,6 +402,9 @@ mod test_helpers;
 pub use add_extension::{AddExtension, AddExtensionLayer};
 #[doc(no_inline)]
 pub use async_trait::async_trait;
+#[cfg(feature = "headers")]
+#[doc(no_inline)]
+pub use headers;
 #[doc(no_inline)]
 pub use http;
 #[doc(no_inline)]


### PR DESCRIPTION
## Motivation

Currently, if one wants to use the `TypedHeader` extractor, one has to do two things in `Cargo.toml` before being able to refer to for example `TypedHeader<Authorization<Bearer>>`:

* Add `headers` to the activated features of axum
* Add a dependency to the `headers` crate

The second step is problematic because the latest version of headers (as added by `cargo add headers`, for example) might not be the one the headers feature adds support for and looking up the version supported by axum introduces an extra roadbump (a small one, but still).

## Solution

Re-export the `headers` crate if the `headers` feature is active.
