### PR TITLE
Implement an alternative SPA solution

### DIFF
--- a/axum-extra/src/routing/mod.rs
+++ b/axum-extra/src/routing/mod.rs
@@ -19,7 +19,7 @@ pub use axum_macros::TypedPath;
 pub use self::typed::{FirstElementIs, TypedPath};
 
 #[cfg(feature = "spa")]
-pub use self::spa::SpaRouter;
+pub use self::spa::{spa_index, SpaRouter, SpaRouterExt};
 
 /// Extension trait that adds additional methods to [`Router`].
 pub trait RouterExt<B>: sealed::Sealed {


### PR DESCRIPTION
This is an experiment, trying to solve the issues faced in #933.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

The current `SpaRouter` has some limitations for certain use cases and this PR tries a different approach to allow more flexibility in how the routing is set up.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

This solution provides an extensions on top of the `Router` through `SpaRouterExt`. It adds a new methods that sets up a combination of `ServeDir` and `ServeFile`. In its very basic form it is equivalent to a `ServeDir` to provide assets from a directory. Based on the additional boolean flags, it allows to define fallbacks for to the `index.html`, as usually needed by Single Page Applications on the frontend.

The logic is as follows in regards to fallbacks:

- NO global, NO assets: Same as using `ServeDir` on the given route to serve assets.
- WITH global, NO assets: Same as first, but with a fallback to the `index.html` for **any** unmatched route. This excludes the assets directory itself, as a missing file is not considered unmatched.
- NO global, WITH assets: Same as first, but falls back to the `index.html` **if** some requested path **inside** the assets directory was missing.
- WITH global, WITH assets: Same as first and a combination of the previous. Falls back to `index.html` for **any** unmatched route  **and** any missing file inside the assets directory.

This solution is currently very similar to #941, but uses an extension trait and allows to set an option to apply a global fallback.

I would like to get away from the fallback, and, if this solution is considered good by the Axum team, would split it up a bit more. My idea for this is something like the following:

```rust
    Router::new()
        .spa_assets("/assets", "dist", true)
        .fallback(spa_index("dist"))
```

Here the `spa_assets` would come from an extension trait and only handle logic for the assets dir serving itself. So only the `ServeDir` + option to fall back to the index file on missing assets paths.

And the `spa_index` would be a public function which is just a shorthand for `ServeFile` with the file being `dist/index.html` in this case.

**Update**:

I changed the implementation to be split up, already. Please see the test cases for the new variants. Basically, no option flags anymore. After all, serving assets from a directory without any fallback is just the same as using `ServeDir` directly.

Therefore, `spa_assets` always enables the `index.html` fallback. And a global fallback can be configured with the `.fallback(spa_index("dist"))` call.

I wonder if it would be more natural to instead go a level lower (to the tower service level), or at least closer. What I mean is to have 2 distinct types `ServeSpaIndex` and `ServeSpaDir` which are just very thin wrappers around the `tower-http` types.

- `ServeSpaIndex` would be just a little shorthand that limits to `GET` requests (eventually check for the right mime type too), and accepts the assets directory, so it will join that folder with the `index.html`.
- `ServeSpaDir` would be the same as what the extension trait does, but as a type instead.

Also, these two types would not implement the `handle_error` part, so the user has to handle it. That gives more freedom by letting the user decide what to do with I/O errors. And, having it as a type again, it'd allow to apply additional layers/middleware on top.