### PR TITLE
remove unused `axum`'s dependency: `tokio-util`

### DIFF
--- a/axum/Cargo.toml
+++ b/axum/Cargo.toml
@@ -40,7 +40,6 @@ serde = "1.0"
 serde_urlencoded = "0.7"
 sync_wrapper = "0.1.1"
 tokio = { version = "1", features = ["time"] }
-tokio-util = "0.6"
 tower = { version = "0.4.11", default-features = false, features = ["util", "buffer", "make"] }
 tower-http = { version = "0.2.0", features = ["util", "map-response-body"] }
 tower-layer = "0.3"


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation
In `axum` crate, the `tokio-util` dependency only exists in `Cargo.toml`, it never be used in lib (`.rs` file).

## Solution
remove `tokio-util` from `axum` dependencies list

