### PR TITLE
Fix accidental breaking change to `FailedToDeserializeQueryString`

### DIFF
--- a/axum-extra/src/extract/form.rs
+++ b/axum-extra/src/extract/form.rs
@@ -67,7 +67,7 @@ where
         if req.method() == Method::GET {
             let query = req.uri().query().unwrap_or_default();
             let value = serde_html_form::from_str(query)
-                .map_err(FailedToDeserializeQueryString::__private_new)?;
+                .map_err(FailedToDeserializeQueryString::__private_new::<(), _>)?;
             Ok(Form(value))
         } else {
             if !has_content_type(req, &mime::APPLICATION_WWW_FORM_URLENCODED) {
@@ -76,7 +76,7 @@ where
 
             let bytes = Bytes::from_request(req).await?;
             let value = serde_html_form::from_bytes(&bytes)
-                .map_err(FailedToDeserializeQueryString::__private_new)?;
+                .map_err(FailedToDeserializeQueryString::__private_new::<(), _>)?;
 
             Ok(Form(value))
         }

--- a/axum-extra/src/extract/query.rs
+++ b/axum-extra/src/extract/query.rs
@@ -68,7 +68,7 @@ where
     async fn from_request(req: &mut RequestParts<B>) -> Result<Self, Self::Rejection> {
         let query = req.uri().query().unwrap_or_default();
         let value = serde_html_form::from_str(query)
-            .map_err(FailedToDeserializeQueryString::__private_new)?;
+            .map_err(FailedToDeserializeQueryString::__private_new::<(), _>)?;
         Ok(Query(value))
     }
 }

--- a/axum/src/extract/query.rs
+++ b/axum/src/extract/query.rs
@@ -59,7 +59,7 @@ where
     async fn from_request(req: &mut RequestParts<B>) -> Result<Self, Self::Rejection> {
         let query = req.uri().query().unwrap_or_default();
         let value = serde_urlencoded::from_str(query)
-            .map_err(FailedToDeserializeQueryString::__private_new)?;
+            .map_err(FailedToDeserializeQueryString::__private_new::<(), _>)?;
         Ok(Query(value))
     }
 }

--- a/axum/src/extract/rejection.rs
+++ b/axum/src/extract/rejection.rs
@@ -104,7 +104,7 @@ pub struct FailedToDeserializeQueryString {
 
 impl FailedToDeserializeQueryString {
     #[doc(hidden)]
-    pub fn __private_new<E>(error: E) -> Self
+    pub fn __private_new<T, E>(error: E) -> Self
     where
         E: Into<BoxError>,
     {

--- a/axum/src/form.rs
+++ b/axum/src/form.rs
@@ -69,7 +69,7 @@ where
         if req.method() == Method::GET {
             let query = req.uri().query().unwrap_or_default();
             let value = serde_urlencoded::from_str(query)
-                .map_err(FailedToDeserializeQueryString::__private_new)?;
+                .map_err(FailedToDeserializeQueryString::__private_new::<(), _>)?;
             Ok(Form(value))
         } else {
             if !has_content_type(req, &mime::APPLICATION_WWW_FORM_URLENCODED) {
@@ -78,7 +78,7 @@ where
 
             let bytes = Bytes::from_request(req).await?;
             let value = serde_urlencoded::from_bytes(&bytes)
-                .map_err(FailedToDeserializeQueryString::__private_new)?;
+                .map_err(FailedToDeserializeQueryString::__private_new::<(), _>)?;
 
             Ok(Form(value))
         }


### PR DESCRIPTION
Fixes #1202

I'll update the changelogs, with notes about why 0.5.14 was yanked, in
the release PR.