### PR TITLE
Implement `Default` for `Extension`

### DIFF
--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
-- None.
+- **added:** Implement `Default` for `Extension` ([#1043])
 
 # 0.5.6 (15. May, 2022)
 

--- a/axum/src/extension.rs
+++ b/axum/src/extension.rs
@@ -69,7 +69,7 @@ use tower_service::Service;
 /// #[derive(Clone)]
 /// struct Foo(&'static str);
 /// ```
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Default)]
 pub struct Extension<T>(pub T);
 
 #[async_trait]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

When using an `Extension` we often have to wrap the inner value in an `Arc` (and some lock if we need mutability). If we then want to use our extension we need to write out `Extension<Arc<Mutex<T>>>` each time we want to use that `T` in a handler. This becomes tedious very quickly. Thus we introduce a type alias for that extension:

```rust
type MyExtension = Extension<Arc<Mutex<...>>>;

// which is used like:
async fn handler(ext: MyExtension) -> ... { ... }
```

With that type alias, it would be really nice if we could easily construct the `Arc<Mutex<...>>` type just by calling `MyExtension::default()`. However, `Extension<T>` does not implement `Default`, even though it is just a simple newtype wrapper around the inner `T`.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

We just add an additional `#[derive(Default)]` to the `Extension` struct.