### PR TITLE
Fix possible panic when doing trailing slash redirect

### DIFF
--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -8,9 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # Unreleased
 
 - **fixed:** Make `Router` cheaper to clone ([#1123])
-- **fixed:** Fix possible panic when doing trailing slash redirect
+- **fixed:** Fix possible panic when doing trailing slash redirect ([#1124])
 
 [#1123]: https://github.com/tokio-rs/axum/pull/1123
+[#1124]: https://github.com/tokio-rs/axum/pull/1124
 
 # 0.5.9 (20. June, 2022)
 

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # Unreleased
 
 - **fixed:** Make `Router` cheaper to clone ([#1123])
+- **fixed:** Fix possible panic when doing trailing slash redirect
 
 [#1123]: https://github.com/tokio-rs/axum/pull/1123
 

--- a/axum/src/routing/mod.rs
+++ b/axum/src/routing/mod.rs
@@ -513,7 +513,7 @@ where
                     MatchError::ExtraTrailingSlash => {
                         replace_path(req.uri(), path.strip_suffix('/').unwrap())
                     }
-                    MatchError::NotFound => return fallback.call(req),
+                    MatchError::NotFound => None,
                 };
 
                 if let Some(new_uri) = new_uri {


### PR DESCRIPTION
Fixes https://github.com/tokio-rs/axum/issues/1122

It panicked because we hit this https://github.com/hyperium/http/blob/master/src/uri/mod.rs#L248-L250 and did an `unwrap`. So rather than panicking we send the request to the fallback. We cannot issue a redirect since we couldn't add the path so guess there isn't much else we can do.