### PR TITLE
axum: Version 0.5.3

### DIFF
--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -11,20 +11,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # 0.5.3 (19. April, 2022)
 
-- **fixed:** Revert [#924] which was an accidental breaking change.
-
-# 0.5.2 (19. April, 2022)
-
 - **added:** Add `AppendHeaders` for appending headers to a response rather than overriding them ([#927])
 - **added:** Add `axum::extract::multipart::Field::chunk` method for streaming a single chunk from
   the field ([#901])
-- **changed:** Allow `Error: Into<Infallible>` for `Route::{layer, route_layer}` ([#924])
 - **fixed:** Fix trailing slash redirection with query parameters ([#936])
 
 [#901]: https://github.com/tokio-rs/axum/pull/901
-[#924]: https://github.com/tokio-rs/axum/pull/924
 [#927]: https://github.com/tokio-rs/axum/pull/927
 [#936]: https://github.com/tokio-rs/axum/pull/936
+
+# 0.5.2 (19. April, 2022)
+
+Yanked, as it contained an accidental breaking change.
 
 # 0.5.1 (03. April, 2022)
 

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -9,14 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - None.
 
+# 0.5.3 (19. April, 2022)
+
+- **fixed:** Revert [#924] which was an accidental breaking change.
+
 # 0.5.2 (19. April, 2022)
 
 - **added:** Add `AppendHeaders` for appending headers to a response rather than overriding them ([#927])
 - **added:** Add `axum::extract::multipart::Field::chunk` method for streaming a single chunk from
   the field ([#901])
+- **changed:** Allow `Error: Into<Infallible>` for `Route::{layer, route_layer}` ([#924])
 - **fixed:** Fix trailing slash redirection with query parameters ([#936])
 
 [#901]: https://github.com/tokio-rs/axum/pull/901
+[#924]: https://github.com/tokio-rs/axum/pull/924
 [#927]: https://github.com/tokio-rs/axum/pull/927
 [#936]: https://github.com/tokio-rs/axum/pull/936
 

--- a/axum/Cargo.toml
+++ b/axum/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axum"
-version = "0.5.2"
+version = "0.5.3"
 categories = ["asynchronous", "network-programming", "web-programming"]
 description = "Web framework that focuses on ergonomics and modularity"
 edition = "2018"
@@ -24,7 +24,7 @@ tower-log = ["tower/log"]
 ws = ["tokio-tungstenite", "sha-1", "base64"]
 
 [dependencies]
-axum-core = { path = "../axum-core", version = "0.2.1" }
+axum-core = { path = "../axum-core", version = "0.2.2" }
 async-trait = "0.1.43"
 bitflags = "1.0"
 bytes = "1.0"


### PR DESCRIPTION
I realized we should keep the changelog entry for the breaking change for version 0.5.2, so added it back here.

Also bumped the version of axum-core to make sure we get the re-export of `AppendHeaders`.