### PR TITLE
added local-addr code

### DIFF
--- a/examples/local-addr/Cargo.toml
+++ b/examples/local-addr/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "local-addr"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+axum = "0.5.11"
+tokio = { version = "1.19.2", features = ["full"] }

--- a/examples/local-addr/src/main.rs
+++ b/examples/local-addr/src/main.rs
@@ -1,0 +1,52 @@
+//! Run with
+//!
+//! ```not_rust
+//! cd examples && cargo run -p local-addr
+//! ```
+
+// Obtain server's IP:port first from the request's pseudo-header
+// authority field, in case of HTTP/2, then from the header's host 
+// field, in case of HTTP/1.
+//
+// Built off the "hello-world" example code.
+
+use axum::{
+    http::{header, uri::Authority, HeaderMap, HeaderValue, Uri},
+    response::Html,
+    routing::get,
+    Router,
+};
+use std::net::SocketAddr;
+
+#[tokio::main]
+async fn main() {
+    // build our application with a route
+    let app = Router::new().route("/", get(handler));
+
+    // run it
+    let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
+    println!("listening on {}", addr);
+    axum::Server::bind(&addr)
+        .serve(app.into_make_service())
+        .await
+        .unwrap();
+}
+
+async fn handler(headers: HeaderMap<HeaderValue>, uri: Uri) -> Html<String> {
+    let host =
+        local_addr(uri.authority(), headers.get(header::HOST)).unwrap_or("[local address None]");
+    Html(format!("<h1>Greetings from {host}!</h1>"))
+}
+
+pub fn local_addr<'l>(
+    auth: Option<&'l Authority>,
+    host: Option<&'l HeaderValue>,
+) -> Option<&'l str> {
+    if let Some(auth) = auth {
+        Some(auth.as_str())               // HTTP/2
+    } else if let Some(host) = host {
+        Some(host.to_str().ok().unwrap()) // HTTP/1
+    } else {
+        None
+    }
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation

To provide example code to obtain server's IP:port used in request Uri.

On a server with multiple IPs, it is sometimes useful to know which IP a client request came in from.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

Obtain server's IP:port first from the request's pseudo-header authority field, in case of HTTP/2, then from the header's host field, in case of HTTP/1.

Example code is built off the "hello-world" example code.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
