### PR TITLE
Change `TestClient` to not follow redirects

### DIFF
--- a/axum/src/routing/tests/mod.rs
+++ b/axum/src/routing/tests/mod.rs
@@ -321,9 +321,9 @@ async fn with_trailing_slash() {
 
     let client = TestClient::new(app);
 
-    // `TestClient` automatically follows redirects
     let res = client.get("/foo/").send().await;
-    assert_eq!(res.status(), StatusCode::OK);
+    assert_eq!(res.status(), StatusCode::PERMANENT_REDIRECT);
+    assert_eq!(res.headers().get("location").unwrap(), "/foo");
 }
 
 #[tokio::test]
@@ -332,9 +332,9 @@ async fn without_trailing_slash() {
 
     let client = TestClient::new(app);
 
-    // `TestClient` automatically follows redirects
     let res = client.get("/foo").send().await;
-    assert_eq!(res.status(), StatusCode::OK);
+    assert_eq!(res.status(), StatusCode::PERMANENT_REDIRECT);
+    assert_eq!(res.headers().get("location").unwrap(), "/foo/");
 }
 
 #[tokio::test]
@@ -363,7 +363,8 @@ async fn with_trailing_slash_post() {
 
     // `TestClient` automatically follows redirects
     let res = client.post("/foo/").send().await;
-    assert_eq!(res.status(), StatusCode::OK);
+    assert_eq!(res.status(), StatusCode::PERMANENT_REDIRECT);
+    assert_eq!(res.headers().get("location").unwrap(), "/foo");
 }
 
 // for https://github.com/tokio-rs/axum/issues/681
@@ -373,9 +374,9 @@ async fn without_trailing_slash_post() {
 
     let client = TestClient::new(app);
 
-    // `TestClient` automatically follows redirects
     let res = client.post("/foo").send().await;
-    assert_eq!(res.status(), StatusCode::OK);
+    assert_eq!(res.status(), StatusCode::PERMANENT_REDIRECT);
+    assert_eq!(res.headers().get("location").unwrap(), "/foo/");
 }
 
 // for https://github.com/tokio-rs/axum/issues/420

--- a/axum/src/test_helpers.rs
+++ b/axum/src/test_helpers.rs
@@ -45,10 +45,12 @@ impl TestClient {
             server.await.expect("server error");
         });
 
-        TestClient {
-            client: reqwest::Client::new(),
-            addr,
-        }
+        let client = reqwest::Client::builder()
+            .redirect(reqwest::redirect::Policy::none())
+            .build()
+            .unwrap();
+
+        TestClient { client, addr }
     }
 
     pub(crate) fn get(&self, url: &str) -> RequestBuilder {


### PR DESCRIPTION
I did this while experimenting with possible solutions for https://github.com/tokio-rs/axum/issues/714 but I think this change makes sense on its own.

No external behavior is changed, it just makes the tests more clear.