### PR TITLE
Improve `Path` error when its extracted multiple times

### DIFF
--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -7,7 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
-- None.
+- **fixed:** Improve error for `PathRejection::WrongNumberOfParameters` to hint at using
+  `Path<(String, String)>` or `Path<SomeStruct>` ([#1023])
+- **fixed:** `PathRejection::WrongNumberOfParameters` now uses `500 Internal Server Error` since
+  its a programmer error and not a client error ([#1023])
+
+[#1023]: https://github.com/tokio-rs/axum/pull/1023
 
 # 0.5.5 (10. May, 2022)
 

--- a/axum/src/extract/path/mod.rs
+++ b/axum/src/extract/path/mod.rs
@@ -66,8 +66,7 @@ use std::{
 /// ```
 ///
 /// Path segments also can be deserialized into any type that implements
-/// [`serde::Deserialize`]. Path segment labels will be matched with struct
-/// field names.
+/// [`serde::Deserialize`]. This includes tuples and structs:
 ///
 /// ```rust,no_run
 /// use axum::{
@@ -78,6 +77,7 @@ use std::{
 /// use serde::Deserialize;
 /// use uuid::Uuid;
 ///
+/// // Path segment labels will be matched with struct field names
 /// #[derive(Deserialize)]
 /// struct Params {
 ///     user_id: Uuid,
@@ -90,7 +90,17 @@ use std::{
 ///     // ...
 /// }
 ///
-/// let app = Router::new().route("/users/:user_id/team/:team_id", get(users_teams_show));
+/// // When using tuples the path segments will be matched by their position in the route
+/// async fn users_teams_create(
+///     Path((user_id, team_id)): Path<(String, String)>,
+/// ) {
+///     // ...
+/// }
+///
+/// let app = Router::new().route(
+///     "/users/:user_id/team/:team_id",
+///     get(users_teams_show).post(users_teams_create),
+/// );
 /// # async {
 /// # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
 /// # };

--- a/axum/src/extract/path/mod.rs
+++ b/axum/src/extract/path/mod.rs
@@ -567,7 +567,7 @@ mod tests {
         assert_eq!(res.status(), StatusCode::INTERNAL_SERVER_ERROR);
         assert_eq!(
             res.text().await,
-            "Wrong number of type parameters to `Path`. Expected 1 but got 2. \
+            "Wrong number of path arguments for `Path`. Expected 1 but got 2. \
             Note that multiple parameters must be extracted with a tuple `Path<(_, _)>` or a struct `Path<YourParams>`",
         );
     }

--- a/axum/src/extract/path/mod.rs
+++ b/axum/src/extract/path/mod.rs
@@ -332,7 +332,7 @@ impl fmt::Display for ErrorKind {
             ErrorKind::WrongNumberOfParameters { got, expected } => {
                 write!(
                     f,
-                    "Wrong number of type parameters to `Path`. Expected {} but got {}",
+                    "Wrong number of path arguments for `Path`. Expected {} but got {}",
                     expected, got
                 )?;
 


### PR DESCRIPTION
This makes the error returned when trying to extract multiple path params with `async fn foo(Path<String>, Path<String>)` and hints at using `async fn foo(Path<(String, String)>)` or a struct.

Fixes https://github.com/tokio-rs/axum/issues/1021