### PR TITLE
feat: allow TypedHeaderRejection pattern matching

### DIFF
--- a/axum/src/typed_header.rs
+++ b/axum/src/typed_header.rs
@@ -109,8 +109,8 @@ where
 #[cfg(feature = "headers")]
 #[derive(Debug)]
 pub struct TypedHeaderRejection {
-    name: &'static http::header::HeaderName,
-    reason: TypedHeaderRejectionReason,
+    pub name: &'static http::header::HeaderName,
+    pub reason: TypedHeaderRejectionReason,
 }
 
 impl TypedHeaderRejection {


### PR DESCRIPTION
Signed-off-by: Roman Volosatovs <rvolosatovs@riseup.net>

## Motivation

Currently it is not possible to use `TypedHeaderRejection` in `match` statements to ergonomically handle the error cases.

## Solution

Expose `name` and `reason` fields, such that pattern matching would work, e.g.: https://github.com/profianinc/drawbridge/blob/b2370859603b2e508767408ab1a2f33060521224/crates/type/src/meta.rs#L61-L76