### PR TITLE
fix missing assets running websockets example

### DIFF
--- a/examples/websockets/src/main.rs
+++ b/examples/websockets/src/main.rs
@@ -32,12 +32,13 @@ async fn main() {
         ))
         .with(tracing_subscriber::fmt::layer())
         .init();
-
+    let mut assets_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    assets_dir.push("assets");
     // build our application with some routes
     let app = Router::new()
         .fallback(
             get_service(
-                ServeDir::new("examples/websockets/assets").append_index_html_on_directories(true),
+                ServeDir::new(assets_dir).append_index_html_on_directories(true),
             )
             .handle_error(|error: std::io::Error| async move {
                 (


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation

Checking out the websockets example recently. When running `cargo run` under `examples/websockets`, the example app isn't serving any assets.

![image](https://user-images.githubusercontent.com/5630513/173242283-20244c07-36a6-4464-affe-8452a63482ee.png)

## Solution

Make the assets folder relative to `CARGO_MANIFEST_DIR`.
