### PR TITLE
Add "Ordering" link to middleware table of contents

### DIFF
--- a/axum/src/docs/middleware.md
+++ b/axum/src/docs/middleware.md
@@ -3,6 +3,7 @@
 - [Intro](#intro)
 - [Applying middleware](#applying-middleware)
 - [Commonly used middleware](#commonly-used-middleware)
+- [Ordering](#ordering)
 - [Writing middleware](#writing-middleware)
 - [Routing to services/middleware and backpressure](#routing-to-servicesmiddleware-and-backpressure)
 - [Sharing state between handlers and middleware](#sharing-state-between-handlers-and-middleware)


### PR DESCRIPTION
Seems I forgot to add it.