### PR TITLE
Change `Handler` to have an associated `Future` type

### DIFF
--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -73,6 +73,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `IntoResponseParts` so `([("x-foo", "foo")], response)` now works ([#797])
 - **breaking:** `InvalidJsonBody` has been replaced with `JsonDataError` to clearly signal that the
   request body was syntactically valid JSON but couldn't be deserialized into the target type
+- **breaking:** `Handler` is no longer an `#[async_trait]` but instead has an
+  associated `Future` type. That allows users to build their own `Handler` types
+  without paying the cost of `#[async_trait]`
 - **changed:** New `JsonSyntaxError` variant added to `JsonRejection`. This is returned when the
   request body contains syntactically invalid JSON
 - **fixed:** Set `Allow` header when responding with `405 Method Not Allowed` ([#733])

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -75,7 +75,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   request body was syntactically valid JSON but couldn't be deserialized into the target type
 - **breaking:** `Handler` is no longer an `#[async_trait]` but instead has an
   associated `Future` type. That allows users to build their own `Handler` types
-  without paying the cost of `#[async_trait]`
+  without paying the cost of `#[async_trait]` ([#879])
 - **changed:** New `JsonSyntaxError` variant added to `JsonRejection`. This is returned when the
   request body contains syntactically invalid JSON
 - **fixed:** Set `Allow` header when responding with `405 Method Not Allowed` ([#733])
@@ -107,6 +107,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#827]: https://github.com/tokio-rs/axum/pull/827
 [#841]: https://github.com/tokio-rs/axum/pull/841
 [#842]: https://github.com/tokio-rs/axum/pull/842
+[#879]: https://github.com/tokio-rs/axum/pull/879
 
 # 0.4.4 (13. January, 2022)
 

--- a/axum/src/handler/future.rs
+++ b/axum/src/handler/future.rs
@@ -1,14 +1,52 @@
 //! Handler future types.
 
 use crate::response::Response;
-use futures_util::future::{BoxFuture, Map};
-use std::convert::Infallible;
+use futures_util::future::Map;
+use http::Request;
+use pin_project_lite::pin_project;
+use std::{convert::Infallible, future::Future, pin::Pin, task::Context};
+use tower::util::Oneshot;
+use tower_service::Service;
 
 opaque_future! {
     /// The response future for [`IntoService`](super::IntoService).
-    pub type IntoServiceFuture =
+    pub type IntoServiceFuture<F> =
         Map<
-            BoxFuture<'static, Response>,
+            F,
             fn(Response) -> Result<Response, Infallible>,
         >;
+}
+
+pin_project! {
+    /// The response future for [`Layered`](super::Layered).
+    pub struct LayeredFuture<S, ReqBody>
+    where
+        S: Service<Request<ReqBody>>,
+    {
+        #[pin]
+        inner: Map<Oneshot<S, Request<ReqBody>>, fn(Result<S::Response, S::Error>) -> Response>,
+    }
+}
+
+impl<S, ReqBody> LayeredFuture<S, ReqBody>
+where
+    S: Service<Request<ReqBody>>,
+{
+    pub(super) fn new(
+        inner: Map<Oneshot<S, Request<ReqBody>>, fn(Result<S::Response, S::Error>) -> Response>,
+    ) -> Self {
+        Self { inner }
+    }
+}
+
+impl<S, ReqBody> Future for LayeredFuture<S, ReqBody>
+where
+    S: Service<Request<ReqBody>>,
+{
+    type Output = Response;
+
+    #[inline]
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> std::task::Poll<Self::Output> {
+        self.project().inner.poll(cx)
+    }
 }

--- a/axum/src/handler/into_service.rs
+++ b/axum/src/handler/into_service.rs
@@ -60,7 +60,7 @@ where
 {
     type Response = Response;
     type Error = Infallible;
-    type Future = super::future::IntoServiceFuture;
+    type Future = super::future::IntoServiceFuture<H::Future>;
 
     #[inline]
     fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
@@ -74,7 +74,8 @@ where
         use futures_util::future::FutureExt;
 
         let handler = self.handler.clone();
-        let future = Handler::call(handler, req).map(Ok::<_, Infallible> as _);
+        let future = Handler::call(handler, req);
+        let future = future.map(Ok as _);
 
         super::future::IntoServiceFuture::new(future)
     }


### PR DESCRIPTION
This removes `#[async_trait]` from `Handler` and replaces that with an
associated `Future` type.

As hinted at in #878 I'm working on something with types that need to
implement `Handler`. I'm doing that by wrapping other `Handler` types so
I can implement `Handler` by simply delegating and thus don't need to
allocate another box for `#[async_trait]`. This change makes that
possible.

It does make `Handler` less ergonomic to implement but thats a very
niche feature so I'm fine with that. It wouldn't be appropriate for
`FromRequest` IMO.