### PR TITLE
Make `IntoResponseParts` more flexible

### DIFF
--- a/axum-core/src/response/mod.rs
+++ b/axum-core/src/response/mod.rs
@@ -11,7 +11,7 @@ mod into_response_parts;
 
 pub use self::{
     into_response::IntoResponse,
-    into_response_parts::{IntoResponseParts, ResponseParts},
+    into_response_parts::{IntoResponseParts, ResponseParts, TryIntoHeaderError},
 };
 
 /// Type alias for [`http::Response`] whose body type defaults to [`BoxBody`], the most common body

--- a/axum/src/extension.rs
+++ b/axum/src/extension.rs
@@ -6,6 +6,7 @@ use async_trait::async_trait;
 use axum_core::response::{IntoResponse, Response, ResponseParts};
 use http::Request;
 use std::{
+    convert::Infallible,
     ops::Deref,
     task::{Context, Poll},
 };
@@ -107,8 +108,11 @@ impl<T> IntoResponseParts for Extension<T>
 where
     T: Send + Sync + 'static,
 {
-    fn into_response_parts(self, res: &mut ResponseParts) {
-        res.insert_extension(self.0);
+    type Error = Infallible;
+
+    fn into_response_parts(self, mut res: ResponseParts) -> Result<ResponseParts, Self::Error> {
+        res.extensions_mut().insert(self.0);
+        Ok(res)
     }
 }
 

--- a/axum/src/typed_header.rs
+++ b/axum/src/typed_header.rs
@@ -90,7 +90,7 @@ where
     type Error = Infallible;
 
     fn into_response_parts(self, mut res: ResponseParts) -> Result<ResponseParts, Self::Error> {
-        res.typed_insert(self.0);
+        res.headers_mut().typed_insert(self.0);
         Ok(res)
     }
 }

--- a/axum/src/typed_header.rs
+++ b/axum/src/typed_header.rs
@@ -2,7 +2,6 @@ use crate::extract::{FromRequest, RequestParts};
 use async_trait::async_trait;
 use axum_core::response::{IntoResponse, IntoResponseParts, Response, ResponseParts};
 use headers::HeaderMapExt;
-use http::header::{HeaderName, HeaderValue};
 use std::{convert::Infallible, ops::Deref};
 
 /// Extractor and response that works with typed header values from [`headers`].

--- a/axum/src/typed_header.rs
+++ b/axum/src/typed_header.rs
@@ -89,31 +89,9 @@ where
 {
     type Error = Infallible;
 
-    fn into_response_parts(self, res: ResponseParts) -> Result<ResponseParts, Self::Error> {
-        struct ExtendHeaders {
-            res: ResponseParts,
-            key: &'static HeaderName,
-        }
-
-        impl Extend<HeaderValue> for ExtendHeaders {
-            fn extend<T>(&mut self, iter: T)
-            where
-                T: IntoIterator<Item = HeaderValue>,
-            {
-                for value in iter {
-                    self.res.headers_mut().append(self.key, value);
-                }
-            }
-        }
-
-        let mut extend = ExtendHeaders {
-            res,
-            key: T::name(),
-        };
-
-        self.0.encode(&mut extend);
-
-        Ok(extend.res)
+    fn into_response_parts(self, mut res: ResponseParts) -> Result<ResponseParts, Self::Error> {
+        res.typed_insert(self.0);
+        Ok(res)
     }
 }
 


### PR DESCRIPTION
I've been thinking that `IntoResponseParts` could be useful for adding cookies, flash messages, or more high level things to the response. Something like:

```rust
(
    Cookie::new("key", "value"),
    Cookie::new("key-2", "value-2"),
    flash::error("something went wrong"),
    response,
)
```

I think this is nicer than something like [tower-cookies](https://docs.rs/tower-cookies/latest/tower_cookies/index.html) which uses a middleware and a `Drop` implementation to set the cookies. This approach should compose more nicely and not require any middleware.

That made me think that `ResponseParts` probably isn't quite flexible enough since it only allows inserting headers and extensions. You can't check for existing values, or call any other methods on `HeaderMap` or `Extensions`.

So this makes the following changes:

- Add `extensions(_mut)` and `headers(_mut)` methods to `ResponseParts`. The `*_mut` methods users can `std::mem::take` them and replace the existing ones but I think thats fine as it makes things much more flexible.
- Add an associated error type to `IntoResponseParts`. I think handling errors, for example when converting things into headers, this way is cleaner. The new method signature `fn into_response_parts(self, res: ResponseParts) -> Result<ResponseParts, Self::Error>` is a bit of a mouthful but at least it forces the caller to check the result vs something like `fn(&mut ResponseParts) -> Result<(), _>` which makes it possible to discard the error.