### PR TITLE
axum-extra: Version 0.1.1

### DIFF
--- a/axum-extra/CHANGELOG.md
+++ b/axum-extra/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
+- None.
+
+# 0.1.1 (27. December, 2021)
+
 - Add `middleware::from_fn` for creating middleware from async functions ([#656])
 
 [#656]: https://github.com/tokio-rs/axum/pull/656

--- a/axum-extra/Cargo.toml
+++ b/axum-extra/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 name = "axum-extra"
 readme = "README.md"
 repository = "https://github.com/tokio-rs/axum"
-version = "0.1.0"
+version = "0.1.1"
 
 [features]
 erased-json = ["serde", "serde_json"]


### PR DESCRIPTION
- Add `middleware::from_fn` for creating middleware from async functions ([#656])

[#656]: https://github.com/tokio-rs/axum/pull/656