### PR TITLE
Implement `IntoResponse` and `IntoResponseParts` for `http::Extensions`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,3 @@ members = [
     "axum-macros",
     "examples/*",
 ]
-
-[patch.crates-io]
-http = { git = "https://github.com/hyperium/http" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,6 @@ members = [
     "axum-macros",
     "examples/*",
 ]
+
+[patch.crates-io]
+http = { git = "https://github.com/hyperium/http" }

--- a/axum-core/CHANGELOG.md
+++ b/axum-core/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
-- None.
+- **added:** Implement `IntoResponse` and `IntoResponseParts` for `http::Extensions`
 
 # 0.2.3 (25. April, 2022)
 

--- a/axum-core/CHANGELOG.md
+++ b/axum-core/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
-- **added:** Implement `IntoResponse` and `IntoResponseParts` for `http::Extensions`
+- **added:** Implement `IntoResponse` and `IntoResponseParts` for `http::Extensions` ([#975])
+
+[#975]: https://github.com/tokio-rs/axum/pull/975
 
 # 0.2.3 (25. April, 2022)
 

--- a/axum-core/Cargo.toml
+++ b/axum-core/Cargo.toml
@@ -14,7 +14,7 @@ version = "0.2.3" # remember to also bump the version that axum depends on
 async-trait = "0.1"
 bytes = "1.0"
 futures-util = { version = "0.3", default-features = false, features = ["alloc"] }
-http = "0.2"
+http = "0.2.7"
 http-body = "0.4"
 mime = "0.3.16"
 

--- a/axum-core/src/response/into_response.rs
+++ b/axum-core/src/response/into_response.rs
@@ -3,7 +3,7 @@ use crate::{body, BoxError};
 use bytes::{buf::Chain, Buf, Bytes, BytesMut};
 use http::{
     header::{self, HeaderMap, HeaderName, HeaderValue},
-    StatusCode,
+    Extensions, StatusCode,
 };
 use http_body::{
     combinators::{MapData, MapErr},
@@ -380,6 +380,14 @@ impl IntoResponse for HeaderMap {
     fn into_response(self) -> Response {
         let mut res = ().into_response();
         *res.headers_mut() = self;
+        res
+    }
+}
+
+impl IntoResponse for Extensions {
+    fn into_response(self) -> Response {
+        let mut res = ().into_response();
+        *res.extensions_mut() = self;
         res
     }
 }

--- a/axum-core/src/response/into_response_parts.rs
+++ b/axum-core/src/response/into_response_parts.rs
@@ -249,3 +249,12 @@ macro_rules! impl_into_response_parts {
 }
 
 all_the_tuples!(impl_into_response_parts);
+
+impl IntoResponseParts for Extensions {
+    type Error = Infallible;
+
+    fn into_response_parts(self, mut res: ResponseParts) -> Result<ResponseParts, Self::Error> {
+        res.extensions_mut().extend(self);
+        Ok(res)
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/tokio-rs/axum/issues/951

Requires a new release of `http`.