### PR TITLE
Add support for returning pretty JSON response in `axum_extra::response::ErasedJson`

### DIFF
--- a/axum-extra/CHANGELOG.md
+++ b/axum-extra/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add support for returning pretty JSON response in `response::ErasedJson` ([#662])
 
 [#656]: https://github.com/tokio-rs/axum/pull/656
+[#662]: https://github.com/tokio-rs/axum/pull/662
 
 # 0.1.0 (02. December, 2021)
 

--- a/axum-extra/CHANGELOG.md
+++ b/axum-extra/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # Unreleased
 
 - Add `middleware::from_fn` for creating middleware from async functions ([#656])
+- Add support for returning pretty JSON response in `response::ErasedJson` ([#662])
 
 [#656]: https://github.com/tokio-rs/axum/pull/656
 

--- a/axum-extra/src/response/erased_json.rs
+++ b/axum-extra/src/response/erased_json.rs
@@ -32,9 +32,14 @@ use serde::Serialize;
 pub struct ErasedJson(serde_json::Result<Vec<u8>>);
 
 impl ErasedJson {
-    /// Create an `ErasedJson` by serializing a value.
+    /// Create an `ErasedJson` by serializing a value with the compact formatter.
     pub fn new<T: Serialize>(val: T) -> Self {
         Self(serde_json::to_vec(&val))
+    }
+
+    /// Create an `ErasedJson` by serializing a value with the pretty formatter.
+    pub fn pretty<T: Serialize>(val: T) -> Self {
+        Self(serde_json::to_vec_pretty(&val))
     }
 }
 


### PR DESCRIPTION
Fixes https://github.com/tokio-rs/axum/issues/657

I can also add a new `PrettyJson` struct as initially discussed in the above issue,
but later seeing the implementation of `ErasedJson`, I thought it's better to just implement it there and avoid bloating the project with a third struct with an almost identical implementation to `axum::Json` and `exum_extra::response::ErasedJson`.