### PR TITLE
axum-debug: Version 0.3.3

### DIFF
--- a/axum-debug/CHANGELOG.md
+++ b/axum-debug/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - None.
 
+# 0.3.3 (31. January 2022)
+
+- This crate is now deprecated. It continues to work but wont receive further
+  updates. Use [axum-macros](https://crates.io/crates/axum-macros) instead.
+
 # 0.3.2 (09. December 2021)
 
 - Support checking `FromRequest` bounds for extractors whose request body is something else than

--- a/axum-debug/Cargo.toml
+++ b/axum-debug/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 name = "axum-debug"
 readme = "README.md"
 repository = "https://github.com/tokio-rs/axum"
-version = "0.3.2"
+version = "0.3.3"
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
No code changes. Just a note in the changelog that the crate is deprecated now that [axum-macros is published](https://crates.io/crates/axum-macros).