### PR TITLE
Dont link to deprecated item with different name

### DIFF
--- a/axum/src/docs/middleware.md
+++ b/axum/src/docs/middleware.md
@@ -442,7 +442,7 @@ extensions you need.
 [`ServiceBuilder::map_response`]: tower::ServiceBuilder::map_response
 [`ServiceBuilder::then`]: tower::ServiceBuilder::then
 [`ServiceBuilder::and_then`]: tower::ServiceBuilder::and_then
-[`axum::middleware::from_extractor`]: crate::extract::extractor_middleware()
+[`axum::middleware::from_extractor`]: crate::middleware::from_extractor
 [`Handler::layer`]: crate::handler::Handler::layer
 [`Router::layer`]: crate::routing::Router::layer
 [`MethodRouter::layer`]: crate::routing::MethodRouter::layer


### PR DESCRIPTION
## Motivation

Clicking a link should lead to the item I clicked on.

## Solution

Link to the item that the text suggests should be linked to.
