### PR TITLE
Move examples to separate workspace

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,8 +19,6 @@ jobs:
           - examples
     steps:
     - uses: actions/checkout@master
-    - name: Print working directory
-      run: pwd
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: beta

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,10 +11,16 @@ on:
 
 jobs:
   check:
-    # Run `cargo check` first to ensure that the pushed code at least compiles.
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        pwd:
+          - .
+          - examples
     steps:
     - uses: actions/checkout@master
+    - name: Print working directory
+      run: pwd
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: beta
@@ -23,15 +29,13 @@ jobs:
         components: clippy, rustfmt
     - uses: Swatinem/rust-cache@v1
     - name: Check
-      uses: actions-rs/cargo@v1
-      with:
-        command: clippy
-        args: --all --all-targets --all-features
+      working-directory: ${{ matrix.pwd }}
+      run: |
+        cargo clippy --all --all-targets --all-features
     - name: rustfmt
-      uses: actions-rs/cargo@v1
-      with:
-        command: fmt
-        args: --all -- --check
+      working-directory: ${{ matrix.pwd }}
+      run: |
+        cargo fmt --all -- --check
 
   check-docs:
     runs-on: ubuntu-latest
@@ -106,6 +110,7 @@ jobs:
         args: >
           -p axum
           -p axum-extra
+          -p axum-core
           --all-features --all-targets
     # the compiler errors are different on 1.54 which makes
     # the trybuild tests in axum-macros fail, so just run the doc

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
+/examples/target
 Cargo.lock
 .DS_Store

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,5 +4,4 @@ members = [
     "axum-core",
     "axum-extra",
     "axum-macros",
-    "examples/*",
 ]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,0 +1,3 @@
+[workspace]
+members = ["*"]
+exclude = ["target"]

--- a/examples/async-graphql/src/main.rs
+++ b/examples/async-graphql/src/main.rs
@@ -3,7 +3,7 @@
 //! Run with
 //!
 //! ```not_rust
-//! cargo run -p example-async-graphql
+//! cd examples && cargo run -p example-async-graphql
 //! ```
 
 mod starwars;

--- a/examples/chat/src/main.rs
+++ b/examples/chat/src/main.rs
@@ -3,7 +3,7 @@
 //! Run with
 //!
 //! ```not_rust
-//! cargo run -p example-chat
+//! cd examples && cargo run -p example-chat
 //! ```
 
 use axum::{

--- a/examples/consume-body-in-extractor-or-middleware/src/main.rs
+++ b/examples/consume-body-in-extractor-or-middleware/src/main.rs
@@ -1,7 +1,7 @@
 //! Run with
 //!
 //! ```not_rust
-//! cargo run -p example-consume-body-in-extractor-or-middleware
+//! cd examples && cargo run -p example-consume-body-in-extractor-or-middleware
 //! ```
 
 use axum::{

--- a/examples/cors/src/main.rs
+++ b/examples/cors/src/main.rs
@@ -1,7 +1,7 @@
 //! Run with
 //!
 //! ```not_rust
-//! cargo run -p example-cors
+//! cd examples && cargo run -p example-cors
 //! ```
 
 use axum::{

--- a/examples/customize-extractor-error/src/main.rs
+++ b/examples/customize-extractor-error/src/main.rs
@@ -1,7 +1,7 @@
 //! Run with
 //!
 //! ```not_rust
-//! cargo run -p example-customize-extractor-error
+//! cd examples && cargo run -p example-customize-extractor-error
 //! ```
 
 use axum::{

--- a/examples/customize-path-rejection/src/main.rs
+++ b/examples/customize-path-rejection/src/main.rs
@@ -1,7 +1,7 @@
 //! Run with
 //!
 //! ```not_rust
-//! cargo run -p example-customize-path-rejection
+//! cd examples && cargo run -p example-customize-path-rejection
 //! ```
 
 use axum::{

--- a/examples/error-handling-and-dependency-injection/src/main.rs
+++ b/examples/error-handling-and-dependency-injection/src/main.rs
@@ -4,7 +4,7 @@
 //! Run with
 //!
 //! ```not_rust
-//! cargo run -p example-error-handling-and-dependency-injection
+//! cd examples && cargo run -p example-error-handling-and-dependency-injection
 //! ```
 
 use axum::{

--- a/examples/form/src/main.rs
+++ b/examples/form/src/main.rs
@@ -1,7 +1,7 @@
 //! Run with
 //!
 //! ```not_rust
-//! cargo run -p example-form
+//! cd examples && cargo run -p example-form
 //! ```
 
 use axum::{extract::Form, response::Html, routing::get, Router};

--- a/examples/global-404-handler/src/main.rs
+++ b/examples/global-404-handler/src/main.rs
@@ -1,7 +1,7 @@
 //! Run with
 //!
 //! ```not_rust
-//! cargo run -p example-global-404-handler
+//! cd examples && cargo run -p example-global-404-handler
 //! ```
 
 use axum::{

--- a/examples/graceful-shutdown/src/main.rs
+++ b/examples/graceful-shutdown/src/main.rs
@@ -1,7 +1,7 @@
 //! Run with
 //!
 //! ```not_rust
-//! cargo run -p example-graceful-shutdown
+//! cd examples && cargo run -p example-graceful-shutdown
 //! kill or ctrl-c
 //! ```
 

--- a/examples/hello-world/src/main.rs
+++ b/examples/hello-world/src/main.rs
@@ -1,7 +1,7 @@
 //! Run with
 //!
 //! ```not_rust
-//! cargo run -p example-hello-world
+//! cd examples && cargo run -p example-hello-world
 //! ```
 
 use axum::{response::Html, routing::get, Router};

--- a/examples/key-value-store/src/main.rs
+++ b/examples/key-value-store/src/main.rs
@@ -3,7 +3,7 @@
 //! Run with:
 //!
 //! ```not_rust
-//! cargo run -p example-key-value-store
+//! cd examples && cargo run -p example-key-value-store
 //! ```
 
 use axum::{

--- a/examples/low-level-rustls/src/main.rs
+++ b/examples/low-level-rustls/src/main.rs
@@ -1,7 +1,7 @@
 //! Run with
 //!
 //! ```not_rust
-//! cargo run -p example-low-level-rustls
+//! cd examples && cargo run -p example-low-level-rustls
 //! ```
 
 use axum::{extract::ConnectInfo, routing::get, Router};

--- a/examples/multipart-form/src/main.rs
+++ b/examples/multipart-form/src/main.rs
@@ -1,7 +1,7 @@
 //! Run with
 //!
 //! ```not_rust
-//! cargo run -p example-multipart-form
+//! cd examples && cargo run -p example-multipart-form
 //! ```
 
 use axum::{

--- a/examples/print-request-response/src/main.rs
+++ b/examples/print-request-response/src/main.rs
@@ -1,7 +1,7 @@
 //! Run with
 //!
 //! ```not_rust
-//! cargo run -p example-print-request-response
+//! cd examples && cargo run -p example-print-request-response
 //! ```
 
 use axum::{

--- a/examples/prometheus-metrics/src/main.rs
+++ b/examples/prometheus-metrics/src/main.rs
@@ -4,7 +4,7 @@
 //! Run with
 //!
 //! ```not_rust
-//! cargo run -p example-prometheus-metrics
+//! cd examples && cargo run -p example-prometheus-metrics
 //! ```
 
 use axum::{

--- a/examples/query-params-with-empty-strings/src/main.rs
+++ b/examples/query-params-with-empty-strings/src/main.rs
@@ -1,7 +1,7 @@
 //! Run with
 //!
 //! ```not_rust
-//! cargo run -p example-query-params-with-empty-strings
+//! cd examples && cargo run -p example-query-params-with-empty-strings
 //! ```
 
 use axum::{extract::Query, routing::get, Router};

--- a/examples/readme/src/main.rs
+++ b/examples/readme/src/main.rs
@@ -1,7 +1,7 @@
 //! Run with
 //!
 //! ```not_rust
-//! cargo run -p example-readme
+//! cd examples && cargo run -p example-readme
 //! ```
 
 use axum::{

--- a/examples/reverse-proxy/src/main.rs
+++ b/examples/reverse-proxy/src/main.rs
@@ -4,7 +4,7 @@
 //! Run with
 //!
 //! ```not_rust
-//! cargo run -p example-reverse-proxy
+//! cd examples && cargo run -p example-reverse-proxy
 //! ```
 
 use axum::{

--- a/examples/routes-and-handlers-close-together/src/main.rs
+++ b/examples/routes-and-handlers-close-together/src/main.rs
@@ -1,7 +1,7 @@
 //! Run with
 //!
 //! ```not_rust
-//! cargo run -p example-routes-and-handlers-close-together
+//! cd examples && cargo run -p example-routes-and-handlers-close-together
 //! ```
 
 use axum::{

--- a/examples/sessions/src/main.rs
+++ b/examples/sessions/src/main.rs
@@ -1,7 +1,7 @@
 //! Run with
 //!
 //! ```not_rust
-//! cargo run -p example-sessions
+//! cd examples && cargo run -p example-sessions
 //! ```
 
 use async_session::{MemoryStore, Session, SessionStore as _};

--- a/examples/sqlx-postgres/src/main.rs
+++ b/examples/sqlx-postgres/src/main.rs
@@ -3,7 +3,7 @@
 //! Run with
 //!
 //! ```not_rust
-//! cargo run -p example-sqlx-postgres
+//! cd examples && cargo run -p example-sqlx-postgres
 //! ```
 //!
 //! Test with curl:

--- a/examples/sse/src/main.rs
+++ b/examples/sse/src/main.rs
@@ -1,7 +1,7 @@
 //! Run with
 //!
 //! ```not_rust
-//! cargo run -p example-sse
+//! cd examples && cargo run -p example-sse
 //! ```
 
 use axum::{

--- a/examples/static-file-server/src/main.rs
+++ b/examples/static-file-server/src/main.rs
@@ -1,7 +1,7 @@
 //! Run with
 //!
 //! ```not_rust
-//! cargo run -p example-static-file-server
+//! cd examples && cargo run -p example-static-file-server
 //! ```
 
 use axum::{http::StatusCode, routing::get_service, Router};

--- a/examples/stream-to-file/src/main.rs
+++ b/examples/stream-to-file/src/main.rs
@@ -1,7 +1,7 @@
 //! Run with
 //!
 //! ```not_rust
-//! cargo run -p example-stream-to-file
+//! cd examples && cargo run -p example-stream-to-file
 //! ```
 
 use axum::{

--- a/examples/templates/src/main.rs
+++ b/examples/templates/src/main.rs
@@ -1,7 +1,7 @@
 //! Run with
 //!
 //! ```not_rust
-//! cargo run -p example-templates
+//! cd examples && cargo run -p example-templates
 //! ```
 
 use askama::Template;

--- a/examples/tls-rustls/src/main.rs
+++ b/examples/tls-rustls/src/main.rs
@@ -1,7 +1,7 @@
 //! Run with
 //!
 //! ```not_rust
-//! cargo run -p example-tls-rustls
+//! cd examples && cargo run -p example-tls-rustls
 //! ```
 
 use axum::{routing::get, Router};

--- a/examples/todos/src/main.rs
+++ b/examples/todos/src/main.rs
@@ -10,7 +10,7 @@
 //! Run with
 //!
 //! ```not_rust
-//! cargo run -p example-todos
+//! cd examples && cargo run -p example-todos
 //! ```
 
 use axum::{

--- a/examples/tokio-postgres/src/main.rs
+++ b/examples/tokio-postgres/src/main.rs
@@ -1,7 +1,7 @@
 //! Run with
 //!
 //! ```not_rust
-//! cargo run -p example-tokio-postgres
+//! cd examples && cargo run -p example-tokio-postgres
 //! ```
 
 use axum::{

--- a/examples/tracing-aka-logging/src/main.rs
+++ b/examples/tracing-aka-logging/src/main.rs
@@ -1,7 +1,7 @@
 //! Run with
 //!
 //! ```not_rust
-//! cargo run -p example-tracing-aka-logging
+//! cd examples && cargo run -p example-tracing-aka-logging
 //! ```
 
 use axum::{

--- a/examples/unix-domain-socket/src/main.rs
+++ b/examples/unix-domain-socket/src/main.rs
@@ -1,7 +1,7 @@
 //! Run with
 //!
 //! ```not_rust
-//! cargo run -p example-unix-domain-socket
+//! cd examples && cargo run -p example-unix-domain-socket
 //! ```
 
 #[cfg(unix)]

--- a/examples/validator/src/main.rs
+++ b/examples/validator/src/main.rs
@@ -1,7 +1,7 @@
 //! Run with
 //!
 //! ```not_rust
-//! cargo run -p example-validator
+//! cd examples && cargo run -p example-validator
 //!
 //! curl '127.0.0.1:3000?name='
 //! -> Input validation error: [name: Can not be empty]

--- a/examples/versioning/src/main.rs
+++ b/examples/versioning/src/main.rs
@@ -1,7 +1,7 @@
 //! Run with
 //!
 //! ```not_rust
-//! cargo run -p example-versioning
+//! cd examples && cargo run -p example-versioning
 //! ```
 
 use axum::{

--- a/examples/websockets/src/main.rs
+++ b/examples/websockets/src/main.rs
@@ -3,7 +3,7 @@
 //! Run with
 //!
 //! ```not_rust
-//! cargo run -p example-websockets
+//! cd examples && cargo run -p example-websockets
 //! ```
 
 use axum::{


### PR DESCRIPTION
This is something I've been considering for some time. The examples folder is slowly getting bigger and gaining more dependencies. Thats not bad in and off itself however it makes developing axum itself slower since there are more crates for rust-analyzer to build.

So I suggest we move the examples into their own workspace so they need to be compiled separately.

Everything is still checked on CI.