### PR TITLE
Support `Option` and `Result` in typed paths

### DIFF
--- a/axum-extra/CHANGELOG.md
+++ b/axum-extra/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning].
 
 # Unreleased
 
-- None.
+- **fixed:** `Option` and `Result` are now supported in typed paths ([#1001])
+
+[#1001]: https://github.com/tokio-rs/axum/pull/1001
 
 # 0.3.0 (27. April, 2022)
 

--- a/axum-extra/CHANGELOG.md
+++ b/axum-extra/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning].
 
 # Unreleased
 
-- **fixed:** `Option` and `Result` are now supported in typed paths ([#1001])
+- **fixed:** `Option` and `Result` are now supported in typed path route handler parameters ([#1001])
 
 [#1001]: https://github.com/tokio-rs/axum/pull/1001
 

--- a/axum-extra/src/routing/typed.rs
+++ b/axum-extra/src/routing/typed.rs
@@ -190,6 +190,26 @@ macro_rules! impl_first_element_is {
         where
             P: TypedPath
         {}
+
+        impl<P, $($ty,)*> FirstElementIs<P> for (Option<P>, $($ty,)*)
+        where
+            P: TypedPath
+        {}
+
+        impl<P, $($ty,)*> Sealed for (Option<P>, $($ty,)*)
+        where
+            P: TypedPath
+        {}
+
+        impl<P, E, $($ty,)*> FirstElementIs<P> for (Result<P, E>, $($ty,)*)
+        where
+            P: TypedPath
+        {}
+
+        impl<P, E, $($ty,)*> Sealed for (Result<P, E>, $($ty,)*)
+        where
+            P: TypedPath
+        {}
     };
 }
 

--- a/axum-macros/CHANGELOG.md
+++ b/axum-macros/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
-- **fixed:** `Option` and `Result` are now supported in typed paths
+- **fixed:** `Option` and `Result` are now supported in typed paths ([#1001])
+
+[#1001]: https://github.com/tokio-rs/axum/pull/1001
 
 # 0.2.0 (31. March, 2022)
 

--- a/axum-macros/CHANGELOG.md
+++ b/axum-macros/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
-- **fixed:** `Option` and `Result` are now supported in typed paths ([#1001])
+- **fixed:** `Option` and `Result` are now supported in typed path route handler parameters ([#1001])
 
 [#1001]: https://github.com/tokio-rs/axum/pull/1001
 

--- a/axum-macros/CHANGELOG.md
+++ b/axum-macros/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
-- None.
+- **fixed:** `Option` and `Result` are now supported in typed paths
 
 # 0.2.0 (31. March, 2022)
 

--- a/axum-macros/tests/typed_path/pass/option_result.rs
+++ b/axum-macros/tests/typed_path/pass/option_result.rs
@@ -1,0 +1,27 @@
+use axum_extra::routing::{TypedPath, RouterExt};
+use axum::{extract::rejection::PathRejection, http::StatusCode};
+use serde::Deserialize;
+
+#[derive(TypedPath, Deserialize)]
+#[typed_path("/users/:id")]
+struct UsersShow {
+    id: String,
+}
+
+async fn option_handler(_: Option<UsersShow>) {}
+
+async fn result_handler(_: Result<UsersShow, PathRejection>) {}
+
+#[derive(TypedPath, Deserialize)]
+#[typed_path("/users")]
+struct UsersIndex;
+
+#[axum_macros::debug_handler]
+async fn result_handler_unit_struct(_: Result<UsersIndex, StatusCode>) {}
+
+fn main() {
+    axum::Router::<axum::body::Body>::new()
+        .typed_get(option_handler)
+        .typed_post(result_handler)
+        .typed_post(result_handler_unit_struct);
+}


### PR DESCRIPTION
Fixes https://github.com/tokio-rs/axum/issues/994

Makes this work:

```rust
#[derive(TypedPath, Deserialize)]
#[typed_path("/users/:id")]
struct UsersShow {
    id: String,
}

// this previously wouldn't compile when used with `Router::typed_*`
async fn option_handler(_: Option<UsersShow>) {}

async fn result_handler(_: Result<UsersShow, PathRejection>) {}
```