### PR TITLE
Improve error for missing extension

### DIFF
--- a/axum/src/extract/extension.rs
+++ b/axum/src/extract/extension.rs
@@ -56,7 +56,7 @@ where
             .get::<T>()
             .ok_or_else(|| {
                 MissingExtension::from_err(format!(
-                    "Extension of type `{}` was not found. Perhaps you forgot to add it?",
+                    "Extension of type `{}` was not found. Perhaps you forgot to add it? See `axum::AddExtensionLayer`.",
                     std::any::type_name::<T>()
                 ))
             })


### PR DESCRIPTION
Just saw https://www.reddit.com/r/rust/comments/t070uj/axum_post_error/ which made realize that it probably would be more helpful if the error for missing extensions mentioned `AddExtensionLayer`.