### PR TITLE
Add OpenTelemetry middleware

### DIFF
--- a/axum-extra/CHANGELOG.md
+++ b/axum-extra/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # Unreleased
 
 - **added:** Add type safe routing. See `axum_extra::routing::typed` for more details ([#756])
-- **added:** OpenTelemetry compatible middleware
+- **added:** OpenTelemetry compatible middleware ([#769])
 - **breaking:** `CachedRejection` has been removed ([#699])
 - **breaking:** `<Cached<T> as FromRequest>::Rejection` is now `T::Rejection`. ([#699])
 - **breaking:** `middleware::from_fn` has been moved into the main axum crate ([#719])
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#699]: https://github.com/tokio-rs/axum/pull/699
 [#719]: https://github.com/tokio-rs/axum/pull/719
 [#756]: https://github.com/tokio-rs/axum/pull/756
+[#769]: https://github.com/tokio-rs/axum/pull/769
 
 # 0.1.2 (13. January, 2021)
 

--- a/axum-extra/CHANGELOG.md
+++ b/axum-extra/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # Unreleased
 
 - **added:** Add type safe routing. See `axum_extra::routing::typed` for more details ([#756])
+- **added:** OpenTelemetry compatible middleware
 - **breaking:** `CachedRejection` has been removed ([#699])
 - **breaking:** `<Cached<T> as FromRequest>::Rejection` is now `T::Rejection`. ([#699])
 - **breaking:** `middleware::from_fn` has been moved into the main axum crate ([#719])

--- a/axum-extra/Cargo.toml
+++ b/axum-extra/Cargo.toml
@@ -46,8 +46,6 @@ tracing-opentelemetry = { version = "0.17", optional = true }
 
 [dev-dependencies]
 assert-json-diff = "2.0"
-axum = { path = "../axum", version = "0.4" }
-http-body = "0.4"
 hyper = "0.14"
 serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "1.14", features = ["full"] }

--- a/axum-extra/Cargo.toml
+++ b/axum-extra/Cargo.toml
@@ -14,9 +14,19 @@ version = "0.1.2"
 default = []
 erased-json = ["serde_json", "serde"]
 typed-routing = ["axum-macros", "serde", "percent-encoding"]
+opentelemetry = [
+    "axum/matched-path",
+    "axum/original-uri",
+    "opentelemetry-http",
+    "opentelemetry-lib",
+    "tower-http/request-id",
+    "tower-http/trace",
+    "tracing",
+    "tracing-opentelemetry",
+]
 
 [dependencies]
-axum = { path = "../axum", version = "0.4" }
+axum = { path = "../axum", version = "0.4", default_features = false }
 bytes = "1.1.0"
 http = "0.2"
 mime = "0.3"
@@ -28,15 +38,23 @@ tower-service = "0.3"
 
 # optional dependencies
 axum-macros = { path = "../axum-macros", version = "0.1", optional = true }
+opentelemetry-http = { version = "0.6", optional = true }
+opentelemetry-lib = { package = "opentelemetry", version = "0.17", optional = true }
+percent-encoding = { version = "2.1", optional = true }
 serde = { version = "1.0", optional = true }
 serde_json = { version = "1.0.71", optional = true }
-percent-encoding = { version = "2.1", optional = true }
+tracing = { version = "0.1", optional = true }
+tracing-opentelemetry = { version = "0.17", optional = true }
 
 [dev-dependencies]
+assert-json-diff = "2.0"
+http-body = "0.4"
 hyper = "0.14"
 serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "1.14", features = ["full"] }
 tower = { version = "0.4", features = ["util"] }
+tracing-subscriber = { version = "0.3", features = ["json", "env-filter"] }
+uuid = { version = "0.8", features = ["v4"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/axum-extra/Cargo.toml
+++ b/axum-extra/Cargo.toml
@@ -26,7 +26,7 @@ opentelemetry = [
 ]
 
 [dependencies]
-axum = { path = "../axum", version = "0.4", default_features = false }
+axum = { path = "../axum", version = "0.4" }
 bytes = "1.1.0"
 http = "0.2"
 mime = "0.3"
@@ -48,6 +48,7 @@ tracing-opentelemetry = { version = "0.17", optional = true }
 
 [dev-dependencies]
 assert-json-diff = "2.0"
+axum = { path = "../axum", version = "0.4" }
 http-body = "0.4"
 hyper = "0.14"
 serde = { version = "1.0", features = ["derive"] }

--- a/axum-extra/Cargo.toml
+++ b/axum-extra/Cargo.toml
@@ -18,7 +18,6 @@ opentelemetry = [
     "axum/matched-path",
     "axum/original-uri",
     "opentelemetry-lib",
-    "tower-http/request-id",
     "tower-http/trace",
     "tracing",
     "tracing-opentelemetry",

--- a/axum-extra/Cargo.toml
+++ b/axum-extra/Cargo.toml
@@ -17,7 +17,6 @@ typed-routing = ["axum-macros", "serde", "percent-encoding"]
 opentelemetry = [
     "axum/matched-path",
     "axum/original-uri",
-    "opentelemetry-http",
     "opentelemetry-lib",
     "tower-http/request-id",
     "tower-http/trace",
@@ -38,7 +37,6 @@ tower-service = "0.3"
 
 # optional dependencies
 axum-macros = { path = "../axum-macros", version = "0.1", optional = true }
-opentelemetry-http = { version = "0.6", optional = true }
 opentelemetry-lib = { package = "opentelemetry", version = "0.17", optional = true }
 percent-encoding = { version = "2.1", optional = true }
 serde = { version = "1.0", optional = true }

--- a/axum-extra/src/lib.rs
+++ b/axum-extra/src/lib.rs
@@ -44,6 +44,7 @@
 #![cfg_attr(test, allow(clippy::float_cmp))]
 
 pub mod extract;
+pub mod middleware;
 pub mod response;
 pub mod routing;
 

--- a/axum-extra/src/middleware/mod.rs
+++ b/axum-extra/src/middleware/mod.rs
@@ -2,3 +2,5 @@
 
 #[cfg(feature = "opentelemetry")]
 pub mod opentelemetry;
+
+pub use self::opentelemetry::opentelemtry_tracing_layer;

--- a/axum-extra/src/middleware/mod.rs
+++ b/axum-extra/src/middleware/mod.rs
@@ -3,4 +3,5 @@
 #[cfg(feature = "opentelemetry")]
 pub mod opentelemetry;
 
+#[cfg(feature = "opentelemetry")]
 pub use self::opentelemetry::opentelemtry_tracing_layer;

--- a/axum-extra/src/middleware/mod.rs
+++ b/axum-extra/src/middleware/mod.rs
@@ -1,0 +1,4 @@
+//! Additional middleware.
+
+#[cfg(feature = "opentelemetry")]
+pub mod opentelemetry;

--- a/axum-extra/src/middleware/mod.rs
+++ b/axum-extra/src/middleware/mod.rs
@@ -4,4 +4,4 @@
 pub mod opentelemetry;
 
 #[cfg(feature = "opentelemetry")]
-pub use self::opentelemetry::opentelemtry_tracing_layer;
+pub use self::opentelemetry::opentelemetry_tracing_layer;

--- a/axum-extra/src/middleware/opentelemetry.rs
+++ b/axum-extra/src/middleware/opentelemetry.rs
@@ -440,7 +440,7 @@ mod tests {
         mut router: Router<Body>,
         reqs: [Request<Body>; N],
     ) -> [(Value, Value); N] {
-        use http_body::Body as _;
+        use axum::body::HttpBody as _;
 
         let (make_writer, rx) = duplex_writer();
         let subscriber = tracing_subscriber::fmt::fmt()

--- a/axum-extra/src/middleware/opentelemetry.rs
+++ b/axum-extra/src/middleware/opentelemetry.rs
@@ -1,0 +1,439 @@
+//! OpenTelemetry middleware.
+//!
+//! # Example
+//!
+//! TODO
+
+// TODO(david): jaeger example
+
+use axum::{
+    extract::{ConnectInfo, MatchedPath, OriginalUri},
+    response::Response,
+};
+use http::{header, uri::Scheme, Method, Request, Version};
+use opentelemetry_lib::trace::TraceContextExt;
+use std::{borrow::Cow, net::SocketAddr, time::Duration};
+use tower_http::{
+    classify::{ServerErrorsAsFailures, ServerErrorsFailureClass, SharedClassifier},
+    request_id::RequestId,
+    trace::{MakeSpan, OnBodyChunk, OnEos, OnFailure, OnRequest, OnResponse, TraceLayer},
+};
+use tracing::{field::Empty, Span};
+use tracing_opentelemetry::OpenTelemetrySpanExt;
+
+/// OpenTelemetry tracing middleware.
+///
+/// It will use [OpenTelemetry's conventional field names][otel].
+///
+/// See the [module docs](self) for more details.
+///
+/// [otel]: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md
+pub fn opentelemtry_tracing_layer() -> TraceLayer<
+    SharedClassifier<ServerErrorsAsFailures>,
+    OtelMakeSpan,
+    OtelOnRequest,
+    OtelOnResponse,
+    OtelOnBodyChunk,
+    OtelOnEos,
+    OtelOnFailure,
+> {
+    TraceLayer::new_for_http()
+        .make_span_with(OtelMakeSpan)
+        .on_request(OtelOnRequest)
+        .on_response(OtelOnResponse)
+        .on_body_chunk(OtelOnBodyChunk)
+        .on_eos(OtelOnEos)
+        .on_failure(OtelOnFailure)
+}
+
+/// A [`MakeSpan`] that creates tracing spans using [OpenTelemetry's conventional field names][otel].
+///
+/// [otel]: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md
+#[derive(Clone, Copy, Debug)]
+pub struct OtelMakeSpan;
+
+impl<B> MakeSpan<B> for OtelMakeSpan {
+    fn make_span(&mut self, req: &Request<B>) -> Span {
+        let user_agent = req
+            .headers()
+            .get(header::USER_AGENT)
+            .map_or("", |h| h.to_str().unwrap_or(""));
+
+        let host = req
+            .headers()
+            .get(header::HOST)
+            .map_or("", |h| h.to_str().unwrap_or(""));
+
+        let scheme = req
+            .uri()
+            .scheme()
+            .map_or_else(|| "HTTP".into(), http_scheme);
+
+        let http_route = if let Some(matched_path) = req.extensions().get::<MatchedPath>() {
+            matched_path.as_str().to_owned()
+        } else if let Some(uri) = req.extensions().get::<OriginalUri>() {
+            uri.0.path().to_owned()
+        } else {
+            req.uri().path().to_owned()
+        };
+
+        let http_target = if let Some(uri) = req.extensions().get::<OriginalUri>() {
+            uri.0.path().to_owned()
+        } else {
+            req.uri().path().to_owned()
+        };
+
+        // TODO(david): document that `into_make_service_with_connect_info` is required
+        let client_ip = req
+            .extensions()
+            .get::<ConnectInfo<SocketAddr>>()
+            .map(|ConnectInfo(client_ip)| Cow::from(client_ip.to_string()))
+            .unwrap_or_default();
+
+        // TODO(david): document that you have to add a request id middleware as well
+        let request_id = req
+            .extensions()
+            .get::<RequestId>()
+            .and_then(|id| id.header_value().to_str().ok())
+            .unwrap_or_default();
+
+        let remote_context = extract_remote_context(req.headers());
+        let remote_span = remote_context.span();
+        let span_context = remote_span.span_context();
+        let trace_id = span_context
+            .is_valid()
+            .then(|| Cow::from(span_context.trace_id().to_string()))
+            .unwrap_or_default();
+
+        let span = tracing::info_span!(
+            "HTTP request",
+            http.client_ip = %client_ip,
+            http.flavor = %http_flavor(req.version()),
+            http.host = %host,
+            http.method = %http_method(req.method()),
+            http.route = %http_route,
+            http.scheme = %scheme,
+            http.status_code = Empty,
+            http.target = %http_target,
+            http.user_agent = %user_agent,
+            otel.kind = "server",
+            otel.status_code = Empty,
+            request_id = request_id,
+            trace_id = %trace_id,
+        );
+
+        span.set_parent(remote_context);
+
+        span
+    }
+}
+
+fn http_method(method: &Method) -> Cow<'static, str> {
+    match method {
+        &Method::CONNECT => "CONNECT".into(),
+        &Method::DELETE => "DELETE".into(),
+        &Method::GET => "GET".into(),
+        &Method::HEAD => "HEAD".into(),
+        &Method::OPTIONS => "OPTIONS".into(),
+        &Method::PATCH => "PATCH".into(),
+        &Method::POST => "POST".into(),
+        &Method::PUT => "PUT".into(),
+        &Method::TRACE => "TRACE".into(),
+        other => other.to_string().into(),
+    }
+}
+
+fn http_flavor(version: Version) -> Cow<'static, str> {
+    match version {
+        Version::HTTP_09 => "0.9".into(),
+        Version::HTTP_10 => "1.0".into(),
+        Version::HTTP_11 => "1.1".into(),
+        Version::HTTP_2 => "2.0".into(),
+        Version::HTTP_3 => "3.0".into(),
+        other => format!("{:?}", other).into(),
+    }
+}
+
+fn http_scheme(scheme: &Scheme) -> Cow<'static, str> {
+    if scheme == &Scheme::HTTP {
+        "http".into()
+    } else if scheme == &Scheme::HTTPS {
+        "https".into()
+    } else {
+        scheme.to_string().into()
+    }
+}
+
+// If remote request has no span data the propagator defaults to an unsampled context
+fn extract_remote_context(headers: &http::HeaderMap) -> opentelemetry_lib::Context {
+    let extractor = opentelemetry_http::HeaderExtractor(headers);
+    opentelemetry_lib::global::get_text_map_propagator(|propagator| propagator.extract(&extractor))
+}
+
+/// Callback that [`Trace`] will call when it receives a request.
+///
+/// [`Trace`]: tower_http::trace::Trace
+#[derive(Clone, Copy, Debug)]
+pub struct OtelOnRequest;
+
+impl<B> OnRequest<B> for OtelOnRequest {
+    #[inline]
+    fn on_request(&mut self, _request: &Request<B>, _span: &Span) {}
+}
+
+/// Callback that [`Trace`] will call when it receives a response.
+///
+/// [`Trace`]: tower_http::trace::Trace
+#[derive(Clone, Copy, Debug)]
+pub struct OtelOnResponse;
+
+impl<B> OnResponse<B> for OtelOnResponse {
+    fn on_response(self, response: &Response<B>, _latency: Duration, span: &Span) {
+        let status = response.status().as_u16().to_string();
+        span.record("http.status_code", &tracing::field::display(status));
+
+        // assume there is no error, if there is `OtelOnFailure` will be called and override this
+        span.record("otel.status_code", &"OK");
+    }
+}
+
+/// Callback that [`Trace`] will call when the response body produces a chunk.
+///
+/// [`Trace`]: tower_http::trace::Trace
+#[derive(Clone, Copy, Debug)]
+pub struct OtelOnBodyChunk;
+
+impl<B> OnBodyChunk<B> for OtelOnBodyChunk {
+    #[inline]
+    fn on_body_chunk(&mut self, _chunk: &B, _latency: Duration, _span: &Span) {}
+}
+
+/// Callback that [`Trace`] will call when a streaming response completes.
+///
+/// [`Trace`]: tower_http::trace::Trace
+#[derive(Clone, Copy, Debug)]
+pub struct OtelOnEos;
+
+impl OnEos for OtelOnEos {
+    #[inline]
+    fn on_eos(self, _trailers: Option<&http::HeaderMap>, _stream_duration: Duration, _span: &Span) {
+    }
+}
+
+/// Callback that [`Trace`] will call when a response or end-of-stream is classified as a failure.
+///
+/// [`Trace`]: tower_http::trace::Trace
+#[derive(Clone, Copy, Debug)]
+pub struct OtelOnFailure;
+
+impl OnFailure<ServerErrorsFailureClass> for OtelOnFailure {
+    fn on_failure(&mut self, failure: ServerErrorsFailureClass, _latency: Duration, span: &Span) {
+        match failure {
+            ServerErrorsFailureClass::StatusCode(status) => {
+                if status.is_server_error() {
+                    span.record("otel.status_code", &"ERROR");
+                }
+            }
+            ServerErrorsFailureClass::Error(_) => {
+                span.record("otel.status_code", &"ERROR");
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use assert_json_diff::assert_json_include;
+    use axum::{body::Body, routing::get, Router};
+    use http::{Request, StatusCode};
+    use serde_json::{json, Value};
+    use std::{
+        convert::TryInto,
+        sync::mpsc::{self, Receiver, SyncSender},
+    };
+    use tower::{Service, ServiceBuilder, ServiceExt};
+    use tower_http::request_id::SetRequestIdLayer;
+    use tracing_subscriber::{
+        fmt::{format::FmtSpan, MakeWriter},
+        util::SubscriberInitExt,
+        EnvFilter,
+    };
+
+    #[tokio::test]
+    async fn correct_fields_on_span_for_http() {
+        let svc = Router::new()
+            .route("/", get(|| async { StatusCode::OK }))
+            .route(
+                "/users/:id",
+                get(|| async { StatusCode::INTERNAL_SERVER_ERROR }),
+            )
+            .layer(
+                ServiceBuilder::new()
+                    .layer(SetRequestIdLayer::x_request_id(MakeRequestUuid))
+                    .layer(opentelemtry_tracing_layer()),
+            );
+
+        let [(root_new, root_close), (users_id_new, users_id_close)] = spans_for_requests(
+            svc,
+            [
+                Request::builder()
+                    .header("x-request-id", "request-id")
+                    .header("user-agent", "tests")
+                    .uri("/")
+                    .body(Body::empty())
+                    .unwrap(),
+                Request::builder()
+                    .uri("/users/123")
+                    .body(Body::empty())
+                    .unwrap(),
+            ],
+        )
+        .await;
+
+        assert_json_include!(
+            actual: root_new,
+            expected: json!({
+                "fields": {
+                    "message": "new",
+                },
+                "level": "INFO",
+                "span": {
+                    "http.client_ip": "",
+                    "http.flavor": "1.1",
+                    "http.host": "",
+                    "http.method": "GET",
+                    "http.route": "/",
+                    "http.scheme": "HTTP",
+                    "http.target": "/",
+                    "http.user_agent": "tests",
+                    "name": "HTTP request",
+                    "otel.kind": "server",
+                    "request_id": "request-id",
+                    "trace_id": ""
+                }
+            }),
+        );
+
+        assert_json_include!(
+            actual: root_close,
+            expected: json!({
+                "fields": {
+                    "message": "close",
+                },
+                "level": "INFO",
+                "span": {
+                    "http.client_ip": "",
+                    "http.flavor": "1.1",
+                    "http.host": "",
+                    "http.method": "GET",
+                    "http.route": "/",
+                    "http.scheme": "HTTP",
+                    "http.status_code": "200",
+                    "http.target": "/",
+                    "http.user_agent": "tests",
+                    "name": "HTTP request",
+                    "otel.kind": "server",
+                    "otel.status_code": "OK",
+                    "request_id": "request-id",
+                    "trace_id": ""
+                }
+            }),
+        );
+
+        assert_json_include!(
+            actual: users_id_new,
+            expected: json!({
+                "span": {
+                    "http.route": "/users/:id",
+                    "http.target": "/users/123",
+                }
+            }),
+        );
+
+        assert_json_include!(
+            actual: users_id_close,
+            expected: json!({
+                "span": {
+                    "http.status_code": "500",
+                    "otel.status_code": "ERROR",
+                }
+            }),
+        );
+    }
+
+    async fn spans_for_requests<const N: usize>(
+        mut router: Router<Body>,
+        reqs: [Request<Body>; N],
+    ) -> [(Value, Value); N] {
+        use http_body::Body as _;
+
+        let (make_writer, rx) = duplex_writer();
+        let subscriber = tracing_subscriber::fmt::fmt()
+            .json()
+            .with_env_filter(EnvFilter::try_new("axum_extra=trace").unwrap())
+            .with_writer(make_writer)
+            .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)
+            .finish();
+        let _guard = subscriber.set_default();
+
+        let mut spans = Vec::new();
+
+        for req in reqs {
+            let mut res = router.ready().await.unwrap().call(req).await.unwrap();
+
+            while res.data().await.is_some() {}
+            res.trailers().await.unwrap();
+            drop(res);
+
+            let logs = std::iter::from_fn(|| rx.try_recv().ok())
+                .map(|bytes| serde_json::from_slice::<Value>(&bytes).unwrap())
+                .collect::<Vec<_>>();
+
+            let [new, close]: [_; 2] = logs.try_into().unwrap();
+
+            spans.push((new, close));
+        }
+
+        spans.try_into().unwrap()
+    }
+
+    fn duplex_writer() -> (DuplexWriter, Receiver<Vec<u8>>) {
+        let (tx, rx) = mpsc::sync_channel(1024);
+        (DuplexWriter { tx }, rx)
+    }
+
+    #[derive(Clone)]
+    struct DuplexWriter {
+        tx: SyncSender<Vec<u8>>,
+    }
+
+    impl<'a> MakeWriter<'a> for DuplexWriter {
+        type Writer = Self;
+
+        fn make_writer(&'a self) -> Self::Writer {
+            self.clone()
+        }
+    }
+
+    impl std::io::Write for DuplexWriter {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.tx.send(buf.to_vec()).unwrap();
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[derive(Clone, Copy)]
+    struct MakeRequestUuid;
+
+    impl tower_http::request_id::MakeRequestId for MakeRequestUuid {
+        fn make_request_id<B>(&mut self, _: &Request<B>) -> Option<RequestId> {
+            let request_id = uuid::Uuid::new_v4().to_string().parse().ok()?;
+            Some(RequestId::new(request_id))
+        }
+    }
+}

--- a/axum-extra/src/middleware/opentelemetry.rs
+++ b/axum-extra/src/middleware/opentelemetry.rs
@@ -1,6 +1,6 @@
 //! OpenTelemetry middleware.
 //!
-//! See [`opentelemtry_tracing_layer`] for more details.
+//! See [`opentelemetry_tracing_layer`] for more details.
 
 use axum::{
     extract::{ConnectInfo, MatchedPath, OriginalUri},
@@ -45,7 +45,7 @@ use tracing::{field::Empty, Span};
 ///
 /// ```
 /// use axum::{Router, routing::get, http::Request};
-/// use axum_extra::middleware::opentelemtry_tracing_layer;
+/// use axum_extra::middleware::opentelemetry_tracing_layer;
 /// use std::net::SocketAddr;
 /// use tower::ServiceBuilder;
 /// use tower_http::request_id::{MakeRequestId, RequestId, SetRequestIdLayer};
@@ -54,10 +54,10 @@ use tracing::{field::Empty, Span};
 ///     .route("/", get(|| async {}))
 ///     .layer(
 ///         ServiceBuilder::new()
-///             // this layer must run before `opentelemtry_tracing_layer` for request ids to be
+///             // this layer must run before `opentelemetry_tracing_layer` for request ids to be
 ///             // picked up
 ///             .layer(SetRequestIdLayer::x_request_id(MyMakeRequestId))
-///             .layer(opentelemtry_tracing_layer())
+///             .layer(opentelemetry_tracing_layer())
 ///     );
 ///
 /// #[derive(Copy, Clone)]
@@ -72,7 +72,7 @@ use tracing::{field::Empty, Span};
 ///
 /// # async {
 /// axum::Server::bind(&"0.0.0.0:3000".parse().unwrap())
-///     // we must use `into_make_service_with_connect_info` for `opentelemtry_tracing_layer` to
+///     // we must use `into_make_service_with_connect_info` for `opentelemetry_tracing_layer` to
 ///     // access the client ip
 ///     .serve(app.into_make_service_with_connect_info::<SocketAddr, _>())
 ///     .await
@@ -88,7 +88,7 @@ use tracing::{field::Empty, Span};
 /// [otel]: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md
 /// [`Router::into_make_service_with_connect_info`]: axum::Router::into_make_service_with_connect_info
 /// [`SetRequestIdLayer`]: tower_http::request_id::SetRequestIdLayer
-pub fn opentelemtry_tracing_layer() -> TraceLayer<
+pub fn opentelemetry_tracing_layer() -> TraceLayer<
     SharedClassifier<ServerErrorsAsFailures>,
     OtelMakeSpan,
     OtelOnRequest,
@@ -345,7 +345,7 @@ mod tests {
             .layer(
                 ServiceBuilder::new()
                     .layer(SetRequestIdLayer::x_request_id(MakeRequestUuid))
-                    .layer(opentelemtry_tracing_layer()),
+                    .layer(opentelemetry_tracing_layer()),
             );
 
         let [(root_new, root_close), (users_id_new, users_id_close)] = spans_for_requests(

--- a/examples/opentelemetry-jaeger/Cargo.toml
+++ b/examples/opentelemetry-jaeger/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "example-opentelemetry-jaeger"
+version = "0.1.0"
+edition = "2018"
+publish = false
+
+[dependencies]
+axum = { path = "../../axum" }
+axum-extra = { path = "../../axum-extra", features = ["opentelemetry"] }
+opentelemetry = { version = "0.17", features = ["rt-tokio"] }
+opentelemetry-jaeger = { version = "0.16", features = ["rt-tokio"] }
+tokio = { version = "1.0", features = ["full"] }
+tower = "0.4"
+tower-http = { version = "0.2", features = ["request-id"] }
+tracing = "0.1"
+tracing-opentelemetry = "0.17"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+uuid = { version = "0.8", features = ["v4"] }

--- a/examples/opentelemetry-jaeger/Cargo.toml
+++ b/examples/opentelemetry-jaeger/Cargo.toml
@@ -11,7 +11,7 @@ opentelemetry = { version = "0.17", features = ["rt-tokio"] }
 opentelemetry-jaeger = { version = "0.16", features = ["rt-tokio"] }
 tokio = { version = "1.0", features = ["full"] }
 tower = "0.4"
-tower-http = { version = "0.2", features = ["request-id"] }
+tower-http = "0.2"
 tracing = "0.1"
 tracing-opentelemetry = "0.17"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/opentelemetry-jaeger/src/main.rs
+++ b/examples/opentelemetry-jaeger/src/main.rs
@@ -11,7 +11,7 @@
 //! ```
 
 use axum::{http::Request, routing::get, Router};
-use axum_extra::middleware::opentelemtry_tracing_layer;
+use axum_extra::middleware::opentelemetry_tracing_layer;
 use std::net::SocketAddr;
 use tower::ServiceBuilder;
 use tower_http::request_id::{RequestId, SetRequestIdLayer};
@@ -48,7 +48,7 @@ async fn main() {
     let app = Router::new().route("/", get(handler)).layer(
         ServiceBuilder::new()
             .layer(SetRequestIdLayer::x_request_id(MakeRequestUuid))
-            .layer(opentelemtry_tracing_layer()),
+            .layer(opentelemetry_tracing_layer()),
     );
 
     // run it

--- a/examples/opentelemetry-jaeger/src/main.rs
+++ b/examples/opentelemetry-jaeger/src/main.rs
@@ -1,0 +1,77 @@
+//! Run jaeger
+//!
+//! ```not_rust
+//! docker run -d -p6831:6831/udp -p6832:6832/udp -p16686:16686 -p14268:14268 jaegertracing/all-in-one:latest
+//! ```
+//!
+//! Run the server
+//!
+//! ```not_rust
+//! cargo run -p example-opentelemetry-jaeger
+//! ```
+
+use axum::{http::Request, routing::get, Router};
+use axum_extra::middleware::opentelemtry_tracing_layer;
+use std::net::SocketAddr;
+use tower::ServiceBuilder;
+use tower_http::request_id::{RequestId, SetRequestIdLayer};
+use tracing_subscriber::prelude::*;
+
+#[tokio::main]
+async fn main() {
+    // set the RUST_LOG, if it hasn't been explicitly defined
+    if std::env::var_os("RUST_LOG").is_none() {
+        std::env::set_var(
+            "RUST_LOG",
+            "axum_extra=debug,example_opentelemetry_jaeger=debug,tower_http=debug",
+        )
+    }
+
+    // start an otel jaeger trace pipeline
+    opentelemetry::global::set_text_map_propagator(
+        opentelemetry::sdk::propagation::TraceContextPropagator::new(),
+    );
+
+    let tracer = opentelemetry_jaeger::new_pipeline()
+        .with_service_name("axum-example")
+        .install_batch(opentelemetry::runtime::Tokio)
+        .unwrap();
+
+    // create a `tracing-subscriber` using `tracing-opentelemetry` and logging
+    tracing_subscriber::registry()
+        .with(tracing_subscriber::fmt::layer())
+        .with(tracing_opentelemetry::layer().with_tracer(tracer))
+        .with(tracing_subscriber::EnvFilter::try_from_default_env().unwrap())
+        .init();
+
+    // build our application with a route
+    let app = Router::new().route("/", get(handler)).layer(
+        ServiceBuilder::new()
+            .layer(SetRequestIdLayer::x_request_id(MakeRequestUuid))
+            .layer(opentelemtry_tracing_layer()),
+    );
+
+    // run it
+    let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
+    tracing::info!("listening on {}", addr);
+    axum::Server::bind(&addr)
+        .serve(app.into_make_service_with_connect_info::<SocketAddr, _>())
+        .await
+        .unwrap();
+
+    opentelemetry::global::shutdown_tracer_provider();
+}
+
+async fn handler() -> &'static str {
+    "Hello, World!"
+}
+
+#[derive(Clone, Copy)]
+struct MakeRequestUuid;
+
+impl tower_http::request_id::MakeRequestId for MakeRequestUuid {
+    fn make_request_id<B>(&mut self, _: &Request<B>) -> Option<RequestId> {
+        let request_id = uuid::Uuid::new_v4().to_string().parse().ok()?;
+        Some(RequestId::new(request_id))
+    }
+}


### PR DESCRIPTION
This adds `axum_extra::middleware::opentelemtry_tracing_layer` which returns a `TraceLayer` that will use [opentelemetry's conventional span field names](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md).

Fixes https://github.com/tokio-rs/axum/issues/750