### PR TITLE
Implement `IntoResponseParts` for `Option<T>`

### DIFF
--- a/axum-core/src/response/into_response_parts.rs
+++ b/axum-core/src/response/into_response_parts.rs
@@ -80,6 +80,21 @@ pub trait IntoResponseParts {
     fn into_response_parts(self, res: ResponseParts) -> Result<ResponseParts, Self::Error>;
 }
 
+impl<T> IntoResponseParts for Option<T>
+where
+    T: IntoResponseParts,
+{
+    type Error = T::Error;
+
+    fn into_response_parts(self, res: ResponseParts) -> Result<ResponseParts, Self::Error> {
+        if let Some(inner) = self {
+            inner.into_response_parts(res)
+        } else {
+            Ok(res)
+        }
+    }
+}
+
 /// Parts of a response.
 ///
 /// Used with [`IntoResponseParts`].


### PR DESCRIPTION
Been thinking that it might be convenient if `Option<T>` implements `IntoResponseParts` so you can conditionally add headers or extensions.