### PR TITLE
Using fully qualified path for Extension

### DIFF
--- a/axum/src/add_extension.rs
+++ b/axum/src/add_extension.rs
@@ -14,7 +14,7 @@ use tower_service::Service;
 #[derive(Clone, Copy, Debug)]
 #[deprecated(
     since = "0.4.7",
-    note = "Use `axum::Extension` instead. It implements `tower::Layer`"
+    note = "Use `axum::extract::Extension` instead. It implements `tower::Layer`"
 )]
 pub struct AddExtensionLayer<T> {
     value: T,
@@ -59,7 +59,7 @@ impl<S, T> AddExtension<S, T> {
     /// Create a new [`AddExtensionLayer`].
     #[deprecated(
         since = "0.4.7",
-        note = "Use `axum::Extension` instead. It implements `tower::Layer`"
+        note = "Use `axum::extract::Extension` instead. It implements `tower::Layer`"
     )]
     #[allow(deprecated)]
     pub fn layer(value: T) -> AddExtensionLayer<T> {


### PR DESCRIPTION
## Motivation

I was updating code after noticing new warnings of deprecations, and I tried to change my usage from AddExtensionLayer to `axum::Extension`, only to find that the type wasn't found.

## Solution

I updated the deprecation message to point to the fully qualified path. It appears this is re-exported in main, but not in 0.4.x. I'm not sure if this should be preferred to exporting it at the new location, but it seemed like the safer fix.