### PR TITLE
Add table of contents to some modules

### DIFF
--- a/axum/src/docs/error_handling.md
+++ b/axum/src/docs/error_handling.md
@@ -1,5 +1,12 @@
 Error handling model and utilities
 
+# Table of contents
+
+- [axum's error handling model](#axums-error-handling-model)
+- [Routing to fallible services](#routing-to-fallible-services)
+- [Applying fallible middleware](#applying-fallible-middleware)
+- [Running extractors for error handling](#running-extractors-for-error-handling)
+
 # axum's error handling model
 
 axum is based on [`tower::Service`] which bundles errors through its associated

--- a/axum/src/docs/extract.md
+++ b/axum/src/docs/extract.md
@@ -1,5 +1,20 @@
 Types and traits for extracting data from requests.
 
+# Table of contents
+
+- [Intro](#intro)
+- [Common extractors](#common-extractors)
+- [Applying multiple extractors](#applying-multiple-extractors)
+- [Be careful when extracting `Request`](#be-careful-when-extracting-request)
+- [Optional extractors](#optional-extractors)
+- [Customizing extractor responses](#customizing-extractor-responses)
+- [Accessing inner errors](#accessing-inner-errors)
+- [Defining custom extractors](#defining-custom-extractors)
+- [Accessing other extractors in `FromRequest` implementations](#accessing-other-extractors-in-fromrequest-implementations)
+- [Request body extractors](#request-body-extractors)
+
+# Intro
+
 A handler function is an async function that takes any number of
 "extractors" as arguments. An extractor is a type that implements
 [`FromRequest`](crate::extract::FromRequest).

--- a/axum/src/docs/middleware.md
+++ b/axum/src/docs/middleware.md
@@ -1,3 +1,14 @@
+# Table of contents
+
+- [Intro](#intro)
+- [Applying middleware](#applying-middleware)
+- [Commonly used middleware](#commonly-used-middleware)
+- [Writing middleware](#writing-middleware)
+- [Routing to services/middleware and backpressure](#routing-to-servicesmiddleware-and-backpressure)
+- [Sharing state between handlers and middleware](#sharing-state-between-handlers-and-middleware)
+
+# Intro
+
 axum is unique in that it doesn't have its own bespoke middleware system and
 instead integrates with [`tower`]. This means the ecosystem of [`tower`] and
 [`tower-http`] middleware all work with axum.

--- a/axum/src/docs/response.md
+++ b/axum/src/docs/response.md
@@ -1,5 +1,10 @@
 Types and traits for generating responses.
 
+# Table of contents
+
+- [Building responses](#building-responses)
+- [Returning different response types](#returning-different-response-types)
+
 # Building responses
 
 Anything that implements [`IntoResponse`] can be returned from a handler. axum


### PR DESCRIPTION
Some modules, such as [extract](https://docs.rs/axum/latest/axum/extract/index.html) have quite a lot of docs. So I figured adding a table of contents would make things easier to navigate.