### PR TITLE
Move `HasRoutes` into axum

### DIFF
--- a/axum-extra/CHANGELOG.md
+++ b/axum-extra/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning].
 - **breaking:** `CachedRejection` has been removed ([#699])
 - **breaking:** `<Cached<T> as FromRequest>::Rejection` is now `T::Rejection`. ([#699])
 - **breaking:** `middleware::from_fn` has been moved into the main axum crate ([#719])
+- **breaking:** `HasRoutes` has been moved into axum
+- **breaking:** `RouterExt::with` method has been removed. Use `Router::merge` instead. It works
+  identically
 
 [#666]: https://github.com/tokio-rs/axum/pull/666
 [#699]: https://github.com/tokio-rs/axum/pull/699

--- a/axum-extra/CHANGELOG.md
+++ b/axum-extra/CHANGELOG.md
@@ -12,15 +12,16 @@ and this project adheres to [Semantic Versioning].
 - **breaking:** `CachedRejection` has been removed ([#699])
 - **breaking:** `<Cached<T> as FromRequest>::Rejection` is now `T::Rejection`. ([#699])
 - **breaking:** `middleware::from_fn` has been moved into the main axum crate ([#719])
-- **breaking:** `HasRoutes` has been moved into axum
+- **breaking:** `HasRoutes` has been removed. `Router::merge` now accepts `Into<Router>` ([#819])
 - **breaking:** `RouterExt::with` method has been removed. Use `Router::merge` instead. It works
-  identically
+  identically ([#819])
 
 [#666]: https://github.com/tokio-rs/axum/pull/666
 [#699]: https://github.com/tokio-rs/axum/pull/699
 [#719]: https://github.com/tokio-rs/axum/pull/719
 [#756]: https://github.com/tokio-rs/axum/pull/756
 [#790]: https://github.com/tokio-rs/axum/pull/790
+[#819]: https://github.com/tokio-rs/axum/pull/819
 
 # 0.1.2 (13. January, 2022)
 

--- a/axum-extra/src/routing/mod.rs
+++ b/axum-extra/src/routing/mod.rs
@@ -1,6 +1,6 @@
 //! Additional types for defining routes.
 
-use axum::{body::Body, handler::Handler, Router};
+use axum::{handler::Handler, Router};
 
 mod resource;
 
@@ -17,31 +17,6 @@ pub use self::typed::{FirstElementIs, TypedPath};
 
 /// Extension trait that adds additional methods to [`Router`].
 pub trait RouterExt<B>: sealed::Sealed {
-    /// Add the routes from `T`'s [`HasRoutes::routes`] to this router.
-    ///
-    /// # Example
-    ///
-    /// Using [`Resource`] which implements [`HasRoutes`]:
-    ///
-    /// ```rust
-    /// use axum::{Router, routing::get};
-    /// use axum_extra::routing::{RouterExt, Resource};
-    ///
-    /// let app = Router::new()
-    ///     .with(
-    ///         Resource::named("users")
-    ///             .index(|| async {})
-    ///             .create(|| async {})
-    ///     )
-    ///     .with(
-    ///         Resource::named("teams").index(|| async {})
-    ///     );
-    /// # let _: Router<axum::body::Body> = app;
-    /// ```
-    fn with<T>(self, routes: T) -> Self
-    where
-        T: HasRoutes<B>;
-
     /// Add a typed `GET` route to the router.
     ///
     /// The path will be inferred from the first argument to the handler function which must
@@ -151,13 +126,6 @@ impl<B> RouterExt<B> for Router<B>
 where
     B: axum::body::HttpBody + Send + 'static,
 {
-    fn with<T>(self, routes: T) -> Self
-    where
-        T: HasRoutes<B>,
-    {
-        self.merge(routes.routes())
-    }
-
     #[cfg(feature = "typed-routing")]
     fn typed_get<H, T, P>(self, handler: H) -> Self
     where
@@ -236,20 +204,6 @@ where
         P: TypedPath,
     {
         self.route(P::PATH, axum::routing::trace(handler))
-    }
-}
-
-/// Trait for things that can provide routes.
-///
-/// Used with [`RouterExt::with`].
-pub trait HasRoutes<B = Body> {
-    /// Get the routes.
-    fn routes(self) -> Router<B>;
-}
-
-impl<B> HasRoutes<B> for Router<B> {
-    fn routes(self) -> Router<B> {
-        self
     }
 }
 

--- a/axum-extra/src/routing/resource.rs
+++ b/axum-extra/src/routing/resource.rs
@@ -1,10 +1,9 @@
-use super::HasRoutes;
 use axum::{
     body::Body,
     handler::Handler,
     http::Request,
     response::Response,
-    routing::{delete, get, on, post, MethodFilter},
+    routing::{delete, get, on, post, HasRoutes, MethodFilter},
     Router,
 };
 use std::convert::Infallible;
@@ -192,7 +191,6 @@ impl<B> HasRoutes<B> for Resource<B> {
 mod tests {
     #[allow(unused_imports)]
     use super::*;
-    use crate::routing::RouterExt;
     use axum::{extract::Path, http::Method, Router};
     use tower::ServiceExt;
 
@@ -214,7 +212,7 @@ mod tests {
                 Router::new().route("/featured", get(|| async move { "users#featured" })),
             );
 
-        let mut app = Router::new().with(users);
+        let mut app = Router::new().merge(users);
 
         assert_eq!(
             call_route(&mut app, Method::GET, "/users").await,

--- a/axum-extra/src/routing/resource.rs
+++ b/axum-extra/src/routing/resource.rs
@@ -44,7 +44,7 @@ use tower_service::Service;
 ///         Router::new().route("/featured", get(|| async {})),
 ///     );
 ///
-/// let app = Router::new().with(users);
+/// let app = Router::new().merge(users);
 /// # let _: Router<axum::body::Body> = app;
 /// ```
 #[derive(Debug)]

--- a/axum-extra/src/routing/resource.rs
+++ b/axum-extra/src/routing/resource.rs
@@ -3,7 +3,7 @@ use axum::{
     handler::Handler,
     http::Request,
     response::Response,
-    routing::{delete, get, on, post, HasRoutes, MethodFilter},
+    routing::{delete, get, on, post, MethodFilter},
     Router,
 };
 use std::convert::Infallible;
@@ -181,9 +181,9 @@ where
     }
 }
 
-impl<B> HasRoutes<B> for Resource<B> {
-    fn routes(self) -> Router<B> {
-        self.router
+impl<B> From<Resource<B>> for Router<B> {
+    fn from(resource: Resource<B>) -> Self {
+        resource.router
     }
 }
 

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **added:** `Extension<_>` can now be used in tuples for building responses, and will set an
   extension on the response ([#797])
 - **added:** Implement `tower::Layer` for `Extension` ([#801])
+- **added:** Add `HasRoutes` trait allowing users to define their own types that work with
+  `Router::merge`
+- **changed:** `Router::merge` now requires the argument to implement `HasRoutes`. This is
+  implemented for `Router`
 - **breaking:** `sse::Event` now accepts types implementing `AsRef<str>` instead of `Into<String>`
   as field values.
 - **breaking:** `sse::Event` now panics if a setter method is called twice instead of silently

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -13,10 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **added:** `Extension<_>` can now be used in tuples for building responses, and will set an
   extension on the response ([#797])
 - **added:** Implement `tower::Layer` for `Extension` ([#801])
-- **added:** Add `HasRoutes` trait allowing users to define their own types that work with
-  `Router::merge`
-- **changed:** `Router::merge` now requires the argument to implement `HasRoutes`. This is
-  implemented for `Router`
+- **changed:** `Router::merge` now accepts `Into<Routes>` ([#819])
 - **breaking:** `sse::Event` now accepts types implementing `AsRef<str>` instead of `Into<String>`
   as field values.
 - **breaking:** `sse::Event` now panics if a setter method is called twice instead of silently
@@ -84,6 +81,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#800]: https://github.com/tokio-rs/axum/pull/800
 [#801]: https://github.com/tokio-rs/axum/pull/801
 [#807]: https://github.com/tokio-rs/axum/pull/807
+[#819]: https://github.com/tokio-rs/axum/pull/819
 
 # 0.4.4 (13. January, 2022)
 

--- a/axum/src/routing/mod.rs
+++ b/axum/src/routing/mod.rs
@@ -247,14 +247,14 @@ where
     #[doc = include_str!("../docs/routing/merge.md")]
     pub fn merge<R>(mut self, other: R) -> Self
     where
-        R: HasRoutes<B>,
+        R: Into<Router<B>>,
     {
         let Router {
             routes,
             node,
             fallback,
             nested_at_root,
-        } = other.routes();
+        } = other.into();
 
         for (id, route) in routes {
             let path = node
@@ -699,74 +699,4 @@ impl<B> fmt::Debug for Endpoint<B> {
 fn traits() {
     use crate::test_helpers::*;
     assert_send::<Router<()>>();
-}
-
-/// Trait for things that can provide routes.
-///
-/// Used with [`Router::merge`].
-///
-/// # Example
-///
-/// This can be used to build your own abstractions for building routes and have it work with
-/// [`Router::merge`].
-///
-/// Consider this hypothetical API for having a bunch of paths all go to the same handler:
-///
-/// ```rust
-/// use axum::{
-///     Router,
-///     routing::{get, post, MethodRouter, HasRoutes},
-///     handler::Handler,
-///     body::HttpBody,
-/// };
-///
-/// struct ToSameHandler<B> {
-///     route: MethodRouter<B>,
-///     routes: Router<B>,
-/// }
-///
-/// impl<B> ToSameHandler<B>
-/// where
-///     B: HttpBody + Send + 'static,
-/// {
-///     fn new<H, T>(handler: H) -> Self
-///     where
-///         H: Handler<T, B>,
-///         T: 'static,
-///     {
-///         Self {
-///             route: get(handler),
-///             routes: Router::new(),
-///         }
-///     }
-///
-///     fn add_path(mut self, path: &str) -> Self {
-///         self.routes = self.routes.route(path, self.route.clone());
-///         self
-///     }
-/// }
-///
-/// impl<B> HasRoutes<B> for ToSameHandler<B> {
-///     fn routes(self) -> Router<B> {
-///         self.routes
-///     }
-/// }
-///
-/// let app = Router::new().merge(
-///     ToSameHandler::new(|| async {})
-///         .add_path("/foo")
-///         .add_path("/bar")
-///         .add_path("/baz")
-/// );
-/// # let _: Router<axum::body::Body> = app;
-/// ```
-pub trait HasRoutes<B> {
-    /// Get the routes.
-    fn routes(self) -> Router<B>;
-}
-
-impl<B> HasRoutes<B> for Router<B> {
-    fn routes(self) -> Router<B> {
-        self
-    }
 }


### PR DESCRIPTION
I think `HasRoutes` in axum-extra is pretty neat. It allows users to build their own abstractions for building routes and have them work directly with axum. I've been thinking that for 0.5 we should promote the trait to live in axum.

This is partly driven by some talks @LucioFranco and I have been having about possibly moving tonic's routing to axum in a more public way. Tonic currently reinvents a bunch of middleware stuff that axum already handles. That'd also give users more flexibility in how they compose their gRPC services. Such a change could have tonic implement `HasRoutes` for its services so they'd work with `axum::Router::merge`. However there are no concrete plans so its mostly speculation on my part.

I don't see much downside to this. `Router` implements `HasRoutes` so everything works like it used to.

@jplatte what do you think?