### PR TITLE
Create BytesMut for Json with initial capacity

### DIFF
--- a/axum/src/json.rs
+++ b/axum/src/json.rs
@@ -186,7 +186,7 @@ where
     T: Serialize,
 {
     fn into_response(self) -> Response {
-        let mut buf = BytesMut::new().writer();
+        let mut buf = BytesMut::with_capacity(128).writer();
         match serde_json::to_writer(&mut buf, &self.0) {
             Ok(()) => (
                 [(

--- a/axum/src/json.rs
+++ b/axum/src/json.rs
@@ -187,7 +187,7 @@ where
 {
     fn into_response(self) -> Response {
         // Use a small initial capacity of 128 bytes like serde_json::to_vec
-        // https://github.com/serde-rs/json/blob/v1.0.82/src/ser.rs#L2189
+        // https://docs.rs/serde_json/1.0.82/src/serde_json/ser.rs.html#2189
         let mut buf = BytesMut::with_capacity(128).writer();
         match serde_json::to_writer(&mut buf, &self.0) {
             Ok(()) => (

--- a/axum/src/json.rs
+++ b/axum/src/json.rs
@@ -186,6 +186,8 @@ where
     T: Serialize,
 {
     fn into_response(self) -> Response {
+        // Use a small initial capacity of 128 bytes like serde_json::to_vec
+        // https://github.com/serde-rs/json/blob/v1.0.82/src/ser.rs#L2189
         let mut buf = BytesMut::with_capacity(128).writer();
         match serde_json::to_writer(&mut buf, &self.0) {
             Ok(()) => (


### PR DESCRIPTION
This PR initializes the `BytesMut` for serializing `Json` with a small initial capacity to reduce allocations as the inner `Vec<u8>` grows.

A [recent PR](https://github.com/tokio-rs/axum/pull/1178) removed an unnecessary copy by introducing `BytesMut` and switching away from `serde_json::to_vec`, but I noticed a small regression that I believe is due to `serde_json::to_vec` creating a `Vec<u8>` with an initial capacity ([code](https://github.com/serde-rs/json/blob/v1.0.82/src/ser.rs#L2189)). I figured matching the initial capacity of "128 bytes" made sense. In a simple benchmark like below (mostly pulled from [this comment](https://github.com/tokio-rs/axum/issues/1177#issuecomment-1194007420)), I'm seeing a modest ~1% speed bump.

```rust
use axum::{routing::get, Json, Router};

#[tokio::main]
async fn main() {
    let app = Router::new().route("/json", get(json));

    axum::Server::bind(&"0.0.0.0:8000".parse().unwrap())
        .serve(app.into_make_service())
        .await
        .unwrap();
}

async fn json() -> Json<Message> {
    let message = Message {
        name: "http-benchmark",
        version: "v0.1.0",
        message: "Hello, World!",
    };
    Json(message)
}

#[derive(serde::Serialize)]
pub struct Message {
    pub name: &'static str,
    pub version: &'static str,
    pub message: &'static str,
}
```