### PR TITLE
Add initial benchmarks

### DIFF
--- a/axum/Cargo.toml
+++ b/axum/Cargo.toml
@@ -102,3 +102,7 @@ features = [
     "multipart",
     "ws",
 ]
+
+[[bench]]
+name = "benches"
+harness = false

--- a/axum/benches/benches.rs
+++ b/axum/benches/benches.rs
@@ -1,0 +1,186 @@
+use axum::{
+    routing::{get, post},
+    Json, Router, Server,
+};
+use hyper::server::conn::AddrIncoming;
+use serde::{Deserialize, Serialize};
+use std::{
+    io::BufRead,
+    process::{Command, Stdio},
+};
+
+fn main() {
+    ensure_rewrk_is_installed();
+
+    benchmark("minimal").run(Router::new);
+
+    benchmark("basic").run(|| Router::new().route("/", get(|| async { "Hello, World!" })));
+
+    benchmark("routing").path("/foo/bar/baz").run(|| {
+        let mut app = Router::new();
+        for a in 0..10 {
+            for b in 0..10 {
+                for c in 0..10 {
+                    app = app.route(&format!("/foo-{}/bar-{}/baz-{}", a, b, c), get(|| async {}));
+                }
+            }
+        }
+        app.route("/foo/bar/baz", get(|| async {}))
+    });
+
+    benchmark("receive-json")
+        .method("post")
+        .headers(&[("content-type", "application/json")])
+        .body(r#"{"n": 123, "s": "hi there", "b": false}"#)
+        .run(|| Router::new().route("/", post(|_: Json<Payload>| async {})));
+
+    benchmark("send-json").run(|| {
+        Router::new().route(
+            "/",
+            get(|| async {
+                Json(Payload {
+                    n: 123,
+                    s: "hi there".to_owned(),
+                    b: false,
+                })
+            }),
+        )
+    });
+}
+
+#[derive(Deserialize, Serialize)]
+struct Payload {
+    n: u32,
+    s: String,
+    b: bool,
+}
+
+fn benchmark(name: &'static str) -> BenchmarkBuilder {
+    BenchmarkBuilder {
+        name,
+        path: None,
+        method: None,
+        headers: None,
+        body: None,
+    }
+}
+
+struct BenchmarkBuilder {
+    name: &'static str,
+    path: Option<&'static str>,
+    method: Option<&'static str>,
+    headers: Option<&'static [(&'static str, &'static str)]>,
+    body: Option<&'static str>,
+}
+
+macro_rules! config_method {
+    ($name:ident, $ty:ty) => {
+        fn $name(mut self, $name: $ty) -> Self {
+            self.$name = Some($name);
+            self
+        }
+    };
+}
+
+impl BenchmarkBuilder {
+    config_method!(path, &'static str);
+    config_method!(method, &'static str);
+    config_method!(headers, &'static [(&'static str, &'static str)]);
+    config_method!(body, &'static str);
+
+    fn run<F>(self, f: F)
+    where
+        F: FnOnce() -> Router,
+    {
+        // support only running some benchmarks with
+        // ```
+        // cargo bench -- routing send-json
+        // ```
+        let args = std::env::args().collect::<Vec<_>>();
+        let names = &args[1..args.len() - 1];
+        if !names.is_empty() && !names.contains(&self.name.to_owned()) {
+            return;
+        }
+
+        let app = f();
+
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        let listener = rt
+            .block_on(tokio::net::TcpListener::bind("0.0.0.0:0"))
+            .unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        std::thread::spawn(move || {
+            rt.block_on(async move {
+                let incoming = AddrIncoming::from_listener(listener).unwrap();
+                Server::builder(incoming)
+                    .serve(app.into_make_service())
+                    .await
+                    .unwrap();
+            });
+        });
+
+        let mut cmd = Command::new("rewrk");
+        cmd.stdout(Stdio::piped());
+
+        cmd.arg("--host");
+        if let Some(path) = self.path {
+            cmd.arg(format!("http://{}{}", addr, path));
+        } else {
+            cmd.arg(format!("http://{}", addr));
+        }
+
+        cmd.args(&["--connections", "10"]);
+        cmd.args(&["--threads", "10"]);
+        cmd.args(&["--duration", "10s"]);
+
+        if let Some(method) = self.method {
+            cmd.arg("--method");
+            cmd.arg(method);
+        }
+
+        for (key, value) in self.headers.into_iter().flatten() {
+            cmd.arg("--header");
+            cmd.arg(format!("{}: {}", key, value));
+        }
+
+        if let Some(body) = self.body {
+            cmd.arg("--body");
+            cmd.arg(body);
+        }
+
+        eprintln!("Running {:?} benchmark", self.name);
+
+        // indent output from `rewrk` so its easier to read when running multiple benchmarks
+        let mut child = cmd.spawn().unwrap();
+        let stdout = child.stdout.take().unwrap();
+        let stdout = std::io::BufReader::new(stdout);
+        for line in stdout.lines() {
+            let line = line.unwrap();
+            println!("  {}", line);
+        }
+
+        let status = child.wait().unwrap();
+
+        if !status.success() {
+            eprintln!("`rewrk` command failed");
+            std::process::exit(status.code().unwrap());
+        }
+    }
+}
+
+fn ensure_rewrk_is_installed() {
+    let mut cmd = Command::new("rewrk");
+    cmd.arg("--help");
+    cmd.stdout(Stdio::null());
+    cmd.stderr(Stdio::null());
+    let status = cmd.status().unwrap();
+    if !status.success() {
+        eprintln!("rewrk is not installed. See https://github.com/lnx-search/rewrk");
+        std::process::exit(1);
+    }
+}

--- a/axum/benches/benches.rs
+++ b/axum/benches/benches.rs
@@ -96,12 +96,12 @@ impl BenchmarkBuilder {
     where
         F: FnOnce() -> Router,
     {
-        if !on_ci() {
-            // support only running some benchmarks with
-            // ```
-            // cargo bench -- routing send-json
-            // ```
-            let args = std::env::args().collect::<Vec<_>>();
+        // support only running some benchmarks with
+        // ```
+        // cargo bench -- routing send-json
+        // ```
+        let args = std::env::args().collect::<Vec<_>>();
+        if !args.len() == 1 {
             let names = &args[1..args.len() - 1];
             if !names.is_empty() && !names.contains(&self.name.to_owned()) {
                 return;

--- a/axum/benches/benches.rs
+++ b/axum/benches/benches.rs
@@ -178,9 +178,7 @@ fn ensure_rewrk_is_installed() {
     cmd.arg("--help");
     cmd.stdout(Stdio::null());
     cmd.stderr(Stdio::null());
-    let status = cmd.status().unwrap();
-    if !status.success() {
-        eprintln!("rewrk is not installed. See https://github.com/lnx-search/rewrk");
-        std::process::exit(1);
-    }
+    cmd.status().unwrap_or_else(|_| {
+        panic!("rewrk is not installed. See https://github.com/lnx-search/rewrk")
+    });
 }

--- a/axum/benches/benches.rs
+++ b/axum/benches/benches.rs
@@ -134,11 +134,7 @@ impl BenchmarkBuilder {
         cmd.stdout(Stdio::piped());
 
         cmd.arg("--host");
-        if let Some(path) = self.path {
-            cmd.arg(format!("http://{}{}", addr, path));
-        } else {
-            cmd.arg(format!("http://{}", addr));
-        }
+        cmd.arg(format!("http://{}{}", addr, self.path.unwrap_or("")));
 
         cmd.args(&["--connections", "10"]);
         cmd.args(&["--threads", "10"]);
@@ -152,8 +148,7 @@ impl BenchmarkBuilder {
         }
 
         if let Some(method) = self.method {
-            cmd.arg("--method");
-            cmd.arg(method);
+            cmd.args(&["--method", method]);
         }
 
         for (key, value) in self.headers.into_iter().flatten() {
@@ -162,8 +157,7 @@ impl BenchmarkBuilder {
         }
 
         if let Some(body) = self.body {
-            cmd.arg("--body");
-            cmd.arg(body);
+            cmd.args(&["--body", body]);
         }
 
         eprintln!("Running {:?} benchmark", self.name);

--- a/axum/benches/benches.rs
+++ b/axum/benches/benches.rs
@@ -96,15 +96,16 @@ impl BenchmarkBuilder {
     where
         F: FnOnce() -> Router,
     {
-        // support only running some benchmarks with
-        // ```
-        // cargo bench -- routing send-json
-        // ```
-        let args = std::env::args().collect::<Vec<_>>();
-        dbg!(&args);
-        let names = &args[1..args.len() - 1];
-        if !names.is_empty() && !names.contains(&self.name.to_owned()) {
-            return;
+        if !on_ci() {
+            // support only running some benchmarks with
+            // ```
+            // cargo bench -- routing send-json
+            // ```
+            let args = std::env::args().collect::<Vec<_>>();
+            let names = &args[1..args.len() - 1];
+            if !names.is_empty() && !names.contains(&self.name.to_owned()) {
+                return;
+            }
         }
 
         let app = f();

--- a/axum/benches/benches.rs
+++ b/axum/benches/benches.rs
@@ -10,6 +10,10 @@ use std::{
 };
 
 fn main() {
+    for (key, value) in std::env::vars() {
+        eprintln!("ENV: {:?} = {:?}", key, value);
+    }
+
     ensure_rewrk_is_installed();
 
     benchmark("minimal").run(Router::new);

--- a/axum/benches/benches.rs
+++ b/axum/benches/benches.rs
@@ -101,6 +101,7 @@ impl BenchmarkBuilder {
         // cargo bench -- routing send-json
         // ```
         let args = std::env::args().collect::<Vec<_>>();
+        dbg!(&args);
         let names = &args[1..args.len() - 1];
         if !names.is_empty() && !names.contains(&self.name.to_owned()) {
             return;

--- a/axum/src/test_helpers/test_client.rs
+++ b/axum/src/test_helpers/test_client.rs
@@ -109,6 +109,7 @@ impl RequestBuilder {
         self
     }
 
+    #[allow(dead_code)]
     pub(crate) fn multipart(mut self, form: reqwest::multipart::Form) -> Self {
         self.builder = self.builder.multipart(form);
         self


### PR DESCRIPTION
This adds a basic setup for writing benchmarks and adds a couple of benchmarks.

The output looks like this

```
❯ cargo bench -p axum -- send-json
   Compiling axum v0.5.10
    Finished bench [optimized] target(s) in 0.68s
     Running unittests src/lib.rs (target/release/deps/axum-732f709dd139ce93)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 203 filtered out; finished in 0.00s

     Running benches/benches.rs (target/release/deps/benches-ddcccec176823e7f)
Running "send-json" benchmark
  Beginning round 1...
  Benchmarking 10 connections @ http://0.0.0.0:58714 for 10 second(s)
    Latencies:
      Avg      Stdev    Min      Max
      0.06ms   0.03ms   0.02ms   4.06ms
    Requests:
      Total: 1689726 Req/Sec: 168960.39
    Transfer:
      Total: 228.83 MB Transfer Rate: 22.88 MB/Sec
```

It basically runs a default hyper server and shells out to [rewrk](https://github.com/lnx-search/rewrk) which does all the heavy lifting.

I went with rewrk rather than the default cargo bench tooling (or criterion) because I'm mainly interested in seeing requests per second and not how long a single request takes. I would also like to avoid configuring and running our own client. This seems fine to be me but let me know what you think.

Fixes https://github.com/tokio-rs/axum/issues/1199