### PR TITLE
Allow `Error: Into<Infallible>` for `Route::{layer, route_layer}`

### DIFF
--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -9,8 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **added:** Add `axum::extract::multipart::Field::chunk` method for streaming a single chunk from
   the field ([#901])
+- **changed:** Allow `Error: Into<Infallible>` for `Route::{layer, route_layer}` ([#924])
 
 [#901]: https://github.com/tokio-rs/axum/pull/901
+[#924]: https://github.com/tokio-rs/axum/pull/924
 
 # 0.5.1 (03. April, 2022)
 

--- a/axum/src/routing/mod.rs
+++ b/axum/src/routing/mod.rs
@@ -291,15 +291,15 @@ where
     pub fn layer<L, NewReqBody, NewResBody>(self, layer: L) -> Router<NewReqBody>
     where
         L: Layer<Route<B>>,
-        L::Service: Service<Request<NewReqBody>, Response = Response<NewResBody>, Error = Infallible>
-            + Clone
-            + Send
-            + 'static,
+        L::Service:
+            Service<Request<NewReqBody>, Response = Response<NewResBody>> + Clone + Send + 'static,
+        <L::Service as Service<Request<NewReqBody>>>::Error: Into<Infallible> + 'static,
         <L::Service as Service<Request<NewReqBody>>>::Future: Send + 'static,
         NewResBody: HttpBody<Data = Bytes> + Send + 'static,
         NewResBody::Error: Into<BoxError>,
     {
         let layer = ServiceBuilder::new()
+            .map_err(Into::into)
             .layer(MapResponseBodyLayer::new(boxed))
             .layer(layer)
             .into_inner();
@@ -332,15 +332,14 @@ where
     pub fn route_layer<L, NewResBody>(self, layer: L) -> Self
     where
         L: Layer<Route<B>>,
-        L::Service: Service<Request<B>, Response = Response<NewResBody>, Error = Infallible>
-            + Clone
-            + Send
-            + 'static,
+        L::Service: Service<Request<B>, Response = Response<NewResBody>> + Clone + Send + 'static,
+        <L::Service as Service<Request<B>>>::Error: Into<Infallible> + 'static,
         <L::Service as Service<Request<B>>>::Future: Send + 'static,
         NewResBody: HttpBody<Data = Bytes> + Send + 'static,
         NewResBody::Error: Into<BoxError>,
     {
         let layer = ServiceBuilder::new()
+            .map_err(Into::into)
             .layer(MapResponseBodyLayer::new(boxed))
             .layer(layer)
             .into_inner();


### PR DESCRIPTION
Fixes https://github.com/tokio-rs/axum/issues/922

Before merging this I'd appreciate it if @lilyball you'd test it and confirm that it works for your use case.