### PR TITLE
Fix typos in RequestParts docstrings

### DIFF
--- a/axum-core/src/extract/mod.rs
+++ b/axum-core/src/extract/mod.rs
@@ -176,7 +176,7 @@ impl<B> RequestParts<B> {
         Ok(req)
     }
 
-    /// Gets a reference the request method.
+    /// Gets a reference to the request method.
     pub fn method(&self) -> &Method {
         &self.method
     }
@@ -186,7 +186,7 @@ impl<B> RequestParts<B> {
         &mut self.method
     }
 
-    /// Gets a reference the request URI.
+    /// Gets a reference to the request URI.
     pub fn uri(&self) -> &Uri {
         &self.uri
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation

Two docstrings are missing a "to".

## Solution

Add them.
