### PR TITLE
Improve workspace caching on CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,7 +26,10 @@ jobs:
         override: true
         profile: minimal
         components: clippy, rustfmt
-    - uses: Swatinem/rust-cache@v1
+    - uses: Swatinem/rust-cache@v2
+      with:
+        key: ${{ matrix.pwd }}
+        workspaces: ${{ matrix.pwd }}
     - name: Check
       working-directory: ${{ matrix.pwd }}
       run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -223,7 +223,10 @@ jobs:
         toolchain: beta
         override: true
         profile: minimal
-    - uses: Swatinem/rust-cache@v1
+    - uses: Swatinem/rust-cache@v2
+      with:
+        key: ${{ matrix.pwd }}
+        workspaces: ${{ matrix.pwd }}
     - name: Install cargo-sort
       run: |
         cargo install cargo-sort


### PR DESCRIPTION
This improves workspace caching performance by using the workspace parameter of `rust-cache@v2`.