### PR TITLE
Don't silently swallow errors in `OriginalUri` extractor

### DIFF
--- a/axum-core/src/error.rs
+++ b/axum-core/src/error.rs
@@ -14,16 +14,6 @@ impl Error {
             inner: error.into(),
         }
     }
-
-    pub(crate) fn downcast<T>(self) -> Result<T, Self>
-    where
-        T: StdError + 'static,
-    {
-        match self.inner.downcast::<T>() {
-            Ok(t) => Ok(*t),
-            Err(err) => Err(*err.downcast().unwrap()),
-        }
-    }
 }
 
 impl fmt::Display for Error {

--- a/axum-core/src/extract/mod.rs
+++ b/axum-core/src/extract/mod.rs
@@ -6,7 +6,6 @@
 
 use self::rejection::*;
 use crate::response::IntoResponse;
-use crate::Error;
 use async_trait::async_trait;
 use http::{Extensions, HeaderMap, Method, Request, Uri, Version};
 use std::convert::Infallible;
@@ -128,7 +127,7 @@ impl<B> RequestParts<B> {
     /// [`take_headers`]: RequestParts::take_headers
     /// [`take_extensions`]: RequestParts::take_extensions
     /// [`take_body`]: RequestParts::take_body
-    pub fn try_into_request(self) -> Result<Request<B>, Error> {
+    pub fn try_into_request(self) -> Result<Request<B>, RequestAlreadyExtracted> {
         let Self {
             method,
             uri,
@@ -141,9 +140,9 @@ impl<B> RequestParts<B> {
         let mut req = if let Some(body) = body.take() {
             Request::new(body)
         } else {
-            return Err(Error::new(RequestAlreadyExtracted::BodyAlreadyExtracted(
+            return Err(RequestAlreadyExtracted::BodyAlreadyExtracted(
                 BodyAlreadyExtracted,
-            )));
+            ));
         };
 
         *req.method_mut() = method;
@@ -153,16 +152,16 @@ impl<B> RequestParts<B> {
         if let Some(headers) = headers.take() {
             *req.headers_mut() = headers;
         } else {
-            return Err(Error::new(
-                RequestAlreadyExtracted::HeadersAlreadyExtracted(HeadersAlreadyExtracted),
+            return Err(RequestAlreadyExtracted::HeadersAlreadyExtracted(
+                HeadersAlreadyExtracted,
             ));
         }
 
         if let Some(extensions) = extensions.take() {
             *req.extensions_mut() = extensions;
         } else {
-            return Err(Error::new(
-                RequestAlreadyExtracted::ExtensionsAlreadyExtracted(ExtensionsAlreadyExtracted),
+            return Err(RequestAlreadyExtracted::ExtensionsAlreadyExtracted(
+                ExtensionsAlreadyExtracted,
             ));
         }
 

--- a/axum-core/src/extract/request_parts.rs
+++ b/axum-core/src/extract/request_parts.rs
@@ -25,18 +25,7 @@ where
             },
         );
 
-        let err = match req.try_into_request() {
-            Ok(req) => return Ok(req),
-            Err(err) => err,
-        };
-
-        match err.downcast::<RequestAlreadyExtracted>() {
-            Ok(err) => return Err(err),
-            Err(err) => unreachable!(
-                "Unexpected error type from `try_into_request`: `{:?}`. This is a bug in axum, please file an issue",
-                err,
-            ),
-        }
+        req.try_into_request()
     }
 }
 

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
-- None.
+- **breaking:** Require `Output = ()` on `WebSocketStream::on_upgrade` ([#644])
+
+[#644]: https://github.com/tokio-rs/axum/pull/644
 
 # 0.4.3 (21. December, 2021)
 

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -8,8 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # Unreleased
 
 - **breaking:** Require `Output = ()` on `WebSocketStream::on_upgrade` ([#644])
+- **breaking:** Make `TypedHeaderRejectionReason` `#[non_exhaustive]` ([#665])
 
 [#644]: https://github.com/tokio-rs/axum/pull/644
+[#665]: https://github.com/tokio-rs/axum/pull/665
 
 # 0.4.3 (21. December, 2021)
 

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -9,9 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **breaking:** Require `Output = ()` on `WebSocketStream::on_upgrade` ([#644])
 - **breaking:** Make `TypedHeaderRejectionReason` `#[non_exhaustive]` ([#665])
+- **breaking:** Rejection type for `OriginalUri` is now `OriginalUriRejection`
+  instead of `Infallible` ([#687])
 
 [#644]: https://github.com/tokio-rs/axum/pull/644
 [#665]: https://github.com/tokio-rs/axum/pull/665
+[#687]: https://github.com/tokio-rs/axum/pull/687
 
 # 0.4.3 (21. December, 2021)
 

--- a/axum/Cargo.toml
+++ b/axum/Cargo.toml
@@ -11,11 +11,13 @@ readme = "README.md"
 repository = "https://github.com/tokio-rs/axum"
 
 [features]
-default = ["http1", "json", "tower-log"]
+default = ["http1", "json", "matched-path", "original-uri", "tower-log"]
 http1 = ["hyper/http1"]
 http2 = ["hyper/http2"]
 json = ["serde_json"]
+matched-path = []
 multipart = ["multer"]
+original-uri = []
 tower-log = ["tower/log"]
 ws = ["tokio-tungstenite", "sha-1", "base64"]
 
@@ -84,10 +86,10 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [package.metadata.playground]
 features = [
-  "http1",
-  "http2",
-  "json",
-  "multipart",
-  "tower",
-  "ws",
+    "http1",
+    "http2",
+    "json",
+    "multipart",
+    "tower",
+    "ws",
 ]

--- a/axum/Cargo.toml
+++ b/axum/Cargo.toml
@@ -53,7 +53,7 @@ tokio-tungstenite = { optional = true, version = "0.16" }
 
 [dev-dependencies]
 futures = "0.3"
-reqwest = { version = "0.11", default-features = false, features = ["json", "stream"] }
+reqwest = { version = "0.11", default-features = false, features = ["json", "stream", "multipart"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1.6.1", features = ["macros", "rt", "rt-multi-thread", "net"] }

--- a/axum/src/extract/mod.rs
+++ b/axum/src/extract/mod.rs
@@ -15,7 +15,6 @@ pub mod ws;
 mod content_length_limit;
 mod extension;
 mod form;
-mod matched_path;
 mod query;
 mod raw_query;
 mod request_parts;
@@ -31,16 +30,22 @@ pub use self::{
     extension::Extension,
     extractor_middleware::extractor_middleware,
     form::Form,
-    matched_path::MatchedPath,
     path::Path,
     query::Query,
     raw_query::RawQuery,
-    request_parts::OriginalUri,
     request_parts::{BodyStream, RawBody},
 };
 #[doc(no_inline)]
 #[cfg(feature = "json")]
 pub use crate::Json;
+
+#[cfg(feature = "matched-path")]
+mod matched_path;
+
+#[cfg(feature = "matched-path")]
+#[cfg_attr(docsrs, doc(cfg(feature = "matched-path")))]
+#[doc(inline)]
+pub use self::matched_path::MatchedPath;
 
 #[cfg(feature = "multipart")]
 #[cfg_attr(docsrs, doc(cfg(feature = "multipart")))]
@@ -50,6 +55,11 @@ pub mod multipart;
 #[cfg_attr(docsrs, doc(cfg(feature = "multipart")))]
 #[doc(inline)]
 pub use self::multipart::Multipart;
+
+#[cfg(feature = "original-uri")]
+#[cfg_attr(docsrs, doc(cfg(feature = "original-uri")))]
+#[doc(inline)]
+pub use self::request_parts::OriginalUri;
 
 #[cfg(feature = "ws")]
 #[cfg_attr(docsrs, doc(cfg(feature = "ws")))]

--- a/axum/src/extract/multipart.rs
+++ b/axum/src/extract/multipart.rs
@@ -8,14 +8,13 @@ use crate::BoxError;
 use async_trait::async_trait;
 use futures_util::stream::Stream;
 use http::header::{HeaderMap, CONTENT_TYPE};
-use mime::Mime;
 use std::{
     fmt,
     pin::Pin,
     task::{Context, Poll},
 };
 
-/// Extractor that parses `multipart/form-data` requests commonly used with file uploads.
+/// Extractor that parses `multipart/form-data` requests (commonly used with file uploads).
 ///
 /// # Example
 ///
@@ -42,7 +41,7 @@ use std::{
 /// # };
 /// ```
 ///
-/// For security reasons its recommended to combine this with
+/// For security reasons it's recommended to combine this with
 /// [`ContentLengthLimit`](super::ContentLengthLimit) to limit the size of the request payload.
 #[derive(Debug)]
 pub struct Multipart {
@@ -120,9 +119,9 @@ impl<'a> Field<'a> {
         self.inner.file_name()
     }
 
-    /// Get the content type of the field.
-    pub fn content_type(&self) -> Option<&Mime> {
-        self.inner.content_type()
+    /// Get the [content type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type) of the field.
+    pub fn content_type(&self) -> Option<&str> {
+        self.inner.content_type().map(|m| m.as_ref())
     }
 
     /// Get a map of headers as [`HeaderMap`].
@@ -190,4 +189,41 @@ define_rejection! {
     /// Rejection type used if the `boundary` in a `multipart/form-data` is
     /// missing or invalid.
     pub struct InvalidBoundary;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{response::IntoResponse, routing::post, test_helpers::*, Router};
+
+    #[tokio::test]
+    async fn content_type_with_encoding() {
+        const BYTES: &[u8] = "<!doctype html><title>🦀</title>".as_bytes();
+        const FILE_NAME: &str = "index.html";
+        const CONTENT_TYPE: &str = "text/html; charset=utf-8";
+
+        async fn handle(mut multipart: Multipart) -> impl IntoResponse {
+            let field = multipart.next_field().await.unwrap().unwrap();
+
+            assert_eq!(field.file_name().unwrap(), FILE_NAME);
+            assert_eq!(field.content_type().unwrap(), CONTENT_TYPE);
+            assert_eq!(field.bytes().await.unwrap(), BYTES);
+
+            assert!(multipart.next_field().await.unwrap().is_none());
+        }
+
+        let app = Router::new().route("/", post(handle));
+
+        let client = TestClient::new(app);
+
+        let form = reqwest::multipart::Form::new().part(
+            "file",
+            reqwest::multipart::Part::bytes(BYTES)
+                .file_name(FILE_NAME)
+                .mime_str(CONTENT_TYPE)
+                .unwrap(),
+        );
+
+        client.post("/").multipart(form).send().await;
+    }
 }

--- a/axum/src/extract/rejection.rs
+++ b/axum/src/extract/rejection.rs
@@ -61,8 +61,9 @@ define_rejection! {
 define_rejection! {
     #[status = INTERNAL_SERVER_ERROR]
     #[body = "No original uri was found for the matched route. This is likely a bug in axum. Please open an issue"]
-    /// Rejection type used if axum's internal representation of original URIs is missing. This
-    /// should never happen and is a bug in axum if it does.
+    /// Rejection type used if axum's internal representation of original URIs is missing.
+    ///
+    /// This should never happen and is likely a bug in axum if it does.
     pub struct MissingOriginalUri;
 }
 

--- a/axum/src/extract/rejection.rs
+++ b/axum/src/extract/rejection.rs
@@ -60,7 +60,7 @@ define_rejection! {
 
 define_rejection! {
     #[status = INTERNAL_SERVER_ERROR]
-    #[body = "No original uri was found for the matched route. This is a bug in axum. Please open an issue"]
+    #[body = "No original uri was found for the matched route. This is likely a bug in axum. Please open an issue"]
     /// Rejection type used if axum's internal representation of original URIs is missing. This
     /// should never happen and is a bug in axum if it does.
     pub struct MissingOriginalUri;

--- a/axum/src/extract/rejection.rs
+++ b/axum/src/extract/rejection.rs
@@ -59,6 +59,14 @@ define_rejection! {
 }
 
 define_rejection! {
+    #[status = INTERNAL_SERVER_ERROR]
+    #[body = "No original uri was found for the matched route. This is a bug in axum. Please open an issue"]
+    /// Rejection type used if axum's internal representation of original URIs is missing. This
+    /// should never happen and is a bug in axum if it does.
+    pub struct MissingOriginalUri;
+}
+
+define_rejection! {
     #[status = BAD_REQUEST]
     #[body = "Form requests must have `Content-Type: x-www-form-urlencoded`"]
     /// Rejection type used if you try and extract the request more than once.
@@ -104,6 +112,17 @@ impl std::fmt::Display for FailedToDeserializeQueryString {
 }
 
 impl std::error::Error for FailedToDeserializeQueryString {}
+
+composite_rejection! {
+    /// Rejection used for [`OriginalUri`](super::OriginalUri).
+    ///
+    /// Contains one variant for each way the [`OriginalUri`](super::OriginalUri) extractor
+    /// can fail.
+    pub enum OriginalUriRejection {
+        MissingOriginalUri,
+        ExtensionsAlreadyExtracted,
+    }
+}
 
 composite_rejection! {
     /// Rejection used for [`Query`](super::Query).

--- a/axum/src/extract/request_parts.rs
+++ b/axum/src/extract/request_parts.rs
@@ -43,9 +43,11 @@ use sync_wrapper::SyncWrapper;
 /// # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
 /// # };
 /// ```
+#[cfg(feature = "original-uri")]
 #[derive(Debug, Clone)]
 pub struct OriginalUri(pub Uri);
 
+#[cfg(feature = "original-uri")]
 #[async_trait]
 impl<B> FromRequest<B> for OriginalUri
 where

--- a/axum/src/extract/typed_header.rs
+++ b/axum/src/extract/typed_header.rs
@@ -98,6 +98,7 @@ impl TypedHeaderRejection {
 
 /// Additional information regarding a [`TypedHeaderRejection`](super::TypedHeaderRejection)
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum TypedHeaderRejectionReason {
     /// The header was missing from the HTTP request
     Missing,

--- a/axum/src/extract/ws.rs
+++ b/axum/src/extract/ws.rs
@@ -201,7 +201,7 @@ impl WebSocketUpgrade {
     pub fn on_upgrade<F, Fut>(self, callback: F) -> Response
     where
         F: FnOnce(WebSocket) -> Fut + Send + 'static,
-        Fut: Future + Send + 'static,
+        Fut: Future<Output = ()> + Send + 'static,
     {
         let on_upgrade = self.on_upgrade;
         let config = self.config;

--- a/axum/src/lib.rs
+++ b/axum/src/lib.rs
@@ -375,12 +375,16 @@
 //! `http1` | Enables hyper's `http1` feature | Yes
 //! `http2` | Enables hyper's `http2` feature | No
 //! `json` | Enables the [`Json`] type and some similar convenience functionality | Yes
+//! `matched-path` | Enables capturing of every request's router path and the [`MatchedPath`] extractor | Yes
 //! `multipart` | Enables parsing `multipart/form-data` requests with [`Multipart`] | No
+//! `original-uri` | Enables capturing of every request's original URI and the [`OriginalUri`] extractor | Yes
 //! `tower-log` | Enables `tower`'s `log` feature | Yes
 //! `ws` | Enables WebSockets support via [`extract::ws`] | No
 //!
 //! [`TypedHeader`]: crate::extract::TypedHeader
+//! [`MatchedPath`]: crate::extract::MatchedPath
 //! [`Multipart`]: crate::extract::Multipart
+//! [`OriginalUri`]: crate::extract::OriginalUri
 //! [`tower`]: https://crates.io/crates/tower
 //! [`tower-http`]: https://crates.io/crates/tower-http
 //! [`tokio`]: http://crates.io/crates/tokio
@@ -392,7 +396,6 @@
 //! [examples]: https://github.com/tokio-rs/axum/tree/main/examples
 //! [`Router::merge`]: crate::routing::Router::merge
 //! [`axum::Server`]: hyper::server::Server
-//! [`OriginalUri`]: crate::extract::OriginalUri
 //! [`Service`]: tower::Service
 //! [`Service::poll_ready`]: tower::Service::poll_ready
 //! [`Service`'s]: tower::Service

--- a/axum/src/test_helpers.rs
+++ b/axum/src/test_helpers.rs
@@ -100,6 +100,7 @@ impl RequestBuilder {
         self.builder = self.builder.json(json);
         self
     }
+
     pub(crate) fn header<K, V>(mut self, key: K, value: V) -> Self
     where
         HeaderName: TryFrom<K>,
@@ -108,6 +109,11 @@ impl RequestBuilder {
         <HeaderValue as TryFrom<V>>::Error: Into<http::Error>,
     {
         self.builder = self.builder.header(key, value);
+        self
+    }
+
+    pub(crate) fn multipart(mut self, form: reqwest::multipart::Form) -> Self {
+        self.builder = self.builder.multipart(form);
         self
     }
 }

--- a/examples/multipart-form/src/main.rs
+++ b/examples/multipart-form/src/main.rs
@@ -65,8 +65,16 @@ async fn accept_form(
 ) {
     while let Some(field) = multipart.next_field().await.unwrap() {
         let name = field.name().unwrap().to_string();
+        let file_name = field.file_name().unwrap().to_string();
+        let content_type = field.content_type().unwrap().to_string();
         let data = field.bytes().await.unwrap();
 
-        println!("Length of `{}` is {} bytes", name, data.len());
+        println!(
+            "Length of `{}` (`{}`: `{}`) is {} bytes",
+            name,
+            file_name,
+            content_type,
+            data.len()
+        );
     }
 }


### PR DESCRIPTION
Failing to extract `OriginalUri` could be the result of a programmer error so we shouldn't swallow those as that might result in wrong data being given to the user.