### PR TITLE
Require `Output = ()` on `WebSocketStream::on_upgrade`

### DIFF
--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -16,11 +16,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `Request`) has previously taken the request extensions. Thus `PathRejection` now contains a
   variant with `ExtensionsAlreadyExtracted`. This is not a breaking change since `PathRejection` is
   marked as `#[non_exhaustive]` ([#619])
+- **breaking:** Require `Output = ()` on `WebSocketStream::on_upgrade` ([#644])
 
 [#599]: https://github.com/tokio-rs/axum/pull/599
 [#600]: https://github.com/tokio-rs/axum/pull/600
 [#607]: https://github.com/tokio-rs/axum/pull/607
 [#619]: https://github.com/tokio-rs/axum/pull/619
+[#644]: https://github.com/tokio-rs/axum/pull/644
 
 # 0.4.2 (06. December, 2021)
 

--- a/axum/src/extract/ws.rs
+++ b/axum/src/extract/ws.rs
@@ -201,7 +201,7 @@ impl WebSocketUpgrade {
     pub fn on_upgrade<F, Fut>(self, callback: F) -> Response
     where
         F: FnOnce(WebSocket) -> Fut + Send + 'static,
-        Fut: Future + Send + 'static,
+        Fut: Future<Output = ()> + Send + 'static,
     {
         let on_upgrade = self.on_upgrade;
         let config = self.config;


### PR DESCRIPTION
Fixes https://github.com/tokio-rs/axum/issues/636

Merging into https://github.com/tokio-rs/axum/pull/644 since its a breaking change.