### PR TITLE
Don't set extension we never use

### DIFF
--- a/axum/src/body/mod.rs
+++ b/axum/src/body/mod.rs
@@ -15,7 +15,3 @@ pub use bytes::Bytes;
 
 #[doc(inline)]
 pub use axum_core::body::{boxed, BoxBody};
-
-pub(crate) fn empty() -> BoxBody {
-    boxed(Empty::new())
-}

--- a/axum/src/routing/mod.rs
+++ b/axum/src/routing/mod.rs
@@ -421,7 +421,6 @@ where
         mut req: Request<B>,
     ) -> RouteFuture<B, Infallible> {
         let id = *match_.value;
-        req.extensions_mut().insert(id);
 
         #[cfg(feature = "matched-path")]
         if let Some(matched_path) = self.node.route_id_to_path.get(&id) {


### PR DESCRIPTION
Quick clean up. I noticed we set `RouteId` as an extension but never used it. Probably a holdover from an other implementation.