### PR TITLE
Store Bytes in ErasedJson

### DIFF
--- a/axum-extra/Cargo.toml
+++ b/axum-extra/Cargo.toml
@@ -15,6 +15,7 @@ erased-json = ["serde", "serde_json"]
 
 [dependencies]
 axum = { path = "../axum", version = "0.4" }
+bytes = "1.1.0"
 http = "0.2"
 mime = "0.3"
 pin-project-lite = "0.2"


### PR DESCRIPTION
## Motivation

Storing a `Vec<u8>` can result in more data copies than necessary:

- `From<Vec<u8>>` for `Bytes` calls `.into_boxed_slice()` which can reallocate.
- Attempts to clone the `Bytes` will then copy the data again.

## Solution

Store a `Bytes` to begin with by writing to a `BytesMut`, making everything zero-copy.