### PR TITLE
Add note about order of extractors in the reverse-proxy example

### DIFF
--- a/examples/reverse-proxy/src/main.rs
+++ b/examples/reverse-proxy/src/main.rs
@@ -36,7 +36,12 @@ async fn main() {
         .unwrap();
 }
 
-async fn handler(Extension(client): Extension<Client>, mut req: Request<Body>) -> Response<Body> {
+async fn handler(
+    Extension(client): Extension<Client>,
+    // NOTE: Make sure to put the request extractor last because once the request
+    // is extracted, extensions can't be extracted anymore.
+    mut req: Request<Body>,
+) -> Response<Body> {
     let path = req.uri().path();
     let path_query = req
         .uri()


### PR DESCRIPTION
## Motivation

When building a proxy handler based on the `reverse-proxy` example, I ran into an error because I put the `Request<Body>` extractor before my `Extension` extractors.

## Solution

Add a note to the `reverse-proxy` example that the order of the extractors is relevant and `Request<Body>` needs to come last.