### PR TITLE
Add exhaustive flag.

### DIFF
--- a/axum/Cargo.toml
+++ b/axum/Cargo.toml
@@ -24,6 +24,7 @@ original-uri = []
 query = ["serde_urlencoded"]
 tower-log = ["tower/log"]
 ws = ["tokio-tungstenite", "sha-1", "base64"]
+exhaustive = []
 
 # Required for intra-doc links to resolve correctly
 __private_docs = ["tower/full", "tower-http/full"]

--- a/axum/src/extract/path/mod.rs
+++ b/axum/src/extract/path/mod.rs
@@ -261,7 +261,7 @@ impl std::error::Error for PathDeserializationError {}
 /// This type is obtained through [`FailedToDeserializePathParams::into_kind`] and is useful for building
 /// more precise error messages.
 #[derive(Debug, PartialEq)]
-#[non_exhaustive]
+#[cfg_attr(not(exhaustive), non_exhaustive)]
 pub enum ErrorKind {
     /// The URI contained the wrong number of parameters.
     WrongNumberOfParameters {

--- a/axum/src/extract/rejection.rs
+++ b/axum/src/extract/rejection.rs
@@ -221,7 +221,7 @@ composite_rejection! {
 /// Contains one variant for each way the
 /// [`ContentLengthLimit`](super::ContentLengthLimit) extractor can fail.
 #[derive(Debug)]
-#[non_exhaustive]
+#[cfg_attr(not(exhaustive), non_exhaustive)]
 pub enum ContentLengthLimitRejection<T> {
     #[allow(missing_docs)]
     PayloadTooLarge(PayloadTooLarge),

--- a/axum/src/macros.rs
+++ b/axum/src/macros.rs
@@ -54,7 +54,7 @@ macro_rules! define_rejection {
     ) => {
         $(#[$m])*
         #[derive(Debug)]
-        #[non_exhaustive]
+        #[cfg_attr(not(exhaustive), non_exhaustive)]
         pub struct $name;
 
         impl $crate::response::IntoResponse for $name {
@@ -130,7 +130,7 @@ macro_rules! composite_rejection {
     ) => {
         $(#[$m])*
         #[derive(Debug)]
-        #[non_exhaustive]
+        #[cfg_attr(not(exhaustive), non_exhaustive)]
         pub enum $name {
             $(
                 #[allow(missing_docs)]

--- a/axum/src/typed_header.rs
+++ b/axum/src/typed_header.rs
@@ -128,7 +128,7 @@ impl TypedHeaderRejection {
 /// Additional information regarding a [`TypedHeaderRejection`]
 #[cfg(feature = "headers")]
 #[derive(Debug)]
-#[non_exhaustive]
+#[cfg_attr(not(exhaustive), non_exhaustive)]
 pub enum TypedHeaderRejectionReason {
     /// The header was missing from the HTTP request
     Missing,


### PR DESCRIPTION
## Motivation

Motivation is simple -- I want to handle all errors and don't ignore new one.
In my opinion, if someone want `non_exhaustive` he / she should use `if-then-else` chain. `match` is supposed to covering all options.

## Solution

By adding ability to suppress `non_exhaustive` for pattern matching.