### PR TITLE
Ignore target directories in individual examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /target
 /examples/target
+/examples/*/target
 Cargo.lock
 .DS_Store


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

These get created with `rust-analyzer`, which pollutes the git status
output.

For example:
```
Untracked files:
  (use "git add <file>..." to include in what will be committed)
        examples/chat/target/
        examples/sqlx-postgres/target/
```

`cargo run -p example-chat` from `/example` doesn't cause this though, which explains why this may not have been an issue faced by anyone else.

## Solution
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Add `/examples/*/target` to `gitignore`. Have been using `.git/info/exclude` for this.