### PR TITLE
feat(examples): add routing-match-http-method-for-any-path example

### DIFF
--- a/examples/routing-match-http-method-for-any-path/Cargo.toml
+++ b/examples/routing-match-http-method-for-any-path/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "example-routing-match-http-method-for-any-path"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+axum = { path = "../../axum" }
+axum-extra = { path = "../../axum-extra" }
+tokio = { version = "1.0", features = ["full"] }
+tracing = "0.1"
+tracing-subscriber = { version="0.3", features = ["env-filter"] }
+tower = { version = "0.4", features = ["util", "filter"] }
+hyper = { version = "0.14", features = ["full"] }

--- a/examples/routing-match-http-method-for-any-path/src/main.rs
+++ b/examples/routing-match-http-method-for-any-path/src/main.rs
@@ -1,0 +1,64 @@
+//! Run with
+//!
+//! ```not_rust
+//! cargo run -p example-routing-match-http-method-for-any-path
+//! # listening on 3000
+//!
+//! curl -v -X OPTIONS http://localhost:3000/some_path
+//! # OPTIONS /some_path matched!
+//!
+//! curl -v -X GET http://localhost:3000/some_path
+//! # GET /some_path matched!
+//!
+//! curl -v -X OPTIONS http://localhost:3000/another_path
+//! # OPTIONS /another_path matched!
+//!
+//! curl -v -X GET http://localhost:3000/another_path
+//! # GET /another_path did not match anything!
+//! ```
+
+use axum::{
+    body::{Body, HttpBody},
+    http::{Method, Request},
+    middleware::{self, Next},
+    response::{IntoResponse, Response},
+    routing::get,
+    Router,
+};
+use std::net::SocketAddr;
+
+#[tokio::main]
+async fn main() {
+    let app = Router::new()
+        // matches "OPTIONS" method for any path
+        .layer(middleware::from_fn(intercept_options_method))
+        // matches "GET" method for "/some_path" only
+        .route("/some_path", get(get_some_path_handler));
+
+    let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
+    println!("listening on {}", addr);
+    axum::Server::bind(&addr)
+        .serve(app.into_make_service())
+        .await
+        .unwrap();
+}
+
+async fn intercept_options_method<B>(req: Request<B>, next: Next<B>) -> impl IntoResponse {
+    if req.method() == Method::OPTIONS {
+        Ok(Response::builder()
+            .header("x-matched-from", req.uri().to_string())
+            .status(200)
+            .body(Body::from("OPTIONS matched!").boxed_unsync())
+            .unwrap())
+    } else {
+        Ok(next.run(req).await)
+    }
+}
+
+async fn get_some_path_handler<B>(req: Request<B>) -> impl IntoResponse {
+    Response::builder()
+        .header("x-matched-from", req.uri().to_string())
+        .status(200)
+        .body(Body::from("GET /some_path matched!").boxed_unsync())
+        .unwrap()
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation

I spent 1 day trying to update my router to always return some `Response` when a specific `HTTP method` is used **for any path** (ℹ️ and I still didn't manage to make it work, see below)

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

I suggest to add an `example` to show how to do it "the good way".


## Problem for the current solution

The current implementation using `Response::builder().body(...).unwrap()` demonstrate a bug in `axum` (which I can't fix from my userland even if I wrap things using `Box::pin(...)`) because we end up with the following compiler errors:

```shell
$ cargo check
    Checking example-routing-match-http-method-for-any-path v0.1.0 (/usr/local/var/www/oliver/axum/examples/routing-match-http-method-for-any-path)
error[E0308]: `if` and `else` have incompatible types
  --> examples/routing-match-http-method-for-any-path/src/main.rs:53:9
   |
46 |  /     if req.method() == Method::OPTIONS {
47 |  |         Ok(Response::builder()
   |  |_________-
48 | ||             .header("x-matched-from", req.uri().to_string())
49 | ||             .status(200)
50 | ||             .body(Body::from("matched OPTIONS method").boxed_unsync())
51 | ||             .unwrap())
   | ||______________________- expected because of this
52 |  |     } else {
53 |  |         Ok(next.run(req).await)
   |  |         ^^^^^^^^^^^^^^^^^^^^^^^ expected struct `hyper::error::Error`, found struct `axum::Error`
54 |  |     }
   |  |_____- `if` and `else` have incompatible types
   |
   = note: expected type `Result<Response<http_body::combinators::box_body::UnsyncBoxBody<_, hyper::error::Error>>, _>`
              found enum `Result<Response<http_body::combinators::box_body::UnsyncBoxBody<_, axum::Error>>, _>`
```


## Useless notes

- Using `warp` (instead of `axum`), matching for all paths for a specific HTTP method is as simple as using the `warp::SOME_METHOD()` filters (e.g. `warp::options()` if we want a custom response when the `OPTIONS` method is used).
