### PR TITLE
ECOSYSTEM.md: add axum-tracing-opentelemetry and sandbox_axum_observa…

### DIFF
--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -18,6 +18,7 @@ If your project isn't listed here and you would like it to be, please feel free 
 - [shuttle](https://github.com/getsynth/shuttle): A serverless platform built for Rust. Now with axum support.
 - [axum-tungstenite](https://github.com/davidpdrsn/axum-tungstenite): WebSocket connections for axum directly using tungstenite
 - [axum-jrpc](https://github.com/0xdeafbeef/axum-jrpc): Json-rpc extractor for axum
+- [axum-tracing-opentelemetry](https://crates.io/crates/aaxum-tracing-opentelemetry): Middlewares and tools to integrate axum + tracing + opentelemetry
 
 ## Project showcase
 
@@ -35,6 +36,7 @@ If your project isn't listed here and you would like it to be, please feel free 
 - [CLOMonitor](https://clomonitor.io) ([repository](https://github.com/cncf/clomonitor)): Checks open source projects repositories to verify they meet certain best practices.
 - [Pinging.net](https://www.pinging.net) ([repository](https://github.com/benhansenslc/pinging)): A new way to check and monitor your internet connection.
 - [wastebin](https://github.com/matze/wastebin): A minimalist pastebin service.
+- [sandbox_axum_observability](https://github.com/davidB/sandbox_axum_observability) A Sandbox/showcase project to experiment axum and observability (tracing, opentelemetry, jaeger, grafana tempo,...)
 
 [Realworld]: https://github.com/gothinkster/realworld
 [SQLx]: https://github.com/launchbadge/sqlx

--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -18,7 +18,7 @@ If your project isn't listed here and you would like it to be, please feel free 
 - [shuttle](https://github.com/getsynth/shuttle): A serverless platform built for Rust. Now with axum support.
 - [axum-tungstenite](https://github.com/davidpdrsn/axum-tungstenite): WebSocket connections for axum directly using tungstenite
 - [axum-jrpc](https://github.com/0xdeafbeef/axum-jrpc): Json-rpc extractor for axum
-- [axum-tracing-opentelemetry](https://crates.io/crates/aaxum-tracing-opentelemetry): Middlewares and tools to integrate axum + tracing + opentelemetry
+- [axum-tracing-opentelemetry](https://crates.io/crates/axum-tracing-opentelemetry): Middlewares and tools to integrate axum + tracing + opentelemetry
 
 ## Project showcase
 


### PR DESCRIPTION
…bility

## Motivation

After the cancellation of the PR to add tracing + opentelemetry into axum-extra, the suggestion was to create a standalone crate

## Solution

Create a standalone crate (published) , and sample project to experiment and to show with axum & observability. And update ECOSYSTEM.md to notify about both project.