### PR TITLE
Add Host extractor

### DIFF
--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **added:** `Extension<_>` can now be used in tuples for building responses, and will set an
   extension on the response ([#797])
 - **added:** Implement `tower::Layer` for `Extension` ([#801])
+- **added:** `extract::Host` for extracting the hostname of a request ([#827])
 - **changed:** `Router::merge` now accepts `Into<Router>` ([#819])
 - **breaking:** `sse::Event` now accepts types implementing `AsRef<str>` instead of `Into<String>`
   as field values.

--- a/axum/src/extract/host.rs
+++ b/axum/src/extract/host.rs
@@ -1,7 +1,17 @@
-use super::{FromRequest, RequestParts, rejection::{HostRejection, FailedToResolveHost}};
+use super::{
+    rejection::{FailedToResolveHost, HostRejection},
+    FromRequest, RequestParts,
+};
 use async_trait::async_trait;
 
-/// Extractor that extracts the host from a request.
+const X_FORWARDED_HOST_HEADER_KEY: &'static str = "X-Forwarded-Host";
+
+/// Extractor that resolves the hostname of the request.
+///
+/// Hostname is resolved through the following, in order:
+/// - `X-Forwarded-Host` header
+/// - `Host` header
+/// - request target / URI
 #[derive(Debug, Clone)]
 pub struct Host(pub String);
 
@@ -15,11 +25,19 @@ where
     async fn from_request(req: &mut RequestParts<B>) -> Result<Self, Self::Rejection> {
         // todo: extract host from http::header::FORWARDED
 
-        if let Some(host) = req.headers().get("X-Forwarded-Host").and_then(|host| host.to_str().ok()) {
+        if let Some(host) = req
+            .headers()
+            .get(X_FORWARDED_HOST_HEADER_KEY)
+            .and_then(|host| host.to_str().ok())
+        {
             return Ok(Host(host.to_owned()));
         }
 
-        if let Some(host) = req.headers().get(http::header::HOST).and_then(|host| host.to_str().ok()) {
+        if let Some(host) = req
+            .headers()
+            .get(http::header::HOST)
+            .and_then(|host| host.to_str().ok())
+        {
             return Ok(Host(host.to_owned()));
         }
 
@@ -34,31 +52,60 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::extract::RequestParts;
-    use http::Request;
+    use crate::{routing::get, test_helpers::TestClient, Router};
+
+    fn test_client() -> TestClient {
+        async fn host_as_body(Host(host): Host) -> String {
+            host
+        }
+
+        TestClient::new(Router::new().route("/", get(host_as_body)))
+    }
 
     #[tokio::test]
-    async fn test_host() {
-        let mut req = RequestParts::new(
-            Request::builder()
-                .uri("http://example.com/test")
-                .body(())
-                .unwrap(),
-        );
-        assert_eq!(
-            &Host::from_request(&mut req).await.unwrap().0,
-            "example.com"
-        );
+    async fn host_header() {
+        let original_host = "some-domain:123";
+        let host = test_client()
+            .get("/")
+            .header(http::header::HOST, original_host)
+            .send()
+            .await
+            .text()
+            .await;
+        assert_eq!(host, original_host);
+    }
 
-        let mut req = RequestParts::new(
-            Request::builder()
-                .header("host", "cats.fun")
-                .body(())
-                .unwrap(),
-        );
-        assert_eq!(
-            &Host::from_request(&mut req).await.unwrap().0,
-            "cats.fun"
-        );
+    #[tokio::test]
+    async fn x_forwarded_host_header() {
+        let original_host = "some-domain:456";
+        let host = test_client()
+            .get("/")
+            .header(X_FORWARDED_HOST_HEADER_KEY, original_host)
+            .send()
+            .await
+            .text()
+            .await;
+        assert_eq!(host, original_host);
+    }
+
+    #[tokio::test]
+    async fn x_forwarded_host_precedence_over_host_header() {
+        let x_forwarded_host_header = "some-domain:456";
+        let host_header = "some-domain:123";
+        let host = test_client()
+            .get("/")
+            .header(X_FORWARDED_HOST_HEADER_KEY, x_forwarded_host_header)
+            .header(http::header::HOST, host_header)
+            .send()
+            .await
+            .text()
+            .await;
+        assert_eq!(host, x_forwarded_host_header);
+    }
+
+    #[tokio::test]
+    async fn uri_host() {
+        let host = test_client().get("/").send().await.text().await;
+        assert!(host.contains("127.0.0.1"));
     }
 }

--- a/axum/src/extract/host.rs
+++ b/axum/src/extract/host.rs
@@ -1,0 +1,59 @@
+use super::{FromRequest, RequestParts};
+use async_trait::async_trait;
+use std::{convert::Infallible};
+
+/// Extractor that extracts the host from a request.
+#[derive(Debug, Clone, Default)]
+pub struct Host(pub String);
+
+#[async_trait]
+impl<B> FromRequest<B> for Host
+where
+    B: Send,
+{
+    type Rejection = Infallible;
+
+    async fn from_request(req: &mut RequestParts<B>) -> Result<Self, Self::Rejection> {
+        if let Some(host) = req.uri().host() {
+            return Ok(Host(host.to_string()));
+        }
+
+        if let Some(Ok(host)) = req.headers().get("host").map(|host| host.to_str()) {
+            return Ok(Host(host.to_string()));
+        }
+
+        Ok(Host("".to_string()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::extract::RequestParts;
+    use http::Request;
+
+    #[tokio::test]
+    async fn test_host() {
+        let mut req = RequestParts::new(
+            Request::builder()
+                .uri("http://example.com/test")
+                .body(())
+                .unwrap(),
+        );
+        assert_eq!(
+            &Host::from_request(&mut req).await.unwrap().0,
+            "example.com"
+        );
+
+        let mut req = RequestParts::new(
+            Request::builder()
+                .header("host", "cats.fun")
+                .body(())
+                .unwrap(),
+        );
+        assert_eq!(
+            &Host::from_request(&mut req).await.unwrap().0,
+            "cats.fun"
+        );
+    }
+}

--- a/axum/src/extract/host.rs
+++ b/axum/src/extract/host.rs
@@ -13,9 +13,7 @@ where
     type Rejection = HostRejection;
 
     async fn from_request(req: &mut RequestParts<B>) -> Result<Self, Self::Rejection> {
-        if let Some(host) = req.headers().get(http::header::FORWARDED).and_then(|host| host.to_str().ok()) {
-            return Ok(Host(host.to_owned()));
-        }
+        // todo: extract host from http::header::FORWARDED
 
         if let Some(host) = req.headers().get("X-Forwarded-Host").and_then(|host| host.to_str().ok()) {
             return Ok(Host(host.to_owned()));

--- a/axum/src/extract/mod.rs
+++ b/axum/src/extract/mod.rs
@@ -14,6 +14,7 @@ pub mod ws;
 mod content_length_limit;
 mod raw_query;
 mod request_parts;
+mod host;
 
 #[doc(inline)]
 pub use axum_core::extract::{FromRequest, RequestParts};
@@ -23,12 +24,11 @@ pub use self::{
     connect_info::ConnectInfo,
     content_length_limit::ContentLengthLimit,
     extractor_middleware::extractor_middleware,
+    host::Host,
     path::Path,
     raw_query::RawQuery,
     request_parts::{BodyStream, RawBody},
 };
-
-pub mod host;
 
 #[doc(no_inline)]
 #[cfg(feature = "json")]

--- a/axum/src/extract/mod.rs
+++ b/axum/src/extract/mod.rs
@@ -12,9 +12,9 @@ pub mod rejection;
 pub mod ws;
 
 mod content_length_limit;
+mod host;
 mod raw_query;
 mod request_parts;
-mod host;
 
 #[doc(inline)]
 pub use axum_core::extract::{FromRequest, RequestParts};

--- a/axum/src/extract/mod.rs
+++ b/axum/src/extract/mod.rs
@@ -28,6 +28,8 @@ pub use self::{
     request_parts::{BodyStream, RawBody},
 };
 
+pub mod host;
+
 #[doc(no_inline)]
 #[cfg(feature = "json")]
 pub use crate::Json;

--- a/axum/src/extract/rejection.rs
+++ b/axum/src/extract/rejection.rs
@@ -69,7 +69,7 @@ define_rejection! {
     #[status = BAD_REQUEST]
     #[body = "No host found in request"]
     /// Rejection type used if the [`Host`](super::Host) extractor is unable to
-    /// resolve a host from it's supplied `RequestParts`.
+    /// resolve a host.
     pub struct FailedToResolveHost;
 }
 

--- a/axum/src/extract/rejection.rs
+++ b/axum/src/extract/rejection.rs
@@ -65,6 +65,14 @@ define_rejection! {
     pub struct InvalidFormContentType;
 }
 
+define_rejection! {
+    #[status = BAD_REQUEST]
+    #[body = "No host found in request"]
+    /// Rejection type used if the [`Host`](super::Host) extractor is unable to
+    /// resolve a host from it's supplied `RequestParts`.
+    pub struct FailedToResolveHost;
+}
+
 /// Rejection type for extractors that deserialize query strings if the input
 /// couldn't be deserialized into the target type.
 #[derive(Debug)]
@@ -157,6 +165,16 @@ composite_rejection! {
     pub enum PathRejection {
         FailedToDeserializePathParams,
         MissingPathParams,
+    }
+}
+
+composite_rejection! {
+    /// Rejection used for [`Host`](super::Host).
+    ///
+    /// Contains one variant for each way the [`Host`](super::Host) extractor
+    /// can fail.
+    pub enum HostRejection {
+        FailedToResolveHost,
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation

This pr closes #826, implementing the host extractor.

## Solution

1. Check the host portion of the `uri` to see if it's already been provided, returning if it has
2. Read from the `"host"` header value and return if it was present
3. Return an empty string if neither strategy yielded a value
