### PR TITLE
Move `Headers` into axum

### DIFF
--- a/axum-core/src/response/mod.rs
+++ b/axum-core/src/response/mod.rs
@@ -144,38 +144,17 @@ pub trait IntoResponse {
 }
 
 /// Trait for generating response headers.
-///
-
-/// **Note: If you see this trait not being implemented in an error message, you are almost
-/// certainly being mislead by the compiler¹. Look for the following snippet in the output and
-/// check [`IntoResponse`]'s documentation if you find it:**
-///
-/// ```text
-/// note: required because of the requirements on the impl of `IntoResponse` for `<type>`
-/// ```
-///
-/// Any type that implements this trait automatically implements `IntoResponse` as well, but can
-/// also be used in a tuple like `(StatusCode, Self)`, `(Self, impl IntoResponseHeaders)`,
-/// `(StatusCode, Self, impl IntoResponseHeaders, impl IntoResponse)` and so on.
-///
-/// This trait can't currently be implemented outside of axum.
-///
-/// ¹ See also [this rustc issue](https://github.com/rust-lang/rust/issues/22590)
 pub trait IntoResponseHeaders {
-    /// The return type of [`.into_headers()`].
+    /// The return type of `into_headers`.
     ///
-    /// The iterator item is a `Result` to allow the implementation to return a server error
+    /// The iterator item is a [`Result`] to allow the implementation to return a server error
     /// instead.
     ///
-    /// The header name is optional because `HeaderMap`s iterator doesn't yield it multiple times
+    /// The header name is optional because [`HeaderMap`]s iterator doesn't yield it multiple times
     /// for headers that have multiple values, to avoid unnecessary copies.
-    #[doc(hidden)]
     type IntoIter: IntoIterator<Item = Result<(Option<HeaderName>, HeaderValue), Response>>;
 
     /// Attempt to turn `self` into a list of headers.
-    ///
-    /// In practice, only the implementation for `axum::response::Headers` ever returns `Err(_)`.
-    #[doc(hidden)]
     fn into_headers(self) -> Self::IntoIter;
 }
 

--- a/axum-core/src/response/mod.rs
+++ b/axum-core/src/response/mod.rs
@@ -19,11 +19,6 @@ use http_body::{
 };
 use std::{borrow::Cow, convert::Infallible, iter};
 
-mod headers;
-
-#[doc(inline)]
-pub use self::headers::Headers;
-
 /// Type alias for [`http::Response`] whose body type defaults to [`BoxBody`], the most common body
 /// type used with axum.
 pub type Response<T = BoxBody> = http::Response<T>;
@@ -356,17 +351,10 @@ impl IntoResponse for StatusCode {
     }
 }
 
-impl<H> IntoResponse for H
-where
-    H: IntoResponseHeaders,
-{
+impl IntoResponse for HeaderMap {
     fn into_response(self) -> Response {
         let mut res = Response::new(boxed(Empty::new()));
-
-        if let Err(e) = try_extend_headers(res.headers_mut(), self.into_headers()) {
-            return e;
-        }
-
+        *res.headers_mut() = self;
         res
     }
 }

--- a/axum-core/src/response/mod.rs
+++ b/axum-core/src/response/mod.rs
@@ -152,9 +152,11 @@ pub trait IntoResponseHeaders {
     ///
     /// The header name is optional because [`HeaderMap`]s iterator doesn't yield it multiple times
     /// for headers that have multiple values, to avoid unnecessary copies.
+    #[doc(hidden)]
     type IntoIter: IntoIterator<Item = Result<(Option<HeaderName>, HeaderValue), Response>>;
 
     /// Attempt to turn `self` into a list of headers.
+    #[doc(hidden)]
     fn into_headers(self) -> Self::IntoIter;
 }
 

--- a/axum-debug/src/lib.rs
+++ b/axum-debug/src/lib.rs
@@ -89,34 +89,6 @@
 //! async fn handler(request: Request<BoxBody>) {}
 //! ```
 //!
-//! # Known limitations
-//!
-//! If your response type doesn't implement `IntoResponse`, you will get a slightly confusing error
-//! message:
-//!
-//! ```text
-//! error[E0277]: the trait bound `bool: axum_core::response::IntoResponseHeaders` is not satisfied
-//!  --> tests/fail/wrong_return_type.rs:4:23
-//!   |
-//! 4 | async fn handler() -> bool {
-//!   |                       ^^^^ the trait `axum_core::response::IntoResponseHeaders` is not implemented for `bool`
-//!   |
-//!   = note: required because of the requirements on the impl of `IntoResponse` for `bool`
-//! note: required by a bound in `__axum_debug_check_handler_into_response::{closure#0}::check`
-//!  --> tests/fail/wrong_return_type.rs:4:23
-//!   |
-//! 4 | async fn handler() -> bool {
-//!   |                       ^^^^ required by this bound in `__axum_debug_check_handler_into_response::{closure#0}::check`
-//! ```
-//!
-//! The main error message when `IntoResponse` isn't implemented will also ways be for a different
-//! trait, `IntoResponseHeaders`, not being implemented. This trait is not meant to be implemented
-//! for types outside of axum and what you really need to do is change your return type or implement
-//! `IntoResponse` for it (if it is your own type that you want to return directly from handlers).
-//!
-//! This issue is not specific to axum and cannot be fixed by us. For more details, see the
-//! [rustc issue about it](https://github.com/rust-lang/rust/issues/22590).
-//!
 //! # Performance
 //!
 //! Macros in this crate have no effect when using release profile. (eg. `cargo build --release`)

--- a/axum-debug/tests/fail/wrong_return_type.stderr
+++ b/axum-debug/tests/fail/wrong_return_type.stderr
@@ -1,10 +1,9 @@
-error[E0277]: the trait bound `bool: axum_core::response::IntoResponseHeaders` is not satisfied
+error[E0277]: the trait bound `bool: IntoResponse` is not satisfied
  --> tests/fail/wrong_return_type.rs:4:23
   |
 4 | async fn handler() -> bool {
-  |                       ^^^^ the trait `axum_core::response::IntoResponseHeaders` is not implemented for `bool`
+  |                       ^^^^ the trait `IntoResponse` is not implemented for `bool`
   |
-  = note: required because of the requirements on the impl of `IntoResponse` for `bool`
 note: required by a bound in `__axum_debug_check_handler_into_response::{closure#0}::check`
  --> tests/fail/wrong_return_type.rs:4:23
   |

--- a/axum/src/response/headers.rs
+++ b/axum/src/response/headers.rs
@@ -68,6 +68,19 @@ where
     }
 }
 
+impl<H, K, V> IntoResponse for Headers<H>
+where
+    H: IntoIterator<Item = (K, V)>,
+    K: TryInto<HeaderName>,
+    K::Error: fmt::Display,
+    V: TryInto<HeaderValue>,
+    V::Error: fmt::Display,
+{
+    fn into_response(self) -> Response {
+        (self, ()).into_response()
+    }
+}
+
 #[doc(hidden)]
 #[derive(Debug)]
 pub struct IntoIter<H> {
@@ -124,7 +137,7 @@ mod tests {
         let res = (Headers(vec![("user-agent", "axum")]), "foo").into_response();
 
         assert_eq!(res.headers()["user-agent"], "axum");
-        let body = crate::body::to_bytes(res.into_body())
+        let body = hyper::body::to_bytes(res.into_body())
             .now_or_never()
             .unwrap()
             .unwrap();
@@ -142,7 +155,7 @@ mod tests {
 
         assert_eq!(res.headers()["user-agent"], "axum");
         assert_eq!(res.status(), StatusCode::NOT_FOUND);
-        let body = crate::body::to_bytes(res.into_body())
+        let body = hyper::body::to_bytes(res.into_body())
             .now_or_never()
             .unwrap()
             .unwrap();

--- a/axum/src/response/mod.rs
+++ b/axum/src/response/mod.rs
@@ -4,6 +4,7 @@ use crate::body::{Bytes, Full};
 use axum_core::body::boxed;
 use http::{header, HeaderValue};
 
+mod headers;
 mod redirect;
 
 pub mod sse;
@@ -13,10 +14,10 @@ pub mod sse;
 pub use crate::Json;
 
 #[doc(inline)]
-pub use axum_core::response::{Headers, IntoResponse, Response};
+pub use axum_core::response::{IntoResponse, IntoResponseHeaders, Response};
 
 #[doc(inline)]
-pub use self::{redirect::Redirect, sse::Sse};
+pub use self::{headers::Headers, redirect::Redirect, sse::Sse};
 
 /// An HTML response.
 ///


### PR DESCRIPTION
- Moves `Headers` from axum-core and into axum.
- Removes the blanket `impl<H> IntoResponse for H where H: IntoResponseHeaders`. This really hurt the error message from `#[debug_handler]` as it would mention the `IntoResponseHeaders` trait instead of `IntoResponse`.
- Implement `IntoResponse` for `HeaderMap` and `Headers`. Having to do this is a bit unfortunate but I'd rather have the better error message for `#[debug_handler]`.
- This also means `IntoResponseHeaders` can be implemented outside of axum-core. I guess thats fine 🤷 