### PR TITLE
Add generic JSON-over-GRPC wrapper to examples/rest-grpc-multiplex

### DIFF
--- a/examples/rest-grpc-multiplex/Cargo.toml
+++ b/examples/rest-grpc-multiplex/Cargo.toml
@@ -7,12 +7,8 @@ publish = false
 [dependencies]
 axum = { path = "../../axum" }
 futures = "0.3"
-<<<<<<< HEAD
 hyper = { version = "0.14", features = ["full"] }
 once_cell = "1.12"
-=======
-hyper = { version = "0.14", features = ["full"] }
->>>>>>> 968ee4463112f495cfe9a5b27590d525f1e9778e
 prost = "0.10"
 serde = {version = "1", features = ["derive"]}
 serde_json = {version = "1"}

--- a/examples/rest-grpc-multiplex/Cargo.toml
+++ b/examples/rest-grpc-multiplex/Cargo.toml
@@ -8,7 +8,10 @@ publish = false
 axum = { path = "../../axum" }
 futures = "0.3"
 hyper = { version = "0.14",  features = ["full"] }
+once_cell = "1.12"
 prost = "0.10"
+serde = {version = "1", features = ["derive"]}
+serde_json = {version = "1"}
 tokio = { version = "1", features = ["full"] }
 tonic = { version = "0.7" }
 tower = { version = "0.4", features = ["full"] }

--- a/examples/rest-grpc-multiplex/build.rs
+++ b/examples/rest-grpc-multiplex/build.rs
@@ -1,3 +1,5 @@
 fn main() {
-    tonic_build::compile_protos("proto/helloworld.proto").unwrap();
+    tonic_build::configure()
+        .type_attribute(".", r#"#[derive(serde::Serialize, serde::Deserialize)]"#)
+        .compile(&["proto/helloworld.proto"], &["proto"]).unwrap();
 }

--- a/examples/rest-grpc-multiplex/build.rs
+++ b/examples/rest-grpc-multiplex/build.rs
@@ -1,5 +1,6 @@
 fn main() {
     tonic_build::configure()
+        // make the gRPC message structs serializable to support the json_wrap_grpc function
         .type_attribute(".", r#"#[derive(serde::Serialize, serde::Deserialize)]"#)
         .compile(&["proto/helloworld.proto"], &["proto"]).unwrap();
 }

--- a/examples/rest-grpc-multiplex/src/main.rs
+++ b/examples/rest-grpc-multiplex/src/main.rs
@@ -100,8 +100,8 @@ async fn main() {
 
     // build the rest service
     let rest = Router::new()
-    .route("/", get(web_root))
-    .route("/Hello", axum::routing::any(json_wrap_grpc(GrpcServiceImpl::say_hello)));
+        .route("/", get(web_root))
+        .route("/Hello", axum::routing::any(json_wrap_grpc(GrpcServiceImpl::say_hello)));
 
     // build the grpc service
     let grpc = GreeterServer::from_arc(GRPC_SERVICE.get().unwrap().clone());

--- a/examples/rest-grpc-multiplex/src/main.rs
+++ b/examples/rest-grpc-multiplex/src/main.rs
@@ -44,14 +44,15 @@ impl Greeter for GrpcServiceImpl {
     }
 }
 
-/// axum::Handler only takes one parameter (request),
+/// axum Handler only takes one parameter (request),
 /// but tokio impls take two parameters (&self + request).
 /// tokio provides &self from an Arc stored in the service,
 /// so create GRPC_SERVICE as a static, pass it to tokio's GreeterServer::from_arc
-///   and statically reference it in the json_wrap_grpc
+///   and statically reference it in the json_wrap_grpc.
+/// This ensures that all endpoints reference the same service.
 static GRPC_SERVICE: OnceCell<Arc<GrpcServiceImpl>> = OnceCell::new();
 
-/// given a gRPC RPC implementation function,
+/// Given a gRPC RPC implementation function,
 /// produce a closure that can be used as an axum Handler that:
 /// 1. deserializes JSON into the request type
 /// 2. calls the gRPC RPC implementation


### PR DESCRIPTION
Resolves https://github.com/tokio-rs/axum/issues/1068 and https://github.com/tokio-rs/axum/discussions/1069.

Add a function to `examples/rest-grpc-multiplex` that provides a generic wrapper to expose a HTTP/JSON frontend for any gRPC call. For the provided example code, this provides a HTTP endpoint with the following behavior:
```
POST localhost:3000/Hello
Header: content-type "application/json"
Body: { "name": "muusbolla" }

RESPONSE 200 OK
Header: content-type "application/json"
Body: { "message": "Hello muusbolla, my name is HAL 9000." }
```

## Motivation

Make it easy to provide an API that is compatible with both gRPC and JSON, that uses a single backing implementation, with minimal additional boilerplate required for each new endpoint. This can be very helpful for users to create backwards/forwards-compatible APIs.

## Solution
For context - the following is a specific implementation of a JSON wrapper around the `GrpcServiceImpl::say_hello` function that is compatible with the axum::Handler trait:
```rust
async fn json_wrap_hello(Json(body): Json<HelloRequest>) -> Result<Json<HelloReply>, GrpcErrorAsJson> {
    let handler = GRPC_SERVICE.get().unwrap();
    let r = handler.say_hello(tonic::Request::new(body)).await;
    match r {
        Ok(r) => Ok(Json(r.into_inner())),
        Err(e) => Err(GrpcErrorAsJson(e))
    }
}

#[tokio::main]
async fn main() {
    let rest = Router::new()
        .route("/Hello", axum::routing::any(json_wrap_hello);
}
```
The json_wrap_grpc function included in this PR is a genericization of the above code, making it possible to wrap any GRPC handler into an axum::Handler with a single function call.

It was quite a hassle to make the generic version compile (I was butting heads with https://github.com/rust-lang/rust/issues/36582 and/or https://github.com/rust-lang/rust/issues/41078), so I am hoping that this can be helpful to others who might want to do something similar.