### PR TITLE
Add note on default responses if extraction fails

### DIFF
--- a/axum/src/lib.rs
+++ b/axum/src/lib.rs
@@ -112,6 +112,10 @@
 //! async fn json(Json(payload): Json<serde_json::Value>) {}
 //! ```
 //!
+//! If an extraction fails, axum [`rejects`](crate::extract::rejection) requests
+//! and responds with an appropriate status code and the respective error message.
+//! This behavior can be adapted by customizing extractor responses.
+//!
 //! See [`extract`](crate::extract) for more details on extractors.
 //!
 //! # Responses


### PR DESCRIPTION
This is useful in case one does not want to expose internal error
messages through the interface.

Fixes #1167

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
