### PR TITLE
Support `Path<Vec<(String, String)>>`

### DIFF
--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # Unreleased
 
 - **added:** Implement `Default` for `Extension` ([#1043])
+- **fixed:** Support deserializing `Vec<(String, String)>` in `extract::Path<_>` to get vector of
+  key/value pairs
 
 # 0.5.6 (15. May, 2022)
 

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -9,7 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **added:** Implement `Default` for `Extension` ([#1043])
 - **fixed:** Support deserializing `Vec<(String, String)>` in `extract::Path<_>` to get vector of
-  key/value pairs
+  key/value pairs ([#1059])
+
+[#1043]: https://github.com/tokio-rs/axum/pull/1043
+[#1059]: https://github.com/tokio-rs/axum/pull/1059
 
 # 0.5.6 (15. May, 2022)
 

--- a/axum/src/extract/path/mod.rs
+++ b/axum/src/extract/path/mod.rs
@@ -571,4 +571,25 @@ mod tests {
             Note that multiple parameters must be extracted with a tuple `Path<(_, _)>` or a struct `Path<YourParams>`",
         );
     }
+
+    #[tokio::test]
+    async fn deserialize_into_vec_of_tuples() {
+        let app = Router::new().route(
+            "/:a/:b",
+            get(|Path(params): Path<Vec<(String, String)>>| async move {
+                assert_eq!(
+                    params,
+                    vec![
+                        ("a".to_owned(), "foo".to_owned()),
+                        ("b".to_owned(), "bar".to_owned())
+                    ]
+                );
+            }),
+        );
+
+        let client = TestClient::new(app);
+
+        let res = client.get("/foo/bar").send().await;
+        assert_eq!(res.status(), StatusCode::OK);
+    }
 }

--- a/axum/src/util.rs
+++ b/axum/src/util.rs
@@ -18,6 +18,10 @@ impl PercentDecodedStr {
     pub(crate) fn as_str(&self) -> &str {
         &*self.0
     }
+
+    pub(crate) fn into_inner(self) -> Arc<str> {
+        self.0
+    }
 }
 
 impl Deref for PercentDecodedStr {


### PR DESCRIPTION
We mentioned using `Path<Vec<(String, String)>>` to get key/value pairs in [the docs](https://docs.rs/axum/latest/axum/extract/struct.Path.html#example) but it didn't work at all 🤦 Was probably just wishful thinking 😅

However this makes it work!

Fixes https://github.com/tokio-rs/axum/issues/1057