### PR TITLE
Change error type for `RequestParts::try_into_request`

### DIFF
--- a/axum-core/src/error.rs
+++ b/axum-core/src/error.rs
@@ -15,6 +15,7 @@ impl Error {
         }
     }
 
+    #[allow(dead_code)]
     pub(crate) fn downcast<T>(self) -> Result<T, Self>
     where
         T: StdError + 'static,

--- a/axum-core/src/error.rs
+++ b/axum-core/src/error.rs
@@ -14,17 +14,6 @@ impl Error {
             inner: error.into(),
         }
     }
-
-    #[allow(dead_code)]
-    pub(crate) fn downcast<T>(self) -> Result<T, Self>
-    where
-        T: StdError + 'static,
-    {
-        match self.inner.downcast::<T>() {
-            Ok(t) => Ok(*t),
-            Err(err) => Err(*err.downcast().unwrap()),
-        }
-    }
 }
 
 impl fmt::Display for Error {

--- a/axum-core/src/extract/mod.rs
+++ b/axum-core/src/extract/mod.rs
@@ -6,7 +6,6 @@
 
 use self::rejection::*;
 use crate::response::IntoResponse;
-use crate::Error;
 use async_trait::async_trait;
 use http::{Extensions, HeaderMap, Method, Request, Uri, Version};
 use std::convert::Infallible;
@@ -128,7 +127,7 @@ impl<B> RequestParts<B> {
     /// [`take_headers`]: RequestParts::take_headers
     /// [`take_extensions`]: RequestParts::take_extensions
     /// [`take_body`]: RequestParts::take_body
-    pub fn try_into_request(self) -> Result<Request<B>, Error> {
+    pub fn try_into_request(self) -> Result<Request<B>, RequestAlreadyExtracted> {
         let Self {
             method,
             uri,
@@ -141,9 +140,9 @@ impl<B> RequestParts<B> {
         let mut req = if let Some(body) = body.take() {
             Request::new(body)
         } else {
-            return Err(Error::new(RequestAlreadyExtracted::BodyAlreadyExtracted(
+            return Err(RequestAlreadyExtracted::BodyAlreadyExtracted(
                 BodyAlreadyExtracted,
-            )));
+            ));
         };
 
         *req.method_mut() = method;
@@ -153,16 +152,16 @@ impl<B> RequestParts<B> {
         if let Some(headers) = headers.take() {
             *req.headers_mut() = headers;
         } else {
-            return Err(Error::new(
-                RequestAlreadyExtracted::HeadersAlreadyExtracted(HeadersAlreadyExtracted),
+            return Err(RequestAlreadyExtracted::HeadersAlreadyExtracted(
+                HeadersAlreadyExtracted,
             ));
         }
 
         if let Some(extensions) = extensions.take() {
             *req.extensions_mut() = extensions;
         } else {
-            return Err(Error::new(
-                RequestAlreadyExtracted::ExtensionsAlreadyExtracted(ExtensionsAlreadyExtracted),
+            return Err(RequestAlreadyExtracted::ExtensionsAlreadyExtracted(
+                ExtensionsAlreadyExtracted,
             ));
         }
 

--- a/axum-core/src/extract/request_parts.rs
+++ b/axum-core/src/extract/request_parts.rs
@@ -25,18 +25,7 @@ where
             },
         );
 
-        let err = match req.try_into_request() {
-            Ok(req) => return Ok(req),
-            Err(err) => err,
-        };
-
-        match err.downcast::<RequestAlreadyExtracted>() {
-            Ok(err) => return Err(err),
-            Err(err) => unreachable!(
-                "Unexpected error type from `try_into_request`: `{:?}`. This is a bug in axum, please file an issue",
-                err,
-            ),
-        }
+        req.try_into_request()
     }
 }
 


### PR DESCRIPTION
## Motivation

Fixes #632.

I'm not sure if `Error::downcast` should be removed or not as it was only used in `try_into_request`, so for now I marked it with `#[allow(dead_code)]`