### PR TITLE
Use 308 status instead of 301 when redirecting

### DIFF
--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **fixed:** Make `nest("", service)` work and mean the same as `nest("/", service)` ([#691])
 - **fixed:** Replace response code `301` with `308` for trailing slash redirects. Also deprecates
   `Redirect::found` (`302`) in favor of `Redirect::temporary` (`307`) or `Redirect::to` (`303`).
-  This is to prevent clients from changing non-`GET` requests to `GET` requests ([#616])
+  This is to prevent clients from changing non-`GET` requests to `GET` requests ([#682])
 
 [#691]: https://github.com/tokio-rs/axum/pull/691
 [#682]: https://github.com/tokio-rs/axum/pull/682

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
-- None.
+- **fixed:** Replace response code `301` with `308` for trailing slash redirects. Also deprecates
+  `Redirect::found` (`302`) in favor of `Redirect::temporary` (`307`) or `Redirect::to` (`303`).
+  This is to prevent clients from changing non-`GET` requests to `GET` requests ([#616])
+
+[#650]: https://github.com/tokio-rs/axum/pull/650
 
 # 0.4.3 (21. December, 2021)
 

--- a/axum/src/extract/typed_header.rs
+++ b/axum/src/extract/typed_header.rs
@@ -80,17 +80,21 @@ impl<T> Deref for TypedHeader<T> {
 #[cfg_attr(docsrs, doc(cfg(feature = "headers")))]
 #[derive(Debug)]
 pub struct TypedHeaderRejection {
-    name: &'static http::header::HeaderName,
-    reason: TypedHeaderRejectionReason,
+    /// Name of the header that caused the rejection
+    pub name: &'static http::header::HeaderName,
+
+    /// Reason why the header extraction has failed
+    pub reason: TypedHeaderRejectionReason,
 }
 
 impl TypedHeaderRejection {
-    /// Name of the header that caused the rejection
+    // TODO remove workaround for rustdoc bug: https://github.com/rust-lang/rust/issues/92544
+    /// returns [name](#structfield.name)
     pub fn name(&self) -> &http::header::HeaderName {
         self.name
     }
 
-    /// Reason why the header extraction has failed
+    /// returns [reason](#structfield.reason)
     pub fn reason(&self) -> &TypedHeaderRejectionReason {
         &self.reason
     }

--- a/axum/src/extract/typed_header.rs
+++ b/axum/src/extract/typed_header.rs
@@ -80,21 +80,17 @@ impl<T> Deref for TypedHeader<T> {
 #[cfg_attr(docsrs, doc(cfg(feature = "headers")))]
 #[derive(Debug)]
 pub struct TypedHeaderRejection {
-    /// Name of the header that caused the rejection
-    pub name: &'static http::header::HeaderName,
-
-    /// Reason why the header extraction has failed
-    pub reason: TypedHeaderRejectionReason,
+    name: &'static http::header::HeaderName,
+    reason: TypedHeaderRejectionReason,
 }
 
 impl TypedHeaderRejection {
-    // TODO remove workaround for rustdoc bug: https://github.com/rust-lang/rust/issues/92544
-    /// returns [name](#structfield.name)
+    /// Name of the header that caused the rejection
     pub fn name(&self) -> &http::header::HeaderName {
         self.name
     }
 
-    /// returns [reason](#structfield.reason)
+    /// Reason why the header extraction has failed
     pub fn reason(&self) -> &TypedHeaderRejectionReason {
         &self.reason
     }

--- a/axum/src/response/redirect.rs
+++ b/axum/src/response/redirect.rs
@@ -33,7 +33,8 @@ impl Redirect {
     /// This redirect instructs the client to change the method to GET for the subsequent request
     /// to the given `uri`, which is useful after successful form submission, file upload or when
     /// you generally don't want the redirected-to page to observe the original request method and
-    /// body (if non-empty).
+    /// body (if non-empty). If you want to preserve the request method and body,
+    /// [`Redirect::temporary`] should be used instead.
     ///
     /// # Panics
     ///
@@ -71,16 +72,19 @@ impl Redirect {
 
     /// Create a new [`Redirect`] that uses a [`302 Found`][mdn] status code.
     ///
-    /// This is the same as [`Redirect::temporary`], except the status code is older and thus
-    /// supported by some legacy applications that doesn't understand the newer one, but some of
-    /// those applications wrongly apply [`Redirect::to`] (`303 See Other`) semantics for this
-    /// status code. It should be avoided where possible.
+    /// This is the same as [`Redirect::temporary`] ([`307 Temporary Redirect`][mdn307]) except this status code is older and
+    /// thus supported by some legacy clients that don't understand the newer one. Some clients
+    /// wrongly apply [`Redirect::to`] ([`303 See Other`][mdn303]) semantics for this status code, so it
+    /// should be avoided where possible.
     ///
     /// # Panics
     ///
     /// If `uri` isn't a valid [`HeaderValue`].
     ///
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/302
+    /// [mdn307]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/307
+    /// [mdn303]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/303
+    #[deprecated(note="This results in different behavior between clients, so Redirect::temporary or Redirect::to should be used instead")]
     pub fn found(uri: Uri) -> Self {
         Self::with_status_code(StatusCode::FOUND, uri)
     }

--- a/axum/src/response/redirect.rs
+++ b/axum/src/response/redirect.rs
@@ -73,7 +73,7 @@ impl Redirect {
     /// Create a new [`Redirect`] that uses a [`302 Found`][mdn] status code.
     ///
     /// This is the same as [`Redirect::temporary`] ([`307 Temporary Redirect`][mdn307]) except this status code is older and
-    /// thus supported by some legacy clients that don't understand the newer one. Some clients
+    /// thus supported by some legacy clients that don't understand the newer one. Many clients
     /// wrongly apply [`Redirect::to`] ([`303 See Other`][mdn303]) semantics for this status code, so it
     /// should be avoided where possible.
     ///

--- a/axum/src/response/redirect.rs
+++ b/axum/src/response/redirect.rs
@@ -84,7 +84,9 @@ impl Redirect {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/302
     /// [mdn307]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/307
     /// [mdn303]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/303
-    #[deprecated(note="This results in different behavior between clients, so Redirect::temporary or Redirect::to should be used instead")]
+    #[deprecated(
+        note = "This results in different behavior between clients, so Redirect::temporary or Redirect::to should be used instead"
+    )]
     pub fn found(uri: Uri) -> Self {
         Self::with_status_code(StatusCode::FOUND, uri)
     }

--- a/axum/src/response/redirect.rs
+++ b/axum/src/response/redirect.rs
@@ -72,10 +72,10 @@ impl Redirect {
 
     /// Create a new [`Redirect`] that uses a [`302 Found`][mdn] status code.
     ///
-    /// This is the same as [`Redirect::temporary`] ([`307 Temporary Redirect`][mdn307]) except this status code is older and
-    /// thus supported by some legacy clients that don't understand the newer one. Many clients
-    /// wrongly apply [`Redirect::to`] ([`303 See Other`][mdn303]) semantics for this status code, so it
-    /// should be avoided where possible.
+    /// This is the same as [`Redirect::temporary`] ([`307 Temporary Redirect`][mdn307]) except
+    /// this status code is older and thus supported by some legacy clients that don't understand
+    /// the newer one. Many clients wrongly apply [`Redirect::to`] ([`303 See Other`][mdn303])
+    /// semantics for this status code, so it should be avoided where possible.
     ///
     /// # Panics
     ///

--- a/axum/src/routing/mod.rs
+++ b/axum/src/routing/mod.rs
@@ -7,12 +7,14 @@ use crate::{
         connect_info::{Connected, IntoMakeServiceWithConnectInfo},
         MatchedPath, OriginalUri,
     },
+    response::IntoResponse,
+    response::Redirect,
     response::Response,
     routing::strip_prefix::StripPrefix,
     util::{try_downcast, ByteStr, PercentDecodedByteStr},
     BoxError,
 };
-use http::{Request, StatusCode, Uri};
+use http::{Request, Uri};
 use std::{
     borrow::Cow,
     collections::HashMap,
@@ -484,12 +486,8 @@ where
                     } else {
                         with_path(req.uri(), &format!("{}/", path))
                     };
-                    let res = Response::builder()
-                        .status(StatusCode::PERMANENT_REDIRECT)
-                        .header(http::header::LOCATION, redirect_to.to_string())
-                        .body(crate::body::empty())
-                        .unwrap();
-                    RouterFuture::from_response(res)
+                    let res = Redirect::permanent(redirect_to);
+                    RouterFuture::from_response(res.into_response())
                 } else {
                     match &self.fallback {
                         Fallback::Default(inner) => {

--- a/axum/src/routing/mod.rs
+++ b/axum/src/routing/mod.rs
@@ -485,7 +485,7 @@ where
                         with_path(req.uri(), &format!("{}/", path))
                     };
                     let res = Response::builder()
-                        .status(StatusCode::MOVED_PERMANENTLY)
+                        .status(StatusCode::PERMANENT_REDIRECT)
                         .header(http::header::LOCATION, redirect_to.to_string())
                         .body(crate::body::empty())
                         .unwrap();

--- a/examples/oauth/Cargo.toml
+++ b/examples/oauth/Cargo.toml
@@ -15,3 +15,4 @@ serde = { version = "1.0", features = ["derive"] }
 # Use Rustls because it makes it easier to cross-compile on CI
 reqwest = { version = "0.11", default-features = false, features = ["rustls-tls", "json"] }
 headers = "0.3"
+http = "0.2"

--- a/examples/oauth/src/main.rs
+++ b/examples/oauth/src/main.rs
@@ -119,7 +119,7 @@ async fn discord_auth(Extension(client): Extension<BasicClient>) -> impl IntoRes
         .url();
 
     // Redirect to Discord's oauth service
-    Redirect::found(auth_url.to_string().parse().unwrap())
+    Redirect::to(auth_url.to_string().parse().unwrap())
 }
 
 // Valid user session required. If there is none, redirect to the auth page
@@ -138,12 +138,12 @@ async fn logout(
     let session = match store.load_session(cookie.to_string()).await.unwrap() {
         Some(s) => s,
         // No session active, just redirect
-        None => return Redirect::found("/".parse().unwrap()),
+        None => return Redirect::to("/".parse().unwrap()),
     };
 
     store.destroy_session(session).await.unwrap();
 
-    Redirect::found("/".parse().unwrap())
+    Redirect::to("/".parse().unwrap())
 }
 
 #[derive(Debug, Deserialize)]
@@ -192,14 +192,14 @@ async fn login_authorized(
     let mut headers = HeaderMap::new();
     headers.insert(SET_COOKIE, cookie.parse().unwrap());
 
-    (headers, Redirect::found("/".parse().unwrap()))
+    (headers, Redirect::to("/".parse().unwrap()))
 }
 
 struct AuthRedirect;
 
 impl IntoResponse for AuthRedirect {
     fn into_response(self) -> Response {
-        Redirect::found("/auth/discord".parse().unwrap()).into_response()
+        Redirect::temporary("/auth/discord".parse().unwrap()).into_response()
     }
 }
 

--- a/examples/oauth/src/main.rs
+++ b/examples/oauth/src/main.rs
@@ -12,8 +12,8 @@ use async_session::{MemoryStore, Session, SessionStore};
 use axum::{
     async_trait,
     extract::{
-        rejection::TypedHeaderRejectionReason,
-        Extension, FromRequest, Query, RequestParts, TypedHeader,
+        rejection::TypedHeaderRejectionReason, Extension, FromRequest, Query, RequestParts,
+        TypedHeader,
     },
     http::{header::SET_COOKIE, HeaderMap},
     response::{IntoResponse, Redirect, Response},
@@ -215,15 +215,15 @@ where
             .await
             .expect("`MemoryStore` extension is missing");
 
-        let cookies = TypedHeader::<headers::Cookie>::from_request(req).await.map_err(|e| {
-            match *e.name() {
+        let cookies = TypedHeader::<headers::Cookie>::from_request(req)
+            .await
+            .map_err(|e| match *e.name() {
                 header::COOKIE => match e.reason() {
                     TypedHeaderRejectionReason::Missing => AuthRedirect,
                     _ => panic!("unexpected error getting Cookie header(s): {}", e),
                 },
                 _ => panic!("unexpected error getting cookies: {}", e),
-            }
-        })?;
+            })?;
         let session_cookie = cookies.get(COOKIE_NAME).ok_or(AuthRedirect)?;
 
         let session = store

--- a/examples/oauth/src/main.rs
+++ b/examples/oauth/src/main.rs
@@ -216,8 +216,8 @@ where
             .expect("`MemoryStore` extension is missing");
 
         let cookies = TypedHeader::<headers::Cookie>::from_request(req).await.map_err(|e| {
-            match e.name() {
-                &header::COOKIE => match e.reason() {
+            match *e.name() {
+                header::COOKIE => match e.reason() {
                     TypedHeaderRejectionReason::Missing => AuthRedirect,
                     _ => panic!("unexpected error getting Cookie header(s): {}", e),
                 },

--- a/examples/oauth/src/main.rs
+++ b/examples/oauth/src/main.rs
@@ -1,33 +1,32 @@
 //! Example OAuth (Discord) implementation.
 //!
-//! Run with
-//!
+//! 1) Create a new application at <https://discord.com/developers/applications>
+//! 2) Visit the OAuth2 tab to get your CLIENT_ID and CLIENT_SECRET
+//! 3) Add a new redirect URI (for this example: `http://127.0.0.1:3000/auth/authorized`)
+//! 4) Run with the following (replacing values appropriately):
 //! ```not_rust
-//! CLIENT_ID=123 CLIENT_SECRET=secret cargo run -p example-oauth
+//! CLIENT_ID=REPLACE_ME CLIENT_SECRET=REPLACE_ME cargo run -p example-oauth
 //! ```
 
 use async_session::{MemoryStore, Session, SessionStore};
 use axum::{
     async_trait,
-    extract::{Extension, FromRequest, Query, RequestParts, TypedHeader},
+    extract::{
+        rejection::{TypedHeaderRejection, TypedHeaderRejectionReason},
+        Extension, FromRequest, Query, RequestParts, TypedHeader,
+    },
     http::{header::SET_COOKIE, HeaderMap},
     response::{IntoResponse, Redirect, Response},
     routing::get,
     AddExtensionLayer, Router,
 };
+use http::header;
 use oauth2::{
     basic::BasicClient, reqwest::async_http_client, AuthUrl, AuthorizationCode, ClientId,
     ClientSecret, CsrfToken, RedirectUrl, Scope, TokenResponse, TokenUrl,
 };
 use serde::{Deserialize, Serialize};
 use std::{env, net::SocketAddr};
-
-// Quick instructions:
-// 1) create a new application at https://discord.com/developers/applications
-// 2) visit the OAuth2 tab to get your CLIENT_ID and CLIENT_SECRET
-// 3) add a new redirect URI (For this example: http://localhost:3000/auth/authorized)
-// 4) AUTH_URL and TOKEN_URL may stay the same for discord.
-// More information: https://discord.com/developers/applications/792730475856527411/oauth2
 
 static COOKIE_NAME: &str = "SESSION";
 
@@ -39,7 +38,7 @@ async fn main() {
     }
     tracing_subscriber::fmt::init();
 
-    // `MemoryStore` just used as an example. Don't use this in production.
+    // `MemoryStore` is just used as an example. Don't use this in production.
     let store = MemoryStore::new();
 
     let oauth_client = oauth_client();
@@ -64,8 +63,8 @@ async fn main() {
 
 fn oauth_client() -> BasicClient {
     // Environment variables (* = required):
-    // *"CLIENT_ID"     "123456789123456789";
-    // *"CLIENT_SECRET" "rAn60Mch4ra-CTErsSf-r04utHcLienT";
+    // *"CLIENT_ID"     "REPLACE_ME";
+    // *"CLIENT_SECRET" "REPLACE_ME";
     //  "REDIRECT_URL"  "http://127.0.0.1:3000/auth/authorized";
     //  "AUTH_URL"      "https://discord.com/api/oauth2/authorize?response_type=code";
     //  "TOKEN_URL"     "https://discord.com/api/oauth2/token";
@@ -203,6 +202,18 @@ impl IntoResponse for AuthRedirect {
     }
 }
 
+impl From<TypedHeaderRejection> for AuthRedirect {
+    fn from(error: TypedHeaderRejection) -> Self {
+        match error {
+            TypedHeaderRejection {
+                name: &header::COOKIE,
+                reason: TypedHeaderRejectionReason::Missing,
+            } => AuthRedirect,
+            _ => panic!("unexpected error getting Cookie header(s)"),
+        }
+    }
+}
+
 #[async_trait]
 impl<B> FromRequest<B> for User
 where
@@ -216,9 +227,7 @@ where
             .await
             .expect("`MemoryStore` extension is missing");
 
-        let cookies = TypedHeader::<headers::Cookie>::from_request(req)
-            .await
-            .expect("could not get cookies");
+        let cookies = TypedHeader::<headers::Cookie>::from_request(req).await?;
 
         let session_cookie = cookies.get(COOKIE_NAME).ok_or(AuthRedirect)?;
 


### PR DESCRIPTION
## Motivation

Assuming a route for `/path` is defined,
`POST` `/path/` currently may redirect to `GET` `/path` when it should redirect to `POST` `/path` (depending on the client).

This was outlined in #681.

This has potential security implications (e.g., if the `POST` contained sensitive data, that data may be saved by the user's client in their browser history and/or in the server's access logs).

It's worth noting that the internal test client, a wrapper for the popular `reqwest` client, is susceptible to this incorrect behavior.

## Solution

This PR replaces the `301` redirect with a `308` and adds corresponding tests to verify the behavior (note that these tests fail without the accompanying code change).

- [x] Determine if this counts as a breaking change
  - [x] if so, this should be rebased onto `axum-next`
  - [x] if not (or regardless), an entry in `CHANGELOG.md` should be added