### PR TITLE
Add tokio feature and make tokio optional

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -183,6 +183,26 @@ jobs:
           -p axum-macros
           --target armv5te-unknown-linux-musleabi
 
+  wasm32-unknown-unknown:
+    needs: check
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        target: wasm32-unknown-unknown
+        override: true
+        profile: minimal
+    - uses: Swatinem/rust-cache@v1
+    - name: Check
+      uses: actions-rs/cargo@v1
+      with:
+        command: check
+        args: >
+          --manifest-path ./examples/simple-router-wasm/Cargo.toml
+          --target wasm32-unknown-unknown
+
   dependecies-are-sorted:
     runs-on: ubuntu-latest
     strategy:

--- a/axum/Cargo.toml
+++ b/axum/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 repository = "https://github.com/tokio-rs/axum"
 
 [features]
-default = ["form", "http1", "json", "matched-path", "original-uri", "query", "tower-log"]
+default = ["form", "http1", "json", "matched-path", "original-uri", "query", "tokio", "tower-log"]
 form = ["serde_urlencoded"]
 http1 = ["hyper/http1"]
 http2 = ["hyper/http2"]
@@ -20,8 +20,9 @@ matched-path = []
 multipart = ["multer"]
 original-uri = []
 query = ["serde_urlencoded"]
+tokio = ["tokio_cr", "hyper/server", "hyper/tcp"]
 tower-log = ["tower/log"]
-ws = ["tokio-tungstenite", "sha-1", "base64"]
+ws = ["tokio", "tokio-tungstenite", "sha-1", "base64"]
 
 [dependencies]
 async-trait = "0.1.43"
@@ -31,7 +32,7 @@ bytes = "1.0"
 futures-util = { version = "0.3", default-features = false, features = ["alloc"] }
 http = "0.2.5"
 http-body = "0.4.4"
-hyper = { version = "0.14.14", features = ["server", "tcp", "stream"] }
+hyper = { version = "0.14.14", features = ["stream"] }
 itoa = "1.0.1"
 matchit = "0.5.0"
 memchr = "2.4.1"
@@ -40,7 +41,6 @@ percent-encoding = "2.1"
 pin-project-lite = "0.2.7"
 serde = "1.0"
 sync_wrapper = "0.1.1"
-tokio = { version = "1", features = ["time"] }
 tower = { version = "0.4.11", default-features = false, features = ["util", "make"] }
 tower-http = { version = "0.3.0", features = ["util", "map-response-body"] }
 tower-layer = "0.3"
@@ -54,6 +54,7 @@ serde_json = { version = "1.0", features = ["raw_value"], optional = true }
 serde_urlencoded = { version = "0.7", optional = true }
 sha-1 = { version = "0.10", optional = true }
 tokio-tungstenite = { version = "0.17", optional = true }
+tokio_cr = { package = "tokio", version = "1", features = ["time"], optional = true }
 
 [dev-dependencies]
 anyhow = "1.0"
@@ -63,8 +64,8 @@ quickcheck_macros = "1.0"
 reqwest = { version = "0.11", default-features = false, features = ["json", "stream", "multipart"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-tokio = { version = "1.6.1", features = ["macros", "rt", "rt-multi-thread", "net", "test-util"] }
 tokio-stream = "0.1"
+tokio_cr = { package = "tokio", version = "1.6.1", features = ["macros", "rt", "rt-multi-thread", "net", "test-util"] }
 tracing = "0.1"
 uuid = { version = "1.0", features = ["serde", "v4"] }
 

--- a/axum/src/extract/mod.rs
+++ b/axum/src/extract/mod.rs
@@ -3,6 +3,7 @@
 use http::header;
 use rejection::*;
 
+#[cfg(feature = "tokio")]
 pub mod connect_info;
 pub mod extractor_middleware;
 pub mod path;
@@ -22,7 +23,6 @@ pub use axum_core::extract::{FromRequest, RequestParts};
 #[doc(inline)]
 #[allow(deprecated)]
 pub use self::{
-    connect_info::ConnectInfo,
     content_length_limit::ContentLengthLimit,
     extractor_middleware::extractor_middleware,
     host::Host,
@@ -30,6 +30,10 @@ pub use self::{
     raw_query::RawQuery,
     request_parts::{BodyStream, RawBody},
 };
+
+#[doc(inline)]
+#[cfg(feature = "tokio")]
+pub use self::connect_info::ConnectInfo;
 
 #[doc(no_inline)]
 #[cfg(feature = "json")]

--- a/axum/src/extract/ws.rs
+++ b/axum/src/extract/ws.rs
@@ -41,7 +41,9 @@
 //! If you need to read and write concurrently from a [`WebSocket`] you can use
 //! [`StreamExt::split`]:
 //!
-//! ```
+//! ```rust,no_run
+//! # use tokio_cr as tokio;
+//!
 //! use axum::{Error, extract::ws::{WebSocket, Message}};
 //! use futures::{sink::SinkExt, stream::{StreamExt, SplitSink, SplitStream}};
 //!

--- a/axum/src/handler/mod.rs
+++ b/axum/src/handler/mod.rs
@@ -35,13 +35,16 @@
 //!
 #![doc = include_str!("../docs/debugging_handler_type_errors.md")]
 
+#[cfg(feature = "tokio")]
+use crate::extract::connect_info::IntoMakeServiceWithConnectInfo;
 use crate::{
     body::{boxed, Body, Bytes, HttpBody},
-    extract::{connect_info::IntoMakeServiceWithConnectInfo, FromRequest, RequestParts},
+    extract::{FromRequest, RequestParts},
     response::{IntoResponse, Response},
     routing::IntoMakeService,
     BoxError,
 };
+
 use http::Request;
 use std::{fmt, future::Future, marker::PhantomData, pin::Pin};
 use tower::ServiceExt;
@@ -202,6 +205,7 @@ pub trait Handler<T, B = Body>: Clone + Send + Sized + 'static {
     ///
     /// [`MakeService`]: tower::make::MakeService
     /// [`Router::into_make_service_with_connect_info`]: crate::routing::Router::into_make_service_with_connect_info
+    #[cfg(feature = "tokio")]
     fn into_make_service_with_connect_info<C>(
         self,
     ) -> IntoMakeServiceWithConnectInfo<IntoService<Self, T, B>, C> {

--- a/axum/src/lib.rs
+++ b/axum/src/lib.rs
@@ -42,6 +42,8 @@
 //! The "Hello, World!" of axum is:
 //!
 //! ```rust,no_run
+//! # use tokio_cr as tokio;
+//!
 //! use axum::{
 //!     routing::get,
 //!     Router,
@@ -313,6 +315,7 @@
 //! `matched-path` | Enables capturing of every request's router path and the [`MatchedPath`] extractor | Yes
 //! `multipart` | Enables parsing `multipart/form-data` requests with [`Multipart`] | No
 //! `original-uri` | Enables capturing of every request's original URI and the [`OriginalUri`] extractor | Yes
+//! `tokio` | Enables `tokio` as a dependency and `axum::Server`, `SSE` and `extract::connect_info` types. | Yes
 //! `tower-log` | Enables `tower`'s `log` feature | Yes
 //! `ws` | Enables WebSockets support via [`extract::ws`] | No
 //! `form` | Enables the `Form` extractor | Yes
@@ -391,6 +394,11 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg, doc_cfg))]
 #![cfg_attr(test, allow(clippy::float_cmp))]
 
+// TODO: Remove once MSRV hits 1.60 and we can
+// use "dep:tokio" instead of this hack.
+#[cfg(feature = "tokio")]
+extern crate tokio_cr as tokio;
+
 #[macro_use]
 pub(crate) mod macros;
 
@@ -419,6 +427,7 @@ pub use async_trait::async_trait;
 pub use headers;
 #[doc(no_inline)]
 pub use http;
+#[cfg(feature = "tokio")]
 #[doc(no_inline)]
 pub use hyper::Server;
 

--- a/axum/src/response/mod.rs
+++ b/axum/src/response/mod.rs
@@ -5,6 +5,7 @@ use http::{header, HeaderValue};
 
 mod redirect;
 
+#[cfg(feature = "tokio")]
 pub mod sse;
 
 #[doc(no_inline)]
@@ -24,7 +25,11 @@ pub use axum_core::response::{
 };
 
 #[doc(inline)]
-pub use self::{redirect::Redirect, sse::Sse};
+pub use self::redirect::Redirect;
+
+#[doc(inline)]
+#[cfg(feature = "tokio")]
+pub use sse::Sse;
 
 /// An HTML response.
 ///

--- a/axum/src/routing/method_routing.rs
+++ b/axum/src/routing/method_routing.rs
@@ -1,8 +1,9 @@
 use super::IntoMakeService;
+#[cfg(feature = "tokio")]
+use crate::extract::connect_info::IntoMakeServiceWithConnectInfo;
 use crate::{
     body::{boxed, Body, Bytes, Empty, HttpBody},
     error_handling::{HandleError, HandleErrorLayer},
-    extract::connect_info::IntoMakeServiceWithConnectInfo,
     handler::Handler,
     http::{Method, Request, StatusCode},
     response::Response,
@@ -653,6 +654,7 @@ where
     ///
     /// [`MakeService`]: tower::make::MakeService
     /// [`Router::into_make_service_with_connect_info`]: crate::routing::Router::into_make_service_with_connect_info
+    #[cfg(feature = "tokio")]
     pub fn into_make_service_with_connect_info<C>(self) -> IntoMakeServiceWithConnectInfo<Self, C> {
         IntoMakeServiceWithConnectInfo::new(self)
     }

--- a/axum/src/routing/mod.rs
+++ b/axum/src/routing/mod.rs
@@ -1,9 +1,10 @@
 //! Routing between [`Service`]s and handlers.
 
 use self::{future::RouteFuture, not_found::NotFound};
+#[cfg(feature = "tokio")]
+use crate::extract::connect_info::IntoMakeServiceWithConnectInfo;
 use crate::{
     body::{boxed, Body, Bytes, HttpBody},
-    extract::connect_info::IntoMakeServiceWithConnectInfo,
     response::{IntoResponse, Redirect, Response},
     routing::strip_prefix::StripPrefix,
     util::try_downcast,
@@ -405,6 +406,7 @@ where
     }
 
     #[doc = include_str!("../docs/routing/into_make_service_with_connect_info.md")]
+    #[cfg(feature = "tokio")]
     pub fn into_make_service_with_connect_info<C>(self) -> IntoMakeServiceWithConnectInfo<Self, C> {
         IntoMakeServiceWithConnectInfo::new(self)
     }

--- a/examples/simple-router-wasm/Cargo.toml
+++ b/examples/simple-router-wasm/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "simple-router-wasm"
+version = "0.1.0"
+edition = "2018"
+publish = false
+
+[dependencies]
+axum = { path = "../../axum", default-features = false }
+futures-executor = "0.3.21"
+http = "0.2.7"
+tower-service = "0.3.1"

--- a/examples/simple-router-wasm/src/main.rs
+++ b/examples/simple-router-wasm/src/main.rs
@@ -1,0 +1,51 @@
+//! Run with
+//!
+//! ```not_rust
+//! cd examples && cargo run -p simple-router-wasm
+//! ```
+//!
+//! This example shows what using axum in a wasm context might look like. This example should
+//! always compile with `--target wasm32-unknown-unknown`.
+//!
+//! [`mio`](https://docs.rs/mio/latest/mio/index.html), tokio's IO layer, does not support the
+//! `wasm32-unknown-unknown` target which is why this crate requires `default-features = false`
+//! for axum.
+//!
+//! Most "serverless" runtimes use Chrome's V8 engine for executing Javascript, and in our
+//! case, WASM Rust code. They generally expect an exported function that takes in a single
+//! request and returns a single response, much like axum's `Handler`. In this example, the
+//! handler function is `app` with `main` acting as the serverless runtime which originally
+//! receives the request and calls the app function.
+//!
+//! We can use axum's routing, extractors, tower services, and everything else to implement
+//! our serverless function, even though we are running axum in a wasm context.
+
+use axum::{
+    response::{Html, Response},
+    routing::get,
+    Router,
+};
+use futures_executor::block_on;
+use http::Request;
+use tower_service::Service;
+
+fn main() {
+    let request: Request<String> = Request::builder()
+        .uri("https://serverless.example/api/")
+        .body("Some Body Data".into())
+        .unwrap();
+
+    let response: Response = block_on(app(request));
+    assert_eq!(200, response.status());
+}
+
+async fn app(request: Request<String>) -> Response {
+    let mut router = Router::new().route("/api/", get(index));
+
+    let response = router.call(request).await.unwrap();
+    response
+}
+
+async fn index() -> Html<&'static str> {
+    Html("<h1>Hello, World!</h1>")
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

I'm trying to use axum's routing and request extraction hardware for a Cloudflare Worker. Workers run in a WASM context (v8 isolate) and therefore tokio cannot be used.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

This PR adds a `tokio` feature that enables tokio as well as `hyper/tcp` and `hyper/server`. The tokio feature also enables SSE and `extract::connect_info`.

This is a breaking change since this breaks usages of `default_features = false`.
