### PR TITLE
Fix path route in extractor docs

### DIFF
--- a/axum/src/docs/extract.md
+++ b/axum/src/docs/extract.md
@@ -82,7 +82,7 @@ async fn extension(Extension(state): Extension<State>) {}
 struct State { /* ... */ }
 
 let app = Router::new()
-    .route("/path", post(path))
+    .route("/path/:user_id", post(path))
     .route("/query", post(query))
     .route("/user_agent", post(user_agent))
     .route("/headers", post(headers))


### PR DESCRIPTION
## Motivation

The [extract](https://docs.rs/axum/latest/axum/extract/index.html#common-extractors) docs suggest that you don't need `path/:variable` in path extractor routes but actually you do.

## Solution

Add `:user_id` to the path of the route.
