### PR TITLE
Fix dependency versions in axum-extra

### DIFF
--- a/axum-extra/CHANGELOG.md
+++ b/axum-extra/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
-- None.
+- **fix:** Depend on the right versions of axum and axum-macros.
 
 # 0.1.3 (22. February, 2022)
 

--- a/axum-extra/Cargo.toml
+++ b/axum-extra/Cargo.toml
@@ -15,7 +15,7 @@ erased-json = ["serde_json", "serde"]
 typed-routing = ["axum-macros", "serde", "percent-encoding"]
 
 [dependencies]
-axum = { path = "../axum", version = "0.4" }
+axum = { path = "../axum", version = "0.4.6" }
 bytes = "1.1.0"
 http = "0.2"
 mime = "0.3"
@@ -26,7 +26,7 @@ tower-layer = "0.3"
 tower-service = "0.3"
 
 # optional dependencies
-axum-macros = { path = "../axum-macros", version = "0.1", optional = true }
+axum-macros = { path = "../axum-macros", version = "0.1.1", optional = true }
 serde = { version = "1.0", optional = true }
 serde_json = { version = "1.0.71", optional = true }
 percent-encoding = { version = "2.1", optional = true }


### PR DESCRIPTION
Updating to axum-extra 0.1.3 might cause the build to fail if axum
wasn't also updated, since axum-extra 0.1.3 needs
`axum::middleware::from_fn`.

This fixes that by depending on the right patch versions for axum and
axum-macros.

Why can't the tooling detect stuff like this 😢 