### PR TITLE
Remove Datafuse from ECOSYSTEM

### DIFF
--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -16,7 +16,6 @@ If your project isn't listed here and you would like it to be, please feel free 
 ## Project showcase
 
 - [Houseflow](https://github.com/gbaranski/houseflow): House automation platform written in Rust.
-- [Datafuse](https://github.com/datafuselabs/datafuse): Cloud native data warehouse written in Rust.
 - [JWT Auth](https://github.com/Z4RX/axum_jwt_example): JWT auth service for educational purposes.
 - [ROAPI](https://github.com/roapi/roapi): Create full-fledged APIs for static datasets without writing a single line of code.
 - [notify.run](https://github.com/notify-run/notify-run-rs): HTTP-to-WebPush relay for sending desktop/mobile notifications to yourself, written in Rust.


### PR DESCRIPTION
Datafuse is no longer using axum, see https://github.com/datafuselabs/databend/issues/2666


