### PR TITLE
Make `RequestParts::body_mut` return `&mut Option<B>`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/checkout@master
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: nightly
+        toolchain: beta
         override: true
         profile: minimal
         components: clippy, rustfmt
@@ -69,7 +69,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [stable, beta, nightly]
+        # nightly has an ICE, so ignore it for now
+        # rust: [stable, beta, nightly]
+        rust: [stable, beta]
     steps:
     - uses: actions/checkout@master
     - uses: actions-rs/toolchain@v1

--- a/axum-core/CHANGELOG.md
+++ b/axum-core/CHANGELOG.md
@@ -37,11 +37,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - `<Request as FromRequest>::Rejection` is now `BodyAlreadyExtracted`.
     - `<http::request::Parts as FromRequest>::Rejection` is now `Infallible`.
     - `ExtensionsAlreadyExtracted` has been removed.
+- **breaking:** `RequestParts::body_mut` now returns `&mut Option<B>` so the
+  body can be swapped ([#869])
 
 [#698]: https://github.com/tokio-rs/axum/pull/698
 [#699]: https://github.com/tokio-rs/axum/pull/699
 [#767]: https://github.com/tokio-rs/axum/pull/767
 [#797]: https://github.com/tokio-rs/axum/pull/797
+[#869]: https://github.com/tokio-rs/axum/pull/869
 
 # 0.1.1 (06. December, 2021)
 

--- a/axum-core/src/extract/mod.rs
+++ b/axum-core/src/extract/mod.rs
@@ -204,7 +204,7 @@ impl<B> RequestParts<B> {
     /// Gets a mutable reference to the request body.
     ///
     /// Returns `None` if the body has been taken by another extractor.
-    // this returns `&mut Option<B>` rather than `Option<&mut B>` such that users can swap it
+    // this returns `&mut Option<B>` rather than `Option<&mut B>` such that users can use it to set the body.
     pub fn body_mut(&mut self) -> &mut Option<B> {
         &mut self.body
     }

--- a/axum-core/src/extract/mod.rs
+++ b/axum-core/src/extract/mod.rs
@@ -204,8 +204,9 @@ impl<B> RequestParts<B> {
     /// Gets a mutable reference to the request body.
     ///
     /// Returns `None` if the body has been taken by another extractor.
-    pub fn body_mut(&mut self) -> Option<&mut B> {
-        self.body.as_mut()
+    // this returns `&mut Option<B>` rather than `Option<&mut B>` such that users can swap it
+    pub fn body_mut(&mut self) -> &mut Option<B> {
+        &mut self.body
     }
 
     /// Takes the body out of the request, leaving a `None` in its place.


### PR DESCRIPTION
So users can swap the body, which isn't possible with an `Option<&mut B>`.