### PR TITLE
axum-macros: use fully qualified Result type

### DIFF
--- a/axum-macros/src/typed_path.rs
+++ b/axum-macros/src/typed_path.rs
@@ -97,7 +97,7 @@ fn expand_named_fields(ident: &syn::Ident, path: LitStr, segments: &[Segment]) -
         {
             type Rejection = <::axum::extract::Path<Self> as ::axum::extract::FromRequest<B>>::Rejection;
 
-            async fn from_request(req: &mut ::axum::extract::RequestParts<B>) -> Result<Self, Self::Rejection> {
+            async fn from_request(req: &mut ::axum::extract::RequestParts<B>) -> ::std::result::Result<Self, Self::Rejection> {
                 ::axum::extract::Path::from_request(req).await.map(|path| path.0)
             }
         }
@@ -186,7 +186,7 @@ fn expand_unnamed_fields(
         {
             type Rejection = <::axum::extract::Path<Self> as ::axum::extract::FromRequest<B>>::Rejection;
 
-            async fn from_request(req: &mut ::axum::extract::RequestParts<B>) -> Result<Self, Self::Rejection> {
+            async fn from_request(req: &mut ::axum::extract::RequestParts<B>) -> ::std::result::Result<Self, Self::Rejection> {
                 ::axum::extract::Path::from_request(req).await.map(|path| path.0)
             }
         }
@@ -245,7 +245,7 @@ fn expand_unit_fields(ident: &syn::Ident, path: LitStr) -> syn::Result<TokenStre
         {
             type Rejection = ::axum::http::StatusCode;
 
-            async fn from_request(req: &mut ::axum::extract::RequestParts<B>) -> Result<Self, Self::Rejection> {
+            async fn from_request(req: &mut ::axum::extract::RequestParts<B>) -> ::std::result::Result<Self, Self::Rejection> {
                 if req.uri().path() == <Self as ::axum_extra::routing::TypedPath>::PATH {
                     Ok(Self)
                 } else {

--- a/axum-macros/tests/typed_path/pass/tuple_struct.rs
+++ b/axum-macros/tests/typed_path/pass/tuple_struct.rs
@@ -1,6 +1,8 @@
 use axum_extra::routing::TypedPath;
 use serde::Deserialize;
 
+pub type Result<T> = std::result::Result<T, ()>;
+
 #[derive(TypedPath, Deserialize)]
 #[typed_path("/users/:user_id/teams/:team_id")]
 struct MyPath(u32, u32);


### PR DESCRIPTION
# Motivation

It is pretty common to define custom `Result<T>` type aliases however the typed_path macros generate `Result<T, E>` on the assumption they are imported from the std prelude. Having the type aliases defined causes errors like:

     #[derive(TypedPath, Deserialize)]
              ^^^^^^^^^
              |
              expected 1 generic argument
              help: remove this generic argument

## Solution

Generate fully qualified `std::result::Result` return types.
