### PR TITLE
Document extracting `OriginalUri` directly via request extensions

### DIFF
--- a/axum/src/extract/request_parts.rs
+++ b/axum/src/extract/request_parts.rs
@@ -48,7 +48,7 @@ use sync_wrapper::SyncWrapper;
 ///
 /// `OriginalUri` can also be accessed from middleware via request extensions.
 /// This is useful for example with [`Trace`](tower_http::trace::Trace) to
-/// create a span that contains the original URI, if your service might be nested:
+/// create a span that contains the full path, if your service might be nested:
 ///
 /// ```
 /// use axum::{

--- a/axum/src/extract/request_parts.rs
+++ b/axum/src/extract/request_parts.rs
@@ -65,11 +65,11 @@ use sync_wrapper::SyncWrapper;
 ///         TraceLayer::new_for_http().make_span_with(|req: &Request<_>| {
 ///             let path = if let Some(path) = req.extensions().get::<OriginalUri>() {
 ///                 // This will include `/api`
-///                 path.as_str()
+///                 path.0.path().to_owned()
 ///             } else {
 ///                 // The `OriginalUri` extension will always be present if using
 ///                 // `Router` unless another extractor or middleware has removed it
-///                 req.uri().path()
+///                 req.uri().path().to_owned()
 ///             };
 ///             tracing::info_span!("http-request", %path)
 ///         }),


### PR DESCRIPTION
Fixes https://github.com/tokio-rs/axum/issues/684