### PR TITLE
Automatically handle `http_body::LengthLimitError`

### DIFF
--- a/axum-core/CHANGELOG.md
+++ b/axum-core/CHANGELOG.md
@@ -7,8 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
+- **added:** Automatically handle `http_body::LengthLimitError` in `FailedToBufferBody` and map
+  such errors to `413 Payload Too Large` ([#1048])
+- **added:** `FailedToBufferBody::is_length_limit_error` to check if the underlying error is
+  `http_body::LengthLimitError`. Its source error can also be downcast to
+  `http_body::LengthLimitError` ([#1048])
 - **fixed:** Use `impl IntoResponse` less in docs ([#1049])
 
+[#1048]: https://github.com/tokio-rs/axum/pull/1048
 [#1049]: https://github.com/tokio-rs/axum/pull/1049
 
 # 0.2.4 (02. May, 2022)

--- a/axum-core/CHANGELOG.md
+++ b/axum-core/CHANGELOG.md
@@ -9,9 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **added:** Automatically handle `http_body::LengthLimitError` in `FailedToBufferBody` and map
   such errors to `413 Payload Too Large` ([#1048])
-- **added:** `FailedToBufferBody::is_length_limit_error` to check if the underlying error is
-  `http_body::LengthLimitError`. Its source error can also be downcast to
-  `http_body::LengthLimitError` ([#1048])
 - **fixed:** Use `impl IntoResponse` less in docs ([#1049])
 
 [#1048]: https://github.com/tokio-rs/axum/pull/1048

--- a/axum-core/Cargo.toml
+++ b/axum-core/Cargo.toml
@@ -23,3 +23,4 @@ futures-util = "0.3"
 axum = { path = "../axum", version = "0.5" }
 hyper = "0.14"
 tokio = { version = "1.0", features = ["macros"] }
+tower-http = { version = "0.3.4", features = ["limit"] }

--- a/axum-core/Cargo.toml
+++ b/axum-core/Cargo.toml
@@ -15,7 +15,7 @@ async-trait = "0.1"
 bytes = "1.0"
 futures-util = { version = "0.3", default-features = false, features = ["alloc"] }
 http = "0.2.7"
-http-body = "0.4"
+http-body = "0.4.5"
 mime = "0.3.16"
 
 [dev-dependencies]

--- a/axum-core/Cargo.toml
+++ b/axum-core/Cargo.toml
@@ -23,4 +23,3 @@ futures-util = "0.3"
 axum = { path = "../axum", version = "0.5" }
 hyper = "0.14"
 tokio = { version = "1.0", features = ["macros"] }
-tower-http = { version = "0.3.4", features = ["limit"] }

--- a/axum-core/src/extract/rejection.rs
+++ b/axum-core/src/extract/rejection.rs
@@ -56,6 +56,11 @@ define_rejection! {
     #[status = PAYLOAD_TOO_LARGE]
     #[body = "Failed to buffer the request body"]
     /// Encountered some other error when buffering the body.
+    ///
+    /// This can  _only_ happen when you're using [`tower_http::limit::RequestBodyLimitLayer`] or
+    /// otherwise wrapping request bodies in [`http_body::Limited`].
+    ///
+    /// [`tower_http::limit::RequestBodyLimitLayer`]: https://docs.rs/tower-http/0.3/tower_http/limit/struct.RequestBodyLimitLayer.html
     pub struct LengthLimitError(Error);
 }
 

--- a/axum-core/src/extract/rejection.rs
+++ b/axum-core/src/extract/rejection.rs
@@ -67,7 +67,7 @@ define_rejection! {
 define_rejection! {
     #[status = BAD_REQUEST]
     #[body = "Failed to buffer the request body"]
-    /// Encountered some other error when buffering the body.
+    /// Encountered an unknown error when buffering the body.
     pub struct UnknownBodyError(Error);
 }
 

--- a/axum-core/src/extract/rejection.rs
+++ b/axum-core/src/extract/rejection.rs
@@ -41,6 +41,8 @@ impl FailedToBufferBody {
     ///
     /// This can  _only_ happen when you're using [`tower_http::limit::RequestBodyLimitLayer`] or
     /// otherwise wrapping request bodies in [`http_body::Limited`].
+    ///
+    /// [`tower_http::limit::RequestBodyLimitLayer`]: https://docs.rs/tower-http/latest/tower_http/limit/struct.RequestBodyLimitLayer.html
     pub fn is_length_limit_error(&self) -> bool {
         matches!(self.0, FailedToBufferBodyInner::LengthLimitError(_))
     }

--- a/axum-core/src/extract/rejection.rs
+++ b/axum-core/src/extract/rejection.rs
@@ -1,8 +1,10 @@
 //! Rejection response types.
 
-use crate::response::{IntoResponse, Response};
+use crate::{
+    response::{IntoResponse, Response},
+    BoxError,
+};
 use http::StatusCode;
-use http_body::LengthLimitError;
 use std::fmt;
 
 /// Rejection type used if you try and extract the request body more than
@@ -29,74 +31,39 @@ impl fmt::Display for BodyAlreadyExtracted {
 
 impl std::error::Error for BodyAlreadyExtracted {}
 
-/// Rejection type for extractors that buffer the request body. Used if the
-/// request body cannot be buffered due to an error.
-// TODO: in next major for axum-core make this a #[non_exhaustive] enum so we don't need the
-// additional indirection
-#[derive(Debug)]
-pub struct FailedToBufferBody(FailedToBufferBodyInner);
-
-impl FailedToBufferBody {
-    /// Check if the body failed to be buffered because a length limit was hit.
-    ///
-    /// This can  _only_ happen when you're using [`tower_http::limit::RequestBodyLimitLayer`] or
-    /// otherwise wrapping request bodies in [`http_body::Limited`].
-    ///
-    /// [`tower_http::limit::RequestBodyLimitLayer`]: https://docs.rs/tower-http/latest/tower_http/limit/struct.RequestBodyLimitLayer.html
-    pub fn is_length_limit_error(&self) -> bool {
-        matches!(self.0, FailedToBufferBodyInner::LengthLimitError(_))
+composite_rejection! {
+    /// Rejection type for extractors that buffer the request body. Used if the
+    /// request body cannot be buffered due to an error.
+    pub enum FailedToBufferBody {
+        LengthLimitError,
+        UnknownBodyError,
     }
-}
-
-#[derive(Debug)]
-enum FailedToBufferBodyInner {
-    Unknown(crate::Error),
-    LengthLimitError(LengthLimitError),
 }
 
 impl FailedToBufferBody {
     pub(crate) fn from_err<E>(err: E) -> Self
     where
-        E: Into<crate::BoxError>,
+        E: Into<BoxError>,
     {
-        let err = err.into();
-        match err.downcast::<LengthLimitError>() {
-            Ok(err) => Self(FailedToBufferBodyInner::LengthLimitError(*err)),
-            Err(err) => Self(FailedToBufferBodyInner::Unknown(crate::Error::new(err))),
+        match err.into().downcast::<http_body::LengthLimitError>() {
+            Ok(err) => Self::LengthLimitError(LengthLimitError::from_err(err)),
+            Err(err) => Self::UnknownBodyError(UnknownBodyError::from_err(err)),
         }
     }
 }
 
-impl crate::response::IntoResponse for FailedToBufferBody {
-    fn into_response(self) -> crate::response::Response {
-        match self.0 {
-            FailedToBufferBodyInner::Unknown(err) => (
-                http::StatusCode::BAD_REQUEST,
-                format!(concat!("Failed to buffer the request body", ": {}"), err),
-            )
-                .into_response(),
-            FailedToBufferBodyInner::LengthLimitError(err) => (
-                StatusCode::PAYLOAD_TOO_LARGE,
-                format!(concat!("Failed to buffer the request body", ": {}"), err),
-            )
-                .into_response(),
-        }
-    }
+define_rejection! {
+    #[status = PAYLOAD_TOO_LARGE]
+    #[body = "Failed to buffer the request body"]
+    /// Encountered some other error when buffering the body.
+    pub struct LengthLimitError(Error);
 }
 
-impl std::fmt::Display for FailedToBufferBody {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "Failed to buffer the request body")
-    }
-}
-
-impl std::error::Error for FailedToBufferBody {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match &self.0 {
-            FailedToBufferBodyInner::Unknown(err) => Some(err),
-            FailedToBufferBodyInner::LengthLimitError(err) => Some(err),
-        }
-    }
+define_rejection! {
+    #[status = BAD_REQUEST]
+    #[body = "Failed to buffer the request body"]
+    /// Encountered some other error when buffering the body.
+    pub struct UnknownBodyError(Error);
 }
 
 define_rejection! {

--- a/axum-core/src/macros.rs
+++ b/axum-core/src/macros.rs
@@ -10,6 +10,7 @@ macro_rules! define_rejection {
         pub struct $name(pub(crate) crate::Error);
 
         impl $name {
+            #[allow(dead_code)]
             pub(crate) fn from_err<E>(err: E) -> Self
             where
                 E: Into<crate::BoxError>,

--- a/axum/Cargo.toml
+++ b/axum/Cargo.toml
@@ -81,7 +81,7 @@ features = [
 ]
 
 [dev-dependencies.tower-http]
-version = "0.3.0"
+version = "0.3.4"
 features = ["full"]
 
 [package.metadata.docs.rs]

--- a/axum/src/extract/content_length_limit.rs
+++ b/axum/src/extract/content_length_limit.rs
@@ -32,8 +32,6 @@ use std::ops::Deref;
 ///
 /// If you want to limit the size of request bodies without requiring a `Content-Length` header
 /// consider using [`tower_http::limit::RequestBodyLimitLayer`].
-// TODO(david): change this to apply `http_body::Limited` so it also supports streaming requests.
-// Will probably require renaming it.
 #[derive(Debug, Clone)]
 pub struct ContentLengthLimit<T, const N: u64>(pub T);
 

--- a/axum/src/extract/content_length_limit.rs
+++ b/axum/src/extract/content_length_limit.rs
@@ -30,7 +30,7 @@ use std::ops::Deref;
 ///
 /// This requires the request to have a `Content-Length` header.
 ///
-/// If you want to limit the size of request bodies without requiring a `Content-Length` header
+/// If you want to limit the size of request bodies without requiring a `Content-Length` header,
 /// consider using [`tower_http::limit::RequestBodyLimitLayer`].
 #[derive(Debug, Clone)]
 pub struct ContentLengthLimit<T, const N: u64>(pub T);

--- a/axum/src/extract/content_length_limit.rs
+++ b/axum/src/extract/content_length_limit.rs
@@ -29,6 +29,11 @@ use std::ops::Deref;
 /// ```
 ///
 /// This requires the request to have a `Content-Length` header.
+///
+/// If you want to limit the size of request bodies without requiring a `Content-Length` header
+/// consider using [`tower_http::limit::RequestBodyLimitLayer`].
+// TODO(david): change this to apply `http_body::Limited` so it also supports streaming requests.
+// Will probably require renaming it.
 #[derive(Debug, Clone)]
 pub struct ContentLengthLimit<T, const N: u64>(pub T);
 

--- a/axum/src/routing/tests/mod.rs
+++ b/axum/src/routing/tests/mod.rs
@@ -8,7 +8,7 @@ use crate::{
     test_helpers::*,
     BoxError, Json, Router,
 };
-use http::{Method, Request, Response, StatusCode, Uri};
+use http::{header::CONTENT_LENGTH, HeaderMap, Method, Request, Response, StatusCode, Uri};
 use hyper::Body;
 use serde::Deserialize;
 use serde_json::{json, Value};
@@ -20,7 +20,7 @@ use std::{
     time::Duration,
 };
 use tower::{service_fn, timeout::TimeoutLayer, ServiceBuilder, ServiceExt};
-use tower_http::auth::RequireAuthorizationLayer;
+use tower_http::{auth::RequireAuthorizationLayer, limit::RequestBodyLimitLayer};
 use tower_service::Service;
 
 mod fallback;
@@ -701,12 +701,17 @@ async fn routes_must_start_with_slash() {
 }
 
 #[tokio::test]
-async fn limited_body() {
+async fn limited_body_with_content_length() {
     const LIMIT: usize = 3;
 
     let app = Router::new()
-        .route("/", post(|_: Bytes| async {}))
-        .layer(tower_http::limit::RequestBodyLimitLayer::new(LIMIT));
+        .route(
+            "/",
+            post(|headers: HeaderMap, _body: Bytes| async move {
+                assert!(headers.get(CONTENT_LENGTH).is_some());
+            }),
+        )
+        .layer(RequestBodyLimitLayer::new(LIMIT));
 
     let client = TestClient::new(app);
 
@@ -714,5 +719,37 @@ async fn limited_body() {
     assert_eq!(res.status(), StatusCode::OK);
 
     let res = client.post("/").body("a".repeat(LIMIT * 2)).send().await;
+    assert_eq!(res.status(), StatusCode::PAYLOAD_TOO_LARGE);
+}
+
+#[tokio::test]
+async fn limited_body_with_streaming_body() {
+    const LIMIT: usize = 3;
+
+    let app = Router::new()
+        .route(
+            "/",
+            post(|headers: HeaderMap, _body: Bytes| async move {
+                assert!(headers.get(CONTENT_LENGTH).is_none());
+            }),
+        )
+        .layer(RequestBodyLimitLayer::new(LIMIT));
+
+    let client = TestClient::new(app);
+
+    let stream = futures_util::stream::iter(vec![Ok::<_, hyper::Error>("a".repeat(LIMIT))]);
+    let res = client
+        .post("/")
+        .body(Body::wrap_stream(stream))
+        .send()
+        .await;
+    assert_eq!(res.status(), StatusCode::OK);
+
+    let stream = futures_util::stream::iter(vec![Ok::<_, hyper::Error>("a".repeat(LIMIT * 2))]);
+    let res = client
+        .post("/")
+        .body(Body::wrap_stream(stream))
+        .send()
+        .await;
     assert_eq!(res.status(), StatusCode::PAYLOAD_TOO_LARGE);
 }

--- a/axum/src/test_helpers/test_client.rs
+++ b/axum/src/test_helpers/test_client.rs
@@ -118,6 +118,7 @@ impl RequestBuilder {
     }
 }
 
+#[derive(Debug)]
 pub(crate) struct TestResponse {
     response: reqwest::Response,
 }


### PR DESCRIPTION
This adds special handling of `http_body::LengthLimitError` to `FailedToBufferBody` such that this just works and returns `413 Payload Too Large` if the limit is exceeded.

tower-http's new `RequestBodyLimitLayer` uses that so limiting both requests with a known length and streaming is just:

```rust
use tower_http::limit::RequestBodyLimitLayer;

Router::new()
    .route("/", post(|body: Bytes| { ... }))
    .layer(RequestBodyLimitLayer::new(1024));
```

---

I think changing `ContentLengthLimit` to use `http_body::Limited` would be good but we cannot do that without breaking changes since it requires `T: FromRequest<B>` but we have to change that to `T: FromRequest<Limited<B>>`.

EDIT: Actually I don't think we can do that since you cannot change the body type in a `RequestParts` with only an `&mut RequestParts`. You'd need an owned value 🤔