### PR TITLE
Set `content-length` for responses to `HEAD` requests

### DIFF
--- a/axum-extra/src/routing/mod.rs
+++ b/axum-extra/src/routing/mod.rs
@@ -36,7 +36,7 @@ pub trait RouterExt<B>: sealed::Sealed {
 
 impl<B> RouterExt<B> for Router<B>
 where
-    B: Send + 'static,
+    B: axum::body::HttpBody + Send + 'static,
 {
     fn with<T>(self, routes: T) -> Self
     where

--- a/axum-extra/src/routing/resource.rs
+++ b/axum-extra/src/routing/resource.rs
@@ -54,7 +54,10 @@ pub struct Resource<B = Body> {
     pub(crate) router: Router<B>,
 }
 
-impl<B: Send + 'static> Resource<B> {
+impl<B> Resource<B>
+where
+    B: axum::body::HttpBody + Send + 'static,
+{
     /// Create a `Resource` with the given name.
     ///
     /// All routes will be nested at `/{resource_name}`.

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -51,15 +51,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
         - `PathRejection`
         - `MatchedPathRejection`
         - `WebSocketUpgradeRejection`
-- **fixed:** Set `Allow` header when responding with `405 Method Not Allowed`
+- **fixed:** Set `Allow` header when responding with `405 Method Not Allowed` ([#733])
 - **fixed:** Correctly set the `Content-Length` header for response to `HEAD`
-  requests
+  requests ([#734])
 
 [#644]: https://github.com/tokio-rs/axum/pull/644
 [#665]: https://github.com/tokio-rs/axum/pull/665
 [#698]: https://github.com/tokio-rs/axum/pull/698
 [#699]: https://github.com/tokio-rs/axum/pull/699
 [#719]: https://github.com/tokio-rs/axum/pull/719
+[#733]: https://github.com/tokio-rs/axum/pull/733
+[#734]: https://github.com/tokio-rs/axum/pull/734
 
 # 0.4.4 (13. January, 2022)
 

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -52,6 +52,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
         - `MatchedPathRejection`
         - `WebSocketUpgradeRejection`
 - **fixed:** Set `Allow` header when responding with `405 Method Not Allowed`
+- **fixed:** Correctly set the `Content-Length` header for response to `HEAD`
+  requests
 
 [#644]: https://github.com/tokio-rs/axum/pull/644
 [#665]: https://github.com/tokio-rs/axum/pull/665

--- a/axum/src/routing/future.rs
+++ b/axum/src/routing/future.rs
@@ -1,26 +1,21 @@
 //! Future types.
 
 use crate::response::Response;
-use futures_util::future::Either;
-use std::{convert::Infallible, future::ready};
+use std::convert::Infallible;
 
 pub use super::{into_make_service::IntoMakeServiceFuture, route::RouteFuture};
 
 opaque_future! {
     /// Response future for [`Router`](super::Router).
-    pub type RouterFuture<B> =
-        futures_util::future::Either<
-            RouteFuture<B, Infallible>,
-            std::future::Ready<Result<Response, Infallible>>,
-        >;
+    pub type RouterFuture<B> = RouteFuture<B, Infallible>;
 }
 
 impl<B> RouterFuture<B> {
     pub(super) fn from_future(future: RouteFuture<B, Infallible>) -> Self {
-        Self::new(Either::Left(future))
+        Self::new(future)
     }
 
     pub(super) fn from_response(response: Response) -> Self {
-        Self::new(Either::Right(ready(Ok(response))))
+        Self::new(RouteFuture::from_response(response))
     }
 }

--- a/axum/src/routing/mod.rs
+++ b/axum/src/routing/mod.rs
@@ -81,7 +81,7 @@ impl<B> Clone for Router<B> {
 
 impl<B> Default for Router<B>
 where
-    B: Send + 'static,
+    B: HttpBody + Send + 'static,
 {
     fn default() -> Self {
         Self::new()
@@ -93,7 +93,7 @@ const NEST_TAIL_PARAM_CAPTURE: &str = "/*axum_nest";
 
 impl<B> Router<B>
 where
-    B: Send + 'static,
+    B: HttpBody + Send + 'static,
 {
     /// Create a new `Router`.
     ///
@@ -162,7 +162,6 @@ where
     where
         T: Service<Request<B>, Response = Response, Error = Infallible> + Clone + Send + 'static,
         T::Future: Send + 'static,
-        B: HttpBody,
     {
         if path.is_empty() {
             // nesting at `""` and `"/"` should mean the same thing
@@ -236,10 +235,7 @@ where
     }
 
     #[doc = include_str!("../docs/routing/merge.md")]
-    pub fn merge(mut self, other: Router<B>) -> Self
-    where
-        B: HttpBody,
-    {
+    pub fn merge(mut self, other: Router<B>) -> Self {
         let Router {
             routes,
             node,
@@ -400,10 +396,7 @@ where
     }
 
     #[inline]
-    fn call_route(&self, match_: matchit::Match<&RouteId>, mut req: Request<B>) -> RouterFuture<B>
-    where
-        B: HttpBody,
-    {
+    fn call_route(&self, match_: matchit::Match<&RouteId>, mut req: Request<B>) -> RouterFuture<B> {
         let id = *match_.value;
         req.extensions_mut().insert(id);
 

--- a/axum/src/routing/mod.rs
+++ b/axum/src/routing/mod.rs
@@ -162,6 +162,7 @@ where
     where
         T: Service<Request<B>, Response = Response, Error = Infallible> + Clone + Send + 'static,
         T::Future: Send + 'static,
+        B: HttpBody,
     {
         if path.is_empty() {
             // nesting at `""` and `"/"` should mean the same thing
@@ -235,7 +236,10 @@ where
     }
 
     #[doc = include_str!("../docs/routing/merge.md")]
-    pub fn merge(mut self, other: Router<B>) -> Self {
+    pub fn merge(mut self, other: Router<B>) -> Self
+    where
+        B: HttpBody,
+    {
         let Router {
             routes,
             node,
@@ -396,7 +400,10 @@ where
     }
 
     #[inline]
-    fn call_route(&self, match_: matchit::Match<&RouteId>, mut req: Request<B>) -> RouterFuture<B> {
+    fn call_route(&self, match_: matchit::Match<&RouteId>, mut req: Request<B>) -> RouterFuture<B>
+    where
+        B: HttpBody,
+    {
         let id = *match_.value;
         req.extensions_mut().insert(id);
 
@@ -461,7 +468,7 @@ where
 
 impl<B> Service<Request<B>> for Router<B>
 where
-    B: Send + 'static,
+    B: HttpBody + Send + 'static,
 {
     type Response = Response;
     type Error = Infallible;

--- a/axum/src/test_helpers.rs
+++ b/axum/src/test_helpers.rs
@@ -59,6 +59,12 @@ impl TestClient {
         }
     }
 
+    pub(crate) fn head(&self, url: &str) -> RequestBuilder {
+        RequestBuilder {
+            builder: self.client.head(format!("http://{}{}", self.addr, url)),
+        }
+    }
+
     pub(crate) fn post(&self, url: &str) -> RequestBuilder {
         RequestBuilder {
             builder: self.client.post(format!("http://{}{}", self.addr, url)),


### PR DESCRIPTION
Hyper will automatically set the length if the body as an exact size, as determined via [`Body::size_hint`](https://docs.rs/http-body/latest/http_body/trait.Body.html#method.size_hint), but since axum would use an empty body for `HEAD` requests the `content-length` would be set to 0 instead of the length of the original response body.

This fixes that by having axum set the `content-length` before removing the body.

I also changed `RouteFuture` to be the future we return regardless if we hit a route or the fallback. That way we only had to make this change in one place.

Required adding some `B: HttpBody` bounds in a few places so we can call `size_hint` but hyper already requires that so its unlikely to cause breakage.

Fixes https://github.com/tokio-rs/axum/issues/730