### PR TITLE
Update to changed compiler error in 1.58

### DIFF
--- a/axum-debug/tests/fail/not_send.stderr
+++ b/axum-debug/tests/fail/not_send.stderr
@@ -4,7 +4,7 @@ error: future cannot be sent between threads safely
 4 | async fn handler() {
   | ^^^^^ future returned by `handler` is not `Send`
   |
-  = help: within `impl Future`, the trait `Send` is not implemented for `Rc<()>`
+  = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `Rc<()>`
 note: future is not `Send` as this value is used across an await
  --> tests/fail/not_send.rs:6:5
   |


### PR DESCRIPTION
The trybuild tests needed to be updated for 1.58. We only run the tests
on stable (but build on other toolchains).