### PR TITLE
examples(jwt): Claims.exp represents a UTC timestamp

### DIFF
--- a/examples/jwt/src/main.rs
+++ b/examples/jwt/src/main.rs
@@ -93,7 +93,8 @@ async fn authorize(Json(payload): Json<AuthPayload>) -> Result<Json<AuthBody>, A
     let claims = Claims {
         sub: "b@b.com".to_owned(),
         company: "ACME".to_owned(),
-        exp: 100000,
+        // Mandatory expiry time as UTC timestamp
+        exp: 2000000000, // May 2033
     };
     // Create the authorization token
     let token = encode(&Header::default(), &claims, &KEYS.encoding)


### PR DESCRIPTION
For the example to work, it should be an epoch value in the future.

See https://github.com/Keats/jsonwebtoken/blob/d8a33def00a61bab12aa5e94ff76d3043d4d474e/README.md?plain=1#L61

## Motivation

Running the curl commands given in the example heade did not validate the JWT.

## Solution

Adjust the Claims.exp value so it represents an epoch value in the future
