### PR TITLE
docs: use local variable in closure

### DIFF
--- a/axum/src/lib.rs
+++ b/axum/src/lib.rs
@@ -234,14 +234,14 @@
 //!         "/users",
 //!         post({
 //!             let shared_state = Arc::clone(&shared_state);
-//!             move |body| create_user(body, Arc::clone(&shared_state))
+//!             move |body| create_user(body, shared_state)
 //!         }),
 //!     )
 //!     .route(
 //!         "/users/:id",
 //!         get({
 //!             let shared_state = Arc::clone(&shared_state);
-//!             move |path| get_user(path, Arc::clone(&shared_state))
+//!             move |path| get_user(path, shared_state)
 //!         }),
 //!     );
 //!


### PR DESCRIPTION
## Motivation

The "Using closure captures for shared state" example creates a local variable for the cloned arc and then clones that clone.

The current example works since the clone in the closure is actually cloning the overshadowing variable, which has been moved into the closure.


## Solution

Since the overshadowing variable is moved into the closure, just use that in the function call.
