### PR TITLE
ECOSYSTEM.md: Add Pinging.net as a showcase

### DIFF
--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -32,6 +32,7 @@ If your project isn't listed here and you would like it to be, please feel free 
 - [Svix](https://www.svix.com) ([repository](https://github.com/svix/svix-webhooks)): Enterprise-ready webhook service
 - [emojied](https://emojied.net) ([repository](https://github.com/sekunho/emojied)): Shorten URLs to emojis!
 - [CLOMonitor](https://clomonitor.io) ([repository](https://github.com/cncf/clomonitor)): Checks open source projects repositories to verify they meet certain best practices.
+- [Pinging.net](https://www.pinging.net) ([repository](https://github.com/benhansenslc/pinging)): A new way to check and monitor your internet connection.
 
 [Realworld]: https://github.com/gothinkster/realworld
 [SQLx]: https://github.com/launchbadge/sqlx


### PR DESCRIPTION
See https://github.com/benhansenslc/pinging or https://www.pinging.net/about for details about the open-source project.

This website handles redirects to HTTPS and www normalization within axum and uses [webrtc-unreliable](https://github.com/triplehex/webrtc-unreliable).
