### PR TITLE
Make `middleware::from_fn` response future public

### DIFF
--- a/axum/src/middleware/mod.rs
+++ b/axum/src/middleware/mod.rs
@@ -5,3 +5,9 @@
 mod from_fn;
 
 pub use self::from_fn::{from_fn, FromFn, FromFnLayer, Next};
+
+pub mod futures {
+    //! Future types.
+
+    pub use super::from_fn::ResponseFuture as FromFnResponseFuture;
+}

--- a/axum/src/middleware/mod.rs
+++ b/axum/src/middleware/mod.rs
@@ -6,7 +6,7 @@ mod from_fn;
 
 pub use self::from_fn::{from_fn, FromFn, FromFnLayer, Next};
 
-pub mod futures {
+pub mod future {
     //! Future types.
 
     pub use super::from_fn::ResponseFuture as FromFnResponseFuture;


### PR DESCRIPTION
While doing https://github.com/tokio-rs/axum/pull/777 I noticed that the response future from `middleware::from_fn` wasn't public so the type wasn't nameable.

I would expect `#[deny(unreachable_pub)]` to catch this but it didn't. Might be a bug 🤔