### PR TITLE
Remove unnecessary default features for axum from axum-extra

### DIFF
--- a/axum-extra/CHANGELOG.md
+++ b/axum-extra/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning].
 
 # Unreleased
 
-- None.
+- **fixed:** Don't depend on axum with default features enabled ([#913])
+
+[#913]: https://github.com/tokio-rs/axum/pull/913
 
 # 0.2.1 (03. April, 2022)
 

--- a/axum-extra/Cargo.toml
+++ b/axum-extra/Cargo.toml
@@ -18,7 +18,7 @@ cookie = ["cookie-lib"]
 spa = ["tower-http/fs"]
 
 [dependencies]
-axum = { path = "../axum", version = "0.5" }
+axum = { path = "../axum", version = "0.5", default-features = false }
 bytes = "1.1.0"
 http = "0.2"
 mime = "0.3"


### PR DESCRIPTION
axum-extra does not need any features from axum.
I'd like to use axum-extra without including axum's default features.
