### PR TITLE
Fix trailing redirection with query parameters

### DIFF
--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -9,8 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **added:** Add `axum::extract::multipart::Field::chunk` method for streaming a single chunk from
   the field ([#901])
+- **fixed:** Fix trailing slash redirection with query parameters ([#936])
 
 [#901]: https://github.com/tokio-rs/axum/pull/901
+[#936]: https://github.com/tokio-rs/axum/pull/936
 
 # 0.5.1 (03. April, 2022)
 

--- a/axum/src/routing/mod.rs
+++ b/axum/src/routing/mod.rs
@@ -9,7 +9,7 @@ use crate::{
     util::try_downcast,
     BoxError,
 };
-use http::Request;
+use http::{Request, Uri};
 use matchit::MatchError;
 use std::{
     borrow::Cow,
@@ -498,17 +498,18 @@ where
         match self.node.at(&path) {
             Ok(match_) => self.call_route(match_, req),
             Err(MatchError::MissingTrailingSlash) => {
-                let new_uri = req.uri().to_string().replace(&path, &format!("{}/", &path));
+                let new_uri = replace_trailing_slash(req.uri(), &format!("{}/", &path));
 
-                RouteFuture::from_response(Redirect::permanent(&new_uri).into_response())
+                RouteFuture::from_response(
+                    Redirect::permanent(&new_uri.to_string()).into_response(),
+                )
             }
             Err(MatchError::ExtraTrailingSlash) => {
-                let new_uri = req
-                    .uri()
-                    .to_string()
-                    .replace(&path, &path.strip_suffix('/').unwrap());
+                let new_uri = replace_trailing_slash(req.uri(), &path.strip_suffix('/').unwrap());
 
-                RouteFuture::from_response(Redirect::permanent(&new_uri).into_response())
+                RouteFuture::from_response(
+                    Redirect::permanent(&new_uri.to_string()).into_response(),
+                )
             }
             Err(MatchError::NotFound) => match &self.fallback {
                 Fallback::Default(inner) => inner.clone().call(req),
@@ -516,6 +517,20 @@ where
             },
         }
     }
+}
+
+fn replace_trailing_slash(uri: &Uri, new_path: &str) -> Uri {
+    let query = uri.query();
+    let mut new_path_and_query = new_path.to_string();
+    if let Some(query) = query {
+        new_path_and_query.push('?');
+        new_path_and_query.push_str(query);
+    }
+
+    let mut parts = uri.clone().into_parts();
+    parts.path_and_query = new_path_and_query.parse().ok();
+
+    Uri::from_parts(parts).unwrap()
 }
 
 /// Wrapper around `matchit::Router` that supports merging two `Router`s.

--- a/axum/src/routing/mod.rs
+++ b/axum/src/routing/mod.rs
@@ -527,7 +527,7 @@ fn replace_trailing_slash(uri: &Uri, new_path: &str) -> Uri {
     }
 
     let mut parts = uri.clone().into_parts();
-    parts.path_and_query = new_path_and_query.parse().ok();
+    parts.path_and_query = Some(new_path_and_query.parse().unwrap());
 
     Uri::from_parts(parts).unwrap()
 }

--- a/axum/src/routing/mod.rs
+++ b/axum/src/routing/mod.rs
@@ -520,9 +520,8 @@ where
 }
 
 fn replace_trailing_slash(uri: &Uri, new_path: &str) -> Uri {
-    let query = uri.query();
     let mut new_path_and_query = new_path.to_string();
-    if let Some(query) = query {
+    if let Some(query) = uri.query() {
         new_path_and_query.push('?');
         new_path_and_query.push_str(query);
     }

--- a/axum/src/routing/tests/mod.rs
+++ b/axum/src/routing/tests/mod.rs
@@ -324,6 +324,10 @@ async fn with_trailing_slash() {
     let res = client.get("/foo/").send().await;
     assert_eq!(res.status(), StatusCode::PERMANENT_REDIRECT);
     assert_eq!(res.headers().get("location").unwrap(), "/foo");
+
+    let res = client.get("/foo/?bar=baz").send().await;
+    assert_eq!(res.status(), StatusCode::PERMANENT_REDIRECT);
+    assert_eq!(res.headers().get("location").unwrap(), "/foo?bar=baz");
 }
 
 #[tokio::test]
@@ -335,6 +339,10 @@ async fn without_trailing_slash() {
     let res = client.get("/foo").send().await;
     assert_eq!(res.status(), StatusCode::PERMANENT_REDIRECT);
     assert_eq!(res.headers().get("location").unwrap(), "/foo/");
+
+    let res = client.get("/foo?bar=baz").send().await;
+    assert_eq!(res.status(), StatusCode::PERMANENT_REDIRECT);
+    assert_eq!(res.headers().get("location").unwrap(), "/foo/?bar=baz");
 }
 
 #[tokio::test]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation

When the request URI matches a route that needs a trailing slash, or has an extra trailing slash, the redirect URI is not generated correctly.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

This change adds or removes a trailing slash to the path part of the URI, instead of the full URI, preserving query parameters during redirection.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
