### PR TITLE
Add `MethodRouter::{into_make_service, into_make_service_with_connect_info}`

### DIFF
--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -12,9 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the request body will not be checked. If they do have a `Content-Length` header they'll be
   rejected. This allows `ContentLengthLimit` to be used as middleware around several routes,
   including `GET` routes ([#989])
-- **added:** Add `MethodRouter::{into_make_service, into_make_service_with_connect_info}`
+- **added:** Add `MethodRouter::{into_make_service, into_make_service_with_connect_info}` ([#1010])
 
 [#989]: https://github.com/tokio-rs/axum/pull/989
+[#1010]: https://github.com/tokio-rs/axum/pull/1010
 
 # 0.5.4 (26. April, 2022)
 

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the request body will not be checked. If they do have a `Content-Length` header they'll be
   rejected. This allows `ContentLengthLimit` to be used as middleware around several routes,
   including `GET` routes ([#989])
+- **added:** Add `MethodRouter::{into_make_service, into_make_service_with_connect_info}`
 
 [#989]: https://github.com/tokio-rs/axum/pull/989
 

--- a/axum/src/routing/method_routing.rs
+++ b/axum/src/routing/method_routing.rs
@@ -1,3 +1,4 @@
+use super::IntoMakeService;
 use crate::{
     body::{boxed, Body, Bytes, Empty, HttpBody},
     error_handling::{HandleError, HandleErrorLayer},
@@ -5,7 +6,7 @@ use crate::{
     handler::Handler,
     http::{Method, Request, StatusCode},
     response::Response,
-    routing::{Fallback, MethodFilter, Route},
+    routing::{future::RouteFuture, Fallback, MethodFilter, Route},
     BoxError,
 };
 use bytes::BytesMut;
@@ -1026,10 +1027,6 @@ where
         Self::new()
     }
 }
-
-use crate::routing::future::RouteFuture;
-
-use super::IntoMakeService;
 
 impl<B, E> Service<Request<B>> for MethodRouter<B, E>
 where


### PR DESCRIPTION
These methods existed on `Router` and `Handler` but not on `MethodRouter`. For consistency I think it makes sense to provide.