### PR TITLE
axum-core: Version 0.2.7

### DIFF
--- a/axum-core/CHANGELOG.md
+++ b/axum-core/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
-- None.
+- **fix:** Fix typos in `RequestParts` docs ([#1147])
+
+[#1147]: https://github.com/tokio-rs/axum/pull/1147
 
 # 0.2.6 (18. June, 2022)
 

--- a/axum-core/Cargo.toml
+++ b/axum-core/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 name = "axum-core"
 readme = "README.md"
 repository = "https://github.com/tokio-rs/axum"
-version = "0.2.6" # remember to also bump the version that axum depends on
+version = "0.2.7" # remember to also bump the version that axum depends on
 
 [dependencies]
 async-trait = "0.1"

--- a/axum/Cargo.toml
+++ b/axum/Cargo.toml
@@ -26,7 +26,7 @@ ws = ["tokio-tungstenite", "sha-1", "base64"]
 
 [dependencies]
 async-trait = "0.1.43"
-axum-core = { path = "../axum-core", version = "0.2.6" }
+axum-core = { path = "../axum-core", version = "0.2.7" }
 bitflags = "1.0"
 bytes = "1.0"
 futures-util = { version = "0.3", default-features = false, features = ["alloc"] }


### PR DESCRIPTION
Wanna do a new release of axum that includes https://github.com/tokio-rs/axum/commit/bed0b83421753550078242c3a687bb384cadd37c and figured it made sense to backport this typo fix first.