### PR TITLE
Improve middleware examples using auth

### DIFF
--- a/axum-extra/src/middleware/middleware_fn.rs
+++ b/axum-extra/src/middleware/middleware_fn.rs
@@ -43,14 +43,21 @@ use tower_service::Service;
 /// use axum_extra::middleware::{self, Next};
 ///
 /// async fn auth<B>(req: Request<B>, next: Next<B>) -> impl IntoResponse {
-///     let auth_header = req.headers().get(http::header::AUTHORIZATION);
+///     let auth_header = req.headers()
+///         .get(http::header::AUTHORIZATION)
+///         .and_then(|header| header.to_str().ok());
 ///
 ///     match auth_header {
-///         Some(auth_header) if auth_header == "secret" => {
+///         Some(auth_header) if token_is_valid(auth_header) => {
 ///             Ok(next.run(req).await)
 ///         }
 ///         _ => Err(StatusCode::UNAUTHORIZED),
 ///     }
+/// }
+///
+/// fn token_is_valid(token: &str) -> bool {
+///     // ...
+///     # false
 /// }
 ///
 /// let app = Router::new()

--- a/axum/src/extract/extractor_middleware.rs
+++ b/axum/src/extract/extractor_middleware.rs
@@ -62,14 +62,18 @@ use tower_service::Service;
 ///             .and_then(|headers| headers.get(http::header::AUTHORIZATION))
 ///             .and_then(|value| value.to_str().ok());
 ///
-///         if let Some(value) = auth_header {
-///             if value == "secret" {
-///                 return Ok(Self);
+///         match auth_header {
+///             Some(auth_header) if token_is_valid(auth_header) => {
+///                 Ok(Self)
 ///             }
+///             _ => Err(StatusCode::UNAUTHORIZED),
 ///         }
-///
-///         Err(StatusCode::UNAUTHORIZED)
 ///     }
+/// }
+///
+/// fn token_is_valid(token: &str) -> bool {
+///     // ...
+///     # false
 /// }
 ///
 /// async fn handler() {


### PR DESCRIPTION
I guess the easiest solution is not to actually check the auth header in the examples but leave that up to the user.

Fixes https://github.com/tokio-rs/axum/issues/664