### PR TITLE
Easily convert typed paths into URIs

### DIFF
--- a/axum-extra/CHANGELOG.md
+++ b/axum-extra/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning].
 
 # Unreleased
 
+- **added:** Add `TypedPath::to_uri` for converting the path into a `Uri` ([#790])
 - **added:** Add type safe routing. See `axum_extra::routing::typed` for more details ([#756])
 - **breaking:** `CachedRejection` has been removed ([#699])
 - **breaking:** `<Cached<T> as FromRequest>::Rejection` is now `T::Rejection`. ([#699])
@@ -16,6 +17,7 @@ and this project adheres to [Semantic Versioning].
 [#699]: https://github.com/tokio-rs/axum/pull/699
 [#719]: https://github.com/tokio-rs/axum/pull/719
 [#756]: https://github.com/tokio-rs/axum/pull/756
+[#790]: https://github.com/tokio-rs/axum/pull/790
 
 # 0.1.2 (13. January, 2022)
 

--- a/axum-extra/src/routing/typed.rs
+++ b/axum-extra/src/routing/typed.rs
@@ -161,6 +161,8 @@ pub trait TypedPath: std::fmt::Display {
     ///
     /// Using `#[derive(TypedPath)]` will never result in a panic since it percent-encodes
     /// arguments.
+    ///
+    /// [`Display`]: std::fmt::Display
     fn to_uri(&self) -> Uri {
         self.to_string().parse().unwrap()
     }

--- a/axum-extra/src/routing/typed.rs
+++ b/axum-extra/src/routing/typed.rs
@@ -87,6 +87,8 @@ use super::sealed::Sealed;
 /// things, create links to known paths and have them verified statically. Note that the
 /// [`Display`] implementation for each field must return something that's compatible with its
 /// [`Deserialize`] implementation.
+/// - A [`TryFrom<_> for Uri`](std::convert::TryFrom) implementation to converting your paths into
+/// [`Uri`](axum::http::Uri).
 ///
 /// Additionally the macro will verify the captures in the path matches the fields of the struct.
 /// For example this fails to compile since the struct doesn't have a `team_id` field:

--- a/axum-extra/src/routing/typed.rs
+++ b/axum-extra/src/routing/typed.rs
@@ -1,4 +1,5 @@
 use super::sealed::Sealed;
+use http::Uri;
 
 /// A type safe path.
 ///
@@ -150,6 +151,19 @@ use super::sealed::Sealed;
 pub trait TypedPath: std::fmt::Display {
     /// The path with optional captures such as `/users/:id`.
     const PATH: &'static str;
+
+    /// Convert the path into a `Uri`.
+    ///
+    /// # Panics
+    ///
+    /// The default implementation parses the required [`Display`] implemetation. If that fails it
+    /// will panic.
+    ///
+    /// Using `#[derive(TypedPath)]` will never result in a panic since it percent-encodes
+    /// arguments.
+    fn to_uri(&self) -> Uri {
+        self.to_string().parse().unwrap()
+    }
 }
 
 /// Utility trait used with [`RouterExt`] to ensure the first element of a tuple type is a

--- a/axum-macros/CHANGELOG.md
+++ b/axum-macros/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
-- Add `#[derive(TypedPath)]` for use with axum-extra's new "type safe" routing API ([#756])
+- **added:** Add `#[derive(TypedPath)]` for use with axum-extra's new "type safe" routing API ([#756])
+- **added:** `#[derive(TypedPath)]` now also generates a `TryFrom<_> for Uri`
+  implementation ([#790])
+
+[#790]: https://github.com/tokio-rs/axum/pull/790
 
 # 0.1.0 (31. January, 2022)
 

--- a/axum-macros/CHANGELOG.md
+++ b/axum-macros/CHANGELOG.md
@@ -8,10 +8,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # Unreleased
 
 - **added:** Add `#[derive(TypedPath)]` for use with axum-extra's new "type safe" routing API ([#756])
-- **added:** `#[derive(TypedPath)]` now also generates a `TryFrom<_> for Uri`
-  implementation ([#790])
-
-[#790]: https://github.com/tokio-rs/axum/pull/790
 
 # 0.1.0 (31. January, 2022)
 

--- a/axum-macros/src/typed_path.rs
+++ b/axum-macros/src/typed_path.rs
@@ -20,29 +20,17 @@ pub(crate) fn expand(item_struct: ItemStruct) -> syn::Result<TokenStream> {
 
     let Attrs { path } = parse_attrs(attrs)?;
 
-    let code = match fields {
+    match fields {
         syn::Fields::Named(_) => {
             let segments = parse_path(&path)?;
-            expand_named_fields(ident, path, &segments)
+            Ok(expand_named_fields(ident, path, &segments))
         }
         syn::Fields::Unnamed(fields) => {
             let segments = parse_path(&path)?;
-            expand_unnamed_fields(fields, ident, path, &segments)?
+            expand_unnamed_fields(fields, ident, path, &segments)
         }
-        syn::Fields::Unit => expand_unit_fields(ident, path)?,
-    };
-
-    Ok(quote! {
-        #code
-
-        impl ::std::convert::TryFrom<#ident> for ::axum::http::Uri {
-            type Error = ::axum::http::uri::InvalidUri;
-
-            fn try_from(value: #ident) -> ::std::result::Result<Self, Self::Error> {
-                value.to_string().parse()
-            }
-        }
-    })
+        syn::Fields::Unit => expand_unit_fields(ident, path),
+    }
 }
 
 struct Attrs {

--- a/axum-macros/tests/typed_path/pass/into_uri.rs
+++ b/axum-macros/tests/typed_path/pass/into_uri.rs
@@ -1,7 +1,6 @@
 use axum_extra::routing::TypedPath;
 use axum::http::Uri;
 use serde::Deserialize;
-use std::convert::TryInto;
 
 #[derive(TypedPath, Deserialize)]
 #[typed_path("/:id")]
@@ -18,7 +17,7 @@ struct Unnamed(u32);
 struct Unit;
 
 fn main() {
-    let _: Uri = Named { id: 1 }.try_into().unwrap();
-    let _: Uri = Unnamed(1).try_into().unwrap();
-    let _: Uri = Unit.try_into().unwrap();
+    let _: Uri = Named { id: 1 }.to_uri();
+    let _: Uri = Unnamed(1).to_uri();
+    let _: Uri = Unit.to_uri();
 }

--- a/axum-macros/tests/typed_path/pass/try_into_uri.rs
+++ b/axum-macros/tests/typed_path/pass/try_into_uri.rs
@@ -1,0 +1,24 @@
+use axum_extra::routing::TypedPath;
+use axum::http::Uri;
+use serde::Deserialize;
+use std::convert::TryInto;
+
+#[derive(TypedPath, Deserialize)]
+#[typed_path("/:id")]
+struct Named {
+    id: u32,
+}
+
+#[derive(TypedPath, Deserialize)]
+#[typed_path("/:id")]
+struct Unnamed(u32);
+
+#[derive(TypedPath, Deserialize)]
+#[typed_path("/")]
+struct Unit;
+
+fn main() {
+    let _: Uri = Named { id: 1 }.try_into().unwrap();
+    let _: Uri = Unnamed(1).try_into().unwrap();
+    let _: Uri = Unit.try_into().unwrap();
+}


### PR DESCRIPTION
`#[derive(TypedPath)]` will now also generate `TryFrom<_> for Uri` for
easily converting paths into URIs for use with `Redirect` and friends.

Fixes https://github.com/tokio-rs/axum/issues/789