### PR TITLE
#955: Make community projects stand out as examples

### DIFF
--- a/axum/README.md
+++ b/axum/README.md
@@ -116,18 +116,17 @@ axum's MSRV is 1.54.
 ## Examples
 
 The [examples] folder contains various examples of how to use `axum`. The
-[docs] also have lots of examples
+[docs] also provide lots of code snippets and examples. For full-fledged examples, check out community-maintained [showcases] or [tutorials].
 
 ## Getting Help
 
 In the `axum`'s repo we also have a [number of examples][examples] showing how
-to put everything together. You're also welcome to ask in the [Discord
-channel][chat] or open an [issue] with your question.
+to put everything together. Community-maintained [showcases] and [tutorials] also demonstrate how to use `axum` for real-world applications. You're also welcome to ask in the [Discord channel][chat] or open an [issue] with your question.
 
 ## Community projects
 
 See [here][ecosystem] for a list of community maintained crates and projects
-built with axum.
+built with `axum`.
 
 ## Contributing
 
@@ -157,4 +156,6 @@ additional terms or conditions.
 [issue]: https://github.com/tokio-rs/axum/issues/new
 [`tower::Service`]: https://docs.rs/tower/latest/tower/trait.Service.html
 [ecosystem]: https://github.com/tokio-rs/axum/blob/main/ECOSYSTEM.md
+[showcases]: https://github.com/tokio-rs/axum/blob/main/ECOSYSTEM.md#project-showcase
+[tutorials]: https://github.com/tokio-rs/axum/blob/main/ECOSYSTEM.md#tutorials
 [license]: https://github.com/tokio-rs/axum/blob/main/axum/LICENSE


### PR DESCRIPTION
## Motivation

This PR addresses [#955](https://github.com/tokio-rs/axum/issues/955), which turns out to be a minor edit after discussion with @davidpdrsn. The motivation is to make the community projects "stand out" more when a new `axum` user reads the `README`.

## Solution

Include community project links to showcases and tutorials in the `examples` section.