### PR TITLE
Fix inconsistent double slash when nesting routes

### DIFF
--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -60,6 +60,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **breaking:** `AddExtensionLayer` has been removed. Use `Extension` instead. It now implements
   `tower::Layer` ([#807])
 - **breaking:** `AddExtension` has been moved from the root module to `middleware`
+- **breaking:** `.nest("/foo/", Router::new().route("/bar", _))` now does the right thing and
+  results in a route at `/foo/bar` instead of `/foo//bar` ([#824])
 - **fixed:** Set `Allow` header when responding with `405 Method Not Allowed` ([#733])
 - **fixed:** Correctly set the `Content-Length` header for response to `HEAD`
   requests ([#734])
@@ -82,6 +84,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#801]: https://github.com/tokio-rs/axum/pull/801
 [#807]: https://github.com/tokio-rs/axum/pull/807
 [#819]: https://github.com/tokio-rs/axum/pull/819
+[#824]: https://github.com/tokio-rs/axum/pull/824
 
 # 0.4.4 (13. January, 2022)
 

--- a/axum/src/routing/mod.rs
+++ b/axum/src/routing/mod.rs
@@ -213,6 +213,8 @@ where
                         path.into()
                     } else if path == "/" {
                         (&*nested_path).into()
+                    } else if let Some(path) = path.strip_suffix('/') {
+                        format!("{}{}", path, nested_path).into()
                     } else {
                         format!("{}{}", path, nested_path).into()
                     };


### PR DESCRIPTION
Previously `.nest("/foo/", Router::new().route("/bar", _))` would result in `/foo//bar` which was inconsistent and broke other use cases described in https://github.com/tokio-rs/axum/issues/714.

This fixes that so the deduplication of slashes is done consistently.

Fixes https://github.com/tokio-rs/axum/issues/714