### PR TITLE
WIP: OpenAPI generator proof-of-concept

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,5 +4,7 @@ members = [
     "axum-core",
     "axum-extra",
     "axum-macros",
+    "axum-openapi",
+    "axum-openapi-macros",
     "examples/*",
 ]

--- a/axum-openapi-macros/Cargo.toml
+++ b/axum-openapi-macros/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "axum-openapi-macros"
+version = "0.1.0"
+edition = "2021"
+authors = ["Austin Bonander <austin@launchbadge.com>"]
+
+[lib]
+proc-macro = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+syn = { version = "1.0.91", features = ["full"] }
+quote = "1.0.18"
+proc-macro2 = "1.0.37"

--- a/axum-openapi-macros/src/json_body.rs
+++ b/axum-openapi-macros/src/json_body.rs
@@ -1,0 +1,29 @@
+use proc_macro2::TokenStream;
+
+use std::mem;
+
+pub fn expand(mut input: syn::DeriveInput) -> syn::Result<TokenStream> {
+    let docs = dbg!(super::collect_docs(&input.attrs))?;
+
+    let shadowed_ident = quote::format_ident!("__{}", input.ident);
+
+    let name = mem::replace(&mut input.ident, shadowed_ident);
+    let shadowed_ident = &input.ident;
+    let description = docs.iter().map(|s| s.trim());
+
+    Ok(quote::quote! {
+        impl axum_openapi::JsonBody for #name {
+            fn description() -> &'static str {
+                concat!(#(#description, "\n"),*).trim()
+            }
+
+            fn json_schema() -> axum_openapi::__macro_reexport::schemars::schema::RootSchema {
+                #[derive(axum_openapi::__macro_reexport::schemars::JsonSchema)]
+                #[schemars(crate = "axum_openapi::__macro_reexport::schemars")]
+                #input
+
+                axum_openapi::__macro_reexport::schemars::schema_for!(#shadowed_ident)
+            }
+        }
+    })
+}

--- a/axum-openapi-macros/src/lib.rs
+++ b/axum-openapi-macros/src/lib.rs
@@ -1,0 +1,53 @@
+use proc_macro::TokenTree;
+use std::mem;
+
+use proc_macro2::TokenStream;
+use quote::ToTokens;
+use syn::{Attribute, DeriveInput, FnArg, Signature, Visibility};
+use syn::parse::{Parse, ParseStream};
+
+mod json_body;
+mod route;
+
+#[proc_macro_attribute]
+pub fn route(args: proc_macro::TokenStream, input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let input_ = input.clone();
+    let handler_fn = syn::parse_macro_input!(input_ as route::HandlerFn);
+
+    syn_result(route::expand(handler_fn))
+}
+
+#[proc_macro_derive(JsonBody, attributes(doc, schemars, serde, validate))]
+pub fn derive_json_body(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let input = syn::parse_macro_input!(input as DeriveInput);
+
+    syn_result(json_body::expand(input))
+}
+
+fn syn_result(res: syn::Result<TokenStream>) -> proc_macro::TokenStream {
+    res.unwrap_or_else(|e| e.into_compile_error())
+        .into()
+}
+
+fn collect_docs(attrs: &[Attribute]) -> syn::Result<Vec<String>> {
+    attrs.iter()
+        .filter(|attr| attr.path.is_ident("doc"))
+        .map(|attr| {
+            parse_doc_attribute(attr.tokens.clone())
+        })
+        .collect()
+}
+
+fn parse_doc_attribute(tokens: TokenStream) -> syn::Result<String> {
+    struct DocAttribute(String);
+
+    impl Parse for DocAttribute {
+        fn parse(input: ParseStream) -> syn::Result<Self> {
+            let _ = input.parse::<syn::Token![=]>()?;
+            Ok(DocAttribute(input.parse::<syn::LitStr>()?.value()))
+        }
+    }
+
+    Ok(syn::parse2::<DocAttribute>(tokens)?.0)
+}
+

--- a/axum-openapi-macros/src/route.rs
+++ b/axum-openapi-macros/src/route.rs
@@ -1,0 +1,92 @@
+use std::mem;
+
+use proc_macro2::TokenStream;
+use syn::{Attribute, FnArg, Signature, Visibility};
+use syn::parse::{Parse, ParseStream};
+
+// We only care about a function's attributes and signature, the rest we pass on verbatim.
+#[derive(Debug)]
+pub struct HandlerFn {
+    attrs: Vec<Attribute>,
+    vis: Visibility,
+    sig: Signature,
+    body: TokenStream
+}
+
+pub fn expand(handler_fn: HandlerFn) -> syn::Result<TokenStream> {
+    let docs = super::collect_docs(&handler_fn.attrs)?;
+
+    let HandlerFn { attrs, vis, mut sig, body } = handler_fn;
+
+    let name = mem::replace(&mut sig.ident, syn::parse_quote! { inner });
+
+    let arg_types = sig.inputs.iter()
+        .map(|arg| match arg {
+            FnArg::Receiver(recv) => Err(syn::Error::new_spanned(recv, "handler function cannot have a receiver")),
+            FnArg::Typed(pat_ty) => Ok(&*pat_ty.ty)
+        })
+        .collect::<syn::Result<Vec<&syn::Type>>>()?;
+
+    let handler_type = quote::quote! {
+        impl axum_openapi::__macro_reexport::Handler<
+            (#(#arg_types),*,),
+            Future = axum_openapi::__macro_reexport::BoxFuture<'static, axum_openapi::__macro_reexport::Response>
+        >
+    };
+
+    let summary = docs.get(0).map_or("", |s| s.trim());
+    let description = docs.iter().map(|s| s.trim());
+
+    let operation = quote::quote! {
+        let mut operation = axum_openapi::openapi::Operation {
+            // TODO: pass tags in via `args`?
+            tags: &[],
+            summary: #summary,
+            description: concat!(#(#description, "\n"),*).trim(),
+            operation_id: concat!(module_path!(), "::", stringify!(#name)),
+            parameters: vec![],
+            request_body: None,
+        };
+
+        #(operation.__push_handler_arg::<#arg_types>();)*
+
+        operation
+    };
+
+    let output = quote::quote! {
+        #(#attrs)*
+        #vis fn #name() -> axum_openapi::RouteHandler<#handler_type> {
+            #sig #body
+
+            axum_openapi::RouteHandler {
+                handler: inner,
+                describe: || {
+                    #operation
+                },
+            }
+        }
+    };
+
+    Ok(output)
+}
+
+
+impl Parse for HandlerFn {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        // Same as `ItemFn::parse()` except we don't parse the body
+        let outer_attrs = input.call(Attribute::parse_outer)?;
+        let vis: Visibility = input.parse()?;
+        let sig: Signature = input.parse()?;
+        // Note: this produces an error because it doesn't fully consume the input.
+        // let body = input.cursor().token_stream();
+        let body: TokenStream = input.parse()?;
+
+        Ok(HandlerFn {
+            attrs: outer_attrs,
+            vis,
+            sig,
+            body
+        })
+    }
+}
+

--- a/axum-openapi/Cargo.toml
+++ b/axum-openapi/Cargo.toml
@@ -8,7 +8,6 @@ authors = ["Austin Bonander <austin@launchbadge.com>"]
 
 [dependencies]
 axum = { version = "=0.5.1", path = "../axum" }
-axum-openapi-macros = { path = "../axum-openapi-macros" }
 
 futures-core = "0.3.21"
 

--- a/axum-openapi/Cargo.toml
+++ b/axum-openapi/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "axum-openapi"
+version = "0.1.0"
+edition = "2021"
+authors = ["Austin Bonander <austin@launchbadge.com>"]
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+axum = { version = "=0.5.1", path = "../axum" }
+axum-openapi-macros = { path = "../axum-openapi-macros" }
+
+futures-core = "0.3.21"
+
+serde = { version = "1.0.136", features = ["derive", "rc"] }
+either = "1.6.1"
+
+serde_json = { version = "1.0.79", features = ["raw_value"] }
+
+schemars = { version = "0.8.8", features = ["preserve_order"] }
+
+indexmap = "1.8.1"

--- a/axum-openapi/src/handler/arg.rs
+++ b/axum-openapi/src/handler/arg.rs
@@ -1,0 +1,23 @@
+use schemars::JsonSchema;
+use axum::Json;
+use crate::{Either, openapi};
+
+pub trait DescribeHandlerArg {
+    fn describe() -> Option<Either<openapi::Parameter, openapi::RequestBody>>;
+}
+
+impl<T: JsonSchema> DescribeHandlerArg for Json<T> {
+    fn describe() -> Option<Either<openapi::Parameter, openapi::RequestBody>> {
+        let schema = schemars::schema_for!(T);
+
+        Some(Either::Right(openapi::RequestBody {
+            description: schema.schema.metadata
+                .as_ref()
+                .and_then(|meta| {
+                    meta.description.clone()
+                })
+                .unwrap_or_default(),
+            content: openapi::RequestBodyContent::Json(schema)
+        }))
+    }
+}

--- a/axum-openapi/src/handler/mod.rs
+++ b/axum-openapi/src/handler/mod.rs
@@ -1,0 +1,94 @@
+mod arg;
+mod response;
+
+use axum::handler::Handler;
+use axum::http::Request;
+use crate::{Either, openapi};
+
+use futures_core::Future;
+
+pub use arg::DescribeHandlerArg;
+pub use response::DescribeResponse;
+
+pub struct OperationParts {
+    pub parameters: Vec<openapi::Parameter>,
+    pub request_body: Option<openapi::RequestBody>,
+    pub responses: openapi::Responses,
+}
+
+pub trait DescribeHandler<T> {
+    fn describe() -> OperationParts;
+}
+
+#[derive(Clone)]
+pub struct DocumentedHandler<H> {
+    pub handler: H,
+    pub operation_id: &'static str,
+    pub tags: &'static [&'static str],
+    pub summary: &'static str,
+    pub description: &'static str,
+}
+
+impl<T, B, H: Handler<T, B>> Handler<T, B> for DocumentedHandler<H> {
+    type Future = H::Future;
+
+    fn call(self, req: Request<B>) -> Self::Future {
+        self.handler.call(req)
+    }
+}
+
+impl<H> DocumentedHandler<H> {
+    pub fn to_operation<T>(&self) -> openapi::Operation where H: DescribeHandler<T> {
+        let OperationParts { parameters, request_body, responses } = H::describe();
+
+        openapi::Operation {
+            tags: self.tags,
+            summary: self.summary,
+            description: self.description,
+            operation_id: self.operation_id,
+            parameters,
+            request_body,
+            responses
+        }
+    }
+}
+
+impl OperationParts {
+    fn push_handler_arg<T: DescribeHandlerArg>(&mut self) {
+        match T::describe() {
+            Some(Either::Left(param)) => self.parameters.push(param),
+            Some(Either::Right(body)) => {
+                if let Some(body) = self.request_body.replace(body) {
+                    panic!("handler has more than one request body: {:?}", body)
+                }
+            },
+            None => (),
+        }
+    }
+}
+
+macro_rules! impl_describe_handler_fn {
+    ($($ty:ident),*) => (
+        impl<F, Fut, Res, $($ty,)*> DescribeHandler<($($ty,)*)> for F
+        where
+            F: FnOnce($($ty,)*) -> Fut,
+            Fut: Future<Output = Res>,
+            Res: DescribeResponse,
+            $( $ty: DescribeHandlerArg,)*
+        {
+            fn describe() -> OperationParts {
+                let mut parts = OperationParts {
+                    parameters: vec![],
+                    request_body: None,
+                    responses: Res::describe(),
+                };
+
+                $(parts.push_handler_arg::<$ty>();)*
+
+                parts
+            }
+        }
+    )
+}
+
+all_the_tuples!(impl_describe_handler_fn);

--- a/axum-openapi/src/handler/response.rs
+++ b/axum-openapi/src/handler/response.rs
@@ -1,0 +1,14 @@
+use crate::openapi;
+
+pub trait DescribeResponse {
+    fn describe() -> openapi::Responses;
+}
+
+impl DescribeResponse for () {
+    fn describe() -> openapi::Responses {
+        openapi::Responses {
+            default: Some(openapi::Response {}),
+            responses: Default::default(),
+        }
+    }
+}

--- a/axum-openapi/src/lib.rs
+++ b/axum-openapi/src/lib.rs
@@ -1,0 +1,61 @@
+use std::ops::Deref;
+use either::Either;
+use axum::handler::Handler;
+use axum::http::Request;
+
+pub mod openapi;
+
+pub mod routing;
+
+use axum::Json;
+
+pub use axum_openapi_macros::{route, JsonBody};
+
+/// A decorated handler created by [`#[route]`][route], capable of providing OpenAPI documentation.
+#[derive(Clone)]
+pub struct RouteHandler<H> {
+    pub handler: H,
+    pub describe: fn() -> openapi::Operation,
+}
+
+impl<T, B, H: Handler<T, B>> Handler<T, B> for RouteHandler<H> {
+    type Future = H::Future;
+
+    fn call(self, req: Request<B>) -> Self::Future {
+        self.handler.call(req)
+    }
+}
+
+pub trait HandlerArg {
+    fn describe() -> Option<Either<openapi::Parameter, openapi::RequestBody>>;
+}
+
+pub enum HandlerArgKind {
+    Parameter(openapi::Parameter),
+    RequestBody(openapi::RequestBody),
+}
+
+pub trait JsonBody {
+    fn description() -> &'static str;
+
+    fn json_schema() -> schemars::schema::RootSchema;
+}
+
+impl<T: JsonBody> HandlerArg for Json<T> {
+    fn describe() -> Option<Either<openapi::Parameter, openapi::RequestBody>> {
+        Some(Either::Right(openapi::RequestBody {
+            description: "",
+            content: openapi::RequestBodyContent::Json(T::json_schema()),
+        }))
+    }
+}
+
+
+#[doc(hidden)]
+pub mod __macro_reexport {
+    pub use axum::handler::Handler;
+    pub use axum::response::Response;
+    pub use futures_core::future::BoxFuture;
+
+    pub use schemars;
+}

--- a/axum-openapi/src/lib.rs
+++ b/axum-openapi/src/lib.rs
@@ -1,61 +1,17 @@
 use std::ops::Deref;
-use either::Either;
+
+pub use either::Either;
+
 use axum::handler::Handler;
 use axum::http::Request;
+use axum::Json;
+
+#[macro_use]
+mod macros;
 
 pub mod openapi;
 
 pub mod routing;
 
-use axum::Json;
+pub mod handler;
 
-pub use axum_openapi_macros::{route, JsonBody};
-
-/// A decorated handler created by [`#[route]`][route], capable of providing OpenAPI documentation.
-#[derive(Clone)]
-pub struct RouteHandler<H> {
-    pub handler: H,
-    pub describe: fn() -> openapi::Operation,
-}
-
-impl<T, B, H: Handler<T, B>> Handler<T, B> for RouteHandler<H> {
-    type Future = H::Future;
-
-    fn call(self, req: Request<B>) -> Self::Future {
-        self.handler.call(req)
-    }
-}
-
-pub trait HandlerArg {
-    fn describe() -> Option<Either<openapi::Parameter, openapi::RequestBody>>;
-}
-
-pub enum HandlerArgKind {
-    Parameter(openapi::Parameter),
-    RequestBody(openapi::RequestBody),
-}
-
-pub trait JsonBody {
-    fn description() -> &'static str;
-
-    fn json_schema() -> schemars::schema::RootSchema;
-}
-
-impl<T: JsonBody> HandlerArg for Json<T> {
-    fn describe() -> Option<Either<openapi::Parameter, openapi::RequestBody>> {
-        Some(Either::Right(openapi::RequestBody {
-            description: "",
-            content: openapi::RequestBodyContent::Json(T::json_schema()),
-        }))
-    }
-}
-
-
-#[doc(hidden)]
-pub mod __macro_reexport {
-    pub use axum::handler::Handler;
-    pub use axum::response::Response;
-    pub use futures_core::future::BoxFuture;
-
-    pub use schemars;
-}

--- a/axum-openapi/src/macros.rs
+++ b/axum-openapi/src/macros.rs
@@ -1,0 +1,105 @@
+#[macro_export]
+macro_rules! route {
+    ($(
+        $(#[$($meta:tt)*])*
+        $verb:ident: $handler:path
+    ),* $(,)?) => {
+        $crate::routing::MethodRouter::new()
+        $(
+            .$verb($crate::handler::DocumentedHandler {
+                handler: $handler,
+                operation_id: concat!(module_path!(), "::", stringify!($handler)),
+                tags: $crate::capture_tags!($(#[$($meta)*])*),
+                summary: $crate::capture_summary!($(#[$($meta)*])*),
+                description: $crate::capture_description!($(#[$($meta)*])*),
+            })
+        )*
+    }
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! capture_summary {
+    () => ("");
+    (#[doc = $doc:expr] $(#[$_meta:meta])*) => (
+        $doc.trim()
+    );
+    // Ignore any leading non-doc attributes
+    (#[$other:meta] $(#[$($rest:tt)*])*) => {
+        $crate::capture_summary!($(#[$($rest)*])*)
+    };
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! capture_tags {
+    () => ({
+        let tags: &'static [&'static str] = &[];
+        tags
+    });
+    (#[tags($($tag:literal),*)] $(#[$_meta:meta])*) => ({
+        let tags: &'static [&'static str] = &[$($tag),*];
+        tags
+    });
+    // Ignore any leading non-tags attributes
+    // We can't use `$rest:meta` as recursive macro invocations can't introspect it:
+    // https://doc.rust-lang.org/reference/macros-by-example.html#transcribing
+    (#[$other:meta] $(#[$($rest:tt)*])*) => {
+        $crate::capture_tags!($(#[$($rest)*])*)
+    };
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! capture_description {
+    () => ("");
+    // Allows mixing other meta like `#[tags()]`
+    ($(#[$($meta:tt)*])+) => {
+        $crate::capture_description!($(#[$($meta)*])* {})
+    };
+    (#[doc = $doc:expr] $(#[$($rest:tt)*])* {$($tt:tt)*}) => {
+        $crate::capture_description!($(#[$($rest)*])* {$($tt)* $doc,})
+    };
+    (#[$other:meta] $(#[$($rest:tt)*])* {$($tt:tt)*}) => {
+        $crate::capture_description!($(#[$($rest)*])* {$($tt)*})
+    };
+    ({$($doc:expr,)*}) => {
+        concat!($($doc, "\n"),*).trim()
+    };
+}
+
+macro_rules! all_the_tuples {
+    ($name:ident) => {
+        $name!(T1);
+        $name!(T1, T2);
+        $name!(T1, T2, T3);
+        $name!(T1, T2, T3, T4);
+        $name!(T1, T2, T3, T4, T5);
+        $name!(T1, T2, T3, T4, T5, T6);
+        $name!(T1, T2, T3, T4, T5, T6, T7);
+        $name!(T1, T2, T3, T4, T5, T6, T7, T8);
+        $name!(T1, T2, T3, T4, T5, T6, T7, T8, T9);
+        $name!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10);
+        $name!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11);
+        $name!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12);
+        $name!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13);
+        $name!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14);
+        $name!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15);
+        $name!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16);
+    };
+}
+
+#[test]
+fn test_capture_description() {
+    assert_eq!(capture_description!(), "");
+    assert_eq!(capture_description!(
+        /// Foo
+    ), "Foo");
+
+    assert_eq!(capture_description!(
+        /// Foo
+        ///
+        /// Bar
+        /// Baz
+    ), " Foo\n \n Bar\n Baz")
+}

--- a/axum-openapi/src/openapi/mod.rs
+++ b/axum-openapi/src/openapi/mod.rs
@@ -1,0 +1,86 @@
+//! Type definitions for OpenAPI descriptions of routes
+
+use either::Either;
+use indexmap::IndexMap;
+use schemars::schema::RootSchema;
+use crate::HandlerArg;
+
+#[derive(serde::Serialize, Debug)]
+pub struct OpenApi {
+    pub(crate) openapi: &'static str,
+    pub info: Info,
+    pub paths: IndexMap<String, PathItem>,
+}
+
+#[derive(serde::Serialize, Debug, Default)]
+pub struct Info {
+    pub title: String,
+    pub description: Option<String>,
+}
+
+#[derive(serde::Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct PathItem {
+    pub post: Option<Operation>,
+}
+
+#[derive(serde::Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct Operation {
+    pub tags: &'static [&'static str],
+    pub summary: &'static str,
+    pub description: &'static str,
+    pub operation_id: &'static str,
+    pub parameters: Vec<Parameter>,
+    pub request_body: Option<RequestBody>,
+}
+
+#[derive(serde::Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct Parameter {
+    #[serde(rename = "in")]
+    pub location: ParameterLocation,
+
+    pub name: &'static str,
+    pub description: &'static str,
+    pub required: bool,
+    pub deprecated: bool,
+}
+
+#[derive(serde::Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub enum ParameterLocation {
+    Query,
+    Header,
+    Path,
+    Cookie
+}
+
+#[derive(serde::Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct RequestBody {
+    pub description: &'static str,
+    pub content: RequestBodyContent,
+}
+
+#[derive(serde::Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub enum RequestBodyContent {
+    #[serde(rename = "application/json")]
+    Json(RootSchema)
+}
+
+impl Operation {
+    #[doc(hidden)]
+    pub fn __push_handler_arg<T: HandlerArg>(&mut self) {
+        match T::describe() {
+            Some(Either::Left(param)) => self.parameters.push(param),
+            Some(Either::Right(body)) => {
+                if let Some(body) = self.request_body.replace(body) {
+                    panic!("handler has more than one request body: {:?}", body)
+                }
+            },
+            None => (),
+        }
+    }
+}

--- a/axum-openapi/src/routing.rs
+++ b/axum-openapi/src/routing.rs
@@ -1,0 +1,107 @@
+use std::convert::Infallible;
+use std::sync::Arc;
+use indexmap::IndexMap;
+use serde_json::value::RawValue;
+use axum::body::{Body, HttpBody};
+use axum::{Extension, Json};
+use axum::handler::Handler;
+use axum::http::Request;
+use axum::response::Response;
+
+use crate::{openapi, RouteHandler};
+use crate::openapi::OpenApi;
+
+pub struct Router<B = Body> {
+    inner: axum::routing::Router<B>,
+    paths: IndexMap<String, openapi::PathItem>
+}
+
+impl<B> Router<B> where B: HttpBody + Send + 'static {
+    pub fn new() -> Self {
+        Self {
+            inner: axum::routing::Router::new(),
+            paths: IndexMap::new(),
+        }
+    }
+
+    pub fn route(mut self, path: &str, service: MethodRouter<B, Infallible>) -> Self {
+        let inner = self.inner.route(path, service.inner);
+        self.paths.insert(path.to_string(), service.path_item);
+
+        Self {
+            inner,
+            paths: self.paths
+        }
+    }
+
+    pub fn spec(self, title: impl Into<String>) -> SpecBuilder<B> {
+        SpecBuilder {
+            router: self.inner,
+            info: openapi::Info {
+                title: title.into(),
+                ..Default::default()
+            },
+            paths: self.paths,
+        }
+    }
+
+    pub fn discard_spec(self) -> axum::routing::Router<B> {
+        self.inner
+    }
+}
+
+pub struct MethodRouter<B = Body, E = Infallible> {
+    inner: axum::routing::MethodRouter<B, E>,
+    path_item: openapi::PathItem
+}
+
+pub struct SpecBuilder<B = Body> {
+    router: axum::routing::Router<B>,
+    info: openapi::Info,
+    paths: IndexMap<String, openapi::PathItem>,
+}
+
+impl<B> SpecBuilder<B> where B: HttpBody + Send + 'static {
+    pub fn description(mut self, description: impl Into<String>) -> Self {
+        self.info.description = Some(description.into());
+        self
+    }
+
+    pub fn serve_at(self, path: &str) -> axum::routing::Router<B> {
+        let openapi = OpenApi {
+            openapi: "3.0.3",
+            info: self.info,
+            paths: self.paths,
+        };
+
+        // eagerly serialize the response
+
+        let serialized: Arc<RawValue> = serde_json::value::to_raw_value(&openapi)
+            .expect("failed to serialize OpenApi")
+            .into();
+
+        self.router.route(
+            path,
+            axum::routing::get(serve_spec)
+                .layer(Extension(serialized))
+        )
+    }
+}
+
+pub fn post<H, T, B>(handler: fn() -> RouteHandler<H>) -> MethodRouter<B>
+where H: Handler<T, B>, B: Send + 'static, T: 'static {
+    let handler = (handler)();
+
+    let operation = (handler.describe)();
+
+    MethodRouter {
+        inner: axum::routing::post(handler.handler),
+        path_item: openapi::PathItem {
+            post: Some(operation),
+        }
+    }
+}
+
+async fn serve_spec(spec: Extension<Arc<RawValue>>) -> Json<Arc<RawValue>> {
+    Json(spec.0)
+}

--- a/examples/openapi-test/Cargo.toml
+++ b/examples/openapi-test/Cargo.toml
@@ -13,3 +13,5 @@ serde = { version = "1", features = ["derive"] }
 tower-http = { version = "0.2.5", features = ["cors"] }
 
 tokio = { version = "1.17.0", features = ["macros"] }
+
+schemars = "0.8.8"

--- a/examples/openapi-test/Cargo.toml
+++ b/examples/openapi-test/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "openapi-test"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+axum = { version = "0.5.1", path = "../../axum" }
+axum-openapi = { path = "../../axum-openapi" }
+serde = { version = "1", features = ["derive"] }
+
+tower-http = { version = "0.2.5", features = ["cors"] }
+
+tokio = { version = "1.17.0", features = ["macros"] }

--- a/examples/openapi-test/src/main.rs
+++ b/examples/openapi-test/src/main.rs
@@ -1,0 +1,34 @@
+use tower_http::cors::CorsLayer;
+use axum::{Json, Server};
+
+/// A Foo
+#[derive(serde::Deserialize, axum_openapi::JsonBody)]
+#[serde(rename_all = "camelCase")]
+struct Foo {
+    /// a fooBar
+    foo_bar: String,
+}
+
+
+/// Foo
+///
+/// Bar
+/// Baz
+#[axum_openapi::route]
+async fn foo_bar(body: Json<Foo>) {
+
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    let app = axum_openapi::routing::Router::new()
+        .route("/foo/bar", axum_openapi::routing::post(foo_bar))
+        .spec("A test API serving an OpenAPI spec")
+        .serve_at("/openapi.json")
+        .layer(CorsLayer::permissive());
+
+    Server::bind(&"0.0.0.0:8080".parse().unwrap())
+        .serve(app.into_make_service())
+        .await
+        .unwrap();
+}

--- a/examples/openapi-test/src/main.rs
+++ b/examples/openapi-test/src/main.rs
@@ -1,31 +1,39 @@
+#![feature(trace_macros)]
+
 use tower_http::cors::CorsLayer;
 use axum::{Json, Server};
 
 /// A Foo
-#[derive(serde::Deserialize, axum_openapi::JsonBody)]
+#[derive(serde::Deserialize, schemars::JsonSchema)]
 #[serde(rename_all = "camelCase")]
 struct Foo {
     /// a fooBar
     foo_bar: String,
 }
 
-
-/// Foo
-///
-/// Bar
-/// Baz
-#[axum_openapi::route]
 async fn foo_bar(body: Json<Foo>) {
 
 }
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
+    println!("{:#?}", schemars::schema_for!(Foo));
+
+    trace_macros!(true);
     let app = axum_openapi::routing::Router::new()
-        .route("/foo/bar", axum_openapi::routing::post(foo_bar))
+        .route("/foo/bar", axum_openapi::route! {
+            /// Foo
+            ///
+            /// Bar
+            /// Baz
+            #[tags("foo", "bar")]
+            post: foo_bar
+        })
         .spec("A test API serving an OpenAPI spec")
         .serve_at("/openapi.json")
         .layer(CorsLayer::permissive());
+
+    trace_macros!(false);
 
     Server::bind(&"0.0.0.0:8080".parse().unwrap())
         .serve(app.into_make_service())


### PR DESCRIPTION
A different approach than #459 with a simpler API. See `examples/openapi-test` for expected usage.

I chose to have the OpenAPI typedefs in-crate instead of using `okapi` as it's actually not that complex and we can use more efficient typedefs for the specific use-case (like having `&'static str` everywhere for strings).

One annoying thing is that `#[route]` changes the function signature which doesn't seem to play well with IDE support. I'm not sure how to avoid that while still being able to attach the documentation string to the function lvalue.

Also `route` and `RouteHandler` are probably the wrong names but it's what came to mind.

TODO: handle path parameters (change `/foo/:id` to `/foo/{id}`), fill out API