### PR TITLE
Add protocol field to WebSocket

### DIFF
--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
-- None.
+- **added:** Add `WebSocket::protocol` to return the selected WebSocket subprotocol, if there is one. ([#1022])
+
+[#1022]: https://github.com/tokio-rs/axum/pull/1022
 
 # 0.5.5 (10. May, 2022)
 

--- a/axum/src/extract/ws.rs
+++ b/axum/src/extract/ws.rs
@@ -207,12 +207,20 @@ impl WebSocketUpgrade {
         let on_upgrade = self.on_upgrade;
         let config = self.config;
 
+        let protocol = self
+            .protocol
+            .as_ref()
+            .map(|header| String::from_utf8_lossy(header.as_bytes()).to_string());
+
         tokio::spawn(async move {
             let upgraded = on_upgrade.await.expect("connection upgrade failed");
             let socket =
                 WebSocketStream::from_raw_socket(upgraded, protocol::Role::Server, Some(config))
                     .await;
-            let socket = WebSocket { inner: socket };
+            let socket = WebSocket {
+                inner: socket,
+                protocol,
+            };
             callback(socket).await;
         });
 
@@ -309,6 +317,7 @@ fn header_contains<B>(req: &RequestParts<B>, key: HeaderName, value: &'static st
 #[derive(Debug)]
 pub struct WebSocket {
     inner: WebSocketStream<Upgraded>,
+    protocol: Option<String>,
 }
 
 impl WebSocket {
@@ -330,6 +339,11 @@ impl WebSocket {
     /// Gracefully close this WebSocket.
     pub async fn close(mut self) -> Result<(), Error> {
         self.inner.close(None).await.map_err(Error::new)
+    }
+
+    /// Return the selected WebSocket subprotocol, if one has been chosen
+    pub fn protocol(&self) -> Option<&str> {
+        self.protocol.as_deref()
     }
 }
 

--- a/axum/src/extract/ws.rs
+++ b/axum/src/extract/ws.rs
@@ -207,10 +207,7 @@ impl WebSocketUpgrade {
         let on_upgrade = self.on_upgrade;
         let config = self.config;
 
-        let protocol = self
-            .protocol
-            .as_ref()
-            .map(|header| String::from_utf8_lossy(header.as_bytes()).to_string());
+        let protocol = self.protocol.clone();
 
         tokio::spawn(async move {
             let upgraded = on_upgrade.await.expect("connection upgrade failed");
@@ -317,7 +314,7 @@ fn header_contains<B>(req: &RequestParts<B>, key: HeaderName, value: &'static st
 #[derive(Debug)]
 pub struct WebSocket {
     inner: WebSocketStream<Upgraded>,
-    protocol: Option<String>,
+    protocol: Option<HeaderValue>,
 }
 
 impl WebSocket {
@@ -342,8 +339,8 @@ impl WebSocket {
     }
 
     /// Return the selected WebSocket subprotocol, if one has been chosen
-    pub fn protocol(&self) -> Option<&str> {
-        self.protocol.as_deref()
+    pub fn protocol(&self) -> Option<&HeaderValue> {
+        self.protocol.as_ref()
     }
 }
 


### PR DESCRIPTION
Signed-off-by: Matteo Joliveau <matteojoliveau@gmail.com>

Closes #1020 

I used `String::from_utf8_lossy` because I didn't want to add complex error handling for a corner case (non-UTF8 characters in an HTTP header) that, for this particular use-case, is pretty rare. I would have loved to use a `Cow` instead of a `String` inside of `WebSocket` to avoid an allocation, but I had a bit of a hard time fighting with lifetimes so I eventually conceded.

Feedbacks and suggestions welcome!