### PR TITLE
Put the Form and Query extractors behind (default-on) Cargo features

### DIFF
--- a/axum/Cargo.toml
+++ b/axum/Cargo.toml
@@ -11,14 +11,15 @@ readme = "README.md"
 repository = "https://github.com/tokio-rs/axum"
 
 [features]
-default = ["form", "http1", "json", "matched-path", "original-uri", "tower-log"]
-form = []
+default = ["form", "http1", "json", "matched-path", "original-uri", "query", "tower-log"]
+form = ["serde_urlencoded"]
 http1 = ["hyper/http1"]
 http2 = ["hyper/http2"]
 json = ["serde_json"]
 matched-path = []
 multipart = ["multer"]
 original-uri = []
+query = ["serde_urlencoded"]
 tower-log = ["tower/log"]
 ws = ["tokio-tungstenite", "sha-1", "base64"]
 
@@ -38,7 +39,6 @@ mime = "0.3.16"
 percent-encoding = "2.1"
 pin-project-lite = "0.2.7"
 serde = "1.0"
-serde_urlencoded = "0.7"
 sync_wrapper = "0.1.1"
 tokio = { version = "1", features = ["time"] }
 tower = { version = "0.4.11", default-features = false, features = ["util", "buffer", "make"] }
@@ -51,6 +51,7 @@ base64 = { optional = true, version = "0.13" }
 headers = { optional = true, version = "0.3" }
 multer = { optional = true, version = "2.0.0" }
 serde_json = { version = "1.0", optional = true, features = ["raw_value"] }
+serde_urlencoded = { version = "0.7", optional = true }
 sha-1 = { optional = true, version = "0.10" }
 tokio-tungstenite = { optional = true, version = "0.16" }
 

--- a/axum/Cargo.toml
+++ b/axum/Cargo.toml
@@ -11,7 +11,8 @@ readme = "README.md"
 repository = "https://github.com/tokio-rs/axum"
 
 [features]
-default = ["http1", "json", "matched-path", "original-uri", "tower-log"]
+default = ["form", "http1", "json", "matched-path", "original-uri", "tower-log"]
+form = []
 http1 = ["hyper/http1"]
 http2 = ["hyper/http2"]
 json = ["serde_json"]

--- a/axum/src/extract/form.rs
+++ b/axum/src/extract/form.rs
@@ -40,6 +40,7 @@ use std::ops::Deref;
 /// ```
 ///
 /// Note that `Content-Type: multipart/form-data` requests are not supported.
+#[cfg_attr(docsrs, doc(cfg(feature = "form")))]
 #[derive(Debug, Clone, Copy, Default)]
 pub struct Form<T>(pub T);
 

--- a/axum/src/extract/mod.rs
+++ b/axum/src/extract/mod.rs
@@ -13,7 +13,6 @@ pub mod ws;
 
 mod content_length_limit;
 mod extension;
-mod form;
 mod query;
 mod raw_query;
 mod request_parts;
@@ -28,15 +27,22 @@ pub use self::{
     content_length_limit::ContentLengthLimit,
     extension::Extension,
     extractor_middleware::extractor_middleware,
-    form::Form,
     path::Path,
     query::Query,
     raw_query::RawQuery,
     request_parts::{BodyStream, RawBody},
 };
+
 #[doc(no_inline)]
 #[cfg(feature = "json")]
 pub use crate::Json;
+
+#[cfg(feature = "form")]
+mod form;
+
+#[cfg(feature = "form")]
+#[doc(inline)]
+pub use self::form::Form;
 
 #[cfg(feature = "matched-path")]
 mod matched_path;

--- a/axum/src/extract/mod.rs
+++ b/axum/src/extract/mod.rs
@@ -13,7 +13,6 @@ pub mod ws;
 
 mod content_length_limit;
 mod extension;
-mod query;
 mod raw_query;
 mod request_parts;
 
@@ -28,7 +27,6 @@ pub use self::{
     extension::Extension,
     extractor_middleware::extractor_middleware,
     path::Path,
-    query::Query,
     raw_query::RawQuery,
     request_parts::{BodyStream, RawBody},
 };
@@ -57,6 +55,13 @@ pub mod multipart;
 #[cfg(feature = "multipart")]
 #[doc(inline)]
 pub use self::multipart::Multipart;
+
+#[cfg(feature = "query")]
+mod query;
+
+#[cfg(feature = "query")]
+#[doc(inline)]
+pub use self::query::Query;
 
 #[cfg(feature = "original-uri")]
 #[doc(inline)]

--- a/axum/src/extract/query.rs
+++ b/axum/src/extract/query.rs
@@ -44,6 +44,7 @@ use std::ops::Deref;
 /// example.
 ///
 /// [example]: https://github.com/tokio-rs/axum/blob/main/examples/query-params-with-empty-strings/src/main.rs
+#[cfg_attr(docsrs, doc(cfg(feature = "query")))]
 #[derive(Debug, Clone, Copy, Default)]
 pub struct Query<T>(pub T);
 


### PR DESCRIPTION
Closes #764.

## Motivation

Allow getting rid of the `serde_urlencoded` dependency for projects that don't need it.

## Solution

See title.