### PR TITLE
Accept `S::Response: IntoResponse` everywhere

### DIFF
--- a/axum-extra/CHANGELOG.md
+++ b/axum-extra/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning].
 
 - **added:** Add `RouterExt::route_with_tsr` for adding routes with an
   additional "trailing slash redirect" route ([#1119])
+- **changed:** For methods that accept some `S: Service`, the bounds have been
+  relaxed so the response type must implement `IntoResponse` rather than being a
+  literal `Response`
 
 [#1119]: https://github.com/tokio-rs/axum/pull/1119
 

--- a/axum-extra/src/routing/mod.rs
+++ b/axum-extra/src/routing/mod.rs
@@ -3,7 +3,7 @@
 use axum::{
     handler::Handler,
     http::Request,
-    response::{Redirect, Response},
+    response::{IntoResponse, Redirect},
     Router,
 };
 use std::{convert::Infallible, future::ready};
@@ -161,7 +161,8 @@ pub trait RouterExt<B>: sealed::Sealed {
     /// ```
     fn route_with_tsr<T>(self, path: &str, service: T) -> Self
     where
-        T: Service<Request<B>, Response = Response, Error = Infallible> + Clone + Send + 'static,
+        T: Service<Request<B>, Error = Infallible> + Clone + Send + 'static,
+        T::Response: IntoResponse,
         T::Future: Send + 'static,
         Self: Sized;
 }
@@ -252,7 +253,8 @@ where
 
     fn route_with_tsr<T>(mut self, path: &str, service: T) -> Self
     where
-        T: Service<Request<B>, Response = Response, Error = Infallible> + Clone + Send + 'static,
+        T: Service<Request<B>, Error = Infallible> + Clone + Send + 'static,
+        T::Response: IntoResponse,
         T::Future: Send + 'static,
         Self: Sized,
     {

--- a/axum-extra/src/routing/resource.rs
+++ b/axum-extra/src/routing/resource.rs
@@ -2,7 +2,7 @@ use axum::{
     body::Body,
     handler::Handler,
     http::Request,
-    response::Response,
+    response::IntoResponse,
     routing::{delete, get, on, post, MethodFilter},
     Router,
 };
@@ -141,7 +141,8 @@ where
     /// The routes will be nested at `/{resource_name}/:{resource_name}_id`.
     pub fn nest<T>(mut self, svc: T) -> Self
     where
-        T: Service<Request<B>, Response = Response, Error = Infallible> + Clone + Send + 'static,
+        T: Service<Request<B>, Error = Infallible> + Clone + Send + 'static,
+        T::Response: IntoResponse,
         T::Future: Send + 'static,
     {
         let path = self.show_update_destroy_path();
@@ -154,7 +155,8 @@ where
     /// The routes will be nested at `/{resource_name}`.
     pub fn nest_collection<T>(mut self, svc: T) -> Self
     where
-        T: Service<Request<B>, Response = Response, Error = Infallible> + Clone + Send + 'static,
+        T: Service<Request<B>, Error = Infallible> + Clone + Send + 'static,
+        T::Response: IntoResponse,
         T::Future: Send + 'static,
     {
         let path = self.index_create_path();
@@ -172,7 +174,8 @@ where
 
     fn route<T>(mut self, path: &str, svc: T) -> Self
     where
-        T: Service<Request<B>, Response = Response, Error = Infallible> + Clone + Send + 'static,
+        T: Service<Request<B>, Error = Infallible> + Clone + Send + 'static,
+        T::Response: IntoResponse,
         T::Future: Send + 'static,
     {
         self.router = self.router.route(path, svc);

--- a/axum-extra/src/routing/spa.rs
+++ b/axum-extra/src/routing/spa.rs
@@ -1,7 +1,7 @@
 use axum::{
     body::{Body, HttpBody},
     error_handling::HandleError,
-    response::Response,
+    response::IntoResponse,
     routing::{get_service, Route},
     Router,
 };
@@ -150,8 +150,8 @@ impl<B, T, F> SpaRouter<B, T, F> {
 impl<B, F, T> From<SpaRouter<B, T, F>> for Router<B>
 where
     F: Clone + Send + 'static,
-    HandleError<Route<B, io::Error>, F, T>:
-        Service<Request<B>, Response = Response, Error = Infallible>,
+    HandleError<Route<B, io::Error>, F, T>: Service<Request<B>, Error = Infallible>,
+    <HandleError<Route<B, io::Error>, F, T> as Service<Request<B>>>::Response: IntoResponse + Send,
     <HandleError<Route<B, io::Error>, F, T> as Service<Request<B>>>::Future: Send,
     B: HttpBody + Send + 'static,
     T: 'static,

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -28,6 +28,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **added:** Support any middleware response that implements `IntoResponse` ([#1152])
 - **breaking:** Require middleware added with `Handler::layer` to have
   `Infallible` as the error type ([#1152])
+- **changed:** For methods that accept some `S: Service`, the bounds have been
+  relaxed so the response type must implement `IntoResponse` rather than being a
+  literal `Response`
 
 [#1077]: https://github.com/tokio-rs/axum/pull/1077
 [#1088]: https://github.com/tokio-rs/axum/pull/1088

--- a/axum/src/middleware/from_extractor.rs
+++ b/axum/src/middleware/from_extractor.rs
@@ -88,6 +88,8 @@ use tower_service::Service;
 /// # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
 /// # };
 /// ```
+///
+/// [`Bytes`]: bytes::Bytes
 pub fn from_extractor<E>() -> FromExtractorLayer<E> {
     FromExtractorLayer(PhantomData)
 }

--- a/axum/src/routing/mod.rs
+++ b/axum/src/routing/mod.rs
@@ -122,7 +122,8 @@ where
     #[doc = include_str!("../docs/routing/route.md")]
     pub fn route<T>(mut self, path: &str, service: T) -> Self
     where
-        T: Service<Request<B>, Response = Response, Error = Infallible> + Clone + Send + 'static,
+        T: Service<Request<B>, Error = Infallible> + Clone + Send + 'static,
+        T::Response: IntoResponse,
         T::Future: Send + 'static,
     {
         if path.is_empty() {
@@ -176,7 +177,8 @@ where
     #[doc = include_str!("../docs/routing/nest.md")]
     pub fn nest<T>(mut self, mut path: &str, svc: T) -> Self
     where
-        T: Service<Request<B>, Response = Response, Error = Infallible> + Clone + Send + 'static,
+        T: Service<Request<B>, Error = Infallible> + Clone + Send + 'static,
+        T::Response: IntoResponse,
         T::Future: Send + 'static,
     {
         if path.is_empty() {
@@ -368,7 +370,8 @@ where
     #[doc = include_str!("../docs/routing/fallback.md")]
     pub fn fallback<T>(mut self, svc: T) -> Self
     where
-        T: Service<Request<B>, Response = Response, Error = Infallible> + Clone + Send + 'static,
+        T: Service<Request<B>, Error = Infallible> + Clone + Send + 'static,
+        T::Response: IntoResponse,
         T::Future: Send + 'static,
     {
         self.fallback = Fallback::Custom(Route::new(svc));


### PR DESCRIPTION
This is a continuation of https://github.com/tokio-rs/axum/pull/1152 by doing the same for all methods that accept some `S: Service`. I think this is a win as it makes things more flexible for advanced users while still allowing `Response`s to be returned.