### PR TITLE
docs: Add `aliri_tower` as an ecosystem project

### DIFF
--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -10,6 +10,7 @@ If your project isn't listed here and you would like it to be, please feel free 
 - [axum-flash](https://crates.io/crates/axum-flash): One-time notifications (aka flash messages) for axum.
 - [axum-msgpack](https://crates.io/crates/axum-msgpack): MessagePack Extractors for axum.
 - [axum-sqlx-tx](https://crates.io/crates/axum-sqlx-tx): Request-bound [SQLx](https://github.com/launchbadge/sqlx#readme) transactions with automatic commit/rollback based on response.
+- [aliri_tower](https://crates.io/crates/aliri_tower): JWT validation and OAuth2 scopes checking middleware.
 
 ## Project showcase
 


### PR DESCRIPTION
## Motivation

Inform users about the `aliri_tower` project. `aliri_tower` provides convenient middleware for validating JWTs of various types as well as enforcing OAuth2 scopes grants for specific endpoints.

Example of use: https://github.com/neoeinstein/aliri/blob/master/aliri_tower/examples/axum.rs

## Solution

Add link to `aliri_tower` into the ecosystem documentation.