### PR TITLE
Remove needless map

### DIFF
--- a/axum/src/routing/url_params.rs
+++ b/axum/src/routing/url_params.rs
@@ -18,7 +18,6 @@ pub(super) fn insert_url_params(extensions: &mut Extensions, params: Params) {
     let params = params
         .iter()
         .filter(|(key, _)| !key.starts_with(super::NEST_TAIL_PARAM))
-        .map(|(key, value)| (key.to_owned(), value.to_owned()))
         .map(|(k, v)| {
             if let Some(decoded) = PercentDecodedByteStr::new(v) {
                 Ok((ByteStr::new(k), decoded))


### PR DESCRIPTION
```rust
pub(crate) fn new<S>(s: S) -> Self
    where
        S: AsRef<str>,
{
        Self(Bytes::copy_from_slice(s.as_ref().as_bytes()))
}
```
ByteStr receives an AsRef\<str\>. So no longer need to convert &str to String.
