### PR TITLE
axum-extra: Version 0.3.6

### DIFF
--- a/axum-extra/CHANGELOG.md
+++ b/axum-extra/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning].
 
 - None.
 
+# 0.3.6 (02. July, 2022)
+
+- **fixed:** Fix feature labels missing in generated docs ([#1137])
+
+[#1137]: https://github.com/tokio-rs/axum/pull/1137
+
 # 0.3.5 (27. June, 2022)
 
 - **added:** Add `JsonLines` for streaming newline delimited JSON ([#1093])

--- a/axum-extra/Cargo.toml
+++ b/axum-extra/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 name = "axum-extra"
 readme = "README.md"
 repository = "https://github.com/tokio-rs/axum"
-version = "0.3.5"
+version = "0.3.6"
 
 [features]
 default = []


### PR DESCRIPTION
I've backported https://github.com/tokio-rs/axum/pull/1137 to 0.5.x and this releases that.