### PR TITLE
Typos in docstrings

### DIFF
--- a/axum/src/extract/ws.rs
+++ b/axum/src/extract/ws.rs
@@ -314,7 +314,7 @@ pub struct WebSocket {
 impl WebSocket {
     /// Receive another message.
     ///
-    /// Returns `None` if the stream stream has closed.
+    /// Returns `None` if the stream has closed.
     pub async fn recv(&mut self) -> Option<Result<Message, Error>> {
         self.next().await
     }

--- a/axum/src/lib.rs
+++ b/axum/src/lib.rs
@@ -262,7 +262,7 @@
 //! # };
 //! ```
 //!
-//! The downside to this approach is that its a little more verbose than using
+//! The downside to this approach is that it's a little more verbose than using
 //! extensions.
 //!
 //! # Building integrations for axum


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation

Simple typos in docstrings.

I looked whether the latter "stream" could have meant an identifier, but no such identifier is used in the file.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->
