### PR TITLE
Support customizing rejections for `#[derive(TypedPath)]`

### DIFF
--- a/axum-extra/CHANGELOG.md
+++ b/axum-extra/CHANGELOG.md
@@ -9,9 +9,12 @@ and this project adheres to [Semantic Versioning].
 
 - **fixed:** `Option` and `Result` are now supported in typed path route handler parameters ([#1001])
 - **fixed:** Support wildcards in typed paths ([#1003])
+- **added:** Support using a custom rejection type for `#[derive(TypedPath)]`
+  instead of `PathRejection` ([#1012])
 
 [#1001]: https://github.com/tokio-rs/axum/pull/1001
 [#1003]: https://github.com/tokio-rs/axum/pull/1003
+[#1012]: https://github.com/tokio-rs/axum/pull/1012
 
 # 0.3.0 (27. April, 2022)
 

--- a/axum-extra/src/routing/typed.rs
+++ b/axum-extra/src/routing/typed.rs
@@ -165,7 +165,7 @@ use http::Uri;
 /// // Your rejection type must implement `From<PathRejection>`.
 /// //
 /// // Here you can grab whatever details from the inner rejection
-/// // that you need
+/// // that you need.
 /// impl From<PathRejection> for UsersMemberRejection {
 ///     fn from(rejection: PathRejection) -> Self {
 ///         # UsersMemberRejection
@@ -173,7 +173,7 @@ use http::Uri;
 ///     }
 /// }
 ///
-/// // And your rejection must implement `IntoResponse`, like all rejections
+/// // Your rejection must implement `IntoResponse`, like all rejections.
 /// impl IntoResponse for UsersMemberRejection {
 ///     fn into_response(self) -> Response {
 ///         # ().into_response()
@@ -193,16 +193,8 @@ use http::Uri;
 /// #[typed_path("/users", rejection(UsersCollectionRejection))]
 /// struct UsersCollection;
 ///
+/// #[derive(Default)]
 /// struct UsersCollectionRejection;
-///
-/// // Since there are no path params the rejection isn't created via `From<PathRejection>` but
-/// // instead via `Default`
-/// impl Default for UsersCollectionRejection {
-///     fn default() -> Self {
-///         # UsersCollectionRejection
-///         // ...
-///     }
-/// }
 ///
 /// impl IntoResponse for UsersCollectionRejection {
 ///     fn into_response(self) -> Response {

--- a/axum-macros/CHANGELOG.md
+++ b/axum-macros/CHANGELOG.md
@@ -10,10 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **fixed:** `Option` and `Result` are now supported in typed path route handler parameters ([#1001])
 - **fixed:** Support wildcards in typed paths ([#1003])
 - **added:** Support `#[derive(FromRequest)]` on enums using `#[from_request(via(OtherExtractor))]` ([#1009])
+- **added:** Support using a custom rejection type for `#[derive(TypedPath)]`
+  instead of `PathRejection` ([#1012])
 
 [#1001]: https://github.com/tokio-rs/axum/pull/1001
 [#1003]: https://github.com/tokio-rs/axum/pull/1003
 [#1009]: https://github.com/tokio-rs/axum/pull/1009
+[#1012]: https://github.com/tokio-rs/axum/pull/1012
 
 # 0.2.0 (31. March, 2022)
 

--- a/axum-macros/src/typed_path.rs
+++ b/axum-macros/src/typed_path.rs
@@ -46,18 +46,15 @@ impl Parse for Attrs {
     fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
         let path = input.parse()?;
 
-        let _ = input.parse::<Token![,]>();
+        let rejection = if input.is_empty() {
+            None
+        } else {
+            let _: Token![,] = input.parse()?;
+            let _: kw::rejection = input.parse()?;
 
-        let lh = input.lookahead1();
-        let rejection = if lh.peek(kw::rejection) {
-            input.parse::<kw::rejection>()?;
             let content;
             syn::parenthesized!(content in input);
             Some(content.parse()?)
-        } else if lh.is_empty() {
-            None
-        } else {
-            return Err(lh.error());
         };
 
         Ok(Self { path, rejection })

--- a/axum-macros/src/typed_path.rs
+++ b/axum-macros/src/typed_path.rs
@@ -48,7 +48,9 @@ impl Parse for Attrs {
 
         let _ = input.parse::<Token![,]>();
 
-        let rejection = if input.parse::<kw::rejection>().is_ok() {
+        let lh = input.lookahead1();
+        let rejection = if lh.peek(kw::rejection) {
+            input.parse::<kw::rejection>()?;
             let content;
             syn::parenthesized!(content in input);
             Some(content.parse()?)

--- a/axum-macros/src/typed_path.rs
+++ b/axum-macros/src/typed_path.rs
@@ -39,7 +39,6 @@ mod kw {
 
 struct Attrs {
     path: LitStr,
-    #[allow(dead_code)]
     rejection: Option<syn::Path>,
 }
 
@@ -62,7 +61,7 @@ impl Parse for Attrs {
 }
 
 fn parse_attrs(attrs: &[syn::Attribute]) -> syn::Result<Attrs> {
-    let mut out = None::<Attrs>;
+    let mut out = None;
 
     for attr in attrs {
         if attr.path.is_ident("typed_path") {

--- a/axum-macros/src/typed_path.rs
+++ b/axum-macros/src/typed_path.rs
@@ -54,8 +54,10 @@ impl Parse for Attrs {
             let content;
             syn::parenthesized!(content in input);
             Some(content.parse()?)
-        } else {
+        } else if lh.is_empty() {
             None
+        } else {
+            return Err(lh.error());
         };
 
         Ok(Self { path, rejection })

--- a/axum-macros/src/typed_path.rs
+++ b/axum-macros/src/typed_path.rs
@@ -387,16 +387,14 @@ fn rejection_assoc_type(rejection: &Option<syn::Path>) -> TokenStream {
 }
 
 fn map_err_rejection(rejection: &Option<syn::Path>) -> TokenStream {
-    if let Some(rejection) = rejection {
+    rejection.map(|rejection| {
         let path_rejection = path_rejection();
         quote! {
             .map_err(|rejection| {
                 <#rejection as ::std::convert::From<#path_rejection>>::from(rejection)
             })
         }
-    } else {
-        quote! {}
-    }
+    })
 }
 
 #[test]

--- a/axum-macros/src/typed_path.rs
+++ b/axum-macros/src/typed_path.rs
@@ -381,22 +381,24 @@ fn path_rejection() -> TokenStream {
 }
 
 fn rejection_assoc_type(rejection: &Option<syn::Path>) -> TokenStream {
-    if let Some(rejection) = rejection {
-        quote! { #rejection }
-    } else {
-        path_rejection()
+    match rejection {
+        Some(rejection) => quote! { #rejection },
+        None => path_rejection(),
     }
 }
 
 fn map_err_rejection(rejection: &Option<syn::Path>) -> TokenStream {
-    rejection.map(|rejection| {
-        let path_rejection = path_rejection();
-        quote! {
-            .map_err(|rejection| {
-                <#rejection as ::std::convert::From<#path_rejection>>::from(rejection)
-            })
-        }
-    })
+    rejection
+        .as_ref()
+        .map(|rejection| {
+            let path_rejection = path_rejection();
+            quote! {
+                .map_err(|rejection| {
+                    <#rejection as ::std::convert::From<#path_rejection>>::from(rejection)
+                })
+            }
+        })
+        .unwrap_or_default()
 }
 
 #[test]

--- a/axum-macros/tests/typed_path/pass/customize_rejection.rs
+++ b/axum-macros/tests/typed_path/pass/customize_rejection.rs
@@ -1,0 +1,47 @@
+use axum::{
+    extract::rejection::PathRejection,
+    response::{IntoResponse, Response},
+};
+use axum_extra::routing::{RouterExt, TypedPath};
+use serde::Deserialize;
+
+#[derive(TypedPath, Deserialize)]
+#[typed_path("/:foo", rejection(MyRejection))]
+struct MyPathNamed {
+    foo: String,
+}
+
+#[derive(TypedPath, Deserialize)]
+#[typed_path("/", rejection(MyRejection))]
+struct MyPathUnit;
+
+#[derive(TypedPath, Deserialize)]
+#[typed_path("/:foo", rejection(MyRejection))]
+struct MyPathUnnamed(String);
+
+struct MyRejection;
+
+impl IntoResponse for MyRejection {
+    fn into_response(self) -> Response {
+        ().into_response()
+    }
+}
+
+impl From<PathRejection> for MyRejection {
+    fn from(_: PathRejection) -> Self {
+        Self
+    }
+}
+
+impl Default for MyRejection {
+    fn default() -> Self {
+        Self
+    }
+}
+
+fn main() {
+    axum::Router::<axum::body::Body>::new()
+        .typed_get(|_: Result<MyPathNamed, MyRejection>| async {})
+        .typed_post(|_: Result<MyPathUnnamed, MyRejection>| async {})
+        .typed_put(|_: Result<MyPathUnit, MyRejection>| async {});
+}


### PR DESCRIPTION
Previously `#[derive(TypedPath)]` would always use `PathRejection` as the rejection type. Your only way to customize that was using `Result<YourPath, PathRejection>` in the handler, which is annoying if you're using it in multiple places.

This makes it possible to use your own rejection instead:

```rust
#[derive(TypedPath, Deserialize)]
#[typed_path("/users/:id", rejection(UsersMemberRejection))]
struct UsersMember {
    id: String,
}

struct UsersMemberRejection;

// Your rejection type must implement `From<PathRejection>`.
//
// Here you can grab whatever details from the inner rejection
// that you need
impl From<PathRejection> for UsersMemberRejection {
    fn from(rejection: PathRejection) -> Self {
        // ...
    }
}

// And your rejection must implement `IntoResponse`, like all rejections
impl IntoResponse for UsersMemberRejection {
    fn into_response(self) -> Response {
        // ...
    }
}
```