### PR TITLE
Requires paths start with a `/`

### DIFF
--- a/axum-macros/CHANGELOG.md
+++ b/axum-macros/CHANGELOG.md
@@ -9,7 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **added:** Add `#[derive(TypedPath)]` for use with axum-extra's new "type safe" routing API ([#756])
 - **breaking:** Routes are now required to start with `/`. Previously empty routes or routes such
-  as `:foo` would be accepted but most likely result in bugs
+  as `:foo` would be accepted but most likely result in bugs ([#823])
+
+[#823]: https://github.com/tokio-rs/axum/pull/823
 
 # 0.1.0 (31. January, 2022)
 

--- a/axum-macros/CHANGELOG.md
+++ b/axum-macros/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # Unreleased
 
 - **added:** Add `#[derive(TypedPath)]` for use with axum-extra's new "type safe" routing API ([#756])
+- **breaking:** Routes are now required to start with `/`. Previously empty routes or routes such
+  as `:foo` would be accepted but most likely result in bugs
 
 # 0.1.0 (31. January, 2022)
 

--- a/axum-macros/src/typed_path.rs
+++ b/axum-macros/src/typed_path.rs
@@ -284,6 +284,16 @@ fn captures_from_path(segments: &[Segment]) -> Vec<syn::Ident> {
 }
 
 fn parse_path(path: &LitStr) -> syn::Result<Vec<Segment>> {
+    let value = path.value();
+    if value.is_empty() {
+        return Err(syn::Error::new_spanned(
+            path,
+            "paths must start with a `/`. Use \"/\" for root routes",
+        ));
+    } else if !path.value().starts_with('/') {
+        return Err(syn::Error::new_spanned(path, "paths must start with a `/`"));
+    }
+
     path.value()
         .split('/')
         .map(|segment| {

--- a/axum-macros/tests/typed_path/fail/route_not_starting_with_slash.rs
+++ b/axum-macros/tests/typed_path/fail/route_not_starting_with_slash.rs
@@ -1,0 +1,7 @@
+use axum_extra::routing::TypedPath;
+
+#[derive(TypedPath)]
+#[typed_path("")]
+struct MyPath;
+
+fn main() {}

--- a/axum-macros/tests/typed_path/fail/route_not_starting_with_slash.stderr
+++ b/axum-macros/tests/typed_path/fail/route_not_starting_with_slash.stderr
@@ -1,0 +1,5 @@
+error: paths must start with a `/`. Use "/" for root routes
+ --> tests/typed_path/fail/route_not_starting_with_slash.rs:4:14
+  |
+4 | #[typed_path("")]
+  |              ^^

--- a/axum-macros/tests/typed_path/fail/route_not_starting_with_slash_non_empty.rs
+++ b/axum-macros/tests/typed_path/fail/route_not_starting_with_slash_non_empty.rs
@@ -1,0 +1,7 @@
+use axum_extra::routing::TypedPath;
+
+#[derive(TypedPath)]
+#[typed_path(":foo")]
+struct MyPath;
+
+fn main() {}

--- a/axum-macros/tests/typed_path/fail/route_not_starting_with_slash_non_empty.stderr
+++ b/axum-macros/tests/typed_path/fail/route_not_starting_with_slash_non_empty.stderr
@@ -1,0 +1,5 @@
+error: paths must start with a `/`
+ --> tests/typed_path/fail/route_not_starting_with_slash_non_empty.rs:4:14
+  |
+4 | #[typed_path(":foo")]
+  |              ^^^^^^

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -61,7 +61,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `tower::Layer` ([#807])
 - **breaking:** `AddExtension` has been moved from the root module to `middleware`
 - **breaking:** Routes are now required to start with `/`. Previously routes such as `:foo` would
-  be accepted but most likely result in bugs
+  be accepted but most likely result in bugs ([#823])
 - **fixed:** Set `Allow` header when responding with `405 Method Not Allowed` ([#733])
 - **fixed:** Correctly set the `Content-Length` header for response to `HEAD`
   requests ([#734])
@@ -84,6 +84,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#801]: https://github.com/tokio-rs/axum/pull/801
 [#807]: https://github.com/tokio-rs/axum/pull/807
 [#819]: https://github.com/tokio-rs/axum/pull/819
+[#823]: https://github.com/tokio-rs/axum/pull/823
 
 # 0.4.4 (13. January, 2022)
 

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -60,6 +60,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **breaking:** `AddExtensionLayer` has been removed. Use `Extension` instead. It now implements
   `tower::Layer` ([#807])
 - **breaking:** `AddExtension` has been moved from the root module to `middleware`
+- **breaking:** Routes are now required to start with `/`. Previously routes such as `:foo` would
+  be accepted but most likely result in bugs
 - **fixed:** Set `Allow` header when responding with `405 Method Not Allowed` ([#733])
 - **fixed:** Correctly set the `Content-Length` header for response to `HEAD`
   requests ([#734])

--- a/axum/src/routing/mod.rs
+++ b/axum/src/routing/mod.rs
@@ -125,7 +125,9 @@ where
         T::Future: Send + 'static,
     {
         if path.is_empty() {
-            panic!("Invalid route: empty path");
+            panic!("Paths must start with a `/`. Use \"/\" for root routes");
+        } else if !path.starts_with('/') {
+            panic!("Paths must start with a `/`");
         }
 
         let service = match try_downcast::<Router<B>, _>(service) {

--- a/axum/src/routing/tests/mod.rs
+++ b/axum/src/routing/tests/mod.rs
@@ -441,7 +441,7 @@ async fn static_and_dynamic_paths() {
 }
 
 #[tokio::test]
-#[should_panic(expected = "Invalid route: empty path")]
+#[should_panic(expected = "Paths must start with a `/`. Use \"/\" for root routes")]
 async fn empty_route() {
     let app = Router::new().route("", get(|| async {}));
     TestClient::new(app);
@@ -677,4 +677,11 @@ async fn head_with_middleware_applied() {
     // no content-length since we cannot know it since the response
     // is compressed
     assert!(!res.headers().contains_key("content-length"));
+}
+
+#[tokio::test]
+#[should_panic(expected = "Paths must start with a `/`")]
+async fn routes_must_start_with_slash() {
+    let app = Router::new().route(":foo", get(|| async {}));
+    TestClient::new(app);
 }


### PR DESCRIPTION
Previously we only guarded against empty paths while paths like `:foo` were accepted.