### PR TITLE
Fix routing for opaque nested services

### DIFF
--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -70,6 +70,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   requests ([#734])
 - **fixed:** Fix wrong `content-length` for `HEAD` requests to endpoints that returns chunked
   responses ([#755])
+- **fixed:** Fixed several routing bugs related to nested "opaque" tower services (i.e.
+  non-`Router` services) ([#841] and [#842])
 - **changed:** Update to tokio-tungstenite 0.17 ([#791])
 
 [#644]: https://github.com/tokio-rs/axum/pull/644
@@ -89,6 +91,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#819]: https://github.com/tokio-rs/axum/pull/819
 [#823]: https://github.com/tokio-rs/axum/pull/823
 [#824]: https://github.com/tokio-rs/axum/pull/824
+[#841]: https://github.com/tokio-rs/axum/pull/841
+[#842]: https://github.com/tokio-rs/axum/pull/842
 
 # 0.4.4 (13. January, 2022)
 

--- a/axum/src/routing/mod.rs
+++ b/axum/src/routing/mod.rs
@@ -236,8 +236,8 @@ where
             }
             // otherwise we add a wildcard route to the service
             Err(svc) => {
-                let path = if path == "/" {
-                    format!("/*{}", NEST_TAIL_PARAM)
+                let path = if path.ends_with('/') {
+                    format!("{}*{}", path, NEST_TAIL_PARAM)
                 } else {
                     format!("{}/*{}", path, NEST_TAIL_PARAM)
                 };

--- a/axum/src/routing/strip_prefix.rs
+++ b/axum/src/routing/strip_prefix.rs
@@ -42,8 +42,7 @@ where
 }
 
 fn strip_prefix(uri: &Uri, prefix: &str) -> Option<Uri> {
-    let path_and_query: http::uri::PathAndQuery = if let Some(path_and_query) = uri.path_and_query()
-    {
+    let path_and_query = if let Some(path_and_query) = uri.path_and_query() {
         // Check whether the prefix matches the path and if so how long the matching prefix is.
         //
         // # Examples
@@ -65,6 +64,8 @@ fn strip_prefix(uri: &Uri, prefix: &str) -> Option<Uri> {
                 Item::Both(path_segment, prefix_segment) => {
                     if prefix_segment.starts_with(':') || path_segment == prefix_segment {
                         *matching_prefix_length.as_mut().unwrap() += path_segment.len();
+                    } else if prefix_segment.is_empty() {
+                        break;
                     } else {
                         matching_prefix_length = None;
                         break;
@@ -183,7 +184,7 @@ mod tests {
         single_segment_root_prefix,
         uri = "/a",
         prefix = "/",
-        expected = None,
+        expected = Some("/a"),
     );
 
     test!(
@@ -332,6 +333,13 @@ mod tests {
         uri = "/a/",
         prefix = "/:param/",
         expected = Some("/"),
+    );
+
+    test!(
+        param_13,
+        uri = "/a/a",
+        prefix = "/a/",
+        expected = Some("/a"),
     );
 
     #[quickcheck]

--- a/axum/src/routing/tests/nest.rs
+++ b/axum/src/routing/tests/nest.rs
@@ -437,7 +437,7 @@ nested_route_test!(nest_6, nest = "/", route = "/a/", expected = "/a/");
 // This case is different for opaque services.
 //
 // The internal route becomes `/a/*__private__axum_nest_tail_param` which, according to matchit
-// doesn't match `/a`. However matchit detects that a route for `/a/` is exists and so it issues a
+// doesn't match `/a`. However matchit detects that a route for `/a/` exists and so it issues a
 // redirect to `/a/`, which ends up calling the inner route as expected.
 //
 // So while the behavior isn't identical, the outcome is the same


### PR DESCRIPTION
Fixes https://github.com/tokio-rs/axum/issues/830

This brings nesting of opaque services inline with nesting `Router`s, except for one case which is explained in a test. Also added a bunch more comments to the prefix stripping so I'll still be able to understanding it two days from now 😅