### PR TITLE
fix typo in the docs

### DIFF
--- a/axum/src/extract/path/mod.rs
+++ b/axum/src/extract/path/mod.rs
@@ -130,7 +130,7 @@ use std::{
 /// # Providing detailed rejection output
 ///
 /// If the URI cannot be deserialized into the target type the request will be rejected and an
-/// error response will be returned. See [`customize-path-rejection`] for an exapmle of how to customize that error.
+/// error response will be returned. See [`customize-path-rejection`] for an example of how to customize that error.
 ///
 /// [`serde`]: https://crates.io/crates/serde
 /// [`serde::Deserialize`]: https://docs.rs/serde/1.0.127/serde/trait.Deserialize.html


### PR DESCRIPTION
Fix a typo in the Path documentation

## Motivation

Fix a minor typo

## Solution
typo fixed in the word `example`

