### PR TITLE
feat/mpack-extractor

### DIFF
--- a/axum/Cargo.toml
+++ b/axum/Cargo.toml
@@ -15,6 +15,7 @@ default = ["http1", "json", "tower-log"]
 http1 = ["hyper/http1"]
 http2 = ["hyper/http2"]
 json = ["serde_json"]
+messagepack = ["rmp-serde"]
 multipart = ["multer"]
 tower-log = ["tower/log"]
 ws = ["tokio-tungstenite", "sha-1", "base64"]
@@ -48,6 +49,7 @@ base64 = { optional = true, version = "0.13" }
 headers = { optional = true, version = "0.3" }
 multer = { optional = true, version = "2.0.0" }
 serde_json = { version = "1.0", optional = true, features = ["raw_value"] }
+rmp-serde = { version = "0.15", optional = true}
 sha-1 = { optional = true, version = "0.9.6" }
 tokio-tungstenite = { optional = true, version = "0.16" }
 
@@ -56,6 +58,7 @@ futures = "0.3"
 reqwest = { version = "0.11", default-features = false, features = ["json", "stream"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+rmp-serde = "0.15"
 tokio = { version = "1.6.1", features = ["macros", "rt", "rt-multi-thread", "net", "test-util"] }
 tokio-stream = "0.1"
 tracing = "0.1"

--- a/axum/src/extract/mod.rs
+++ b/axum/src/extract/mod.rs
@@ -42,6 +42,10 @@ pub use self::{
 #[cfg(feature = "json")]
 pub use crate::Json;
 
+#[doc(no_inline)]
+#[cfg(feature = "messagepack")]
+pub use crate::MessagePack;
+
 #[cfg(feature = "multipart")]
 #[cfg_attr(docsrs, doc(cfg(feature = "multipart")))]
 pub mod multipart;

--- a/axum/src/extract/rejection.rs
+++ b/axum/src/extract/rejection.rs
@@ -26,6 +26,23 @@ define_rejection! {
     pub struct MissingJsonContentType;
 }
 
+#[cfg(feature = "messagepack")]
+define_rejection! {
+    #[status = BAD_REQUEST]
+    #[body = "Failed to parse the request body as MessagePack"]
+    #[cfg_attr(docsrs, doc(cfg(feature = "messagepack")))]
+    /// Rejection type for [`MessagePack`](super::MessagePack).
+    pub struct InvalidMessagePackBody(Error);
+}
+
+define_rejection! {
+    #[status = BAD_REQUEST]
+    #[body = "Expected request with `Content-Type: application/msgpack`"]
+    /// Rejection type for [`MessagePack`](super::MessagePack) used if the `Content-Type`
+    /// header is missing.
+    pub struct MissingMessagePackContentType;
+}
+
 define_rejection! {
     #[status = INTERNAL_SERVER_ERROR]
     #[body = "Missing request extension"]
@@ -138,6 +155,21 @@ composite_rejection! {
     pub enum JsonRejection {
         InvalidJsonBody,
         MissingJsonContentType,
+        BytesRejection,
+        HeadersAlreadyExtracted,
+    }
+}
+
+#[cfg(feature = "messagepack")]
+composite_rejection! {
+    /// Rejection used for [`MessagePack`](super::MessagePack).
+    ///
+    /// Contains one variant for each way the [`MessagePack`](super::MessagePack) extractor
+    /// can fail.
+    #[cfg_attr(docsrs, doc(cfg(feature = "json")))]
+    pub enum MessagePackRejection {
+        InvalidMessagePackBody,
+        MissingMessagePackContentType,
         BytesRejection,
         HeadersAlreadyExtracted,
     }

--- a/axum/src/lib.rs
+++ b/axum/src/lib.rs
@@ -375,6 +375,7 @@
 //! `http1` | Enables hyper's `http1` feature | Yes
 //! `http2` | Enables hyper's `http2` feature | No
 //! `json` | Enables the [`Json`] type and some similar convenience functionality | Yes
+//! `messagepack` | Enables the [`MessagePack`] type leveraging rmp-serde | No 
 //! `multipart` | Enables parsing `multipart/form-data` requests with [`Multipart`] | No
 //! `tower-log` | Enables `tower`'s `log` feature | Yes
 //! `ws` | Enables WebSockets support via [`extract::ws`] | No
@@ -457,6 +458,8 @@ pub(crate) mod macros;
 mod add_extension;
 #[cfg(feature = "json")]
 mod json;
+#[cfg(feature = "messagepack")]
+mod messagepack;
 mod util;
 
 pub mod body;
@@ -483,6 +486,8 @@ pub use hyper::Server;
 #[doc(inline)]
 #[cfg(feature = "json")]
 pub use self::json::Json;
+#[cfg(feature = "messagepack")]
+pub use self::messagepack::MessagePack;
 #[doc(inline)]
 pub use self::routing::Router;
 

--- a/axum/src/lib.rs
+++ b/axum/src/lib.rs
@@ -486,6 +486,7 @@ pub use hyper::Server;
 #[doc(inline)]
 #[cfg(feature = "json")]
 pub use self::json::Json;
+#[doc(inline)]
 #[cfg(feature = "messagepack")]
 pub use self::messagepack::MessagePack;
 #[doc(inline)]

--- a/axum/src/messagepack.rs
+++ b/axum/src/messagepack.rs
@@ -130,12 +130,12 @@ fn message_pack_content_type<B>(req: &RequestParts<B>) -> Result<bool, HeadersAl
         return Ok(false)
     };
 
-    let is_rmp = mime.type_() == "application" && (
+    let is_message_pack = mime.type_() == "application" && (
         ["msgpack", "x-msgpack"].iter()
             .any(|subtype| *subtype == mime.subtype()) ||
         mime.suffix().map_or(false, |suffix| suffix == "msgpack"));
 
-    Ok(is_rmp)
+    Ok(is_message_pack)
 }
 
 impl<T> Deref for MessagePack<T> {
@@ -220,8 +220,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn json_content_types() {
-        async fn valid_json_content_type(content_type: &str) -> bool {
+    async fn message_pack_content_types() {
+        async fn valid_message_pack_content_type(content_type: &str) -> bool {
             println!("testing {:?}", content_type);
             let body = rmp_serde::to_vec(&Input {foo: "bar".into()}).expect("Failed to serialize to MessagePack");
             let app = Router::new().route("/", post(|MessagePack(_): MessagePack<Input>| async {}));
@@ -236,10 +236,10 @@ mod tests {
             res.status() == StatusCode::OK
         }
 
-        assert!(valid_json_content_type("application/msgpack").await);
-        assert!(valid_json_content_type("application/msgpack; charset=utf-8").await);
-        assert!(valid_json_content_type("application/msgpack;charset=utf-8").await);
-        assert!(valid_json_content_type("application/cloudevents+msgpack").await);
-        assert!(!valid_json_content_type("text/json").await);
+        assert!(valid_message_pack_content_type("application/msgpack").await);
+        assert!(valid_message_pack_content_type("application/msgpack; charset=utf-8").await);
+        assert!(valid_message_pack_content_type("application/msgpack;charset=utf-8").await);
+        assert!(valid_message_pack_content_type("application/cloudevents+msgpack").await);
+        assert!(!valid_message_pack_content_type("text/msgpack").await);
     }
 }

--- a/axum/src/messagepack.rs
+++ b/axum/src/messagepack.rs
@@ -1,0 +1,245 @@
+use crate::{
+    body::{self, Bytes, Full, HttpBody},
+    extract::{rejection::*, FromRequest, RequestParts},
+    response::{IntoResponse, Response},
+    BoxError,
+};
+use async_trait::async_trait;
+use http::{
+    header::{self, HeaderValue},
+    StatusCode,
+};
+use serde::{de::DeserializeOwned, Serialize};
+use std::ops::{Deref, DerefMut};
+
+/// MessagePack Extractor / Response.
+///
+/// When used as an extractor, it can deserialize request bodies into some type that
+/// implements [`serde::Deserialize`]. If the request body cannot be parsed, or value of the 
+/// `Content-Type` header does not match any of the `application/msgpack`, `application/x-msgpack`
+/// or `application/*+msgpack` it will reject the request and return a `400 Bad Request` response.
+///
+/// # Extractor example
+///
+/// ```rust,no_run
+/// use axum::{
+///     extract::MessagePack,
+///     routing::post,
+///     Router,
+/// };
+/// use serde::Deserialize;
+///
+/// #[derive(Deserialize)]
+/// struct CreateUser {
+///     email: String,
+///     password: String,
+/// }
+///
+/// async fn create_user(MessagePack(payload): MessagePack<CreateUser>) {
+///     // payload is a `CreateUser`
+/// }
+///
+/// let app = Router::new().route("/users", post(create_user));
+/// # async {
+/// # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
+/// # };
+/// ```
+///
+/// When used as a response, it can serialize any type that implements [`serde::Serialize`] to
+/// `MessagePack`, and will automatically set `Content-Type: application/msgpack` header.
+///
+/// # Response example
+///
+/// ```
+/// use axum::{
+///     extract::{Path, MessagePack},
+///     routing::get,
+///     Router,
+/// };
+/// use serde::Serialize;
+/// use uuid::Uuid;
+///
+/// #[derive(Serialize)]
+/// struct User {
+///     id: Uuid,
+///     username: String,
+/// }
+///
+/// async fn get_user(Path(user_id) : Path<Uuid>) -> MessagePack<User> {
+///     let user = find_user(user_id).await;
+///     MessagePack(user)
+/// }
+///
+/// async fn find_user(user_id: Uuid) -> User {
+///     // ...
+///     # unimplemented!()
+/// }
+///
+/// let app = Router::new().route("/users/:id", get(get_user));
+/// # async {
+/// # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
+/// # };
+/// ```
+#[derive(Debug, Clone, Copy, Default)]
+#[cfg_attr(docsrs, doc(cfg(feature = "messagepack")))]
+pub struct MessagePack<T>(pub T);
+
+#[async_trait]
+impl<T, B> FromRequest<B> for MessagePack<T> 
+where 
+    T: DeserializeOwned,
+    B: HttpBody + Send,
+    B::Data: Send,
+    B::Error: Into<BoxError>,
+{
+    type Rejection = MessagePackRejection;
+
+    async fn from_request(req: &mut RequestParts<B>) -> Result<Self, Self::Rejection> {
+        if message_pack_content_type(req)? {
+            let bytes = Bytes::from_request(req).await?;
+            
+            let value = rmp_serde::from_read_ref(&bytes)
+                .map_err(InvalidMessagePackBody::from_err)?;
+
+            Ok(MessagePack(value))
+        } else {
+            Err(MissingMessagePackContentType.into())
+        }
+    }
+}
+
+fn message_pack_content_type<B>(req: &RequestParts<B>) -> Result<bool, HeadersAlreadyExtracted> {
+    let content_type = if let Some(content_type) = req 
+        .headers()
+        .ok_or_else(HeadersAlreadyExtracted::default)?
+        .get(header::CONTENT_TYPE) {
+            content_type
+        } else {
+            return Ok(false)
+        };
+
+    let content_type = if let Ok(content_type) = content_type.to_str() {
+        content_type
+    } else {
+        return Ok(false)
+    };
+
+    let mime = if let Ok(mime) = content_type.parse::<mime::Mime>() {
+        mime
+    } else {
+        return Ok(false)
+    };
+
+    let is_rmp = mime.type_() == "application" && (
+        ["msgpack", "x-msgpack"].iter()
+            .any(|subtype| *subtype == mime.subtype()) ||
+        mime.suffix().map_or(false, |suffix| suffix == "msgpack"));
+
+    Ok(is_rmp)
+}
+
+impl<T> Deref for MessagePack<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T> DerefMut for MessagePack<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<T> From<T> for MessagePack<T> {
+    fn from(inner: T) -> Self {
+        Self(inner)
+    }
+}
+
+impl<T> IntoResponse for MessagePack<T> 
+    where 
+        T: Serialize,
+{
+    fn into_response(self) -> Response {
+        let bytes = match rmp_serde::to_vec(&self.0) {
+            Ok(bytes) => bytes,
+            Err(err) => {
+                return Response::builder()
+                    .status(StatusCode::INTERNAL_SERVER_ERROR)
+                    .header(header::CONTENT_TYPE, HeaderValue::from_static(mime::TEXT_PLAIN_UTF_8.as_ref()))
+                    .body(body::boxed(Full::from(err.to_string())))
+                    .unwrap();
+            },
+        };
+
+        let mut res = Response::new(body::boxed(Full::from(bytes)));
+        res.headers_mut()
+            .insert(header::CONTENT_TYPE, HeaderValue::from_static(mime::MSGPACK.as_ref()));
+
+        res
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{routing::post, test_helpers::*, Router};
+    use serde::Deserialize;
+
+    #[derive(Debug, Serialize, Deserialize)]
+    struct Input {
+        foo: String,
+    }
+
+    #[tokio::test]
+    async fn deserialize_body() {
+        let app = Router::new().route("/", post(|input: MessagePack<Input>| async { input.0.foo }));
+        let client = TestClient::new(app);
+        let body = rmp_serde::to_vec(&Input {foo: "bar".into()}).expect("Failed to serialize to MessagePack");
+        let res = client.post("/").body(body).header("Content-Type", "application/msgpack").send().await;
+
+        let body = res.text().await;
+
+        assert_eq!(body, "bar");
+    }
+
+    #[tokio::test]
+    async fn consume_body_to_messagepack_requires_messagepack_content_type() {
+
+        let app = Router::new().route("/", post(|input: MessagePack<Input>| async { input.0.foo }));
+
+        let client = TestClient::new(app);
+        let body = rmp_serde::to_vec(&Input {foo: "bar".into()}).expect("Failed to serialize to MessagePack");
+        let res = client.post("/").body(body).send().await;
+
+        let status = res.status();
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn json_content_types() {
+        async fn valid_json_content_type(content_type: &str) -> bool {
+            println!("testing {:?}", content_type);
+            let body = rmp_serde::to_vec(&Input {foo: "bar".into()}).expect("Failed to serialize to MessagePack");
+            let app = Router::new().route("/", post(|MessagePack(_): MessagePack<Input>| async {}));
+
+            let res = TestClient::new(app)
+                .post("/")
+                .header("content-type", content_type)
+                .body(body)
+                .send()
+                .await;
+
+            res.status() == StatusCode::OK
+        }
+
+        assert!(valid_json_content_type("application/msgpack").await);
+        assert!(valid_json_content_type("application/msgpack; charset=utf-8").await);
+        assert!(valid_json_content_type("application/msgpack;charset=utf-8").await);
+        assert!(valid_json_content_type("application/cloudevents+msgpack").await);
+        assert!(!valid_json_content_type("text/json").await);
+    }
+}


### PR DESCRIPTION
TL;DR: Adds [`MessagePack`](https://msgpack.org/index.html) extractor via [rmp-serde](https://docs.rs/rmp-serde/latest/rmp_serde)

## Motivation

Using `axum` in a couple of projects and liking it a lot. Since I use it with `MessagePack`, decided to add extractor for the format. Given that `MessagePack` is not as ubiquitous as `JSON`, gated by feature flag. 

## Solution

Following implementation of `Json` extractor added similar functionality, docs & tests for `MessagePack`.
