### PR TITLE
axum-extra: re-export the Expiration and SameSite structs from the co…

### DIFF
--- a/axum-extra/CHANGELOG.md
+++ b/axum-extra/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning].
 
 # Unreleased
 
-- None.
+- **added:** Re-export `SameSite` and `Expiration` from the `cookie` crate.
 
 # 0.2.0 (31. March, 2022)
 

--- a/axum-extra/src/extract/cookie.rs
+++ b/axum-extra/src/extract/cookie.rs
@@ -15,7 +15,7 @@ use http::{
 };
 use std::{convert::Infallible, fmt, marker::PhantomData};
 
-pub use cookie_lib::{Cookie, Key};
+pub use cookie_lib::{Cookie, Expiration, Key, SameSite};
 
 /// Extractor that grabs cookies from the request and manages the jar.
 ///


### PR DESCRIPTION
## Motivation

Makes it possible to set `SameSite` cookies without having to import the `cookie` crate

## Solution

Re-exports it. While at it I also re-exported `Expiration`