### PR TITLE
Revert "Allow `Error: Into<Infallible>` for `Route::{layer, route_layer}`"

### DIFF
--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -14,11 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **added:** Add `AppendHeaders` for appending headers to a response rather than overriding them ([#927])
 - **added:** Add `axum::extract::multipart::Field::chunk` method for streaming a single chunk from
   the field ([#901])
-- **changed:** Allow `Error: Into<Infallible>` for `Route::{layer, route_layer}` ([#924])
 - **fixed:** Fix trailing slash redirection with query parameters ([#936])
 
 [#901]: https://github.com/tokio-rs/axum/pull/901
-[#924]: https://github.com/tokio-rs/axum/pull/924
 [#927]: https://github.com/tokio-rs/axum/pull/927
 [#936]: https://github.com/tokio-rs/axum/pull/936
 

--- a/axum/src/routing/mod.rs
+++ b/axum/src/routing/mod.rs
@@ -291,15 +291,15 @@ where
     pub fn layer<L, NewReqBody, NewResBody>(self, layer: L) -> Router<NewReqBody>
     where
         L: Layer<Route<B>>,
-        L::Service:
-            Service<Request<NewReqBody>, Response = Response<NewResBody>> + Clone + Send + 'static,
-        <L::Service as Service<Request<NewReqBody>>>::Error: Into<Infallible> + 'static,
+        L::Service: Service<Request<NewReqBody>, Response = Response<NewResBody>, Error = Infallible>
+            + Clone
+            + Send
+            + 'static,
         <L::Service as Service<Request<NewReqBody>>>::Future: Send + 'static,
         NewResBody: HttpBody<Data = Bytes> + Send + 'static,
         NewResBody::Error: Into<BoxError>,
     {
         let layer = ServiceBuilder::new()
-            .map_err(Into::into)
             .layer(MapResponseBodyLayer::new(boxed))
             .layer(layer)
             .into_inner();
@@ -332,14 +332,15 @@ where
     pub fn route_layer<L, NewResBody>(self, layer: L) -> Self
     where
         L: Layer<Route<B>>,
-        L::Service: Service<Request<B>, Response = Response<NewResBody>> + Clone + Send + 'static,
-        <L::Service as Service<Request<B>>>::Error: Into<Infallible> + 'static,
+        L::Service: Service<Request<B>, Response = Response<NewResBody>, Error = Infallible>
+            + Clone
+            + Send
+            + 'static,
         <L::Service as Service<Request<B>>>::Future: Send + 'static,
         NewResBody: HttpBody<Data = Bytes> + Send + 'static,
         NewResBody::Error: Into<BoxError>,
     {
         let layer = ServiceBuilder::new()
-            .map_err(Into::into)
             .layer(MapResponseBodyLayer::new(boxed))
             .layer(layer)
             .into_inner();


### PR DESCRIPTION
Turns out it was a breaking change.

This reverts commit ca7ecb159bb1bc77c2c3623358ea028b0722e686.