### PR TITLE
Use `IntoResponse` rather than `Response::builder` internally

### DIFF
--- a/axum/src/error_handling/mod.rs
+++ b/axum/src/error_handling/mod.rs
@@ -1,7 +1,7 @@
 #![doc = include_str!("../docs/error_handling.md")]
 
 use crate::{
-    body::{boxed, Bytes, Full, HttpBody},
+    body::{boxed, Bytes, HttpBody},
     extract::{FromRequest, RequestParts},
     http::{Request, StatusCode},
     response::{IntoResponse, Response},
@@ -197,10 +197,7 @@ macro_rules! impl_service {
                     let req = match req.try_into_request() {
                         Ok(req) => req,
                         Err(err) => {
-                            return Ok(Response::builder()
-                                .status(StatusCode::INTERNAL_SERVER_ERROR)
-                                .body(boxed(Full::from(err.to_string())))
-                                .unwrap());
+                            return Ok((StatusCode::INTERNAL_SERVER_ERROR, err.to_string()).into_response());
                         }
                     };
 

--- a/axum/src/routing/not_found.rs
+++ b/axum/src/routing/not_found.rs
@@ -1,4 +1,5 @@
 use crate::response::Response;
+use axum_core::response::IntoResponse;
 use http::{Request, StatusCode};
 use std::{
     convert::Infallible,
@@ -28,11 +29,6 @@ where
     }
 
     fn call(&mut self, _req: Request<B>) -> Self::Future {
-        let res = Response::builder()
-            .status(StatusCode::NOT_FOUND)
-            .body(crate::body::empty())
-            .unwrap();
-
-        ready(Ok(res))
+        ready(Ok(StatusCode::NOT_FOUND.into_response()))
     }
 }

--- a/axum/src/routing/tests/get_to_head.rs
+++ b/axum/src/routing/tests/get_to_head.rs
@@ -40,18 +40,15 @@ mod for_handlers {
 mod for_services {
     use super::*;
     use crate::routing::get_service;
-    use http::header::HeaderValue;
 
     #[tokio::test]
     async fn get_handles_head() {
         let app = Router::new().route(
             "/",
             get_service(service_fn(|_req: Request<Body>| async move {
-                let res = Response::builder()
-                    .header("x-some-header", "foobar".parse::<HeaderValue>().unwrap())
-                    .body(Body::from("you shouldn't see this"))
-                    .unwrap();
-                Ok::<_, Infallible>(res)
+                Ok::<_, Infallible>(
+                    ([("x-some-header", "foobar")], "you shouldn't see this").into_response(),
+                )
             })),
         );
 


### PR DESCRIPTION
This cleans up a few instances of `Response::builder` used internally and replaces them with `IntoResponse`. I personally think its a bit cleaner.