### PR TITLE
Add trait IntoResponseHeaders

### DIFF
--- a/axum-core/src/response/mod.rs
+++ b/axum-core/src/response/mod.rs
@@ -150,11 +150,22 @@ pub trait IntoResponse {
 
 /// Trait for generating response headers.
 ///
+
+/// **Note: If you see this trait not being implemented in an error message, you are almost
+/// certainly being mislead by the compiler¹. Look for the following snippet in the output and
+/// check [`IntoResponse`]'s documentation if you find it:**
+///
+/// ```text
+/// note: required because of the requirements on the impl of `IntoResponse` for `<type>`
+/// ```
+///
 /// Any type that implements this trait automatically implements `IntoResponse` as well, but can
 /// also be used in a tuple like `(StatusCode, Self)`, `(Self, impl IntoResponseHeaders)`,
 /// `(StatusCode, Self, impl IntoResponseHeaders, impl IntoResponse)` and so on.
 ///
 /// This trait can't currently be implemented outside of axum.
+///
+/// ¹ See also [this rustc issue](https://github.com/rust-lang/rust/issues/22590)
 pub trait IntoResponseHeaders {
     /// The return type of [`.into_headers()`].
     ///

--- a/axum-core/src/response/mod.rs
+++ b/axum-core/src/response/mod.rs
@@ -17,7 +17,7 @@ use http_body::{
     combinators::{MapData, MapErr},
     Empty, Full,
 };
-use std::{borrow::Cow, convert::Infallible};
+use std::{borrow::Cow, convert::Infallible, iter};
 
 mod headers;
 
@@ -384,5 +384,18 @@ impl IntoResponse for HeaderMap {
         let mut res = Response::new(boxed(Empty::new()));
         *res.headers_mut() = self;
         res
+    }
+}
+
+impl IntoResponseHeaders for HeaderMap {
+    type IntoIter = iter::Map<
+        http::header::IntoIter<HeaderValue>,
+        fn(
+            (Option<HeaderName>, HeaderValue),
+        ) -> Result<(Option<HeaderName>, HeaderValue), Response>,
+    >;
+
+    fn into_headers(self) -> Self::IntoIter {
+        self.into_iter().map(Ok)
     }
 }

--- a/axum-debug/src/lib.rs
+++ b/axum-debug/src/lib.rs
@@ -89,6 +89,34 @@
 //! async fn handler(request: Request<BoxBody>) {}
 //! ```
 //!
+//! # Known limitations
+//!
+//! If your response type doesn't implement `IntoResponse`, you will get a slightly confusing error
+//! message:
+//!
+//! ```text
+//! error[E0277]: the trait bound `bool: axum_core::response::IntoResponseHeaders` is not satisfied
+//!  --> tests/fail/wrong_return_type.rs:4:23
+//!   |
+//! 4 | async fn handler() -> bool {
+//!   |                       ^^^^ the trait `axum_core::response::IntoResponseHeaders` is not implemented for `bool`
+//!   |
+//!   = note: required because of the requirements on the impl of `IntoResponse` for `bool`
+//! note: required by a bound in `__axum_debug_check_handler_into_response::{closure#0}::check`
+//!  --> tests/fail/wrong_return_type.rs:4:23
+//!   |
+//! 4 | async fn handler() -> bool {
+//!   |                       ^^^^ required by this bound in `__axum_debug_check_handler_into_response::{closure#0}::check`
+//! ```
+//!
+//! The main error message when `IntoResponse` isn't implemented will also ways be for a different
+//! trait, `IntoResponseHeaders`, not being implemented. This trait is not meant to be implemented
+//! for types outside of axum and what you really need to do is change your return type or implement
+//! `IntoResponse` for it (if it is your own type that you want to return directly from handlers).
+//!
+//! This issue is not specific to axum and cannot be fixed by us. For more details, see the
+//! [rustc issue about it](https://github.com/rust-lang/rust/issues/22590).
+//!
 //! # Performance
 //!
 //! Macros in this crate have no effect when using release profile. (eg. `cargo build --release`)

--- a/axum-debug/src/lib.rs
+++ b/axum-debug/src/lib.rs
@@ -21,7 +21,7 @@
 //! ```
 //!
 //! You will get a long error message about function not implementing [`Handler`] trait. But why
-//! this function does not implement it? To figure it out [`debug_handler`] macro can be used.
+//! does this function not implement it? To figure it out, the [`debug_handler`] macro can be used.
 //!
 //! ```rust,compile_fail
 //! # use axum::{routing::get, Router};

--- a/axum-debug/tests/fail/wrong_return_type.stderr
+++ b/axum-debug/tests/fail/wrong_return_type.stderr
@@ -1,9 +1,10 @@
-error[E0277]: the trait bound `bool: IntoResponse` is not satisfied
+error[E0277]: the trait bound `bool: axum_core::response::IntoResponseHeaders` is not satisfied
  --> tests/fail/wrong_return_type.rs:4:23
   |
 4 | async fn handler() -> bool {
-  |                       ^^^^ the trait `IntoResponse` is not implemented for `bool`
+  |                       ^^^^ the trait `axum_core::response::IntoResponseHeaders` is not implemented for `bool`
   |
+  = note: required because of the requirements on the impl of `IntoResponse` for `bool`
 note: required by a bound in `__axum_debug_check_handler_into_response::{closure#0}::check`
  --> tests/fail/wrong_return_type.rs:4:23
   |


### PR DESCRIPTION
## Motivation

It would be nice to be able to return `TypedHeader` in the same positions as `Headers<_>`, but that doesn't work without moving it into `axum-core` due to coherence and that would be very unfortunate. Also, `Headers` only lives in `axum-core` due to the same coherence issues.

## Solution

Introduce a new trait `IntoResponseHeaders` and implement it for `HeaderMap` and `Headers`. Move `Headers` into axum.

## Notes

I think this is all of the hard stuff dealt with. It should now be straight-forward to ~~move `Headers` into axum~~ (done), implement `IntoResponseHeaders` for `TypedHeader` and move it into its own module (outside `response`) / re-export it from the `axum` crate root like `Json` and add `IntoResponse` impls for tuples with more `IntoResponseHeaders` items.