### PR TITLE
Move `middleware::from_fn` into axum

### DIFF
--- a/axum-extra/CHANGELOG.md
+++ b/axum-extra/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **fix:** Depend on tower with `default_features = false` ([#666])
 - **breaking:** `CachedRejection` has been removed ([#699])
 - **breaking:** `<Cached<T> as FromRequest>::Error` is now `T::Rejection`. ([#699])
+- **breaking:** `middleware::from_fn` has been moved into the main axum crate
 
 [#666]: https://github.com/tokio-rs/axum/pull/666
 [#699]: https://github.com/tokio-rs/axum/pull/699

--- a/axum-extra/CHANGELOG.md
+++ b/axum-extra/CHANGELOG.md
@@ -14,10 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **fix:** Depend on tower with `default_features = false` ([#666])
 - **breaking:** `CachedRejection` has been removed ([#699])
 - **breaking:** `<Cached<T> as FromRequest>::Error` is now `T::Rejection`. ([#699])
-- **breaking:** `middleware::from_fn` has been moved into the main axum crate
+- **breaking:** `middleware::from_fn` has been moved into the main axum crate ([#719])
 
 [#666]: https://github.com/tokio-rs/axum/pull/666
 [#699]: https://github.com/tokio-rs/axum/pull/699
+[#719]: https://github.com/tokio-rs/axum/pull/719
 
 # 0.1.1 (27. December, 2021)
 

--- a/axum-extra/Cargo.toml
+++ b/axum-extra/Cargo.toml
@@ -20,7 +20,7 @@ http = "0.2"
 mime = "0.3"
 pin-project-lite = "0.2"
 tower = { version = "0.4", default_features = false, features = ["util"] }
-tower-http = { version = "0.2", features = ["util", "map-response-body"] }
+tower-http = { version = "0.2", features = ["map-response-body"] }
 tower-layer = "0.3"
 tower-service = "0.3"
 

--- a/axum-extra/src/lib.rs
+++ b/axum-extra/src/lib.rs
@@ -44,6 +44,5 @@
 #![cfg_attr(test, allow(clippy::float_cmp))]
 
 pub mod extract;
-pub mod middleware;
 pub mod response;
 pub mod routing;

--- a/axum-extra/src/middleware/mod.rs
+++ b/axum-extra/src/middleware/mod.rs
@@ -1,5 +1,0 @@
-//! Additional types for creating middleware.
-
-pub mod middleware_fn;
-
-pub use self::middleware_fn::{from_fn, Next};

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -7,8 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
-- **added:** `axum_extra::middleware::from_fn` has been moved into the main axum crate. It is used
-  to easily crate a middleware from an async function ([#719])
+- **added:** `middleware::from_fn` for creating middleware from async functions.
+  This previously lived in axum-extra but has been moved to axum ([#719])
 - **breaking:** `sse::Event` now accepts types implementing `AsRef<str>` instead of `Into<String>`
   as field values.
 - **breaking:** `sse::Event` now panics if a setter method is called twice instead of silently

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
+- **added:** `axum_extra::middleware::from_fn` has been moved into the main axum crate. It is used
+  to easily crate a middleware from an async function
 - **breaking:** `sse::Event` now accepts types implementing `AsRef<str>` instead of `Into<String>`
   as field values.
 - **breaking:** `sse::Event` now panics if a setter method is called twice instead of silently

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # Unreleased
 
 - **added:** `axum_extra::middleware::from_fn` has been moved into the main axum crate. It is used
-  to easily crate a middleware from an async function
+  to easily crate a middleware from an async function ([#719])
 - **breaking:** `sse::Event` now accepts types implementing `AsRef<str>` instead of `Into<String>`
   as field values.
 - **breaking:** `sse::Event` now panics if a setter method is called twice instead of silently
@@ -59,6 +59,7 @@ is mentioned here.
 [#665]: https://github.com/tokio-rs/axum/pull/665
 [#698]: https://github.com/tokio-rs/axum/pull/698
 [#699]: https://github.com/tokio-rs/axum/pull/699
+[#719]: https://github.com/tokio-rs/axum/pull/719
 
 # 0.4.4 (13. January, 2021)
 

--- a/axum/Cargo.toml
+++ b/axum/Cargo.toml
@@ -42,7 +42,7 @@ sync_wrapper = "0.1.1"
 tokio = { version = "1", features = ["time"] }
 tokio-util = "0.6"
 tower = { version = "0.4.11", default-features = false, features = ["util", "buffer", "make"] }
-tower-http = { version = "0.2.0", features = ["map-response-body"] }
+tower-http = { version = "0.2.0", features = ["util", "map-response-body"] }
 tower-layer = "0.3"
 tower-service = "0.3"
 

--- a/axum/src/lib.rs
+++ b/axum/src/lib.rs
@@ -466,6 +466,7 @@ pub mod body;
 pub mod error_handling;
 pub mod extract;
 pub mod handler;
+pub mod middleware;
 pub mod response;
 pub mod routing;
 

--- a/axum/src/middleware/mod.rs
+++ b/axum/src/middleware/mod.rs
@@ -1,0 +1,5 @@
+//! Utilities for writing middleware
+
+mod from_fn;
+
+pub use self::from_fn::{from_fn, FromFn, FromFnLayer, Next};

--- a/examples/print-request-response/src/main.rs
+++ b/examples/print-request-response/src/main.rs
@@ -7,11 +7,11 @@
 use axum::{
     body::{Body, Bytes},
     http::{Request, StatusCode},
+    middleware::{self, Next},
     response::{IntoResponse, Response},
     routing::post,
     Router,
 };
-use axum_extra::middleware::{self, Next};
 use std::net::SocketAddr;
 
 #[tokio::main]

--- a/examples/prometheus-metrics/src/main.rs
+++ b/examples/prometheus-metrics/src/main.rs
@@ -7,8 +7,14 @@
 //! cargo run -p example-prometheus-metrics
 //! ```
 
-use axum::{extract::MatchedPath, http::Request, response::IntoResponse, routing::get, Router};
-use axum_extra::middleware::{self, Next};
+use axum::{
+    extract::MatchedPath,
+    http::Request,
+    middleware::{self, Next},
+    response::IntoResponse,
+    routing::get,
+    Router,
+};
 use metrics_exporter_prometheus::{Matcher, PrometheusBuilder, PrometheusHandle};
 use std::{
     future::ready,


### PR DESCRIPTION
I've been very happy with `axum_extra::middleware::from_fn` so for 0.5 I think we should move it into the main axum crate.

Also renamed the type from `MiddlewareFn` to `FromFn` to match std's `std::iter::FromFn`.