### PR TITLE
Fix "unnecessary use of `to_string`" lint for `#[derive(TypedPath)]`

### DIFF
--- a/axum-macros/CHANGELOG.md
+++ b/axum-macros/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # Unreleased
 
 - **change:** axum's MSRV is now 1.56 ([#1098])
+- **fixed:** Fix "unnecessary use of `to_string`" lint for `#[derive(TypedPath)]`
 
 [#1098]: https://github.com/tokio-rs/axum/pull/1098
 

--- a/axum-macros/src/typed_path.rs
+++ b/axum-macros/src/typed_path.rs
@@ -104,12 +104,18 @@ fn expand_named_fields(
     let display_impl = quote_spanned! {path.span()=>
         #[automatically_derived]
         impl ::std::fmt::Display for #ident {
+            #[allow(clippy::unnecessary_to_owned)]
             fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
                 let Self { #(#captures,)* } = self;
                 write!(
                     f,
                     #format_str,
-                    #(#captures = ::axum_extra::__private::utf8_percent_encode(&#captures.to_string(), ::axum_extra::__private::PATH_SEGMENT)),*
+                    #(
+                        #captures = ::axum_extra::__private::utf8_percent_encode(
+                            &#captures.to_string(),
+                            ::axum_extra::__private::PATH_SEGMENT,
+                        )
+                    ),*
                 )
             }
         }
@@ -200,12 +206,18 @@ fn expand_unnamed_fields(
     let display_impl = quote_spanned! {path.span()=>
         #[automatically_derived]
         impl ::std::fmt::Display for #ident {
+            #[allow(clippy::unnecessary_to_owned)]
             fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
                 let Self { #(#destructure_self)* } = self;
                 write!(
                     f,
                     #format_str,
-                    #(#captures = ::axum_extra::__private::utf8_percent_encode(&#captures.to_string(), ::axum_extra::__private::PATH_SEGMENT)),*
+                    #(
+                        #captures = ::axum_extra::__private::utf8_percent_encode(
+                            &#captures.to_string(),
+                            ::axum_extra::__private::PATH_SEGMENT,
+                        )
+                    ),*
                 )
             }
         }


### PR DESCRIPTION
Fixes https://github.com/tokio-rs/axum/issues/1111