### PR TITLE
Check for multiple body extractors in `debug_handler`

### DIFF
--- a/axum-macros/CHANGELOG.md
+++ b/axum-macros/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **added:** In `debug_handler`, check if `Request` is used as non-final extractor ([#1035])
 - **added:** In `debug_handler`, check if multiple `Path` extractors are used ([#1035])
+- **added:** In `debug_handler`, check if multiple body extractors are used
 
 [#1035]: https://github.com/tokio-rs/axum/pull/1035
 

--- a/axum-macros/CHANGELOG.md
+++ b/axum-macros/CHANGELOG.md
@@ -9,9 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **added:** In `debug_handler`, check if `Request` is used as non-final extractor ([#1035])
 - **added:** In `debug_handler`, check if multiple `Path` extractors are used ([#1035])
-- **added:** In `debug_handler`, check if multiple body extractors are used
+- **added:** In `debug_handler`, check if multiple body extractors are used ([#1036])
 
 [#1035]: https://github.com/tokio-rs/axum/pull/1035
+[#1036]: https://github.com/tokio-rs/axum/pull/1036
 
 # 0.2.1 (10. May, 2022)
 

--- a/axum-macros/tests/debug_handler/fail/multiple_body_extractors.rs
+++ b/axum-macros/tests/debug_handler/fail/multiple_body_extractors.rs
@@ -1,0 +1,7 @@
+use axum_macros::debug_handler;
+use axum::body::Bytes;
+
+#[debug_handler]
+async fn handler(_: String, _: Bytes) {}
+
+fn main() {}

--- a/axum-macros/tests/debug_handler/fail/multiple_body_extractors.stderr
+++ b/axum-macros/tests/debug_handler/fail/multiple_body_extractors.stderr
@@ -1,0 +1,11 @@
+error: Only one body extractor can be applied
+ --> tests/debug_handler/fail/multiple_body_extractors.rs:5:18
+  |
+5 | async fn handler(_: String, _: Bytes) {}
+  |                  ^^^^^^^^^
+
+error: Only one body extractor can be applied
+ --> tests/debug_handler/fail/multiple_body_extractors.rs:5:29
+  |
+5 | async fn handler(_: String, _: Bytes) {}
+  |                             ^^^^^^^^

--- a/axum-macros/tests/debug_handler/fail/too_many_extractors.rs
+++ b/axum-macros/tests/debug_handler/fail/too_many_extractors.rs
@@ -1,24 +1,25 @@
 use axum_macros::debug_handler;
+use axum::http::Uri;
 
 #[debug_handler]
 async fn handler(
-    e1: String,
-    e2: String,
-    e3: String,
-    e4: String,
-    e5: String,
-    e6: String,
-    e7: String,
-    e8: String,
-    e9: String,
-    e10: String,
-    e11: String,
-    e12: String,
-    e13: String,
-    e14: String,
-    e15: String,
-    e16: String,
-    e17: String,
+    e1: Uri,
+    e2: Uri,
+    e3: Uri,
+    e4: Uri,
+    e5: Uri,
+    e6: Uri,
+    e7: Uri,
+    e8: Uri,
+    e9: Uri,
+    e10: Uri,
+    e11: Uri,
+    e12: Uri,
+    e13: Uri,
+    e14: Uri,
+    e15: Uri,
+    e16: Uri,
+    e17: Uri,
 ) {}
 
 fn main() {}

--- a/axum-macros/tests/debug_handler/fail/too_many_extractors.stderr
+++ b/axum-macros/tests/debug_handler/fail/too_many_extractors.stderr
@@ -1,11 +1,11 @@
 error: Handlers cannot take more than 16 arguments. Use `(a, b): (ExtractorA, ExtractorA)` to further nest extractors
-  --> tests/debug_handler/fail/too_many_extractors.rs:5:5
+  --> tests/debug_handler/fail/too_many_extractors.rs:6:5
    |
-5  | /     e1: String,
-6  | |     e2: String,
-7  | |     e3: String,
-8  | |     e4: String,
+6  | /     e1: Uri,
+7  | |     e2: Uri,
+8  | |     e3: Uri,
+9  | |     e4: Uri,
 ...  |
-20 | |     e16: String,
-21 | |     e17: String,
-   | |________________^
+21 | |     e16: Uri,
+22 | |     e17: Uri,
+   | |_____________^

--- a/axum-macros/tests/debug_handler/pass/multiple_extractors.rs
+++ b/axum-macros/tests/debug_handler/pass/multiple_extractors.rs
@@ -1,6 +1,7 @@
 use axum_macros::debug_handler;
+use axum::http::{Method, Uri};
 
 #[debug_handler]
-async fn handler(_one: String, _two: String, _three: String) {}
+async fn handler(_one: Method, _two: Uri, _three: String) {}
 
 fn main() {}


### PR DESCRIPTION
Since we're expanding the kinds of checks we do in `debug_handler` I think checking for multiple body extractors also makes sense. Of course we cannot have an exhaustive list of all bodies but probably better than nothing.