### PR TITLE
Fix `SignedCookieJar` with custom key type

### DIFF
--- a/axum-extra/CHANGELOG.md
+++ b/axum-extra/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning].
 # Unreleased
 
 - **added:** Re-export `SameSite` and `Expiration` from the `cookie` crate.
+- **fixed:** Fix `SignedCookieJar` when using custom key types ([#899])
+
+[#899]: https://github.com/tokio-rs/axum/pull/899
 
 # 0.2.0 (31. March, 2022)
 


### PR DESCRIPTION
There were several things wrong with it:

- It always extracted `Extension<Key>` instead of using the custom type.
- `IntoResponseParts` was only implemented for `SignedCookieJar<Key>`.

This fixes that and adds a test for it.