### PR TITLE
Add `middleware::from_fn` for creating middleware from async fns

### DIFF
--- a/axum-extra/CHANGELOG.md
+++ b/axum-extra/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
-- None.
+- Add `middleware::from_fn` for creating middleware from async functions
 
 # 0.1.0 (02. December, 2021)
 

--- a/axum-extra/CHANGELOG.md
+++ b/axum-extra/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
-- Add `middleware::from_fn` for creating middleware from async functions
+- Add `middleware::from_fn` for creating middleware from async functions ([#656])
+
+[#656]: https://github.com/tokio-rs/axum/pull/656
 
 # 0.1.0 (02. December, 2021)
 

--- a/axum-extra/Cargo.toml
+++ b/axum-extra/Cargo.toml
@@ -17,6 +17,10 @@ erased-json = ["serde", "serde_json"]
 axum = { path = "../axum", version = "0.4" }
 http = "0.2"
 mime = "0.3"
+pin-project-lite = "0.2"
+tower = { version = "0.4", features = ["util"] }
+tower-http = { version = "0.2", features = ["util", "map-response-body"] }
+tower-layer = "0.3"
 tower-service = "0.3"
 
 # optional dependencies

--- a/axum-extra/src/lib.rs
+++ b/axum-extra/src/lib.rs
@@ -44,5 +44,6 @@
 #![cfg_attr(test, allow(clippy::float_cmp))]
 
 pub mod extract;
+pub mod middleware;
 pub mod response;
 pub mod routing;

--- a/axum-extra/src/middleware/middleware_fn.rs
+++ b/axum-extra/src/middleware/middleware_fn.rs
@@ -89,6 +89,7 @@ where
 impl<F> fmt::Debug for MiddlewareFnLayer<F> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("MiddlewareFnLayer")
+            // Write out the type name, without quoting it as `&type_name::<F>()` would
             .field("f", &format_args!("{}", type_name::<F>()))
             .finish()
     }
@@ -152,7 +153,7 @@ where
     }
 }
 
-/// The remainder of a middleware stack, including the endpoint.
+/// The remainder of a middleware stack, including the handler.
 pub struct Next<ReqBody> {
     inner: BoxCloneService<Request<ReqBody>, Response, Infallible>,
 }

--- a/axum-extra/src/middleware/middleware_fn.rs
+++ b/axum-extra/src/middleware/middleware_fn.rs
@@ -55,7 +55,7 @@ use tower_service::Service;
 ///
 /// let app = Router::new()
 ///     .route("/", get(|| async { /* ... */ }))
-///     .layer(middleware::from_fn(auth));
+///     .route_layer(middleware::from_fn(auth));
 /// # let app: Router = app;
 /// ```
 pub fn from_fn<F>(f: F) -> MiddlewareFnLayer<F> {

--- a/axum-extra/src/middleware/middleware_fn.rs
+++ b/axum-extra/src/middleware/middleware_fn.rs
@@ -1,0 +1,239 @@
+//! Create middleware from async functions.
+//!
+//! See [`from_fn`] for more details.
+
+use axum::{
+    body::{self, Bytes, HttpBody},
+    response::{IntoResponse, Response},
+    BoxError,
+};
+use http::Request;
+use pin_project_lite::pin_project;
+use std::{
+    any::type_name,
+    convert::Infallible,
+    fmt,
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+use tower::{util::BoxCloneService, ServiceBuilder};
+use tower_http::ServiceBuilderExt;
+use tower_layer::Layer;
+use tower_service::Service;
+
+/// Create a middleware from an async function.
+///
+/// `from_fn` requires the function given to
+///
+/// 1. Be an `async fn`.
+/// 2. Take [`Request`](http::Request) as the first argument.
+/// 3. Take [`Next<B>`](Next) as the second argument.
+/// 4. Return something that implements [`IntoResponse`].
+///
+/// # Example
+///
+/// ```rust
+/// use axum::{
+///     Router,
+///     http::{Request, StatusCode},
+///     routing::get,
+///     response::IntoResponse,
+/// };
+/// use axum_extra::middleware::{from_fn, Next};
+///
+/// async fn auth<B>(req: Request<B>, next: Next<B>) -> impl IntoResponse {
+///     let auth_header = req.headers().get(http::header::AUTHORIZATION);
+///
+///     match auth_header {
+///         Some(auth_header) if auth_header == "secret" => {
+///             Ok(next.call(req).await)
+///         }
+///         _ => Err(StatusCode::UNAUTHORIZED),
+///     }
+/// }
+///
+/// let app = Router::new()
+///     .route("/", get(|| async { /* ... */ }))
+///     .layer(from_fn(auth));
+/// # let app: Router = app;
+/// ```
+pub fn from_fn<F>(f: F) -> MiddlewareFnLayer<F> {
+    MiddlewareFnLayer { f }
+}
+
+/// A [`tower::Layer`] from an async function.
+///
+/// [`tower::Layer`] is used to apply middleware to [`axum::Router`]s.
+///
+/// Created with [`from_fn`]. See that function for more details.
+#[derive(Clone, Copy)]
+pub struct MiddlewareFnLayer<F> {
+    f: F,
+}
+
+impl<S, F> Layer<S> for MiddlewareFnLayer<F>
+where
+    F: Clone,
+{
+    type Service = MiddlewareFn<F, S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        MiddlewareFn {
+            f: self.f.clone(),
+            inner,
+        }
+    }
+}
+
+impl<F> fmt::Debug for MiddlewareFnLayer<F> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("MiddlewareFnLayer")
+            .field("f", &format_args!("{}", type_name::<F>()))
+            .finish()
+    }
+}
+
+/// A middleware created from an async function.
+///
+/// Created with [`from_fn`]. See that function for more details.
+#[derive(Clone, Copy)]
+pub struct MiddlewareFn<F, S> {
+    f: F,
+    inner: S,
+}
+
+impl<F, Fut, Out, S, ReqBody, ResBody> Service<Request<ReqBody>> for MiddlewareFn<F, S>
+where
+    F: FnMut(Request<ReqBody>, Next<ReqBody>) -> Fut,
+    Fut: Future<Output = Out>,
+    Out: IntoResponse,
+    S: Service<Request<ReqBody>, Response = Response<ResBody>, Error = Infallible>
+        + Clone
+        + Send
+        + 'static,
+    S::Future: Send + 'static,
+    ResBody: HttpBody<Data = Bytes> + Send + 'static,
+    ResBody::Error: Into<BoxError>,
+{
+    type Response = Response;
+    type Error = Infallible;
+    type Future = ResponseFuture<Fut>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Request<ReqBody>) -> Self::Future {
+        let not_ready_inner = self.inner.clone();
+        let ready_inner = std::mem::replace(&mut self.inner, not_ready_inner);
+
+        let inner = ServiceBuilder::new()
+            .boxed_clone()
+            .map_response_body(body::boxed)
+            .service(ready_inner);
+        let next = Next { inner };
+
+        ResponseFuture {
+            inner: (self.f)(req, next),
+        }
+    }
+}
+
+impl<F, S> fmt::Debug for MiddlewareFn<F, S>
+where
+    S: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("MiddlewareFnLayer")
+            .field("f", &format_args!("{}", type_name::<F>()))
+            .field("inner", &self.inner)
+            .finish()
+    }
+}
+
+/// The remainder of a middleware stack, including the endpoint.
+pub struct Next<ReqBody> {
+    inner: BoxCloneService<Request<ReqBody>, Response, Infallible>,
+}
+
+impl<ReqBody> Next<ReqBody> {
+    /// Execute the remaining middleware stack.
+    pub async fn call(mut self, req: Request<ReqBody>) -> Response {
+        match self.inner.call(req).await {
+            Ok(res) => res,
+            Err(err) => match err {},
+        }
+    }
+}
+
+impl<ReqBody> fmt::Debug for Next<ReqBody> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("MiddlewareFnLayer")
+            .field("inner", &self.inner)
+            .finish()
+    }
+}
+
+pin_project! {
+    /// Response future for [`MiddlewareFn`].
+    pub struct ResponseFuture<F> {
+        #[pin]
+        inner: F,
+    }
+}
+
+impl<F, Out> Future for ResponseFuture<F>
+where
+    F: Future<Output = Out>,
+    Out: IntoResponse,
+{
+    type Output = Result<Response, Infallible>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        self.project()
+            .inner
+            .poll(cx)
+            .map(IntoResponse::into_response)
+            .map(Ok)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{body::Empty, routing::get, Router};
+    use http::{HeaderMap, StatusCode};
+    use tower::ServiceExt;
+
+    #[tokio::test]
+    async fn basic() {
+        async fn insert_header<B>(mut req: Request<B>, next: Next<B>) -> impl IntoResponse {
+            req.headers_mut()
+                .insert("x-axum-test", "ok".parse().unwrap());
+
+            next.call(req).await
+        }
+
+        async fn handle(headers: HeaderMap) -> String {
+            (&headers["x-axum-test"]).to_str().unwrap().to_owned()
+        }
+
+        let app = Router::new()
+            .route("/", get(handle))
+            .layer(from_fn(insert_header));
+
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .uri("/")
+                    .body(body::boxed(Empty::new()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+        let body = hyper::body::to_bytes(res).await.unwrap();
+        assert_eq!(&body[..], b"ok");
+    }
+}

--- a/axum-extra/src/middleware/middleware_fn.rs
+++ b/axum-extra/src/middleware/middleware_fn.rs
@@ -175,28 +175,6 @@ impl<ReqBody> fmt::Debug for Next<ReqBody> {
     }
 }
 
-impl<ReqBody> Clone for Next<ReqBody> {
-    fn clone(&self) -> Self {
-        Self {
-            inner: self.inner.clone(),
-        }
-    }
-}
-
-impl<ReqBody> Service<Request<ReqBody>> for Next<ReqBody> {
-    type Response = Response;
-    type Error = Infallible;
-    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
-
-    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.inner.poll_ready(cx)
-    }
-
-    fn call(&mut self, req: Request<ReqBody>) -> Self::Future {
-        self.inner.call(req)
-    }
-}
-
 pin_project! {
     /// Response future for [`MiddlewareFn`].
     pub struct ResponseFuture<F> {

--- a/axum-extra/src/middleware/middleware_fn.rs
+++ b/axum-extra/src/middleware/middleware_fn.rs
@@ -42,7 +42,7 @@ use tower_service::Service;
 /// };
 /// use axum_extra::middleware::{self, Next};
 ///
-/// async fn auth<B>(req: Request<B>, mut next: Next<B>) -> impl IntoResponse {
+/// async fn auth<B>(req: Request<B>, next: Next<B>) -> impl IntoResponse {
 ///     let auth_header = req.headers().get(http::header::AUTHORIZATION);
 ///
 ///     match auth_header {
@@ -159,7 +159,7 @@ pub struct Next<ReqBody> {
 
 impl<ReqBody> Next<ReqBody> {
     /// Execute the remaining middleware stack.
-    pub async fn run(&mut self, req: Request<ReqBody>) -> Response {
+    pub async fn run(mut self, req: Request<ReqBody>) -> Response {
         match self.inner.call(req).await {
             Ok(res) => res,
             Err(err) => match err {},
@@ -230,7 +230,7 @@ mod tests {
 
     #[tokio::test]
     async fn basic() {
-        async fn insert_header<B>(mut req: Request<B>, mut next: Next<B>) -> impl IntoResponse {
+        async fn insert_header<B>(mut req: Request<B>, next: Next<B>) -> impl IntoResponse {
             req.headers_mut()
                 .insert("x-axum-test", "ok".parse().unwrap());
 

--- a/axum-extra/src/middleware/mod.rs
+++ b/axum-extra/src/middleware/mod.rs
@@ -2,5 +2,4 @@
 
 pub mod middleware_fn;
 
-#[doc(inline)]
 pub use self::middleware_fn::{from_fn, Next};

--- a/axum-extra/src/middleware/mod.rs
+++ b/axum-extra/src/middleware/mod.rs
@@ -1,0 +1,6 @@
+//! Additional types for creating middleware.
+
+pub mod middleware_fn;
+
+#[doc(inline)]
+pub use self::middleware_fn::{from_fn, Next};

--- a/examples/print-request-response/Cargo.toml
+++ b/examples/print-request-response/Cargo.toml
@@ -6,6 +6,7 @@ publish = false
 
 [dependencies]
 axum = { path = "../../axum" }
+axum-extra = { path = "../../axum-extra" }
 tokio = { version = "1.0", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version="0.3", features = ["env-filter"] }


### PR DESCRIPTION
I feel axum is in a pretty good place in terms of ease of use. However one area that is still a big hurdle for some people is `tower::Service` which quickly comes up up when writing custom middleware. Suddenly you cannot use high level `async`/`await` syntax anymore and have to worry about pinning, `poll_ready`, and most likely lots of generics.

This is something I've been thinking about for awhile but hadn't found a good solution for. But today I discovered poem's [`middleware_fn`](https://github.com/poem-web/poem/blob/master/examples/poem/middleware_fn/src/main.rs) which I think is perfect for this!

So this PR introduces `axum_extra::middleware::from_fn` that works like this:

```rust
use axum::{
    Router,
    http::{Request, StatusCode},
    routing::get,
    response::IntoResponse,
};
use axum_extra::middleware::{self, Next};

async fn auth<B>(req: Request<B>, next: Next<B>) -> impl IntoResponse {
    let auth_header = req.headers().get(http::header::AUTHORIZATION);

    match auth_header {
        Some(auth_header) if auth_header == "secret" => {
            Ok(next.run(req).await)
        }
        _ => Err(StatusCode::UNAUTHORIZED),
    }
}

let app = Router::new()
    .route("/", get(|| async { /* ... */ }))
    .route_layer(middleware::from_fn(auth));
```

You have pretty much the same level of control as with `tower::Service` but with a higher level API.