### PR TITLE
Add security note about `extract::Host`

### DIFF
--- a/axum/src/extract/host.rs
+++ b/axum/src/extract/host.rs
@@ -13,8 +13,8 @@ const X_FORWARDED_HOST_HEADER_KEY: &str = "X-Forwarded-Host";
 /// - `Host` header
 /// - request target / URI
 ///
-/// Note that user agents can set `X-Forwarded-Host` and `Host` headers to arbitrarily so make sure
-/// to validate them to avoid security issues.
+/// Note that user agents can set `X-Forwarded-Host` and `Host` headers to arbitrary values so make
+/// sure to validate them to avoid security issues.
 #[derive(Debug, Clone)]
 pub struct Host(pub String);
 

--- a/axum/src/extract/host.rs
+++ b/axum/src/extract/host.rs
@@ -4,7 +4,7 @@ use super::{
 };
 use async_trait::async_trait;
 
-const X_FORWARDED_HOST_HEADER_KEY: &'static str = "X-Forwarded-Host";
+const X_FORWARDED_HOST_HEADER_KEY: &str = "X-Forwarded-Host";
 
 /// Extractor that resolves the hostname of the request.
 ///
@@ -12,6 +12,9 @@ const X_FORWARDED_HOST_HEADER_KEY: &'static str = "X-Forwarded-Host";
 /// - `X-Forwarded-Host` header
 /// - `Host` header
 /// - request target / URI
+///
+/// Note that user agents can set `X-Forwarded-Host` and `Host` headers to arbitrarily so make sure
+/// to validate them to avoid security issues.
 #[derive(Debug, Clone)]
 pub struct Host(pub String);
 


### PR DESCRIPTION
As discussed in https://github.com/tokio-rs/axum/pull/827 users should take care to validate the value extracted by `Host`. This adds a note about that to the docs.