### PR TITLE
feat: use serde_qs to parse query

### DIFF
--- a/axum/Cargo.toml
+++ b/axum/Cargo.toml
@@ -12,14 +12,14 @@ repository = "https://github.com/tokio-rs/axum"
 
 [features]
 default = ["form", "http1", "json", "matched-path", "original-uri", "query", "tower-log"]
-form = ["serde_urlencoded"]
+form = ["serde_qs"]
 http1 = ["hyper/http1"]
 http2 = ["hyper/http2"]
 json = ["serde_json"]
 matched-path = []
 multipart = ["multer"]
 original-uri = []
-query = ["serde_urlencoded"]
+query = ["serde_qs"]
 tower-log = ["tower/log"]
 ws = ["tokio-tungstenite", "sha-1", "base64"]
 
@@ -51,7 +51,7 @@ base64 = { optional = true, version = "0.13" }
 headers = { optional = true, version = "0.3" }
 multer = { optional = true, version = "2.0.0" }
 serde_json = { version = "1.0", optional = true, features = ["raw_value"] }
-serde_urlencoded = { version = "0.7", optional = true }
+serde_qs = { verison = "0.9", optional = true }
 sha-1 = { optional = true, version = "0.10" }
 tokio-tungstenite = { optional = true, version = "0.17" }
 

--- a/axum/src/extract/form.rs
+++ b/axum/src/extract/form.rs
@@ -57,7 +57,7 @@ where
     async fn from_request(req: &mut RequestParts<B>) -> Result<Self, Self::Rejection> {
         if req.method() == Method::GET {
             let query = req.uri().query().unwrap_or_default();
-            let value = serde_urlencoded::from_str(query)
+            let value = serde_qs::from_str(query)
                 .map_err(FailedToDeserializeQueryString::__private_new::<T, _>)?;
             Ok(Form(value))
         } else {
@@ -66,7 +66,7 @@ where
             }
 
             let bytes = Bytes::from_request(req).await?;
-            let value = serde_urlencoded::from_bytes(&bytes)
+            let value = serde_qs::from_bytes(&bytes)
                 .map_err(FailedToDeserializeQueryString::__private_new::<T, _>)?;
 
             Ok(Form(value))
@@ -117,7 +117,7 @@ mod tests {
                     mime::APPLICATION_WWW_FORM_URLENCODED.as_ref(),
                 )
                 .body(Full::<Bytes>::new(
-                    serde_urlencoded::to_string(&value).unwrap().into(),
+                    serde_qs::to_string(&value).unwrap().into(),
                 ))
                 .unwrap(),
         );
@@ -183,7 +183,7 @@ mod tests {
                 .method(Method::POST)
                 .header(http::header::CONTENT_TYPE, mime::APPLICATION_JSON.as_ref())
                 .body(Full::<Bytes>::new(
-                    serde_urlencoded::to_string(&Pagination {
+                    serde_qs::to_string(&Pagination {
                         size: Some(10),
                         page: None,
                     })

--- a/axum/src/extract/query.rs
+++ b/axum/src/extract/query.rs
@@ -58,7 +58,7 @@ where
 
     async fn from_request(req: &mut RequestParts<B>) -> Result<Self, Self::Rejection> {
         let query = req.uri().query().unwrap_or_default();
-        let value = serde_urlencoded::from_str(query)
+        let value = serde_qs::from_str(query)
             .map_err(FailedToDeserializeQueryString::__private_new::<T, _>)?;
         Ok(Query(value))
     }
@@ -116,6 +116,27 @@ mod tests {
             Pagination {
                 size: Some(10),
                 page: Some(20),
+            },
+        )
+        .await;
+
+        #[derive(Debug, PartialEq, Deserialize)]
+        struct Users {
+            user_ids: Vec<u8>,
+        }
+
+        check(
+            "http://example.com/test?user_ids[0]=1&user_ids[1]=2&user_ids[2]=3&user_ids[3]=4",
+            Users {
+                user_ids: vec![1, 2, 3, 4],
+            },
+        )
+        .await;
+
+        check(
+            "http://example.com/test?user_ids[]=1&user_ids[]=2&user_ids[]=3&user_ids[]=4",
+            Users {
+                user_ids: vec![1, 2, 3, 4],
             },
         )
         .await;


### PR DESCRIPTION
## Motivation

In some daily works, I need to parse vector in query which serde_urlencoded not support

## Solution

Change to serde_qs which support parsing vector in query and fully compatible with serde_urlencoded
