### PR TITLE
axum-extra:re-export `time::OffsetDatetime` and `time::Duration` from…

### DIFF
--- a/axum-extra/CHANGELOG.md
+++ b/axum-extra/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning].
 
 # Unreleased
 
+- **added:** Re-export `time::OffsetDatetime` and `time::Duration` from the `cookie` crate.
 - **fixed:** Don't depend on axum with default features enabled ([#913])
 
 [#913]: https://github.com/tokio-rs/axum/pull/913

--- a/axum-extra/src/extract/cookie.rs
+++ b/axum-extra/src/extract/cookie.rs
@@ -18,7 +18,10 @@ use std::{convert::Infallible, fmt, marker::PhantomData};
 mod private;
 
 pub use self::private::PrivateCookieJar;
-pub use cookie_lib::{Cookie, Expiration, Key, SameSite};
+pub use cookie_lib::{
+    time::{Duration, OffsetDateTime},
+    Cookie, Expiration, Key, SameSite,
+};
 
 /// Extractor that grabs cookies from the request and manages the jar.
 ///


### PR DESCRIPTION
… `cookie` crate

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation 
the `Expiration` which already be re-exported from `cookie` needs `time::OffsetDatetime` and `time::Duration` for its construction sometimes. and `time::Duration` also required by `Cookie`'s `max_age` api.
So I think it would nice to add a re-export, then users can avoid `time` crate as a dependency.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution
re-export `time::OffsetDate` and  `time::Duration` from `cookie` crate.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
