### PR TITLE
Backport impl `tower::Layer` for `Extension`

### DIFF
--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -8,9 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # Unreleased
 
 - **added:** Implement `tower::Layer` for `Extension` ([#801])
-- **changed:** Deprecate `AddExtensionLayer`. Use `Extension` instead
+- **changed:** Deprecate `AddExtensionLayer`. Use `Extension` instead ([#805])
 
 [#801]: https://github.com/tokio-rs/axum/pull/801
+[#805]: https://github.com/tokio-rs/axum/pull/805
 
 # 0.4.6 (22. February, 2022)
 

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -7,7 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
-- None.
+- **added:** Implement `tower::Layer` for `Extension` ([#801])
+- **changed:** Deprecate `AddExtensionLayer`. Use `Extension` instead
+
+[#801]: https://github.com/tokio-rs/axum/pull/801
 
 # 0.4.6 (22. February, 2022)
 

--- a/axum/src/add_extension.rs
+++ b/axum/src/add_extension.rs
@@ -12,10 +12,15 @@ use tower_service::Service;
 ///
 /// [request extensions]: https://docs.rs/http/latest/http/struct.Extensions.html
 #[derive(Clone, Copy, Debug)]
+#[deprecated(
+    since = "0.4.7",
+    note = "Use `axum::Extension` instead. It implements `tower::Layer`"
+)]
 pub struct AddExtensionLayer<T> {
     value: T,
 }
 
+#[allow(deprecated)]
 impl<T> AddExtensionLayer<T> {
     /// Create a new [`AddExtensionLayer`].
     pub fn new(value: T) -> Self {
@@ -23,6 +28,7 @@ impl<T> AddExtensionLayer<T> {
     }
 }
 
+#[allow(deprecated)]
 impl<S, T> Layer<S> for AddExtensionLayer<T>
 where
     T: Clone,
@@ -51,6 +57,11 @@ pub struct AddExtension<S, T> {
 
 impl<S, T> AddExtension<S, T> {
     /// Create a new [`AddExtensionLayer`].
+    #[deprecated(
+        since = "0.4.7",
+        note = "Use `axum::Extension` instead. It implements `tower::Layer`"
+    )]
+    #[allow(deprecated)]
     pub fn layer(value: T) -> AddExtensionLayer<T> {
         AddExtensionLayer::new(value)
     }

--- a/axum/src/add_extension.rs
+++ b/axum/src/add_extension.rs
@@ -45,8 +45,8 @@ where
 /// [request extensions]: https://docs.rs/http/latest/http/struct.Extensions.html
 #[derive(Clone, Copy, Debug)]
 pub struct AddExtension<S, T> {
-    inner: S,
-    value: T,
+    pub(crate) inner: S,
+    pub(crate) value: T,
 }
 
 impl<S, T> AddExtension<S, T> {

--- a/axum/src/extract/connect_info.rs
+++ b/axum/src/extract/connect_info.rs
@@ -5,7 +5,7 @@
 //! [`Router::into_make_service_with_connect_info`]: crate::routing::Router::into_make_service_with_connect_info
 
 use super::{Extension, FromRequest, RequestParts};
-use crate::{AddExtension, AddExtensionLayer};
+use crate::AddExtension;
 use async_trait::async_trait;
 use hyper::server::conn::AddrStream;
 use std::{
@@ -104,7 +104,7 @@ where
 
     fn call(&mut self, target: T) -> Self::Future {
         let connect_info = ConnectInfo(C::connect_info(target));
-        let svc = AddExtensionLayer::new(connect_info).layer(self.svc.clone());
+        let svc = Extension(connect_info).layer(self.svc.clone());
         ResponseFuture::new(ready(Ok(svc)))
     }
 }

--- a/axum/src/extract/request_parts.rs
+++ b/axum/src/extract/request_parts.rs
@@ -218,9 +218,10 @@ where
 mod tests {
     use crate::{
         body::Body,
+        extract::Extension,
         routing::{get, post},
         test_helpers::*,
-        AddExtensionLayer, Router,
+        Router,
     };
     use http::{Method, Request, StatusCode};
 
@@ -253,11 +254,7 @@ mod tests {
             parts.extensions.get::<Ext>().unwrap();
         }
 
-        let client = TestClient::new(
-            Router::new()
-                .route("/", get(handler))
-                .layer(AddExtensionLayer::new(Ext)),
-        );
+        let client = TestClient::new(Router::new().route("/", get(handler)).layer(Extension(Ext)));
 
         let res = client.get("/").header("x-foo", "123").send().await;
         assert_eq!(res.status(), StatusCode::OK);

--- a/axum/src/lib.rs
+++ b/axum/src/lib.rs
@@ -173,13 +173,11 @@
 //!
 //! ## Using request extensions
 //!
-//! The easiest way to extract state in handlers is using [`AddExtension`]
-//! middleware (applied with [`AddExtensionLayer`]) and the
-//! [`Extension`](crate::extract::Extension) extractor:
+//! The easiest way to extract state in handlers is using [`Extension`](crate::extract::Extension)
+//! as layer and extractor:
 //!
 //! ```rust,no_run
 //! use axum::{
-//!     AddExtensionLayer,
 //!     extract::Extension,
 //!     routing::get,
 //!     Router,
@@ -194,7 +192,7 @@
 //!
 //! let app = Router::new()
 //!     .route("/", get(handler))
-//!     .layer(AddExtensionLayer::new(shared_state));
+//!     .layer(Extension(shared_state));
 //!
 //! async fn handler(
 //!     Extension(state): Extension<Arc<State>>,
@@ -217,7 +215,6 @@
 //!
 //! ```rust,no_run
 //! use axum::{
-//!     AddExtensionLayer,
 //!     Json,
 //!     extract::{Extension, Path},
 //!     routing::{get, post},

--- a/axum/src/lib.rs
+++ b/axum/src/lib.rs
@@ -405,7 +405,10 @@ pub mod routing;
 #[cfg(test)]
 mod test_helpers;
 
-pub use add_extension::{AddExtension, AddExtensionLayer};
+pub use add_extension::AddExtension;
+#[allow(deprecated)]
+pub use add_extension::AddExtensionLayer;
+
 #[doc(no_inline)]
 pub use async_trait::async_trait;
 #[cfg(feature = "headers")]

--- a/axum/src/middleware/from_fn.rs
+++ b/axum/src/middleware/from_fn.rs
@@ -102,11 +102,11 @@ use tower_service::Service;
 /// ```rust
 /// use axum::{
 ///     Router,
+///     extract::Extension,
 ///     http::{Request, StatusCode},
 ///     routing::get,
 ///     response::IntoResponse,
 ///     middleware::{self, Next},
-///     AddExtensionLayer,
 /// };
 /// use tower::ServiceBuilder;
 ///
@@ -129,7 +129,7 @@ use tower_service::Service;
 ///     .route("/", get(|| async { /* ... */ }))
 ///     .layer(
 ///         ServiceBuilder::new()
-///             .layer(AddExtensionLayer::new(state))
+///             .layer(Extension(state))
 ///             .layer(middleware::from_fn(my_middleware)),
 ///     );
 /// # let app: Router = app;

--- a/examples/async-graphql/src/main.rs
+++ b/examples/async-graphql/src/main.rs
@@ -8,7 +8,7 @@ use axum::{
     extract::Extension,
     response::{Html, IntoResponse},
     routing::get,
-    AddExtensionLayer, Json, Router,
+    Json, Router,
 };
 use starwars::{QueryRoot, StarWars, StarWarsSchema};
 
@@ -28,7 +28,7 @@ async fn main() {
 
     let app = Router::new()
         .route("/", get(graphql_playground).post(graphql_handler))
-        .layer(AddExtensionLayer::new(schema));
+        .layer(Extension(schema));
 
     println!("Playground: http://localhost:3000");
 

--- a/examples/chat/src/main.rs
+++ b/examples/chat/src/main.rs
@@ -13,7 +13,7 @@ use axum::{
     },
     response::{Html, IntoResponse},
     routing::get,
-    AddExtensionLayer, Router,
+    Router,
 };
 use futures::{sink::SinkExt, stream::StreamExt};
 use std::{
@@ -39,7 +39,7 @@ async fn main() {
     let app = Router::new()
         .route("/", get(index))
         .route("/websocket", get(websocket_handler))
-        .layer(AddExtensionLayer::new(app_state));
+        .layer(Extension(app_state));
 
     let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
 

--- a/examples/error-handling-and-dependency-injection/src/main.rs
+++ b/examples/error-handling-and-dependency-injection/src/main.rs
@@ -13,7 +13,7 @@ use axum::{
     http::StatusCode,
     response::{IntoResponse, Response},
     routing::{get, post},
-    AddExtensionLayer, Json, Router,
+    Json, Router,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -41,7 +41,7 @@ async fn main() {
         .route("/users", post(users_create))
         // Add our `user_repo` to all request's extensions so handlers can access
         // it.
-        .layer(AddExtensionLayer::new(user_repo));
+        .layer(Extension(user_repo));
 
     // Run our application
     let addr = SocketAddr::from(([127, 0, 0, 1], 3000));

--- a/examples/key-value-store/src/main.rs
+++ b/examples/key-value-store/src/main.rs
@@ -25,8 +25,7 @@ use std::{
 };
 use tower::{BoxError, ServiceBuilder};
 use tower_http::{
-    add_extension::AddExtensionLayer, auth::RequireAuthorizationLayer,
-    compression::CompressionLayer, trace::TraceLayer,
+    auth::RequireAuthorizationLayer, compression::CompressionLayer, trace::TraceLayer,
 };
 
 #[tokio::main]
@@ -58,7 +57,7 @@ async fn main() {
                 .concurrency_limit(1024)
                 .timeout(Duration::from_secs(10))
                 .layer(TraceLayer::new_for_http())
-                .layer(AddExtensionLayer::new(SharedState::default()))
+                .layer(Extension(SharedState::default()))
                 .into_inner(),
         );
 

--- a/examples/oauth/src/main.rs
+++ b/examples/oauth/src/main.rs
@@ -18,7 +18,7 @@ use axum::{
     http::{header::SET_COOKIE, HeaderMap},
     response::{IntoResponse, Redirect, Response},
     routing::get,
-    AddExtensionLayer, Router,
+    Router,
 };
 use http::header;
 use oauth2::{
@@ -49,8 +49,8 @@ async fn main() {
         .route("/auth/authorized", get(login_authorized))
         .route("/protected", get(protected))
         .route("/logout", get(logout))
-        .layer(AddExtensionLayer::new(store))
-        .layer(AddExtensionLayer::new(oauth_client));
+        .layer(Extension(store))
+        .layer(Extension(oauth_client));
 
     let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
     tracing::debug!("listening on {}", addr);

--- a/examples/reverse-proxy/src/main.rs
+++ b/examples/reverse-proxy/src/main.rs
@@ -11,7 +11,7 @@ use axum::{
     extract::Extension,
     http::{uri::Uri, Request, Response},
     routing::get,
-    AddExtensionLayer, Router,
+    Router,
 };
 use hyper::{client::HttpConnector, Body};
 use std::{convert::TryFrom, net::SocketAddr};
@@ -26,7 +26,7 @@ async fn main() {
 
     let app = Router::new()
         .route("/", get(handler))
-        .layer(AddExtensionLayer::new(client));
+        .layer(Extension(client));
 
     let addr = SocketAddr::from(([127, 0, 0, 1], 4000));
     println!("reverse proxy listening on {}", addr);

--- a/examples/sessions/src/main.rs
+++ b/examples/sessions/src/main.rs
@@ -16,7 +16,7 @@ use axum::{
     },
     response::IntoResponse,
     routing::get,
-    AddExtensionLayer, Router,
+    Router,
 };
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
@@ -38,7 +38,7 @@ async fn main() {
 
     let app = Router::new()
         .route("/", get(handler))
-        .layer(AddExtensionLayer::new(store));
+        .layer(Extension(store));
 
     let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
     tracing::debug!("listening on {}", addr);

--- a/examples/todos/src/main.rs
+++ b/examples/todos/src/main.rs
@@ -29,7 +29,7 @@ use std::{
     time::Duration,
 };
 use tower::{BoxError, ServiceBuilder};
-use tower_http::{add_extension::AddExtensionLayer, trace::TraceLayer};
+use tower_http::trace::TraceLayer;
 use uuid::Uuid;
 
 #[tokio::main]
@@ -61,7 +61,7 @@ async fn main() {
                 }))
                 .timeout(Duration::from_secs(10))
                 .layer(TraceLayer::new_for_http())
-                .layer(AddExtensionLayer::new(db))
+                .layer(Extension(db))
                 .into_inner(),
         );
 

--- a/examples/tokio-postgres/src/main.rs
+++ b/examples/tokio-postgres/src/main.rs
@@ -9,7 +9,7 @@ use axum::{
     extract::{Extension, FromRequest, RequestParts},
     http::StatusCode,
     routing::get,
-    AddExtensionLayer, Router,
+    Router,
 };
 use bb8::{Pool, PooledConnection};
 use bb8_postgres::PostgresConnectionManager;
@@ -36,7 +36,7 @@ async fn main() {
             "/",
             get(using_connection_pool_extractor).post(using_connection_extractor),
         )
-        .layer(AddExtensionLayer::new(pool));
+        .layer(Extension(pool));
 
     // run it with hyper
     let addr = SocketAddr::from(([127, 0, 0, 1], 3000));


### PR DESCRIPTION
Backports https://github.com/tokio-rs/axum/pull/801 to 0.4.x and deprecates `AddExtensionLayer`.