### PR TITLE
Support `#[derive(FromRequest)]` on enums

### DIFF
--- a/axum-macros/CHANGELOG.md
+++ b/axum-macros/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **fixed:** `Option` and `Result` are now supported in typed path route handler parameters ([#1001])
 - **fixed:** Support wildcards in typed paths ([#1003])
+- **added:** Support `#[derive(FromRequest)]` on enums
 
 [#1001]: https://github.com/tokio-rs/axum/pull/1001
 [#1003]: https://github.com/tokio-rs/axum/pull/1003

--- a/axum-macros/CHANGELOG.md
+++ b/axum-macros/CHANGELOG.md
@@ -9,10 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **fixed:** `Option` and `Result` are now supported in typed path route handler parameters ([#1001])
 - **fixed:** Support wildcards in typed paths ([#1003])
-- **added:** Support `#[derive(FromRequest)]` on enums using `#[from_request(via(OtherExtractor))]`
+- **added:** Support `#[derive(FromRequest)]` on enums using `#[from_request(via(OtherExtractor))]` ([#1009])
 
 [#1001]: https://github.com/tokio-rs/axum/pull/1001
 [#1003]: https://github.com/tokio-rs/axum/pull/1003
+[#1009]: https://github.com/tokio-rs/axum/pull/1009
 
 # 0.2.0 (31. March, 2022)
 

--- a/axum-macros/CHANGELOG.md
+++ b/axum-macros/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **fixed:** `Option` and `Result` are now supported in typed path route handler parameters ([#1001])
 - **fixed:** Support wildcards in typed paths ([#1003])
-- **added:** Support `#[derive(FromRequest)]` on enums
+- **added:** Support `#[derive(FromRequest)]` on enums using `#[from_request(via(OtherExtractor))]`
 
 [#1001]: https://github.com/tokio-rs/axum/pull/1001
 [#1003]: https://github.com/tokio-rs/axum/pull/1003

--- a/axum-macros/Cargo.toml
+++ b/axum-macros/Cargo.toml
@@ -17,7 +17,7 @@ proc-macro = true
 heck = "0.4"
 proc-macro2 = "1.0"
 quote = "1.0"
-syn = { version = "1.0", features = ["full"] }
+syn = { version = "1.0", features = ["full", "extra-traits"] }
 
 [dev-dependencies]
 axum = { path = "../axum", version = "0.5", features = ["headers"] }

--- a/axum-macros/Cargo.toml
+++ b/axum-macros/Cargo.toml
@@ -17,7 +17,7 @@ proc-macro = true
 heck = "0.4"
 proc-macro2 = "1.0"
 quote = "1.0"
-syn = { version = "1.0", features = ["full", "extra-traits"] }
+syn = { version = "1.0", features = ["full"] }
 
 [dev-dependencies]
 axum = { path = "../axum", version = "0.5", features = ["headers"] }

--- a/axum-macros/src/from_request/attr.rs
+++ b/axum-macros/src/from_request/attr.rs
@@ -12,7 +12,7 @@ pub(crate) struct FromRequestFieldAttr {
 
 pub(crate) enum FromRequestContainerAttr {
     Via(syn::Path),
-    RejectionDerive(RejectionDeriveOptOuts),
+    RejectionDerive(kw::rejection_derive, RejectionDeriveOptOuts),
     None,
 }
 
@@ -91,7 +91,9 @@ pub(crate) fn parse_container_attrs(
             }
         }
         (Some((_, _, path)), None) => Ok(FromRequestContainerAttr::Via(path)),
-        (None, Some((_, _, opt_outs))) => Ok(FromRequestContainerAttr::RejectionDerive(opt_outs)),
+        (None, Some((_, rejection_derive, opt_outs))) => Ok(
+            FromRequestContainerAttr::RejectionDerive(rejection_derive, opt_outs),
+        ),
         (None, None) => Ok(FromRequestContainerAttr::None),
     }
 }

--- a/axum-macros/tests/from_request/fail/enum_from_request_ident_in_variant.rs
+++ b/axum-macros/tests/from_request/fail/enum_from_request_ident_in_variant.rs
@@ -1,0 +1,12 @@
+use axum_macros::FromRequest;
+
+#[derive(FromRequest, Clone)]
+#[from_request(via(axum::Extension))]
+enum Extractor {
+    Foo {
+        #[from_request(via(axum::Extension))]
+        foo: (),
+    }
+}
+
+fn main() {}

--- a/axum-macros/tests/from_request/fail/enum_from_request_ident_in_variant.stderr
+++ b/axum-macros/tests/from_request/fail/enum_from_request_ident_in_variant.stderr
@@ -1,0 +1,5 @@
+error: `#[from_request(via(...))]` cannot be used inside variants
+ --> tests/from_request/fail/enum_from_request_ident_in_variant.rs:7:24
+  |
+7 |         #[from_request(via(axum::Extension))]
+  |                        ^^^

--- a/axum-macros/tests/from_request/fail/enum_from_request_on_variant.rs
+++ b/axum-macros/tests/from_request/fail/enum_from_request_on_variant.rs
@@ -1,0 +1,10 @@
+use axum_macros::FromRequest;
+
+#[derive(FromRequest, Clone)]
+#[from_request(via(axum::Extension))]
+enum Extractor {
+    #[from_request(via(axum::Extension))]
+    Foo,
+}
+
+fn main() {}

--- a/axum-macros/tests/from_request/fail/enum_from_request_on_variant.stderr
+++ b/axum-macros/tests/from_request/fail/enum_from_request_on_variant.stderr
@@ -1,0 +1,5 @@
+error: `#[from_request(via(...))]` cannot be used on variants
+ --> tests/from_request/fail/enum_from_request_on_variant.rs:6:20
+  |
+6 |     #[from_request(via(axum::Extension))]
+  |                    ^^^

--- a/axum-macros/tests/from_request/fail/enum_no_via.rs
+++ b/axum-macros/tests/from_request/fail/enum_no_via.rs
@@ -1,0 +1,6 @@
+use axum_macros::FromRequest;
+
+#[derive(FromRequest, Clone)]
+enum Extractor {}
+
+fn main() {}

--- a/axum-macros/tests/from_request/fail/enum_no_via.stderr
+++ b/axum-macros/tests/from_request/fail/enum_no_via.stderr
@@ -1,0 +1,7 @@
+error: missing `#[from_request(via(...))]`
+ --> tests/from_request/fail/enum_no_via.rs:3:10
+  |
+3 | #[derive(FromRequest, Clone)]
+  |          ^^^^^^^^^^^
+  |
+  = note: this error originates in the derive macro `FromRequest` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/axum-macros/tests/from_request/fail/enum_rejection_derive.rs
+++ b/axum-macros/tests/from_request/fail/enum_rejection_derive.rs
@@ -1,0 +1,7 @@
+use axum_macros::FromRequest;
+
+#[derive(FromRequest, Clone)]
+#[from_request(rejection_derive(!Error))]
+enum Extractor {}
+
+fn main() {}

--- a/axum-macros/tests/from_request/fail/enum_rejection_derive.stderr
+++ b/axum-macros/tests/from_request/fail/enum_rejection_derive.stderr
@@ -1,0 +1,5 @@
+error: cannot use `rejection_derive` on enums
+ --> tests/from_request/fail/enum_rejection_derive.rs:4:16
+  |
+4 | #[from_request(rejection_derive(!Error))]
+  |                ^^^^^^^^^^^^^^^^

--- a/axum-macros/tests/from_request/fail/not_enum_or_struct.rs
+++ b/axum-macros/tests/from_request/fail/not_enum_or_struct.rs
@@ -1,0 +1,6 @@
+use axum_macros::FromRequest;
+
+#[derive(FromRequest)]
+union Extractor {}
+
+fn main() {}

--- a/axum-macros/tests/from_request/fail/not_enum_or_struct.stderr
+++ b/axum-macros/tests/from_request/fail/not_enum_or_struct.stderr
@@ -1,0 +1,11 @@
+error: expected `struct` or `enum`
+ --> tests/from_request/fail/not_enum_or_struct.rs:4:1
+  |
+4 | union Extractor {}
+  | ^^^^^^^^^^^^^^^^^^
+
+error: unions cannot have zero fields
+ --> tests/from_request/fail/not_enum_or_struct.rs:4:1
+  |
+4 | union Extractor {}
+  | ^^^^^^^^^^^^^^^^^^

--- a/axum-macros/tests/from_request/pass/enum_via.rs
+++ b/axum-macros/tests/from_request/pass/enum_via.rs
@@ -1,0 +1,12 @@
+use axum::{body::Body, routing::get, Extension, Router};
+use axum_macros::FromRequest;
+
+#[derive(FromRequest, Clone)]
+#[from_request(via(Extension))]
+enum Extractor {}
+
+async fn foo(_: Extractor) {}
+
+fn main() {
+    Router::<Body>::new().route("/", get(foo));
+}


### PR DESCRIPTION
This adds support for `#[derive(FromRequest)]` on enums. It requires using `#[from_request(via(OtherExtractor))]` such as

```rust
#[derive(FromRequest, Clone)]
#[from_request(via(Extension))]
enum Env {
    Production,
    Development,
    Test,
}
```

A future improvement of this could be supporting something like

```rust
#[derive(FromRequest)]
enum Role {
    Admin(Admin),
    User(User),
    NotSignedIn,
}
```

Which would first attempt to extract `Admin`, then `User`, and finally fallback to `Role::NotSignedIn`. I might tackle that in the future :)

Fixes https://github.com/tokio-rs/axum/issues/997