### PR TITLE
`Path` extractor works with `Deserialize` impls using `&str`

### DIFF
--- a/axum/src/extract/path/de.rs
+++ b/axum/src/extract/path/de.rs
@@ -88,7 +88,7 @@ impl<'de> Deserializer<'de> for PathDeserializer<'de> {
                 .got(self.url_params.len())
                 .expected(1));
         }
-        visitor.visit_str(&self.url_params[0].1)
+        visitor.visit_borrowed_str(&self.url_params[0].1)
     }
 
     fn deserialize_unit<V>(self, visitor: V) -> Result<V::Value, Self::Error>
@@ -608,6 +608,8 @@ mod tests {
         check_single_value!(f64, "123", 123.0);
         check_single_value!(String, "abc", "abc");
         check_single_value!(String, "one%20two", "one two");
+        check_single_value!(&str, "abc", "abc");
+        check_single_value!(&str, "one%20two", "one two");
         check_single_value!(char, "a", 'a');
 
         let url_params = create_url_params(vec![("a", "B")]);

--- a/axum/src/extract/path/mod.rs
+++ b/axum/src/extract/path/mod.rs
@@ -534,5 +534,9 @@ mod tests {
 
         let res = client.get("/foo").send().await;
         assert_eq!(res.text().await, "foo");
+
+        // percent decoding should also work
+        let res = client.get("/foo%20bar").send().await;
+        assert_eq!(res.text().await, "foo bar");
     }
 }


### PR DESCRIPTION
Before this change the extractor `Path<Test>` would fail if the `Deserialize` implementation of `Test` was calling
`Deserializer::deserialize_str()`.

Now we use `Visitor::visit_borrowed_str()` instead of `Visitor::visit_str()` which is also recommended in the [guide to implement a deserializer][1].

[1]: https://serde.rs/impl-deserializer.html