### PR TITLE
fix `examples/todos`'s `async fn todos_index` iter_overeager_cloned

### DIFF
--- a/axum/Cargo.toml
+++ b/axum/Cargo.toml
@@ -40,7 +40,6 @@ serde = "1.0"
 serde_urlencoded = "0.7"
 sync_wrapper = "0.1.1"
 tokio = { version = "1", features = ["time"] }
-tokio-util = "0.6"
 tower = { version = "0.4.11", default-features = false, features = ["util", "buffer", "make"] }
 tower-http = { version = "0.2.0", features = ["util", "map-response-body"] }
 tower-layer = "0.3"

--- a/examples/todos/src/main.rs
+++ b/examples/todos/src/main.rs
@@ -90,9 +90,9 @@ async fn todos_index(
 
     let todos = todos
         .values()
-        .cloned()
         .skip(pagination.offset.unwrap_or(0))
         .take(pagination.limit.unwrap_or(usize::MAX))
+        .cloned()
         .collect::<Vec<_>>();
 
     Json(todos)


### PR DESCRIPTION
## Motivation
fix `examples/todos`'s `async fn todos_index` [iter_overeager_cloned](https://rust-lang.github.io/rust-clippy/master/index.html#iter_overeager_cloned)

It’s often inefficient to clone all elements of an iterator.
> `iter.clone().skip(..).take(..)` 


## Solution
remove unneeded `clone` by
replacing `iter.clone().skip(..).take(..)` with `iter.skip(..).take(..).clone()`

