### PR TITLE
Update dependencies

### DIFF
--- a/axum/Cargo.toml
+++ b/axum/Cargo.toml
@@ -51,7 +51,7 @@ base64 = { optional = true, version = "0.13" }
 headers = { optional = true, version = "0.3" }
 multer = { optional = true, version = "2.0.0" }
 serde_json = { version = "1.0", optional = true, features = ["raw_value"] }
-sha-1 = { optional = true, version = "0.9.6" }
+sha-1 = { optional = true, version = "0.10" }
 tokio-tungstenite = { optional = true, version = "0.16" }
 
 [dev-dependencies]

--- a/deny.toml
+++ b/deny.toml
@@ -35,14 +35,13 @@ license-files = [
 [bans]
 multiple-versions = "deny"
 highlight = "all"
-skip-tree = []
-skip = [
-    # rustls uses old version (dev dep)
-    { name = "spin", version = "=0.5.2" },
-    { name = "webpki", version = "=0.21.4" },
-    # pulled in by hyper, http, and serde_urlencoded
-    { name = "itoa", version = "=0.4.8" },
+skip-tree = [
+    # these crates are only used in examples
+    { name = "sqlx" },
+    { name = "async-graphql" },
+    { name = "axum-server" },
 ]
+skip = []
 
 [sources]
 unknown-registry = "warn"

--- a/deny.toml
+++ b/deny.toml
@@ -40,8 +40,13 @@ skip-tree = [
     { name = "sqlx" },
     { name = "async-graphql" },
     { name = "axum-server" },
+    # remove when tungstenite has had a new release
+    # https://github.com/snapview/tungstenite-rs/issues/262
+    { name = "tungstenite" },
 ]
-skip = []
+skip = [
+    { name = "spin", version = "=0.5.2" },
+]
 
 [sources]
 unknown-registry = "warn"

--- a/examples/async-graphql/Cargo.toml
+++ b/examples/async-graphql/Cargo.toml
@@ -8,6 +8,6 @@ publish = false
 axum = { path = "../../axum" }
 tokio = { version = "1.0", features = ["full"] }
 tracing = "0.1"
-tracing-subscriber = { version="0.3", features = ["env-filter"] }
-async-graphql = "2.9.9"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+async-graphql = "3.0"
 slab = "0.4.3"

--- a/examples/async-graphql/src/starwars/model.rs
+++ b/examples/async-graphql/src/starwars/model.rs
@@ -181,7 +181,7 @@ async fn query_characters(
 
             if let Some(after) = after {
                 if after >= characters.len() {
-                    return Ok(Connection::new(false, false));
+                    return Ok::<_, async_graphql::Error>(Connection::new(false, false));
                 }
                 start = after + 1;
             }

--- a/examples/jwt/Cargo.toml
+++ b/examples/jwt/Cargo.toml
@@ -12,5 +12,5 @@ tracing-subscriber = { version="0.3", features = ["env-filter"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 headers = "0.3"
-jsonwebtoken = "7"
+jsonwebtoken = "8.0"
 once_cell = "1.8"

--- a/examples/jwt/src/main.rs
+++ b/examples/jwt/src/main.rs
@@ -154,17 +154,16 @@ impl IntoResponse for AuthError {
     }
 }
 
-#[derive(Debug)]
 struct Keys {
     encoding: EncodingKey,
-    decoding: DecodingKey<'static>,
+    decoding: DecodingKey,
 }
 
 impl Keys {
     fn new(secret: &[u8]) -> Self {
         Self {
             encoding: EncodingKey::from_secret(secret),
-            decoding: DecodingKey::from_secret(secret).into_static(),
+            decoding: DecodingKey::from_secret(secret),
         }
     }
 }

--- a/examples/low-level-rustls/Cargo.toml
+++ b/examples/low-level-rustls/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 axum = { path = "../../axum" }
 futures-util = "0.3"
 hyper = { version = "0.14", features = ["full"] }
-rustls-pemfile = "0.2"
+rustls-pemfile = "0.3"
 tokio = { version = "1", features = ["full"] }
 tokio-rustls = "0.23"
 tower = { version = "0.4", features = ["make"] }

--- a/examples/prometheus-metrics/Cargo.toml
+++ b/examples/prometheus-metrics/Cargo.toml
@@ -7,8 +7,8 @@ publish = false
 [dependencies]
 axum = { path = "../../axum" }
 axum-extra = { path = "../../axum-extra" }
-metrics = "0.17"
-metrics-exporter-prometheus = "0.7"
+metrics = "0.18"
+metrics-exporter-prometheus = "0.8"
 tokio = { version = "1.0", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/prometheus-metrics/src/main.rs
+++ b/examples/prometheus-metrics/src/main.rs
@@ -56,18 +56,14 @@ fn setup_metrics_recorder() -> PrometheusHandle {
         0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0,
     ];
 
-    let recorder = PrometheusBuilder::new()
+    PrometheusBuilder::new()
         .set_buckets_for_metric(
             Matcher::Full("http_requests_duration_seconds".to_string()),
             EXPONENTIAL_SECONDS,
         )
-        .build();
-
-    let recorder_handle = recorder.handle();
-
-    metrics::set_boxed_recorder(Box::new(recorder)).unwrap();
-
-    recorder_handle
+        .unwrap()
+        .install_recorder()
+        .unwrap()
 }
 
 async fn track_metrics<B>(req: Request<B>, next: Next<B>) -> impl IntoResponse {

--- a/examples/templates/Cargo.toml
+++ b/examples/templates/Cargo.toml
@@ -9,4 +9,4 @@ axum = { path = "../../axum" }
 tokio = { version = "1.0", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version="0.3", features = ["env-filter"] }
-askama = "0.10"
+askama = "0.11"


### PR DESCRIPTION
axum depended on an old version of sha-1 which could result in multiple versions being pulled in. Its an internal dependency so is safe to update.

Also updated dependencies in the examples while I was at it.

Also gonna backport this patch.