### PR TITLE
Reference axum-macros instead of axum-debug

### DIFF
--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -8,10 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # Unreleased
 
 - Reference [axum-macros] instead of [axum-debug]. The latter has been superseded by
-  axum-macros and is deprecated
+  axum-macros and is deprecated ([#738])
 
-[axum-macros]: https://docs.rs/axum-macros
+[#738]: https://github.com/tokio-rs/axum/pull/738
 [axum-debug]: https://docs.rs/axum-debug
+[axum-macros]: https://docs.rs/axum-macros
 
 # 0.4.4 (13. January, 2021)
 

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
-- None.
+- Reference [axum-macros] instead of [axum-debug]. The latter has been superseded by
+  axum-macros and is deprecated
+
+[axum-macros]: https://docs.rs/axum-macros
+[axum-debug]: https://docs.rs/axum-debug
 
 # 0.4.4 (13. January, 2021)
 

--- a/axum/src/docs/handlers_intro.md
+++ b/axum/src/docs/handlers_intro.md
@@ -5,4 +5,4 @@ can be converted [into a response](crate::response).
 Handlers is where your application logic lives and axum applications are built
 by routing between handlers.
 
-[`debug_handler`]: https://docs.rs/axum-debug/latest/axum_debug/attr.debug_handler.html
+[`debug_handler`]: https://docs.rs/axum-macros/latest/axum_macros/attr.debug_handler.html

--- a/axum/src/handler/mod.rs
+++ b/axum/src/handler/mod.rs
@@ -66,9 +66,9 @@
 //!
 //! This error doesn't tell you _why_ your function doesn't implement
 //! [`Handler`]. It's possible to improve the error with the [`debug_handler`]
-//! proc-macro from the [axum-debug] crate.
+//! proc-macro from the [axum-macros] crate.
 //!
-//! [axum-debug]: https://docs.rs/axum-debug
+//! [axum-macros]: https://docs.rs/axum-macros
 
 use crate::{
     body::{boxed, Body, Bytes, HttpBody},

--- a/axum/src/lib.rs
+++ b/axum/src/lib.rs
@@ -403,8 +403,8 @@
 //! [`HeaderMap`]: http::header::HeaderMap
 //! [`Request`]: http::Request
 //! [customize-extractor-error]: https://github.com/tokio-rs/axum/blob/main/examples/customize-extractor-error/src/main.rs
-//! [axum-debug]: https://docs.rs/axum-debug
-//! [`debug_handler`]: https://docs.rs/axum-debug/latest/axum_debug/attr.debug_handler.html
+//! [axum-macros]: https://docs.rs/axum-macros
+//! [`debug_handler`]: https://docs.rs/axum-macros/latest/axum_macros/attr.debug_handler.html
 //! [`Handler`]: crate::handler::Handler
 //! [`Infallible`]: std::convert::Infallible
 //! [load shed]: tower::load_shed


### PR DESCRIPTION
This goes into the `v0.4.x` branch for backports.