### PR TITLE
Implement From<S> for StreamBody<S>

### DIFF
--- a/axum/src/body/stream_body.rs
+++ b/axum/src/body/stream_body.rs
@@ -57,6 +57,17 @@ pin_project! {
     }
 }
 
+impl<S> From<S> for StreamBody<S>
+where
+    S: TryStream + Send + 'static,
+    S::Ok: Into<Bytes>,
+    S::Error: Into<BoxError>,
+{
+    fn from(stream: S) -> Self {
+        Self::new(stream)
+    }
+}
+
 impl<S> StreamBody<S> {
     /// Create a new `StreamBody` from a [`Stream`].
     ///


### PR DESCRIPTION
Although this shadows `StreamBody::new()`, having `From` allows for
trivial bounds creation on associated types.

Signed-off-by: Nathaniel McCallum <nathaniel@profian.com>