### PR TITLE
upgrade uuid from 0.8 to 1.0

### DIFF
--- a/axum/Cargo.toml
+++ b/axum/Cargo.toml
@@ -63,7 +63,7 @@ serde_json = "1.0"
 tokio = { version = "1.6.1", features = ["macros", "rt", "rt-multi-thread", "net", "test-util"] }
 tokio-stream = "0.1"
 tracing = "0.1"
-uuid = { version = "0.8", features = ["serde", "v4"] }
+uuid = { version = "1.0", features = ["serde", "v4"] }
 anyhow = "1.0"
 quickcheck = "1.0"
 quickcheck_macros = "1.0"

--- a/examples/error-handling-and-dependency-injection/Cargo.toml
+++ b/examples/error-handling-and-dependency-injection/Cargo.toml
@@ -12,4 +12,4 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-uuid = { version = "0.8", features = ["v4", "serde"] }
+uuid = { version = "1.0", features = ["v4", "serde"] }

--- a/examples/sessions/Cargo.toml
+++ b/examples/sessions/Cargo.toml
@@ -10,5 +10,5 @@ tokio = { version = "1.0", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 serde = { version = "1.0", features = ["derive"] }
-uuid = { version = "0.8", features = ["v4", "serde"] }
+uuid = { version = "1.0", features = ["v4", "serde"] }
 async-session = "3.0.0"

--- a/examples/todos/Cargo.toml
+++ b/examples/todos/Cargo.toml
@@ -11,5 +11,5 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tower = { version = "0.4", features = ["util", "timeout"] }
 tower-http = { version = "0.3.0", features = ["add-extension", "trace"] }
-uuid = { version = "0.8", features = ["serde", "v4"] }
+uuid = { version = "1.0", features = ["serde", "v4"] }
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
Here is uuid 1.0 change log [1.0.0](https://github.com/uuid-rs/uuid/releases/tag/1.0.0)

In short: it's faster and safer.

There's no reason not to upgrade.