### PR TITLE
Add methods to easily run extractors from middleware

### DIFF
--- a/axum-core/src/extract/mod.rs
+++ b/axum-core/src/extract/mod.rs
@@ -176,6 +176,28 @@ impl<B> RequestParts<B> {
         Ok(req)
     }
 
+    /// Get the underlying `http::request::Parts`.
+    pub fn into_parts(self) -> http::request::Parts {
+        let Self {
+            method,
+            uri,
+            version,
+            headers,
+            extensions,
+            body: _,
+        } = self;
+
+        let mut req = Request::new(());
+
+        *req.method_mut() = method;
+        *req.uri_mut() = uri;
+        *req.version_mut() = version;
+        *req.headers_mut() = headers;
+        *req.extensions_mut() = extensions;
+
+        req.into_parts().0
+    }
+
     /// Gets a reference the request method.
     pub fn method(&self) -> &Method {
         &self.method

--- a/axum/src/docs/extract.md
+++ b/axum/src/docs/extract.md
@@ -489,6 +489,11 @@ let app = Router::new().route("/", get(handler)).layer(Extension(state));
 # };
 ```
 
+# Running extractors from middleware
+
+See [`RequestExt::extract`] and [`RequestExt::extract_body`] for running
+extractors from middleware.
+
 # Request body extractors
 
 Most of the time your request body type will be [`body::Body`] (a re-export
@@ -569,3 +574,5 @@ let app = Router::new()
 [`HeaderMap`]: https://docs.rs/http/latest/http/header/struct.HeaderMap.html
 [`Request`]: https://docs.rs/http/latest/http/struct.Request.html
 [`RequestParts::body_mut`]: crate::extract::RequestParts::body_mut
+[`RequestExt::extract`]: crate::RequestExt::extract
+[`RequestExt::extract_body`]: crate::RequestExt::extract_body

--- a/axum/src/docs/middleware.md
+++ b/axum/src/docs/middleware.md
@@ -312,6 +312,11 @@ let app = Router::new()
 See [`error_handling`](crate::error_handling) for more details on axum's error
 handling model.
 
+# Running extractors from middleware
+
+See [`RequestExt::extract`] and [`RequestExt::extract_body`] for running
+extractors from middleware.
+
 # Routing to services/middleware and backpressure
 
 Generally routing to one of multiple services and backpressure doesn't mix
@@ -450,3 +455,5 @@ extensions you need.
 [`MethodRouter::route_layer`]: crate::routing::MethodRouter::route_layer
 [request extensions]: https://docs.rs/http/latest/http/request/struct.Request.html#method.extensions
 [Response extensions]: https://docs.rs/http/latest/http/response/struct.Response.html#method.extensions
+[`RequestExt::extract`]: crate::RequestExt::extract
+[`RequestExt::extract_body`]: crate::RequestExt::extract_body

--- a/axum/src/lib.rs
+++ b/axum/src/lib.rs
@@ -397,6 +397,7 @@ pub(crate) mod macros;
 mod extension;
 #[cfg(feature = "json")]
 mod json;
+mod request_ext;
 #[cfg(feature = "headers")]
 mod typed_header;
 mod util;
@@ -436,3 +437,5 @@ pub use self::typed_header::TypedHeader;
 
 #[doc(inline)]
 pub use axum_core::{BoxError, Error};
+
+pub use self::request_ext::RequestExt;

--- a/axum/src/request_ext.rs
+++ b/axum/src/request_ext.rs
@@ -1,0 +1,131 @@
+use async_trait::async_trait;
+use axum_core::extract::{FromRequest, RequestParts};
+use http::Request;
+
+/// Extension trait that adds additional methods to [`Request`].
+///
+/// This trait is sealed so it cannot be implemented outside of axum.
+#[async_trait]
+pub trait RequestExt<B>: sealed::Sealed {
+    /// Extract a value from the request.
+    ///
+    /// # Example
+    ///
+    /// This can be used to run extractors from middleware:
+    ///
+    /// ```
+    /// use axum::{
+    ///     Router,
+    ///     RequestExt,
+    ///     extract::{Query, rejection::QueryRejection},
+    ///     http::Request,
+    ///     middleware::{self, Next},
+    ///     response::Response,
+    /// };
+    /// use std::collections::HashMap;
+    ///
+    /// async fn my_middleware<B>(
+    ///     request: Request<B>,
+    ///     next: Next<B>
+    /// ) -> Result<Response, QueryRejection>
+    /// where
+    ///     B: Send
+    /// {
+    ///     let (query_params, request) = request
+    ///         .extract::<Query<HashMap<String, String>>>()
+    ///         .await?;
+    ///
+    ///     // do something with `query_params`...
+    ///
+    ///     Ok(next.run(request).await)
+    /// }
+    ///
+    /// let app = Router::new().layer(middleware::from_fn(my_middleware));
+    /// # let _: Router = app;
+    /// ```
+    ///
+    /// # Panics
+    ///
+    /// Panics if the request body is extracted. Use [`RequestExt::extract_body`] instead if you
+    /// wish to extract the request body.
+    async fn extract<T>(self) -> Result<(T, Request<B>), T::Rejection>
+    where
+        T: FromRequest<B>;
+
+    /// Extract a value (possibly the body) from the request.
+    ///
+    /// This differs from [`RequestExt::extract`] in that it does not panic if the request body is
+    /// extracted. Instead it returns the request parts so you can rebuild the request if
+    /// necessary.
+    ///
+    /// # Example
+    ///
+    /// This can be used to run extractors from middleware:
+    ///
+    /// ```
+    /// use axum::{
+    ///     Router,
+    ///     RequestExt,
+    ///     extract::rejection::BytesRejection,
+    ///     http::Request,
+    ///     middleware::{self, Next},
+    ///     response::Response,
+    ///     body::{Body, Bytes},
+    /// };
+    ///
+    /// async fn my_middleware(
+    ///     request: Request<Body>,
+    ///     next: Next<Body>
+    /// ) -> Result<Response, BytesRejection> {
+    ///     let (bytes, parts) = request.extract_body::<Bytes>().await?;
+    ///
+    ///     // do something with `bytes`...
+    ///
+    ///     // rebuild the request so can we pass it to `next`
+    ///     let request = Request::from_parts(parts, Body::from(bytes));
+    ///
+    ///     Ok(next.run(request).await)
+    /// }
+    ///
+    /// let app = Router::new().layer(middleware::from_fn(my_middleware));
+    /// # let _: Router = app;
+    /// ```
+    async fn extract_body<T>(self) -> Result<(T, http::request::Parts), T::Rejection>
+    where
+        T: FromRequest<B>;
+}
+
+#[async_trait]
+impl<B> RequestExt<B> for Request<B>
+where
+    B: Send,
+{
+    async fn extract<T>(self) -> Result<(T, Request<B>), T::Rejection>
+    where
+        T: FromRequest<B>,
+    {
+        let mut parts = RequestParts::new(self);
+        let t = T::from_request(&mut parts).await?;
+        let req = parts.try_into_request().expect(
+            "`RequestExt::extract` does not support extracting the request body. \
+            Use `RequestExt::extract_body` instead",
+        );
+        Ok((t, req))
+    }
+
+    async fn extract_body<T>(self) -> Result<(T, http::request::Parts), T::Rejection>
+    where
+        T: FromRequest<B>,
+    {
+        let mut parts = RequestParts::new(self);
+        let t = T::from_request(&mut parts).await?;
+        let parts = parts.into_parts();
+        Ok((t, parts))
+    }
+}
+
+impl<B> sealed::Sealed for Request<B> {}
+
+mod sealed {
+    pub trait Sealed {}
+}


### PR DESCRIPTION
Lately we've had a few people ask about how run extractors from middleware. This was previously possible by building your own `RequestParts` and then running the extractor. However the fact that people had to ask means we probably should have an easier way of doing it.

So this adds a `RequestExt` trait with helper methods for doing that. It also adds `RequestParts::into_parts` so you can get the `http::request::Parts` back and rebuild the request.

## TODO

- [ ] changelog