### PR TITLE
Update static file server example

### DIFF
--- a/examples/static-file-server/Cargo.toml
+++ b/examples/static-file-server/Cargo.toml
@@ -6,7 +6,9 @@ publish = false
 
 [dependencies]
 axum = { path = "../../axum" }
+axum-extra = { path = "../../axum-extra", features = ["spa"] }
 tokio = { version = "1.0", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-tower-http = { version = "0.3.0", features = ["fs", "trace"] }
+tower-http = { version = "0.3.0", features = ["fs"] }
+tower = { version = "0.4", features = ["make"] }

--- a/examples/static-file-server/Cargo.toml
+++ b/examples/static-file-server/Cargo.toml
@@ -10,5 +10,4 @@ axum-extra = { path = "../../axum-extra", features = ["spa"] }
 tokio = { version = "1.0", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-tower-http = { version = "0.3.0", features = ["fs"] }
-tower = { version = "0.4", features = ["make"] }
+tower-http = { version = "0.3.0", features = ["fs", "trace"] }


### PR DESCRIPTION
Serving static files has gotten easier lately thanks to `SpaRouter` and `ServeDir::fallback` so think it makes sense to show those in the static file server example.