### PR TITLE
Fix axum-extra's optional feature documentation

### DIFF
--- a/axum-extra/Cargo.toml
+++ b/axum-extra/Cargo.toml
@@ -31,3 +31,7 @@ serde_json = { version = "1.0.71", optional = true }
 hyper = "0.14"
 tokio = { version = "1.14", features = ["full"] }
 tower = { version = "0.4", features = ["util"] }
+
+[package.metadata.docs.rs]
+all-features = true
+rustdocflags = ["--cfg", "docsrs"]

--- a/axum-extra/src/response/erased_json.rs
+++ b/axum-extra/src/response/erased_json.rs
@@ -28,6 +28,7 @@ use serde::Serialize;
 ///     }
 /// }
 /// ```
+#[cfg_attr(docsrs, doc(cfg(feature = "erased-json")))]
 #[derive(Debug)]
 pub struct ErasedJson(serde_json::Result<Vec<u8>>);
 


### PR DESCRIPTION
## Motivation

* docs.rs doesn't display `axum_extra::response::ErasedJson`.
* If it was displayed, it doesn't have the purple feature box.

## Solution

Make sure to enable `--all-features` and `--cfg docsrs` when building `axum_extra` on docs.rs, and add the appropriate `doc(cfg)` to `ErasedJson`.