### PR TITLE
Remove `RequestParts::take_extensions`

### DIFF
--- a/axum-core/CHANGELOG.md
+++ b/axum-core/CHANGELOG.md
@@ -21,8 +21,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
         - `RequestAlreadyExtracted`
         - `RequestPartsAlreadyExtracted`
     - `<HeaderMap as FromRequest<_>>::Error` has been changed to `std::convert::Infallible`.
+- **breaking:** `axum::http::Extensions` is no longer an extractor (ie it
+  doesn't implement `FromRequest`). The `axum::extract::Extension` extractor is
+  _not_ impacted by this and works the same. This change makes it harder to
+  accidentally remove all extensions which would result in confusing errors
+  elsewhere ([#699])
+  This includes these breaking changes:
+    - `RequestParts::take_extensions` has been removed.
+    - `RequestParts::extensions` returns `&Extensions`.
+    - `RequestParts::extensions_mut` returns `&mut Extensions`.
+    - `RequestAlreadyExtracted` has been removed.
+    - `<Request as FromRequest>::Error` is now `BodyAlreadyExtracted`.
+    - `<http::request::Parts as FromRequest>::Error` is now `Infallible`.
+    - `ExtensionsAlreadyExtracted` has been removed.
 
 [#698]: https://github.com/tokio-rs/axum/pull/698
+[#699]: https://github.com/tokio-rs/axum/pull/699
 
 # 0.1.1 (06. December, 2021)
 

--- a/axum-core/src/extract/mod.rs
+++ b/axum-core/src/extract/mod.rs
@@ -115,7 +115,7 @@ impl<B> RequestParts<B> {
 
     /// Convert this `RequestParts` back into a [`Request`].
     ///
-    /// Fails if The request body has been extracted, that is [`take_body`] have
+    /// Fails if The request body has been extracted, that is [`take_body`] has
     /// been called.
     ///
     /// [`take_body`]: RequestParts::take_body

--- a/axum-core/src/extract/mod.rs
+++ b/axum-core/src/extract/mod.rs
@@ -115,14 +115,9 @@ impl<B> RequestParts<B> {
 
     /// Convert this `RequestParts` back into a [`Request`].
     ///
-    /// Fails if
+    /// Fails if The request body has been extracted, that is [`take_body`] have
+    /// been called.
     ///
-    /// - The full [`Extensions`] has been extracted, that is
-    /// [`take_extensions`] have been called.
-    /// - The request body has been extracted, that is [`take_body`] have been
-    /// called.
-    ///
-    /// [`take_extensions`]: RequestParts::take_extensions
     /// [`take_body`]: RequestParts::take_body
     pub fn try_into_request(self) -> Result<Request<B>, BodyAlreadyExtracted> {
         let Self {

--- a/axum-core/src/extract/mod.rs
+++ b/axum-core/src/extract/mod.rs
@@ -192,15 +192,11 @@ impl<B> RequestParts<B> {
     }
 
     /// Gets a reference to the request extensions.
-    ///
-    /// Returns `None` if the extensions has been taken by another extractor.
     pub fn extensions(&self) -> &Extensions {
         &self.extensions
     }
 
     /// Gets a mutable reference to the request extensions.
-    ///
-    /// Returns `None` if the extensions has been taken by another extractor.
     pub fn extensions_mut(&mut self) -> &mut Extensions {
         &mut self.extensions
     }

--- a/axum-core/src/extract/mod.rs
+++ b/axum-core/src/extract/mod.rs
@@ -124,7 +124,7 @@ impl<B> RequestParts<B> {
     ///
     /// [`take_extensions`]: RequestParts::take_extensions
     /// [`take_body`]: RequestParts::take_body
-    pub fn try_into_request(self) -> Result<Request<B>, RequestAlreadyExtracted> {
+    pub fn try_into_request(self) -> Result<Request<B>, BodyAlreadyExtracted> {
         let Self {
             method,
             uri,
@@ -137,9 +137,7 @@ impl<B> RequestParts<B> {
         let mut req = if let Some(body) = body.take() {
             Request::new(body)
         } else {
-            return Err(RequestAlreadyExtracted::BodyAlreadyExtracted(
-                BodyAlreadyExtracted,
-            ));
+            return Err(BodyAlreadyExtracted);
         };
 
         *req.method_mut() = method;

--- a/axum-core/src/extract/mod.rs
+++ b/axum-core/src/extract/mod.rs
@@ -78,7 +78,7 @@ pub struct RequestParts<B> {
     uri: Uri,
     version: Version,
     headers: HeaderMap,
-    extensions: Option<Extensions>,
+    extensions: Extensions,
     body: Option<B>,
 }
 
@@ -108,7 +108,7 @@ impl<B> RequestParts<B> {
             uri,
             version,
             headers,
-            extensions: Some(extensions),
+            extensions,
             body: Some(body),
         }
     }
@@ -130,7 +130,7 @@ impl<B> RequestParts<B> {
             uri,
             version,
             headers,
-            mut extensions,
+            extensions,
             mut body,
         } = self;
 
@@ -146,14 +146,7 @@ impl<B> RequestParts<B> {
         *req.uri_mut() = uri;
         *req.version_mut() = version;
         *req.headers_mut() = headers;
-
-        if let Some(extensions) = extensions.take() {
-            *req.extensions_mut() = extensions;
-        } else {
-            return Err(RequestAlreadyExtracted::ExtensionsAlreadyExtracted(
-                ExtensionsAlreadyExtracted,
-            ));
-        }
+        *req.extensions_mut() = extensions;
 
         Ok(req)
     }
@@ -201,20 +194,15 @@ impl<B> RequestParts<B> {
     /// Gets a reference to the request extensions.
     ///
     /// Returns `None` if the extensions has been taken by another extractor.
-    pub fn extensions(&self) -> Option<&Extensions> {
-        self.extensions.as_ref()
+    pub fn extensions(&self) -> &Extensions {
+        &self.extensions
     }
 
     /// Gets a mutable reference to the request extensions.
     ///
     /// Returns `None` if the extensions has been taken by another extractor.
-    pub fn extensions_mut(&mut self) -> Option<&mut Extensions> {
-        self.extensions.as_mut()
-    }
-
-    /// Takes the extensions out of the request, leaving a `None` in its place.
-    pub fn take_extensions(&mut self) -> Option<Extensions> {
-        self.extensions.take()
+    pub fn extensions_mut(&mut self) -> &mut Extensions {
+        &mut self.extensions
     }
 
     /// Gets a reference to the request body.

--- a/axum-core/src/extract/rejection.rs
+++ b/axum-core/src/extract/rejection.rs
@@ -1,13 +1,35 @@
 //! Rejection response types.
 
-define_rejection! {
-    #[status = INTERNAL_SERVER_ERROR]
-    #[body = "Cannot have two request body extractors for a single handler"]
-    /// Rejection type used if you try and extract the request body more than
-    /// once.
-    #[derive(Default)]
-    pub struct BodyAlreadyExtracted;
+use crate::body;
+use http::{Response, StatusCode};
+use http_body::Full;
+use std::fmt;
+
+/// Rejection type used if you try and extract the request body more than
+/// once.
+#[derive(Debug, Default)]
+#[non_exhaustive]
+pub struct BodyAlreadyExtracted;
+
+impl BodyAlreadyExtracted {
+    const BODY: &'static str = "Cannot have two request body extractors for a single handler";
 }
+
+impl crate::response::IntoResponse for BodyAlreadyExtracted {
+    fn into_response(self) -> crate::response::Response {
+        let mut res = Response::new(body::boxed(Full::from(Self::BODY)));
+        *res.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
+        res
+    }
+}
+
+impl fmt::Display for BodyAlreadyExtracted {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", Self::BODY)
+    }
+}
+
+impl std::error::Error for BodyAlreadyExtracted {}
 
 define_rejection! {
     #[status = BAD_REQUEST]

--- a/axum-core/src/extract/rejection.rs
+++ b/axum-core/src/extract/rejection.rs
@@ -5,15 +5,8 @@ define_rejection! {
     #[body = "Cannot have two request body extractors for a single handler"]
     /// Rejection type used if you try and extract the request body more than
     /// once.
+    #[derive(Default)]
     pub struct BodyAlreadyExtracted;
-}
-
-define_rejection! {
-    #[status = INTERNAL_SERVER_ERROR]
-    #[body = "Extensions taken by other extractor"]
-    /// Rejection used if the request extension has been taken by another
-    /// extractor.
-    pub struct ExtensionsAlreadyExtracted;
 }
 
 define_rejection! {
@@ -40,7 +33,6 @@ composite_rejection! {
     /// [`Request<_>`]: http::Request
     pub enum RequestAlreadyExtracted {
         BodyAlreadyExtracted,
-        ExtensionsAlreadyExtracted,
     }
 }
 
@@ -63,14 +55,5 @@ composite_rejection! {
         BodyAlreadyExtracted,
         FailedToBufferBody,
         InvalidUtf8,
-    }
-}
-
-composite_rejection! {
-    /// Rejection used for [`http::request::Parts`].
-    ///
-    /// Contains one variant for each way the [`http::request::Parts`] extractor can fail.
-    pub enum RequestPartsAlreadyExtracted {
-        ExtensionsAlreadyExtracted,
     }
 }

--- a/axum-core/src/extract/rejection.rs
+++ b/axum-core/src/extract/rejection.rs
@@ -26,17 +26,6 @@ define_rejection! {
 }
 
 composite_rejection! {
-    /// Rejection used for [`Request<_>`].
-    ///
-    /// Contains one variant for each way the [`Request<_>`] extractor can fail.
-    ///
-    /// [`Request<_>`]: http::Request
-    pub enum RequestAlreadyExtracted {
-        BodyAlreadyExtracted,
-    }
-}
-
-composite_rejection! {
     /// Rejection used for [`Bytes`](bytes::Bytes).
     ///
     /// Contains one variant for each way the [`Bytes`](bytes::Bytes) extractor

--- a/axum-core/src/extract/request_parts.rs
+++ b/axum-core/src/extract/request_parts.rs
@@ -10,7 +10,7 @@ impl<B> FromRequest<B> for Request<B>
 where
     B: Send,
 {
-    type Rejection = RequestAlreadyExtracted;
+    type Rejection = BodyAlreadyExtracted;
 
     async fn from_request(req: &mut RequestParts<B>) -> Result<Self, Self::Rejection> {
         let req = std::mem::replace(

--- a/axum-core/src/macros.rs
+++ b/axum-core/src/macros.rs
@@ -3,35 +3,6 @@ macro_rules! define_rejection {
         #[status = $status:ident]
         #[body = $body:expr]
         $(#[$m:meta])*
-        pub struct $name:ident;
-    ) => {
-        $(#[$m])*
-        #[derive(Debug)]
-        #[non_exhaustive]
-        pub struct $name;
-
-        #[allow(deprecated)]
-        impl $crate::response::IntoResponse for $name {
-            fn into_response(self) -> $crate::response::Response {
-                let mut res = http::Response::new($crate::body::boxed(http_body::Full::from($body)));
-                *res.status_mut() = http::StatusCode::$status;
-                res
-            }
-        }
-
-        impl std::fmt::Display for $name {
-            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                write!(f, "{}", $body)
-            }
-        }
-
-        impl std::error::Error for $name {}
-    };
-
-    (
-        #[status = $status:ident]
-        #[body = $body:expr]
-        $(#[$m:meta])*
         pub struct $name:ident (Error);
     ) => {
         $(#[$m])*

--- a/axum-core/src/macros.rs
+++ b/axum-core/src/macros.rs
@@ -26,12 +26,6 @@ macro_rules! define_rejection {
         }
 
         impl std::error::Error for $name {}
-
-        impl Default for $name {
-            fn default() -> Self {
-                Self
-            }
-        }
     };
 
     (

--- a/axum-extra/CHANGELOG.md
+++ b/axum-extra/CHANGELOG.md
@@ -8,8 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # Unreleased
 
 - **fix:** Depend on tower with `default_features = false` ([#666])
+- **breaking:** `CachedRejection` has been removed ([#699])
+- **breaking:** `<Cached<T> as FromRequest>::Error` is now `T::Rejection`. ([#699])
 
 [#666]: https://github.com/tokio-rs/axum/pull/666
+[#699]: https://github.com/tokio-rs/axum/pull/699
 
 # 0.1.1 (27. December, 2021)
 

--- a/axum-extra/src/extract/mod.rs
+++ b/axum-extra/src/extract/mod.rs
@@ -3,9 +3,3 @@
 mod cached;
 
 pub use self::cached::Cached;
-
-pub mod rejection {
-    //! Rejection response types.
-
-    pub use super::cached::CachedRejection;
-}

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -31,10 +31,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
         - `ContentLengthLimitRejection`
         - `WebSocketUpgradeRejection`
     - `<HeaderMap as FromRequest<_>>::Error` has been changed to `std::convert::Infallible`.
+- **breaking:** `axum::http::Extensions` is no longer an extractor (ie it
+  doesn't implement `FromRequest`). The `axum::extract::Extension` extractor is
+  _not_ impacted by this and works the same. This change makes it harder to
+  accidentally remove all extensions which would result in confusing errors
+  elsewhere ([#699])
+  This includes these breaking changes:
+    - `RequestParts::take_extensions` has been removed.
+    - `RequestParts::extensions` returns `&Extensions`.
+    - `RequestParts::extensions_mut` returns `&mut Extensions`.
+    - `RequestAlreadyExtracted` has been removed.
+    - `<Request as FromRequest>::Error` is now `BodyAlreadyExtracted`.
+    - `<http::request::Parts as FromRequest>::Error` is now `Infallible`.
+    - `ExtensionsAlreadyExtracted` has been removed.
+    - The `ExtensionsAlreadyExtracted` removed variant has been removed from these rejections:
+        - `ExtensionRejection`
+        - `PathRejection`
+        - `MatchedPathRejection`
+        - `WebSocketUpgradeRejection`
 
 [#644]: https://github.com/tokio-rs/axum/pull/644
 [#665]: https://github.com/tokio-rs/axum/pull/665
 [#698]: https://github.com/tokio-rs/axum/pull/698
+[#699]: https://github.com/tokio-rs/axum/pull/699
 
 # 0.4.3 (21. December, 2021)
 

--- a/axum/src/extract/extension.rs
+++ b/axum/src/extract/extension.rs
@@ -53,7 +53,6 @@ where
     async fn from_request(req: &mut RequestParts<B>) -> Result<Self, Self::Rejection> {
         let value = req
             .extensions()
-            .ok_or_else(ExtensionsAlreadyExtracted::default)?
             .get::<T>()
             .ok_or_else(|| {
                 MissingExtension::from_err(format!(

--- a/axum/src/extract/matched_path.rs
+++ b/axum/src/extract/matched_path.rs
@@ -70,11 +70,8 @@ where
     type Rejection = MatchedPathRejection;
 
     async fn from_request(req: &mut RequestParts<B>) -> Result<Self, Self::Rejection> {
-        let extensions = req.extensions().ok_or_else(|| {
-            MatchedPathRejection::ExtensionsAlreadyExtracted(ExtensionsAlreadyExtracted::default())
-        })?;
-
-        let matched_path = extensions
+        let matched_path = req
+            .extensions()
             .get::<Self>()
             .ok_or(MatchedPathRejection::MatchedPathMissing(MatchedPathMissing))?
             .clone();

--- a/axum/src/extract/path/mod.rs
+++ b/axum/src/extract/path/mod.rs
@@ -514,6 +514,9 @@ mod tests {
 
         let res = client.get("/foo").send().await;
         assert_eq!(res.status(), StatusCode::INTERNAL_SERVER_ERROR);
-        assert_eq!(res.text().await, "Extensions taken by other extractor");
+        assert_eq!(
+            res.text().await,
+            "No paths parameters found for matched route. Are you also extracting `Request<_>`?"
+        );
     }
 }

--- a/axum/src/extract/path/mod.rs
+++ b/axum/src/extract/path/mod.rs
@@ -3,7 +3,6 @@
 
 mod de;
 
-use super::rejection::ExtensionsAlreadyExtracted;
 use crate::{
     body::{boxed, Full},
     extract::{rejection::*, FromRequest, RequestParts},
@@ -164,11 +163,7 @@ where
     type Rejection = PathRejection;
 
     async fn from_request(req: &mut RequestParts<B>) -> Result<Self, Self::Rejection> {
-        let ext = req
-            .extensions_mut()
-            .ok_or_else::<Self::Rejection, _>(|| ExtensionsAlreadyExtracted::default().into())?;
-
-        let params = match ext.get::<Option<UrlParams>>() {
+        let params = match req.extensions_mut().get::<Option<UrlParams>>() {
             Some(Some(UrlParams(Ok(params)))) => Cow::Borrowed(params),
             Some(Some(UrlParams(Err(InvalidUtf8InPathParam { key })))) => {
                 let err = PathDeserializationError {

--- a/axum/src/extract/rejection.rs
+++ b/axum/src/extract/rejection.rs
@@ -148,7 +148,6 @@ composite_rejection! {
     /// can fail.
     pub enum ExtensionRejection {
         MissingExtension,
-        ExtensionsAlreadyExtracted,
     }
 }
 
@@ -160,7 +159,6 @@ composite_rejection! {
     pub enum PathRejection {
         FailedToDeserializePathParams,
         MissingPathParams,
-        ExtensionsAlreadyExtracted,
     }
 }
 
@@ -176,7 +174,6 @@ define_rejection! {
 composite_rejection! {
     /// Rejection used for [`MatchedPath`](super::MatchedPath).
     pub enum MatchedPathRejection {
-        ExtensionsAlreadyExtracted,
         MatchedPathMissing,
     }
 }

--- a/axum/src/extract/rejection.rs
+++ b/axum/src/extract/rejection.rs
@@ -52,9 +52,10 @@ define_rejection! {
 
 define_rejection! {
     #[status = INTERNAL_SERVER_ERROR]
-    #[body = "No paths parameters found for matched route. This is a bug in axum. Please open an issue"]
-    /// Rejection type used if axum's internal representation of path parameters is missing. This
-    /// should never happen and is a bug in axum if it does.
+    #[body = "No paths parameters found for matched route. Are you also extracting `Request<_>`?"]
+    /// Rejection type used if axum's internal representation of path parameters
+    /// is missing. This is commonly caused by extracting `Request<_>`. `Path`
+    /// must be extracted first.
     pub struct MissingPathParams;
 }
 

--- a/axum/src/extract/ws.rs
+++ b/axum/src/extract/ws.rs
@@ -64,7 +64,7 @@
 //! [`StreamExt::split`]: https://docs.rs/futures/0.3.17/futures/stream/trait.StreamExt.html#method.split
 
 use self::rejection::*;
-use super::{rejection::*, FromRequest, RequestParts};
+use super::{FromRequest, RequestParts};
 use crate::{
     body::{self, Bytes},
     response::Response,
@@ -268,11 +268,7 @@ where
                 return Err(WebSocketKeyHeaderMissing.into());
             };
 
-        let on_upgrade = req
-            .extensions_mut()
-            .ok_or_else(ExtensionsAlreadyExtracted::default)?
-            .remove::<OnUpgrade>()
-            .unwrap();
+        let on_upgrade = req.extensions_mut().remove::<OnUpgrade>().unwrap();
 
         let sec_websocket_protocol = req.headers().get(header::SEC_WEBSOCKET_PROTOCOL).cloned();
 
@@ -514,8 +510,6 @@ fn sign(key: &[u8]) -> HeaderValue {
 pub mod rejection {
     //! WebSocket specific rejections.
 
-    use crate::extract::rejection::*;
-
     define_rejection! {
         #[status = METHOD_NOT_ALLOWED]
         #[body = "Request method must be `GET`"]
@@ -562,7 +556,6 @@ pub mod rejection {
             InvalidUpgradeHeader,
             InvalidWebSocketVersionHeader,
             WebSocketKeyHeaderMissing,
-            ExtensionsAlreadyExtracted,
         }
     }
 }


### PR DESCRIPTION
Same story as https://github.com/tokio-rs/axum/pull/698 but this time for extensions.

Removes `RequestParts::take_extensions` and `impl FromRequest for Extensions` meaning `Extensions` is no longer an extractor. Been thinking before that it probably didn't have much utility in the first place since all you can do is [`get`](https://docs.rs/http/latest/http/struct.Extensions.html#method.get) types, which `extract::Extension` can also do. Users can still use `RequestParts::extensions_mut` however to `std::mem::take` them if they really need to.

## TODO

- [x] Changelog