### PR TITLE
Add `Field::chunk`

### DIFF
--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -7,7 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
-- None.
+- **added:** Add `axum::extract::multipart::Field::chunk` method for streaming a single chunk from
+  the field ([#901])
+
+[#901]: https://github.com/tokio-rs/axum/pull/901
 
 # 0.5.1 (03. April, 2022)
 

--- a/axum/src/extract/multipart.rs
+++ b/axum/src/extract/multipart.rs
@@ -147,21 +147,23 @@ impl<'a> Field<'a> {
     ///
     /// When the field data has been exhausted, this will return [`None`].
     ///
-    /// This does the exact same thing as the `Stream` impl and is for convenience
+    /// Note this does the same thing as `Field`'s [`Stream`] implementation.
     ///
-    /// # Examples
+    /// # Example
     ///
     /// ```
     /// use axum::{
     ///    extract::Multipart,
     ///    routing::post,
+    ///    response::IntoResponse,
     ///    Router,
     /// };
+    /// use http::StatusCode;
     ///
-    /// async fn upload(mut multipart: Multipart) {
-    ///     while let Some(mut field) = multipart.next_field().await.unwrap() {
+    /// async fn upload(mut multipart: Multipart) -> impl IntoResponse {
+    ///     while let Some(mut field) = multipart.next_field().await.map_err(|err| (StatusCode::BAD_REQUEST, err.to_string()))? {
     ///         while let Some(chunk) = field.chunk().await.unwrap() {
-    ///             println!("Chunk: {:?}", chunk);
+    ///             println!("received {} bytes", chunk.len());
     ///         }
     ///     }
     /// }

--- a/axum/src/extract/multipart.rs
+++ b/axum/src/extract/multipart.rs
@@ -162,7 +162,7 @@ impl<'a> Field<'a> {
     ///
     /// async fn upload(mut multipart: Multipart) -> impl IntoResponse {
     ///     while let Some(mut field) = multipart.next_field().await.map_err(|err| (StatusCode::BAD_REQUEST, err.to_string()))? {
-    ///         while let Some(chunk) = field.chunk().await.unwrap() {
+    ///         while let Some(chunk) = field.chunk().await {
     ///             println!("received {} bytes", chunk.len());
     ///         }
     ///     }

--- a/axum/src/extract/multipart.rs
+++ b/axum/src/extract/multipart.rs
@@ -143,8 +143,32 @@ impl<'a> Field<'a> {
         self.inner.text().await.map_err(MultipartError::from_multer)
     }
     
-    // Stream a chunk of the field data.
-    pub async fn chunk(self) -> Result<Option<Bytes>, MultipartError> {
+    /// Stream a chunk of the field data.
+    ///
+    /// When the field data has been exhausted, this will return [`None`].
+    ///
+    /// This does the exact same thing as the `Stream` impl and is for convenience
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use axum::{
+    ///    extract::Multipart,
+    ///    routing::post,
+    ///    Router,
+    /// };
+    ///
+    /// async fn upload(mut multipart: Multipart) {
+    ///     while let Some(mut field) = multipart.next_field().await.unwrap() {
+    ///         while let Some(chunk) = field.chunk().await.unwrap() {
+    ///             println!("Chunk: {:?}", chunk);
+    ///         }
+    ///     }
+    /// }
+    ///
+    /// let app = Router::new().route("/upload", post(upload));
+    /// ```
+    pub async fn chunk(&mut self) -> Result<Option<Bytes>, MultipartError> {
         self.inner.chunk().await.map_err(MultipartError::from_multer)
     }
 }

--- a/axum/src/extract/multipart.rs
+++ b/axum/src/extract/multipart.rs
@@ -156,19 +156,30 @@ impl<'a> Field<'a> {
     ///    extract::Multipart,
     ///    routing::post,
     ///    response::IntoResponse,
+    ///    http::StatusCode,
     ///    Router,
     /// };
-    /// use http::StatusCode;
     ///
-    /// async fn upload(mut multipart: Multipart) -> impl IntoResponse {
-    ///     while let Some(mut field) = multipart.next_field().await.map_err(|err| (StatusCode::BAD_REQUEST, err.to_string()))? {
-    ///         while let Some(chunk) = field.chunk().await {
+    /// async fn upload(mut multipart: Multipart) -> Result<(), (StatusCode, String)> {
+    ///     while let Some(mut field) = multipart
+    ///         .next_field()
+    ///         .await
+    ///         .map_err(|err| (StatusCode::BAD_REQUEST, err.to_string()))?
+    ///     {
+    ///         while let Some(chunk) = field
+    ///             .chunk()
+    ///             .await
+    ///             .map_err(|err| (StatusCode::BAD_REQUEST, err.to_string()))?
+    ///         {
     ///             println!("received {} bytes", chunk.len());
     ///         }
     ///     }
+    ///
+    ///     Ok(())
     /// }
     ///
     /// let app = Router::new().route("/upload", post(upload));
+    /// # let _: Router<axum::body::Body> = app;
     /// ```
     pub async fn chunk(&mut self) -> Result<Option<Bytes>, MultipartError> {
         self.inner

--- a/axum/src/extract/multipart.rs
+++ b/axum/src/extract/multipart.rs
@@ -142,7 +142,7 @@ impl<'a> Field<'a> {
     pub async fn text(self) -> Result<String, MultipartError> {
         self.inner.text().await.map_err(MultipartError::from_multer)
     }
-    
+
     /// Stream a chunk of the field data.
     ///
     /// When the field data has been exhausted, this will return [`None`].
@@ -169,7 +169,10 @@ impl<'a> Field<'a> {
     /// let app = Router::new().route("/upload", post(upload));
     /// ```
     pub async fn chunk(&mut self) -> Result<Option<Bytes>, MultipartError> {
-        self.inner.chunk().await.map_err(MultipartError::from_multer)
+        self.inner
+            .chunk()
+            .await
+            .map_err(MultipartError::from_multer)
     }
 }
 

--- a/axum/src/extract/multipart.rs
+++ b/axum/src/extract/multipart.rs
@@ -142,6 +142,11 @@ impl<'a> Field<'a> {
     pub async fn text(self) -> Result<String, MultipartError> {
         self.inner.text().await.map_err(MultipartError::from_multer)
     }
+    
+    // Stream a chunk of the field data.
+    pub async fn chunk(self) -> Result<Option<Bytes>, MultipartError> {
+        self.inner.chunk().await.map_err(MultipartError::from_multer)
+    }
 }
 
 /// Errors associated with parsing `multipart/form-data` requests.


### PR DESCRIPTION
Added the function `chunk` for `exum::extract's multipart Field` to give a clearer option to use rather than try_next.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation

I needed a way to stream large files from a frontend file uploader directly into a file. These files can be 10gb+ in size, and need to be paused at any time. Though this is doable with try_next, I felt that it was clearer from the user's side to have chunk.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

By implementing the `chunk` function for `axum::extract's multipart Field`, readability of code and nicer access the underlying multer::Field's `chunk` funciton is allowed.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->


## Change log
1. Added chunk function to multipart field
2. Changed to doc comment for clarification of usage, and changed `&self` to `&mut self`
3. Fixed formatting
4. Cleaned up nits and correct example to reflex best practices
5. Removed last unwrap