### PR TITLE
refactor: refine session cookie example

### DIFF
--- a/examples/sessions/Cargo.toml
+++ b/examples/sessions/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2018"
 publish = false
 
 [dependencies]
-axum = { path = "../../axum" }
+axum = { path = "../../axum", features = ["headers"] }
 tokio = { version = "1.0", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version="0.3", features = ["env-filter"] }

--- a/examples/sessions/src/main.rs
+++ b/examples/sessions/src/main.rs
@@ -91,12 +91,10 @@ where
             .await
             .expect("`MemoryStore` extension missing");
 
-        let session_cookie =
-            if let Ok(TypedHeader(cookie)) = TypedHeader::<Cookie>::from_request(req).await {
-                cookie.get(AXUM_SESSION_COOKIE_NAME).map(|x| x.to_owned())
-            } else {
-                None
-            };
+        let session_cookie = Option::<TypedHeader<Cookie>>::from_request(req)
+            .await
+            .unwrap()
+            .and_then(|cookie| Some(cookie.get(AXUM_SESSION_COOKIE_NAME)?.to_owned()));
 
         // return the new created session cookie for client
         if session_cookie.is_none() {

--- a/examples/sessions/src/main.rs
+++ b/examples/sessions/src/main.rs
@@ -115,7 +115,7 @@ where
         }
 
         tracing::debug!(
-            "UserIdFromSession: got exists session cookie, {}={}",
+            "UserIdFromSession: got session cookie from user agent, {}={}",
             AXUM_SESSION_COOKIE_NAME,
             session_cookie.unwrap()
         );

--- a/examples/sessions/src/main.rs
+++ b/examples/sessions/src/main.rs
@@ -7,7 +7,8 @@
 use async_session::{MemoryStore, Session, SessionStore as _};
 use axum::{
     async_trait,
-    extract::{Extension, FromRequest, RequestParts},
+    extract::{Extension, FromRequest, RequestParts, TypedHeader},
+    headers::Cookie,
     http::{
         self,
         header::{HeaderMap, HeaderValue},
@@ -18,8 +19,11 @@ use axum::{
     AddExtensionLayer, Router,
 };
 use serde::{Deserialize, Serialize};
+use std::fmt::Debug;
 use std::net::SocketAddr;
 use uuid::Uuid;
+
+const AXUM_SESSION_COOKIE_NAME: &str = "axum_session";
 
 #[tokio::main]
 async fn main() {
@@ -45,26 +49,34 @@ async fn main() {
 }
 
 async fn handler(user_id: UserIdFromSession) -> impl IntoResponse {
-    let (headers, user_id) = match user_id {
-        UserIdFromSession::FoundUserId(user_id) => (HeaderMap::new(), user_id),
-        UserIdFromSession::CreatedFreshUserId { user_id, cookie } => {
+    let (headers, user_id, create_cookie) = match user_id {
+        UserIdFromSession::FoundUserId(user_id) => (HeaderMap::new(), user_id, false),
+        UserIdFromSession::CreatedFreshUserId(new_user) => {
             let mut headers = HeaderMap::new();
-            headers.insert(http::header::SET_COOKIE, cookie);
-            (headers, user_id)
+            headers.insert(http::header::SET_COOKIE, new_user.cookie);
+            (headers, new_user.user_id, true)
         }
     };
 
-    dbg!(user_id);
+    tracing::debug!("handler: user_id={:?} send_headers={:?}", user_id, headers);
 
-    headers
+    (
+        headers,
+        format!(
+            "user_id={:?} session_cookie_name={} create_new_session_cookie={}",
+            user_id, AXUM_SESSION_COOKIE_NAME, create_cookie
+        ),
+    )
+}
+
+struct FreshUserId {
+    pub user_id: UserId,
+    pub cookie: HeaderValue,
 }
 
 enum UserIdFromSession {
     FoundUserId(UserId),
-    CreatedFreshUserId {
-        user_id: UserId,
-        cookie: HeaderValue,
-    },
+    CreatedFreshUserId(FreshUserId),
 }
 
 #[async_trait]
@@ -79,28 +91,44 @@ where
             .await
             .expect("`MemoryStore` extension missing");
 
-        let headers = req.headers().expect("other extractor taken headers");
+        let session_cookie =
+            if let Ok(TypedHeader(cookie)) = TypedHeader::<Cookie>::from_request(req).await {
+                cookie.get(AXUM_SESSION_COOKIE_NAME).map(|x| x.to_owned())
+            } else {
+                None
+            };
 
-        let cookie = if let Some(cookie) = headers
-            .get(http::header::COOKIE)
-            .and_then(|value| value.to_str().ok())
-            .map(|value| value.to_string())
-        {
-            cookie
-        } else {
+        // return the new created session cookie for client
+        if session_cookie.is_none() {
             let user_id = UserId::new();
             let mut session = Session::new();
             session.insert("user_id", user_id).unwrap();
             let cookie = store.store_session(session).await.unwrap().unwrap();
-
-            return Ok(Self::CreatedFreshUserId {
+            return Ok(Self::CreatedFreshUserId(FreshUserId {
                 user_id,
-                cookie: cookie.parse().unwrap(),
-            });
-        };
+                cookie: HeaderValue::from_str(
+                    format!("{}={}", AXUM_SESSION_COOKIE_NAME, cookie).as_str(),
+                )
+                .unwrap(),
+            }));
+        }
 
-        let user_id = if let Some(session) = store.load_session(cookie).await.unwrap() {
+        tracing::debug!(
+            "UserIdFromSession: got exists session cookie, {}={}",
+            AXUM_SESSION_COOKIE_NAME,
+            session_cookie.as_ref().unwrap()
+        );
+        // continue to decode the session cookie
+        let user_id = if let Some(session) = store
+            .load_session(session_cookie.as_ref().unwrap().to_owned())
+            .await
+            .unwrap()
+        {
             if let Some(user_id) = session.get::<UserId>("user_id") {
+                tracing::debug!(
+                    "UserIdFromSession: session decoded success, user_id={:?}",
+                    user_id
+                );
                 user_id
             } else {
                 return Err((
@@ -109,6 +137,11 @@ where
                 ));
             }
         } else {
+            tracing::debug!(
+                "UserIdFromSession: err session not exists in store, {}={}",
+                AXUM_SESSION_COOKIE_NAME,
+                session_cookie.as_ref().unwrap()
+            );
             return Err((StatusCode::BAD_REQUEST, "No session found for cookie"));
         };
 


### PR DESCRIPTION
## Motivation

Current session example use the cookie method to send the session ID.

but the cookie it send is not valid, the whole cookie looks like this:

```
wa4TKv3HOc9muZR1/HHgOOq/LGnKzSKYvhzlF4iI6cNXkqp5Luhx1S9BOUQkv1nupwDTDNTwUJny61SjPGIRXA==
```

most client will parse this into `key=value` format like this:

```
key: wa4TKv3HOc9muZR1/HHgOOq/LGnKzSKYvhzlF4iI6cNXkqp5Luhx1S9BOUQkv1nupwDTDNTwUJny61SjPGIRXA=

value: =
```

this is not the expected behavior

according to RFC examples: https://datatracker.ietf.org/doc/html/rfc6265#section-3.1
 
a simple set cookie header to send the cookie with name `SID` and value with `31d4d96e407aad42` like this:
```
   == Server -> User Agent ==

   Set-Cookie: SID=31d4d96e407aad42

   == User Agent -> Server ==

   Cookie: SID=31d4d96e407aad42
```

and rfc6265 5.2.  The Set-Cookie Header 
 https://datatracker.ietf.org/doc/html/rfc6265#section-5.2

>  4.1.  Set-Cookie
>   The Set-Cookie HTTP response header is used to send cookies from the
>   server to the user agent.

4.1.1.  Syntax  https://datatracker.ietf.org/doc/html/rfc6265#section-4.1.1

>   Informally, the Set-Cookie response header contains the header name
>   "Set-Cookie" followed by a ":" and a cookie.  Each cookie begins with
>   a name-value-pair, followed by zero or more attribute-value pairs.

So there are several problems with the current implementation:

1. the `Set-Cookie` send the cookie header in an  invalid format
2. the cookie extract from client assume that client only send one cookie, this is not the situation in most case.

the actual cookie send from client may like this:

```
CSRF-Token-YNVMA=mnmXXXXXXXXXXXXXX; phpMyAdmin=e406a99bfefcc27xxxxxxxxxxxxxxx; SID=UX7bR/cxxxxxxxxxxx; io=93-xxxxxxx; mw_installer_session=6b29879d9xxxxxxxxxxxxxxxx; cockpit=dj0yO2s9Nxxxxxxxxxxxxx==; _flash={"_":{"kind":"success","message":"Post succcessfully added"}}; axum_session=wa4TKv3HOc9muZR1/HHgOOq/LGnKzSKYvhzlF4iI6cNXkqp5Luhx1S9BOUQkv1nupwDTDNTwUJny61SjPGIRXA==
```

we need to parse the cookie header and extract the cookie name we needed, in here it is `axum_session`

## Solution

1. **cookie send from server to client**: change the set cookie header to follow `key=value`  **name-value-pair** format

2. **cookie receive from client**: parse cookie from client, use a fixed cookie name (like `axum_session` or `axum_sid`) to extract the session cookie back to ourself (as a lib it should allow user to change it, but here it is just working demo, so I think hardcoded name is OK)

(exists example: https://github.com/actix/actix-extras/blob/6676a509443306cd589e10e16d1617154c40ee23/actix-session/src/cookie.rs#L60  actix use  `actix-session` as the `default` cookie name, but it also allow caller to set it to a different one)
