### PR TITLE
Fix nesting of opaque services that paths that contain params

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,5 +4,5 @@ members = [
     "axum-core",
     "axum-extra",
     "axum-macros",
-    "examples/*",
+    # "examples/*",
 ]

--- a/axum/Cargo.toml
+++ b/axum/Cargo.toml
@@ -65,6 +65,8 @@ tokio-stream = "0.1"
 tracing = "0.1"
 uuid = { version = "0.8", features = ["serde", "v4"] }
 anyhow = "1.0"
+quickcheck = "1.0"
+quickcheck_macros = "1.0"
 
 [dev-dependencies.tower]
 package = "tower"

--- a/axum/src/routing/strip_prefix.rs
+++ b/axum/src/routing/strip_prefix.rs
@@ -148,7 +148,7 @@ mod tests {
             $name:ident,
             uri = $uri:literal,
             prefix = $prefix:literal,
-            expected = $expected:expr $(,)?
+            expected = $expected:expr,
         ) => {
             #[test]
             fn $name() {
@@ -159,7 +159,7 @@ mod tests {
         };
     }
 
-    test!(empty, uri = "/", prefix = "/", expected = Some("/"));
+    test!(empty, uri = "/", prefix = "/", expected = Some("/"),);
 
     test!(
         single_segment,
@@ -194,7 +194,7 @@ mod tests {
         single_segment_trailing_slash,
         uri = "/a/",
         prefix = "/a/",
-        expected = Some("/")
+        expected = Some("/"),
     );
 
     test!(
@@ -208,14 +208,14 @@ mod tests {
         single_segment_trailing_slash_3,
         uri = "/a/",
         prefix = "/a",
-        expected = Some("/")
+        expected = Some("/"),
     );
 
     test!(
         multi_segment,
         uri = "/a/b",
         prefix = "/a",
-        expected = Some("/b")
+        expected = Some("/b"),
     );
 
     test!(
@@ -236,14 +236,14 @@ mod tests {
         multi_segment_4,
         uri = "/a/b",
         prefix = "/b",
-        expected = None
+        expected = None,
     );
 
     test!(
         multi_segment_trailing_slash,
         uri = "/a/b/",
         prefix = "/a/b/",
-        expected = Some("/")
+        expected = Some("/"),
     );
 
     test!(
@@ -257,37 +257,37 @@ mod tests {
         multi_segment_trailing_slash_3,
         uri = "/a/b/",
         prefix = "/a/b",
-        expected = Some("/")
+        expected = Some("/"),
     );
 
-    test!(param_0, uri = "/", prefix = "/:param", expected = Some("/"));
+    test!(param_0, uri = "/", prefix = "/:param", expected = Some("/"),);
 
     test!(
         param_1,
         uri = "/a",
         prefix = "/:param",
-        expected = Some("/")
+        expected = Some("/"),
     );
 
     test!(
         param_2,
         uri = "/a/b",
         prefix = "/:param",
-        expected = Some("/b")
+        expected = Some("/b"),
     );
 
     test!(
         param_3,
         uri = "/b/a",
         prefix = "/:param",
-        expected = Some("/a")
+        expected = Some("/a"),
     );
 
     test!(
         param_4,
         uri = "/a/b",
         prefix = "/a/:param",
-        expected = Some("/")
+        expected = Some("/"),
     );
 
     test!(param_5, uri = "/b/a", prefix = "/a/:param", expected = None,);
@@ -298,14 +298,14 @@ mod tests {
         param_7,
         uri = "/b/a",
         prefix = "/:param/a",
-        expected = Some("/")
+        expected = Some("/"),
     );
 
     test!(
         param_8,
         uri = "/a/b/c",
         prefix = "/a/:param/c",
-        expected = Some("/")
+        expected = Some("/"),
     );
 
     test!(
@@ -319,7 +319,7 @@ mod tests {
         param_10,
         uri = "/a/",
         prefix = "/:param",
-        expected = Some("/")
+        expected = Some("/"),
     );
 
     test!(param_11, uri = "/a", prefix = "/:param/", expected = None,);
@@ -328,7 +328,7 @@ mod tests {
         param_12,
         uri = "/a/",
         prefix = "/:param/",
-        expected = Some("/")
+        expected = Some("/"),
     );
 
     #[quickcheck]

--- a/axum/src/routing/strip_prefix.rs
+++ b/axum/src/routing/strip_prefix.rs
@@ -121,12 +121,15 @@ where
 {
     let a = a.map(Some).chain(std::iter::repeat_with(|| None));
     let b = b.map(Some).chain(std::iter::repeat_with(|| None));
-    a.zip(b).map_while(|(a, b)| match (a, b) {
-        (Some(a), Some(b)) => Some(Item::Both(a, b)),
-        (Some(a), None) => Some(Item::First(a)),
-        (None, Some(b)) => Some(Item::Second(b)),
-        (None, None) => None,
-    })
+    a.zip(b)
+        // use `map_while` when its stable in our MSRV
+        .take_while(|(a, b)| a.is_some() || b.is_some())
+        .filter_map(|(a, b)| match (a, b) {
+            (Some(a), Some(b)) => Some(Item::Both(a, b)),
+            (Some(a), None) => Some(Item::First(a)),
+            (None, Some(b)) => Some(Item::Second(b)),
+            (None, None) => unreachable!("take_while removes these"),
+        })
 }
 
 #[derive(Debug)]

--- a/axum/src/routing/strip_prefix.rs
+++ b/axum/src/routing/strip_prefix.rs
@@ -1,3 +1,4 @@
+use crate::util::IteratorExt;
 use http::{Request, Uri};
 use std::{
     borrow::Cow,
@@ -41,32 +42,71 @@ where
     }
 }
 
+#[allow(unused_must_use)]
 fn strip_prefix(uri: &Uri, prefix: &str) -> Uri {
-    let path_and_query = if let Some(path_and_query) = uri.path_and_query() {
-        let new_path = if let Some(path) = path_and_query.path().strip_prefix(prefix) {
-            path
+    let path_and_query = uri.path_and_query().map(|path_and_query| {
+        let mut matching_prefix_length = Some(0);
+
+        for (path_segment, prefix_segment) in segments(path_and_query.path()).zip(segments(prefix))
+        {
+            // add the `/`
+            *matching_prefix_length.as_mut().unwrap() += 1;
+
+            // dbg!((&path_segment, &prefix_segment));
+
+            match (path_segment, prefix_segment) {
+                (Some(path_segment), Some(prefix_segment)) => {
+                    if prefix_segment.starts_with(':') || path_segment == prefix_segment {
+                        *matching_prefix_length.as_mut().unwrap() += path_segment.len();
+                    } else {
+                        matching_prefix_length = None;
+                        break;
+                    }
+                }
+                // the prefix had more segments than the path
+                // it cannot match
+                (None, Some(_)) => {
+                    matching_prefix_length = None;
+                    break;
+                }
+                // the path had more segments than the prefix
+                // the prefix might still match
+                (Some(_), None) => {
+                    break;
+                }
+                // path and prefix had same number of segments
+                (None, None) => {
+                    break;
+                }
+            }
+        }
+
+        let prefix_with_interpolations = if let Some(idx) = matching_prefix_length {
+            dbg!(&idx);
+            dbg!(&uri.path());
+            let (prefix, _) = uri.path().split_at(idx - 1);
+            prefix
         } else {
-            path_and_query.path()
+            return path_and_query.clone();
         };
 
-        let new_path = if new_path.starts_with('/') {
-            Cow::Borrowed(new_path)
+        let path_after_prefix = path_and_query
+            .path()
+            .strip_prefix(&prefix_with_interpolations)
+            .unwrap_or_else(|| path_and_query.path());
+
+        let new_path = if path_after_prefix.starts_with('/') {
+            Cow::Borrowed(path_after_prefix)
         } else {
-            Cow::Owned(format!("/{}", new_path))
+            Cow::Owned(format!("/{}", path_after_prefix))
         };
 
         if let Some(query) = path_and_query.query() {
-            Some(
-                format!("{}?{}", new_path, query)
-                    .parse::<http::uri::PathAndQuery>()
-                    .unwrap(),
-            )
+            format!("{}?{}", new_path, query).parse().unwrap()
         } else {
-            Some(new_path.parse().unwrap())
+            new_path.parse().unwrap()
         }
-    } else {
-        None
-    };
+    });
 
     let mut parts = http::uri::Parts::default();
     parts.scheme = uri.scheme().cloned();
@@ -74,4 +114,168 @@ fn strip_prefix(uri: &Uri, prefix: &str) -> Uri {
     parts.path_and_query = path_and_query;
 
     Uri::from_parts(parts).unwrap()
+}
+
+fn segments(s: &str) -> impl Iterator<Item = Option<&str>> {
+    assert!(
+        s.starts_with('/'),
+        "path didn't start with '/'. axum should have caught this higher up."
+    );
+
+    s.split('/')
+        // skip one because paths always start with `/` so `/a/b` would become ["", "a", "b"]
+        // otherwise
+        .skip(1)
+        .map(Some)
+        .chain(std::iter::repeat_with(|| None))
+}
+
+#[cfg(test)]
+mod tests {
+    #[allow(unused_imports)]
+    use super::*;
+
+    macro_rules! test {
+        (
+            $name:ident,
+            uri = $uri:literal,
+            prefix = $prefix:literal,
+            expected = $expected:literal $(,)?
+        ) => {
+            #[test]
+            fn $name() {
+                let uri = $uri.parse().unwrap();
+                assert_eq!(
+                    strip_prefix(&uri, $prefix),
+                    $expected,
+                    "without query params"
+                );
+
+                let uri = concat!($uri, "?foo=bar").parse().unwrap();
+                assert_eq!(
+                    strip_prefix(&uri, $prefix),
+                    concat!($expected, "?foo=bar"),
+                    "with query params"
+                );
+            }
+        };
+    }
+
+    test!(empty, uri = "/", prefix = "/", expected = "/");
+
+    test!(single_segment, uri = "/a", prefix = "/a", expected = "/");
+    test!(
+        single_segment_root_uri,
+        uri = "/",
+        prefix = "/a",
+        expected = "/"
+    );
+    test!(
+        single_segment_root_prefix,
+        uri = "/a",
+        prefix = "/",
+        expected = "/a"
+    );
+    test!(
+        single_segment_missing,
+        uri = "/a",
+        prefix = "/b",
+        expected = "/a"
+    );
+
+    test!(
+        single_segment_trailing_slash,
+        uri = "/a/",
+        prefix = "/a/",
+        expected = "/"
+    );
+    // TODO(david): write integration test for this, is this behavior correct?
+    test!(
+        single_segment_trailing_slash_2,
+        uri = "/a",
+        prefix = "/a/",
+        expected = "/a"
+    );
+    test!(
+        single_segment_trailing_slash_3,
+        uri = "/a/",
+        prefix = "/a",
+        expected = "/"
+    );
+
+    test!(multi_segment, uri = "/a/b", prefix = "/a", expected = "/b");
+    test!(
+        multi_segment_2,
+        uri = "/b/a",
+        prefix = "/a",
+        expected = "/b/a"
+    );
+    test!(
+        multi_segment_3,
+        uri = "/a",
+        prefix = "/a/b",
+        expected = "/a"
+    );
+    test!(
+        multi_segment_4,
+        uri = "/a/b",
+        prefix = "/b",
+        expected = "/a/b"
+    );
+
+    test!(
+        multi_segment_trailing_slash,
+        uri = "/a/b/",
+        prefix = "/a/b/",
+        expected = "/"
+    );
+    // TODO(david): write integration test for this, is this behavior correct?
+    test!(
+        multi_segment_trailing_slash_2,
+        uri = "/a/b",
+        prefix = "/a/b/",
+        expected = "/a/b"
+    );
+    test!(
+        multi_segment_trailing_slash_3,
+        uri = "/a/b/",
+        prefix = "/a/b",
+        expected = "/"
+    );
+
+    test!(param_0, uri = "/", prefix = "/:param", expected = "/");
+    test!(param_1, uri = "/a", prefix = "/:param", expected = "/");
+    test!(param_2, uri = "/a/b", prefix = "/:param", expected = "/b");
+    test!(param_3, uri = "/b/a", prefix = "/:param", expected = "/a");
+    test!(param_4, uri = "/a/b", prefix = "/a/:param", expected = "/");
+    test!(
+        param_5,
+        uri = "/b/a",
+        prefix = "/a/:param",
+        expected = "/b/a"
+    );
+    test!(
+        param_6,
+        uri = "/a/b",
+        prefix = "/:param/a",
+        expected = "/a/b"
+    );
+    test!(param_7, uri = "/b/a", prefix = "/:param/a", expected = "/");
+    test!(
+        param_8,
+        uri = "/a/b/c",
+        prefix = "/a/:param/c",
+        expected = "/"
+    );
+    test!(
+        param_9,
+        uri = "/c/b/a",
+        prefix = "/a/:param/c",
+        expected = "/c/b/a"
+    );
+    test!(param_10, uri = "/a/", prefix = "/:param", expected = "/");
+    test!(param_11, uri = "/a", prefix = "/:param/", expected = "/a");
+    test!(param_12, uri = "/a/", prefix = "/:param/", expected = "/");
+
+    // TODO(david): quickcheck tests that we don't panic
 }


### PR DESCRIPTION
While working on https://github.com/tokio-rs/axum/issues/830 I discovered that nesting opaque services at paths that contain params was totally broken. Things like

```rust
let api_routes = Router::new().route("/:b", get(|| async {})).boxed_clone();
let app = Router::new().nest("/:a", api_routes);
```

We would try and strip the prefix as `/:a` but thats a placeholder that should match anything. It shouldn't be used as the literal prefix.

This required some changes to [`StripPrefix`](https://github.com/tokio-rs/axum/blob/main/axum%2Fsrc%2Frouting%2Fstrip_prefix.rs). I also added a bunch more tests and some property tests to get better coverage against panics.