### PR TITLE
fix `route` module clippy warning

### DIFF
--- a/axum/src/routing/mod.rs
+++ b/axum/src/routing/mod.rs
@@ -498,10 +498,10 @@ where
         match self.node.at(&path) {
             Ok(match_) => self.call_route(match_, req),
             Err(MatchError::MissingTrailingSlash) => RouteFuture::from_response(
-                Redirect::permanent(&format!("{}/", req.uri().to_string())).into_response(),
+                Redirect::permanent(&format!("{}/", req.uri())).into_response(),
             ),
             Err(MatchError::ExtraTrailingSlash) => RouteFuture::from_response(
-                Redirect::permanent(&req.uri().to_string().strip_suffix('/').unwrap())
+                Redirect::permanent(req.uri().to_string().strip_suffix('/').unwrap())
                     .into_response(),
             ),
             Err(MatchError::NotFound) => match &self.fallback {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->
clippy warning
## Solution
adopt clippy advices

remove `Redirect::permanent(&format!("{}/", req.uri().to_string()))`'s uneeded `to_string()`, because `Uri` already impl `Display` 

remove `Redirect::permanent(&req.uri().to_string().strip_suffix('/').unwrap())`'s `&`, because the  reference be immediately dereferenced by compiler


<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
