### PR TITLE
Avoid exposure of type names by QueryRejection

### DIFF
--- a/axum/src/extract/rejection.rs
+++ b/axum/src/extract/rejection.rs
@@ -100,7 +100,6 @@ define_rejection! {
 #[derive(Debug)]
 pub struct FailedToDeserializeQueryString {
     error: Error,
-    type_name: &'static str,
 }
 
 impl FailedToDeserializeQueryString {
@@ -111,7 +110,6 @@ impl FailedToDeserializeQueryString {
     {
         FailedToDeserializeQueryString {
             error: Error::new(error),
-            type_name: std::any::type_name::<T>(),
         }
     }
 }
@@ -124,11 +122,7 @@ impl IntoResponse for FailedToDeserializeQueryString {
 
 impl std::fmt::Display for FailedToDeserializeQueryString {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "Failed to deserialize query string. Expected something of type `{}`. Error: {}",
-            self.type_name, self.error,
-        )
+        write!(f, "Failed to deserialize query string: {}", self.error,)
     }
 }
 


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation

This is neccessary, to avoid public exposure of implementation details
by the default error message if the extractor fails to deserialize
the query parameters into the target type.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Removing the `type_name` field from `FailedToDeserializeQueryString`.
