### PR TITLE
Fix setting `content-length: 0` for HEAD responses with compression middleware

### DIFF
--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -54,6 +54,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **fixed:** Set `Allow` header when responding with `405 Method Not Allowed` ([#733])
 - **fixed:** Correctly set the `Content-Length` header for response to `HEAD`
   requests ([#734])
+- **fixed:** Fix wrong `content-length` for `HEAD` requests to endpoints that returns chunked
+  responses ([#755])
 
 [#644]: https://github.com/tokio-rs/axum/pull/644
 [#665]: https://github.com/tokio-rs/axum/pull/665
@@ -62,6 +64,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#719]: https://github.com/tokio-rs/axum/pull/719
 [#733]: https://github.com/tokio-rs/axum/pull/733
 [#734]: https://github.com/tokio-rs/axum/pull/734
+[#755]: https://github.com/tokio-rs/axum/pull/755
 
 # 0.4.4 (13. January, 2022)
 

--- a/axum/src/routing/future.rs
+++ b/axum/src/routing/future.rs
@@ -1,21 +1,3 @@
 //! Future types.
 
-use crate::response::Response;
-use std::convert::Infallible;
-
 pub use super::{into_make_service::IntoMakeServiceFuture, route::RouteFuture};
-
-opaque_future! {
-    /// Response future for [`Router`](super::Router).
-    pub type RouterFuture<B> = RouteFuture<B, Infallible>;
-}
-
-impl<B> RouterFuture<B> {
-    pub(super) fn from_future(future: RouteFuture<B, Infallible>) -> Self {
-        Self::new(future)
-    }
-
-    pub(super) fn from_response(response: Response) -> Self {
-        Self::new(RouteFuture::from_response(response))
-    }
-}

--- a/axum/src/routing/method_routing.rs
+++ b/axum/src/routing/method_routing.rs
@@ -983,7 +983,7 @@ where
             ) => {
                 if $method == Method::$method_variant {
                     if let Some(svc) = $svc {
-                        return RouteFuture::from_future(svc.0.clone().oneshot($req))
+                        return RouteFuture::from_future(svc.oneshot_inner($req))
                             .strip_body($method == Method::HEAD);
                     }
                 }
@@ -1018,11 +1018,9 @@ where
         call!(req, method, TRACE, trace);
 
         let future = match fallback {
-            Fallback::Default(fallback) => {
-                RouteFuture::from_future(fallback.0.clone().oneshot(req))
-                    .strip_body(method == Method::HEAD)
-            }
-            Fallback::Custom(fallback) => RouteFuture::from_future(fallback.0.clone().oneshot(req))
+            Fallback::Default(fallback) => RouteFuture::from_future(fallback.oneshot_inner(req))
+                .strip_body(method == Method::HEAD),
+            Fallback::Custom(fallback) => RouteFuture::from_future(fallback.oneshot_inner(req))
                 .strip_body(method == Method::HEAD),
         };
 

--- a/axum/src/routing/tests/mod.rs
+++ b/axum/src/routing/tests/mod.rs
@@ -645,3 +645,36 @@ async fn head_content_length_through_hyper_server_that_hits_fallback() {
     let res = client.head("/").send().await;
     assert_eq!(res.headers()["content-length"], "3");
 }
+
+#[tokio::test]
+async fn head_with_middleware_applied() {
+    use tower_http::compression::{predicate::SizeAbove, CompressionLayer};
+
+    let app = Router::new()
+        .route("/", get(|| async { "Hello, World!" }))
+        .layer(CompressionLayer::new().compress_when(SizeAbove::new(0)));
+
+    let client = TestClient::new(app);
+
+    // send GET request
+    let res = client
+        .get("/")
+        .header("accept-encoding", "gzip")
+        .send()
+        .await;
+    assert_eq!(res.headers()["transfer-encoding"], "chunked");
+    // cannot have `transfer-encoding: chunked` and `content-length`
+    assert!(!res.headers().contains_key("content-length"));
+
+    // send HEAD request
+    let res = client
+        .head("/")
+        .header("accept-encoding", "gzip")
+        .send()
+        .await;
+    // no response body so no `transfer-encoding`
+    assert!(!res.headers().contains_key("transfer-encoding"));
+    // no content-length since we cannot know it since the response
+    // is compressed
+    assert!(!res.headers().contains_key("content-length"));
+}

--- a/deny.toml
+++ b/deny.toml
@@ -35,14 +35,13 @@ license-files = [
 [bans]
 multiple-versions = "deny"
 highlight = "all"
-skip-tree = []
-skip = [
-    # rustls uses old version (dev dep)
-    { name = "spin", version = "=0.5.2" },
-    { name = "webpki", version = "=0.21.4" },
-    # pulled in by hyper, http, and serde_urlencoded
-    { name = "itoa", version = "=0.4.8" },
+skip-tree = [
+    # these crates are only used in examples
+    { name = "sqlx" },
+    { name = "async-graphql" },
+    { name = "axum-server" },
 ]
+skip = []
 
 [sources]
 unknown-registry = "warn"

--- a/deny.toml
+++ b/deny.toml
@@ -47,7 +47,6 @@ skip-tree = [
 skip = [
     { name = "spin", version = "=0.5.2" },
 ]
-skip = []
 
 [sources]
 unknown-registry = "warn"


### PR DESCRIPTION
Fixes #747

The bug was that applying a middleware to a method router would cause the response to pass through a `RouteFuture` twice and we'd set the `content-length` and strip the response body twice. That happened because `Router::layer` wrapped things in a `Route` then called `MethodRoute::route` which also applied a `Route`.

Solved it by having `RouteFuture::poll` set a response extension and not alter the response if that is present. Its a little unfortunate to add more overhead here but couldn't think of another solution since `Router` and `MethodRouter` need to be correct and make sense on their own, and needs to support general services that might not handle `HEAD` requests correctly.

I also removed `RouterFuture` so `Router`'s response is now `RouteFuture<RequestBody, Infallible>`. The additional indirection of `RouterFuture` hasn't proven to be useful so I think its safe to remove.