### PR TITLE
Don't derive debug impl for `Resource`

### DIFF
--- a/axum-extra/src/routing/resource.rs
+++ b/axum-extra/src/routing/resource.rs
@@ -6,7 +6,7 @@ use axum::{
     routing::{delete, get, on, post, MethodFilter},
     Router,
 };
-use std::convert::Infallible;
+use std::{convert::Infallible, fmt};
 use tower_service::Service;
 
 /// A resource which defines a set of conventional CRUD routes.
@@ -47,7 +47,6 @@ use tower_service::Service;
 /// let app = Router::new().merge(users);
 /// # let _: Router<axum::body::Body> = app;
 /// ```
-#[derive(Debug)]
 pub struct Resource<B = Body> {
     pub(crate) name: String,
     pub(crate) router: Router<B>,
@@ -184,6 +183,15 @@ where
 impl<B> From<Resource<B>> for Router<B> {
     fn from(resource: Resource<B>) -> Self {
         resource.router
+    }
+}
+
+impl<B> fmt::Debug for Resource<B> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Resource")
+            .field("name", &self.name)
+            .field("router", &self.router)
+            .finish()
     }
 }
 


### PR DESCRIPTION
We don't actually require `B` to be `Debug` but the derived impl does.