### PR TITLE
TryFrom<http::Method> for MethodFilter

### DIFF
--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -16,7 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `/foo/`). That is no longer supported and such requests will now be sent to
   the fallback. Consider using `axum_extra::routing::RouterExt::route_with_tsr`
   if you want the old behavior ([#1119])
+- **added** Implement `TryFrom<http:: Method>` for `MethodFilter` and use new `NoMatchingMethodFilter` error in case of failure ([#1130])
 
+[#1130]: https://github.com/tokio-rs/axum/pull/1130
 [#1077]: https://github.com/tokio-rs/axum/pull/1077
 [#1102]: https://github.com/tokio-rs/axum/pull/1102
 [#1119]: https://github.com/tokio-rs/axum/pull/1119

--- a/axum/src/routing/method_filter.rs
+++ b/axum/src/routing/method_filter.rs
@@ -61,7 +61,60 @@ impl TryFrom<Method> for MethodFilter {
             Method::POST => Ok(MethodFilter::POST),
             Method::PUT => Ok(MethodFilter::PUT),
             Method::TRACE => Ok(MethodFilter::TRACE),
-            other => Err(NoMatchingMethodFilter { method: other}),
+            other => Err(NoMatchingMethodFilter { method: other }),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_http_method() {
+        assert_eq!(
+            MethodFilter::try_from(Method::DELETE).unwrap(),
+            MethodFilter::DELETE
+        );
+
+        assert_eq!(
+            MethodFilter::try_from(Method::GET).unwrap(),
+            MethodFilter::GET
+        );
+
+        assert_eq!(
+            MethodFilter::try_from(Method::HEAD).unwrap(),
+            MethodFilter::HEAD
+        );
+
+        assert_eq!(
+            MethodFilter::try_from(Method::OPTIONS).unwrap(),
+            MethodFilter::OPTIONS
+        );
+
+        assert_eq!(
+            MethodFilter::try_from(Method::PATCH).unwrap(),
+            MethodFilter::PATCH
+        );
+
+        assert_eq!(
+            MethodFilter::try_from(Method::POST).unwrap(),
+            MethodFilter::POST
+        );
+
+        assert_eq!(
+            MethodFilter::try_from(Method::PUT).unwrap(),
+            MethodFilter::PUT
+        );
+
+        assert_eq!(
+            MethodFilter::try_from(Method::TRACE).unwrap(),
+            MethodFilter::TRACE
+        );
+
+        assert!(MethodFilter::try_from(http::Method::CONNECT)
+            .unwrap_err()
+            .to_string()
+            .contains("CONNECT"));
     }
 }

--- a/axum/src/routing/method_filter.rs
+++ b/axum/src/routing/method_filter.rs
@@ -1,4 +1,6 @@
 use bitflags::bitflags;
+use http::Method;
+use axum_core::Error;
 
 bitflags! {
     /// A filter that matches one or more HTTP methods.
@@ -19,5 +21,23 @@ bitflags! {
         const PUT =     0b010000000;
         /// Match `TRACE` requests.
         const TRACE =   0b100000000;
+    }
+}
+
+impl TryFrom<Method> for MethodFilter {
+    type Error = Error;
+
+    fn try_from(m: Method) -> Result<Self, Error> {
+        match m {
+            Method::DELETE => Ok(MethodFilter::DELETE),
+            Method::GET => Ok(MethodFilter::GET),
+            Method::HEAD => Ok(MethodFilter::HEAD),
+            Method::OPTIONS => Ok(MethodFilter::OPTIONS),
+            Method::PATCH => Ok(MethodFilter::PATCH),
+            Method::POST => Ok(MethodFilter::POST),
+            Method::PUT => Ok(MethodFilter::PUT),
+            Method::TRACE => Ok(MethodFilter::TRACE),
+            _ => Err(Error::new("could not map method")),
+        }
     }
 }

--- a/axum/src/routing/method_filter.rs
+++ b/axum/src/routing/method_filter.rs
@@ -1,6 +1,9 @@
-use std::{fmt, fmt::{Debug, Formatter}};
 use bitflags::bitflags;
 use http::Method;
+use std::{
+    fmt,
+    fmt::{Debug, Formatter},
+};
 
 bitflags! {
     /// A filter that matches one or more HTTP methods.
@@ -24,23 +27,22 @@ bitflags! {
     }
 }
 
-/// Error type used when converting a [`http::Method`] to a [`MethodFilter`] fails,
-/// because there is no matching [`MethodFilter`] for that [`http::Method`].
+/// Error type used when converting a [`Method`] to a [`MethodFilter`] fails.
 #[derive(Debug)]
 pub struct NoMatchingMethodFilter {
-    method: http::Method,
+    method: Method,
 }
 
 impl NoMatchingMethodFilter {
-    /// [`NoMatchingMethodFilter`] exposes [`NoMatchingMethodFilter::method()`] to make the [`http::Method`] that was responsible for the error accessible.
-    pub fn method(&self) -> &http::Method {
+    /// Get the [`Method`] that couldn't be converted to a [`MethodFilter`].
+    pub fn method(&self) -> &Method {
         &self.method
     }
 }
 
 impl fmt::Display for NoMatchingMethodFilter {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "Failed to match http method: {}", self.method.as_str())
+        write!(f, "no `MethodFilter` for `{}`", self.method.as_str())
     }
 }
 

--- a/axum/src/routing/tests/mod.rs
+++ b/axum/src/routing/tests/mod.rs
@@ -720,21 +720,3 @@ async fn limited_body_with_streaming_body() {
         .await;
     assert_eq!(res.status(), StatusCode::PAYLOAD_TOO_LARGE);
 }
-
-#[test]
-fn from_http_method() {
-    assert_eq!(MethodFilter::try_from(Method::DELETE).unwrap(), MethodFilter::DELETE);
-    assert_eq!(MethodFilter::try_from(Method::GET).unwrap(), MethodFilter::GET);
-    assert_eq!(MethodFilter::try_from(Method::HEAD).unwrap(), MethodFilter::HEAD);
-    assert_eq!(MethodFilter::try_from(Method::OPTIONS).unwrap(), MethodFilter::OPTIONS);
-    assert_eq!(MethodFilter::try_from(Method::PATCH).unwrap(), MethodFilter::PATCH);
-    assert_eq!(MethodFilter::try_from(Method::POST).unwrap(), MethodFilter::POST);
-    assert_eq!(MethodFilter::try_from(Method::PUT).unwrap(), MethodFilter::PUT);
-    assert_eq!(MethodFilter::try_from(Method::TRACE).unwrap(), MethodFilter::TRACE);
-    match MethodFilter::try_from(http::Method::CONNECT) {
-        Ok(_) => panic!("test failed, the method 'CONNECT' is not supported"),
-        Err(e) => {
-            assert!(format!("{}", e).contains(e.method().as_str()))
-        }
-    }
-}

--- a/axum/src/routing/tests/mod.rs
+++ b/axum/src/routing/tests/mod.rs
@@ -731,4 +731,10 @@ fn from_http_method() {
     assert_eq!(MethodFilter::try_from(Method::POST).unwrap(), MethodFilter::POST);
     assert_eq!(MethodFilter::try_from(Method::PUT).unwrap(), MethodFilter::PUT);
     assert_eq!(MethodFilter::try_from(Method::TRACE).unwrap(), MethodFilter::TRACE);
+    match MethodFilter::try_from(http::Method::CONNECT) {
+        Ok(_) => panic!("test failed, the method 'CONNECT' is not supported"),
+        Err(e) => {
+            assert!(format!("{}", e).contains(e.method().as_str()))
+        }
+    }
 }

--- a/axum/src/routing/tests/mod.rs
+++ b/axum/src/routing/tests/mod.rs
@@ -720,3 +720,15 @@ async fn limited_body_with_streaming_body() {
         .await;
     assert_eq!(res.status(), StatusCode::PAYLOAD_TOO_LARGE);
 }
+
+#[test]
+fn from_http_method() {
+    assert_eq!(MethodFilter::try_from(Method::DELETE).unwrap(), MethodFilter::DELETE);
+    assert_eq!(MethodFilter::try_from(Method::GET).unwrap(), MethodFilter::GET);
+    assert_eq!(MethodFilter::try_from(Method::HEAD).unwrap(), MethodFilter::HEAD);
+    assert_eq!(MethodFilter::try_from(Method::OPTIONS).unwrap(), MethodFilter::OPTIONS);
+    assert_eq!(MethodFilter::try_from(Method::PATCH).unwrap(), MethodFilter::PATCH);
+    assert_eq!(MethodFilter::try_from(Method::POST).unwrap(), MethodFilter::POST);
+    assert_eq!(MethodFilter::try_from(Method::PUT).unwrap(), MethodFilter::PUT);
+    assert_eq!(MethodFilter::try_from(Method::TRACE).unwrap(), MethodFilter::TRACE);
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation
I am currently switching from tide to axum in a project which also uses http-types to dynamicaly set methods. When I wanted to change that to `axum::routing::MethodFilter`, I thought that it would be nice to just have a `TryFrom<http::Method> `for the MethodFilter, since axum already uses http and there is no unclear semantics going from e.g. `http::Method::GET` to `MethodFilter::GET`
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution
I just added a very simple `TryFrom<Method> for MethodFilter` implementation that maps the intersecting methods from both `Method` and `MethodFillter` appropriately and just returns a result if there is no method in `MethodFilter` for the given `http::Method `
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
