### PR TITLE
Implement path extraction for untagged enums.

### DIFF
--- a/axum/src/extract/path/de.rs
+++ b/axum/src/extract/path/de.rs
@@ -837,20 +837,20 @@ mod tests {
 
     #[test]
     fn test_untagged_enum() {
-        #[derive(serde::Serialize, serde::Deserialize, PartialEq, Eq, Debug)]
+        #[derive(Deserialize, PartialEq, Eq, Debug)]
         #[serde(untagged)]
         enum Main {
             A(A),
             B(B),
         }
 
-        #[derive(serde::Serialize, serde::Deserialize, PartialEq, Eq, Debug)]
+        #[derive(Deserialize, PartialEq, Eq, Debug)]
         enum A {
             A1,
             A2,
         }
 
-        #[derive(serde::Serialize, serde::Deserialize, PartialEq, Eq, Debug)]
+        #[derive(Deserialize, PartialEq, Eq, Debug)]
         enum B {
             B1,
             B2,


### PR DESCRIPTION
This PR implements path extraction for untagged enums.

I'm not sure if this this is the right approach though, so any feedback is appreciated.

This enables "flattened" enums:
```rust
#[derive(serde::Deserialize, Debug)]
#[serde(untagged)]
enum Main {
    A(A),
    B(B),
}

#[derive(serde::Deserialize, Debug)]
enum A {
    A1,
    A2,
}

#[derive(serde::Deserialize, Debug)]
enum B {
    B1,
    B2,
}
```