### PR TITLE
Add trait IntoResponseHeaders

### DIFF
--- a/axum-core/src/response/headers.rs
+++ b/axum-core/src/response/headers.rs
@@ -1,11 +1,5 @@
-use super::{IntoResponse, Response};
-use crate::body::boxed;
-use bytes::Bytes;
-use http::{
-    header::{HeaderMap, HeaderName, HeaderValue},
-    StatusCode,
-};
-use http_body::{Empty, Full};
+use super::{IntoResponse, IntoResponseHeaders, Response};
+use http::header::{HeaderName, HeaderValue};
 use std::{convert::TryInto, fmt};
 
 /// A response with headers.
@@ -54,38 +48,7 @@ use std::{convert::TryInto, fmt};
 #[derive(Clone, Copy, Debug)]
 pub struct Headers<H>(pub H);
 
-impl<H> Headers<H> {
-    fn try_into_header_map<K, V>(self) -> Result<HeaderMap, Response>
-    where
-        H: IntoIterator<Item = (K, V)>,
-        K: TryInto<HeaderName>,
-        K::Error: fmt::Display,
-        V: TryInto<HeaderValue>,
-        V::Error: fmt::Display,
-    {
-        self.0
-            .into_iter()
-            .map(|(key, value)| {
-                let key = key.try_into().map_err(Either::A)?;
-                let value = value.try_into().map_err(Either::B)?;
-                Ok((key, value))
-            })
-            .collect::<Result<_, _>>()
-            .map_err(|err| {
-                let err = match err {
-                    Either::A(err) => err.to_string(),
-                    Either::B(err) => err.to_string(),
-                };
-
-                let body = boxed(Full::new(Bytes::copy_from_slice(err.as_bytes())));
-                let mut res = Response::new(body);
-                *res.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
-                res
-            })
-    }
-}
-
-impl<H, K, V> IntoResponse for Headers<H>
+impl<H, K, V> IntoResponseHeaders for Headers<H>
 where
     H: IntoIterator<Item = (K, V)>,
     K: TryInto<HeaderName>,
@@ -93,68 +56,48 @@ where
     V: TryInto<HeaderValue>,
     V::Error: fmt::Display,
 {
-    fn into_response(self) -> Response {
-        let headers = self.try_into_header_map();
+    type IntoIter = IntoIter<H::IntoIter>;
 
-        match headers {
-            Ok(headers) => {
-                let mut res = Response::new(boxed(Empty::new()));
-                *res.headers_mut() = headers;
-                res
-            }
-            Err(err) => err,
+    fn into_headers(self) -> Self::IntoIter {
+        IntoIter {
+            inner: self.0.into_iter(),
         }
     }
 }
 
-impl<H, T, K, V> IntoResponse for (Headers<H>, T)
+#[doc(hidden)]
+#[derive(Debug)]
+pub struct IntoIter<H> {
+    inner: H,
+}
+
+impl<H, K, V> Iterator for IntoIter<H>
 where
-    T: IntoResponse,
-    H: IntoIterator<Item = (K, V)>,
+    H: Iterator<Item = (K, V)>,
     K: TryInto<HeaderName>,
     K::Error: fmt::Display,
     V: TryInto<HeaderValue>,
     V::Error: fmt::Display,
 {
-    fn into_response(self) -> Response {
-        let headers = match self.0.try_into_header_map() {
-            Ok(headers) => headers,
-            Err(res) => return res,
-        };
+    type Item = Result<(Option<HeaderName>, HeaderValue), Response>;
 
-        (headers, self.1).into_response()
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next().map(|(key, value)| {
+            let key = key.try_into().map_err(|e| e.to_string().into_response())?;
+            let value = value
+                .try_into()
+                .map_err(|e| e.to_string().into_response())?;
+
+            Ok((Some(key), value))
+        })
     }
-}
-
-impl<H, T, K, V> IntoResponse for (StatusCode, Headers<H>, T)
-where
-    T: IntoResponse,
-    H: IntoIterator<Item = (K, V)>,
-    K: TryInto<HeaderName>,
-    K::Error: fmt::Display,
-    V: TryInto<HeaderValue>,
-    V::Error: fmt::Display,
-{
-    fn into_response(self) -> Response {
-        let headers = match self.1.try_into_header_map() {
-            Ok(headers) => headers,
-            Err(res) => return res,
-        };
-
-        (self.0, headers, self.2).into_response()
-    }
-}
-
-enum Either<A, B> {
-    A(A),
-    B(B),
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use futures_util::FutureExt;
-    use http::header::USER_AGENT;
+    use http::{header::USER_AGENT, StatusCode};
 
     #[test]
     fn vec_of_header_name_and_value() {

--- a/axum-core/src/response/mod.rs
+++ b/axum-core/src/response/mod.rs
@@ -17,7 +17,7 @@ use http_body::{
     combinators::{MapData, MapErr},
     Empty, Full,
 };
-use std::{borrow::Cow, convert::Infallible};
+use std::{borrow::Cow, convert::Infallible, iter};
 
 mod headers;
 
@@ -387,5 +387,18 @@ impl IntoResponse for HeaderMap {
         let mut res = Response::new(boxed(Empty::new()));
         *res.headers_mut() = self;
         res
+    }
+}
+
+impl IntoResponseHeaders for HeaderMap {
+    type IntoIter = iter::Map<
+        http::header::IntoIter<HeaderValue>,
+        fn(
+            (Option<HeaderName>, HeaderValue),
+        ) -> Result<(Option<HeaderName>, HeaderValue), Response>,
+    >;
+
+    fn into_headers(self) -> Self::IntoIter {
+        self.into_iter().map(Ok)
     }
 }

--- a/axum-core/src/response/mod.rs
+++ b/axum-core/src/response/mod.rs
@@ -348,6 +348,21 @@ impl IntoResponse for StatusCode {
     }
 }
 
+impl<H> IntoResponse for H
+where
+    H: IntoResponseHeaders,
+{
+    fn into_response(self) -> Response {
+        let mut res = Response::new(boxed(Empty::new()));
+
+        if let Err(e) = try_extend_headers(res.headers_mut(), self.into_headers()) {
+            return e;
+        }
+
+        res
+    }
+}
+
 impl<T> IntoResponse for (StatusCode, T)
 where
     T: IntoResponse,
@@ -359,38 +374,41 @@ where
     }
 }
 
-impl<T> IntoResponse for (HeaderMap, T)
+impl<H, T> IntoResponse for (H, T)
 where
+    H: IntoResponseHeaders,
     T: IntoResponse,
 {
     fn into_response(self) -> Response {
         let mut res = self.1.into_response();
-        res.headers_mut().extend(self.0);
+
+        if let Err(e) = try_extend_headers(res.headers_mut(), self.0.into_headers()) {
+            return e;
+        }
+
         res
     }
 }
 
-impl<T> IntoResponse for (StatusCode, HeaderMap, T)
+impl<H, T> IntoResponse for (StatusCode, H, T)
 where
+    H: IntoResponseHeaders,
     T: IntoResponse,
 {
     fn into_response(self) -> Response {
         let mut res = self.2.into_response();
         *res.status_mut() = self.0;
-        res.headers_mut().extend(self.1);
-        res
-    }
-}
 
-impl IntoResponse for HeaderMap {
-    fn into_response(self) -> Response {
-        let mut res = Response::new(boxed(Empty::new()));
-        *res.headers_mut() = self;
+        if let Err(e) = try_extend_headers(res.headers_mut(), self.1.into_headers()) {
+            return e;
+        }
+
         res
     }
 }
 
 impl IntoResponseHeaders for HeaderMap {
+    // FIXME: Use type_alias_impl_trait when available
     type IntoIter = iter::Map<
         http::header::IntoIter<HeaderValue>,
         fn(
@@ -400,5 +418,54 @@ impl IntoResponseHeaders for HeaderMap {
 
     fn into_headers(self) -> Self::IntoIter {
         self.into_iter().map(Ok)
+    }
+}
+
+// Slightly adjusted version of `impl<T> Extend<(Option<HeaderName>, T)> for HeaderMap<T>`.
+// Accepts an iterator that returns Results and short-circuits on an `Err`.
+fn try_extend_headers(
+    headers: &mut HeaderMap,
+    iter: impl IntoIterator<Item = Result<(Option<HeaderName>, HeaderValue), Response>>,
+) -> Result<(), Response> {
+    use http::header::Entry;
+
+    let mut iter = iter.into_iter();
+
+    // The structure of this is a bit weird, but it is mostly to make the
+    // borrow checker happy.
+    let (mut key, mut val) = match iter.next().transpose()? {
+        Some((Some(key), val)) => (key, val),
+        Some((None, _)) => panic!("expected a header name, but got None"),
+        None => return Ok(()),
+    };
+
+    'outer: loop {
+        let mut entry = match headers.entry(key) {
+            Entry::Occupied(mut e) => {
+                // Replace all previous values while maintaining a handle to
+                // the entry.
+                e.insert(val);
+                e
+            }
+            Entry::Vacant(e) => e.insert_entry(val),
+        };
+
+        // As long as `HeaderName` is none, keep inserting the value into
+        // the current entry
+        loop {
+            match iter.next().transpose()? {
+                Some((Some(k), v)) => {
+                    key = k;
+                    val = v;
+                    continue 'outer;
+                }
+                Some((None, v)) => {
+                    entry.append(v);
+                }
+                None => {
+                    return Ok(());
+                }
+            }
+        }
     }
 }

--- a/axum-core/src/response/mod.rs
+++ b/axum-core/src/response/mod.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 use bytes::Bytes;
 use http::{
-    header::{self, HeaderMap, HeaderValue},
+    header::{self, HeaderMap, HeaderName, HeaderValue},
     StatusCode,
 };
 use http_body::{
@@ -146,6 +146,34 @@ pub type Response<T = BoxBody> = http::Response<T>;
 pub trait IntoResponse {
     /// Create a response.
     fn into_response(self) -> Response;
+}
+
+/// Trait for generating response headers.
+///
+/// Any type that implements this trait automatically implements `IntoResponse`
+/// as well, but can also be used in a tuple like `(StatusCode, Self)`,
+/// `(Self, impl IntoResponseHeaders)`,
+/// `(StatusCode, Self, impl IntoResponseHeaders, impl IntoResponse)` and so on.
+///
+/// This trait can't currently be implemented outside of axum.
+pub trait IntoResponseHeaders {
+    /// The return type of [`.into_headers()`].
+    ///
+    /// The iterator item is a `Result` to allow the implementation to return
+    /// a server error instead.
+    ///
+    /// The header name is optional because `HeaderMap`s iterator doesn't yield
+    /// it multiple times for headers that have multiple values, to avoid
+    /// unnecessary copies.
+    #[doc(hidden)]
+    type IntoIter: IntoIterator<Item = Result<(Option<HeaderName>, HeaderValue), Response>>;
+
+    /// Attempt to turn `self` into a list of headers.
+    ///
+    /// In practice, only the implementation for `axum::response::Headers` ever
+    /// returns `Err(_)`.
+    #[doc(hidden)]
+    fn into_headers(self) -> Self::IntoIter;
 }
 
 impl IntoResponse for () {


### PR DESCRIPTION
## Motivation

TODO

## Solution

See the code? 😅

## Notes

I think this is all of the hard stuff dealt with. It should now be straight-forward to move `Headers` into axum, implement `IntoResponseHeaders` for `TypedHeader` and move it into its own module (outside `response`) / re-export it from the `axum` crate root like `Json` and add `IntoResponse` impls for tuples with more `IntoResponseHeaders` items.