### PR TITLE
Remove bound from `into_make_service_with_connect_info`

### DIFF
--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -88,6 +88,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **changed:** Update to tokio-tungstenite 0.17 ([#791])
 - **breaking:** `Redirect::{to, temporary, permanent}` now accept `&str` instead
   of `Uri` ([#889])
+- **breaking:** Remove second type parameter from `Router::into_make_service_with_connect_info`
+  and `Handler::into_make_service_with_connect_info` to support `MakeService`s
+  that accept multiple targets
 
 [#644]: https://github.com/tokio-rs/axum/pull/644
 [#665]: https://github.com/tokio-rs/axum/pull/665

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -90,7 +90,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   of `Uri` ([#889])
 - **breaking:** Remove second type parameter from `Router::into_make_service_with_connect_info`
   and `Handler::into_make_service_with_connect_info` to support `MakeService`s
-  that accept multiple targets
+  that accept multiple targets ([#892])
 
 [#644]: https://github.com/tokio-rs/axum/pull/644
 [#665]: https://github.com/tokio-rs/axum/pull/665
@@ -114,6 +114,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#842]: https://github.com/tokio-rs/axum/pull/842
 [#879]: https://github.com/tokio-rs/axum/pull/879
 [#889]: https://github.com/tokio-rs/axum/pull/889
+[#892]: https://github.com/tokio-rs/axum/pull/892
 
 # 0.4.4 (13. January, 2022)
 

--- a/axum/src/docs/routing/into_make_service_with_connect_info.md
+++ b/axum/src/docs/routing/into_make_service_with_connect_info.md
@@ -23,7 +23,7 @@ async fn handler(ConnectInfo(addr): ConnectInfo<SocketAddr>) -> String {
 # async {
 axum::Server::bind(&"0.0.0.0:3000".parse().unwrap())
     .serve(
-        app.into_make_service_with_connect_info::<SocketAddr, _>()
+        app.into_make_service_with_connect_info::<SocketAddr>()
     )
     .await
     .expect("server failed");
@@ -64,7 +64,7 @@ impl Connected<&AddrStream> for MyConnectInfo {
 # async {
 axum::Server::bind(&"0.0.0.0:3000".parse().unwrap())
     .serve(
-        app.into_make_service_with_connect_info::<MyConnectInfo, _>()
+        app.into_make_service_with_connect_info::<MyConnectInfo>()
     )
     .await
     .expect("server failed");

--- a/axum/src/extract/connect_info.rs
+++ b/axum/src/extract/connect_info.rs
@@ -161,7 +161,7 @@ mod tests {
             let app = Router::new().route("/", get(handler));
             let server = Server::from_tcp(listener)
                 .unwrap()
-                .serve(app.into_make_service_with_connect_info::<SocketAddr, _>());
+                .serve(app.into_make_service_with_connect_info::<SocketAddr>());
             tx.send(()).unwrap();
             server.await.expect("server error");
         });
@@ -201,7 +201,7 @@ mod tests {
             let app = Router::new().route("/", get(handler));
             let server = Server::from_tcp(listener)
                 .unwrap()
-                .serve(app.into_make_service_with_connect_info::<MyConnectInfo, _>());
+                .serve(app.into_make_service_with_connect_info::<MyConnectInfo>());
             tx.send(()).unwrap();
             server.await.expect("server error");
         });

--- a/axum/src/handler/mod.rs
+++ b/axum/src/handler/mod.rs
@@ -72,10 +72,7 @@
 
 use crate::{
     body::{boxed, Body, Bytes, HttpBody},
-    extract::{
-        connect_info::{Connected, IntoMakeServiceWithConnectInfo},
-        FromRequest, RequestParts,
-    },
+    extract::{connect_info::IntoMakeServiceWithConnectInfo, FromRequest, RequestParts},
     response::{IntoResponse, Response},
     routing::IntoMakeService,
     BoxError,
@@ -230,7 +227,7 @@ pub trait Handler<T, B = Body>: Clone + Send + Sized + 'static {
     ///
     /// # async {
     /// Server::bind(&SocketAddr::from(([127, 0, 0, 1], 3000)))
-    ///     .serve(handler.into_make_service_with_connect_info::<SocketAddr, _>())
+    ///     .serve(handler.into_make_service_with_connect_info::<SocketAddr>())
     ///     .await?;
     /// # Ok::<_, hyper::Error>(())
     /// # };
@@ -238,12 +235,9 @@ pub trait Handler<T, B = Body>: Clone + Send + Sized + 'static {
     ///
     /// [`MakeService`]: tower::make::MakeService
     /// [`Router::into_make_service_with_connect_info`]: crate::routing::Router::into_make_service_with_connect_info
-    fn into_make_service_with_connect_info<C, Target>(
+    fn into_make_service_with_connect_info<C>(
         self,
-    ) -> IntoMakeServiceWithConnectInfo<IntoService<Self, T, B>, C>
-    where
-        C: Connected<Target>,
-    {
+    ) -> IntoMakeServiceWithConnectInfo<IntoService<Self, T, B>, C> {
         IntoMakeServiceWithConnectInfo::new(self.into_service())
     }
 }

--- a/axum/src/routing/mod.rs
+++ b/axum/src/routing/mod.rs
@@ -3,7 +3,7 @@
 use self::{future::RouteFuture, not_found::NotFound};
 use crate::{
     body::{boxed, Body, Bytes, HttpBody},
-    extract::connect_info::{Connected, IntoMakeServiceWithConnectInfo},
+    extract::connect_info::IntoMakeServiceWithConnectInfo,
     response::{IntoResponse, Redirect, Response},
     routing::strip_prefix::StripPrefix,
     util::try_downcast,
@@ -405,12 +405,7 @@ where
     }
 
     #[doc = include_str!("../docs/routing/into_make_service_with_connect_info.md")]
-    pub fn into_make_service_with_connect_info<C, Target>(
-        self,
-    ) -> IntoMakeServiceWithConnectInfo<Self, C>
-    where
-        C: Connected<Target>,
-    {
+    pub fn into_make_service_with_connect_info<C>(self) -> IntoMakeServiceWithConnectInfo<Self, C> {
         IntoMakeServiceWithConnectInfo::new(self)
     }
 

--- a/examples/low-level-rustls/src/main.rs
+++ b/examples/low-level-rustls/src/main.rs
@@ -41,7 +41,7 @@ async fn main() {
 
     let mut app = Router::new()
         .route("/", get(handler))
-        .into_make_service_with_connect_info::<SocketAddr, _>();
+        .into_make_service_with_connect_info::<SocketAddr>();
 
     loop {
         let stream = poll_fn(|cx| Pin::new(&mut listener).poll_accept(cx))

--- a/examples/unix-domain-socket/src/main.rs
+++ b/examples/unix-domain-socket/src/main.rs
@@ -57,7 +57,7 @@ async fn main() {
         let app = Router::new().route("/", get(handler));
 
         axum::Server::builder(ServerAccept { uds })
-            .serve(app.into_make_service_with_connect_info::<UdsConnectInfo, _>())
+            .serve(app.into_make_service_with_connect_info::<UdsConnectInfo>())
             .await
             .unwrap();
     });


### PR DESCRIPTION
Fixes https://github.com/tokio-rs/axum/issues/859

Turns out removing the bound doesn't actually hurt the compile error. So I think we can just remove it.