### PR TITLE
Annotate panicking functions with `#[track_caller]`

### DIFF
--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -44,9 +44,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **change:** axum's MSRV is now 1.60 ([#1239])
 - **fixed:** Annotate panicking functions with `#[track_caller]` so the error
   message points to where the user added the invalid router, rather than
-  somewhere internally in axum
+  somewhere internally in axum ([#1248])
 
-[#1171]: https://github.com/tokio-rs/axum/pull/1171
 [#1077]: https://github.com/tokio-rs/axum/pull/1077
 [#1086]: https://github.com/tokio-rs/axum/pull/1086
 [#1088]: https://github.com/tokio-rs/axum/pull/1088
@@ -55,7 +54,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#1130]: https://github.com/tokio-rs/axum/pull/1130
 [#1135]: https://github.com/tokio-rs/axum/pull/1135
 [#1152]: https://github.com/tokio-rs/axum/pull/1152
+[#1171]: https://github.com/tokio-rs/axum/pull/1171
 [#1239]: https://github.com/tokio-rs/axum/pull/1239
+[#1248]: https://github.com/tokio-rs/axum/pull/1248
 [#924]: https://github.com/tokio-rs/axum/pull/924
 
 # 0.5.10 (28. June, 2022)

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -42,6 +42,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   relaxed so the response type must implement `IntoResponse` rather than being a
   literal `Response`
 - **change:** axum's MSRV is now 1.60 ([#1239])
+- **fixed:** Annotate panicking functions with `#[track_caller]` so the error
+  message points to where the user added the invalid router, rather than
+  somewhere internally in axum
 
 [#1171]: https://github.com/tokio-rs/axum/pull/1171
 [#1077]: https://github.com/tokio-rs/axum/pull/1077

--- a/axum/src/routing/method_routing.rs
+++ b/axum/src/routing/method_routing.rs
@@ -205,6 +205,7 @@ macro_rules! chained_service_fn {
         $name:ident, $method:ident
     ) => {
         $(#[$m])+
+        #[track_caller]
         pub fn $name<S>(self, svc: S) -> Self
         where
             S: Service<Request<ReqBody>, Error = E>
@@ -268,6 +269,7 @@ macro_rules! chained_handler_fn {
         $name:ident, $method:ident
     ) => {
         $(#[$m])+
+        #[track_caller]
         pub fn $name<H, T>(self, handler: H) -> Self
         where
             H: Handler<T, B>,
@@ -577,6 +579,7 @@ where
     /// # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
     /// # };
     /// ```
+    #[track_caller]
     pub fn on<H, T>(self, filter: MethodFilter, handler: H) -> Self
     where
         H: Handler<T, B>,
@@ -689,6 +692,7 @@ impl<ReqBody, E> MethodRouter<ReqBody, E> {
     /// # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
     /// # };
     /// ```
+    #[track_caller]
     pub fn on_service<S>(self, filter: MethodFilter, svc: S) -> Self
     where
         S: Service<Request<ReqBody>, Error = E> + Clone + Send + 'static,
@@ -783,8 +787,10 @@ impl<ReqBody, E> MethodRouter<ReqBody, E> {
     }
 
     #[doc = include_str!("../docs/method_routing/merge.md")]
+    #[track_caller]
     pub fn merge(mut self, other: MethodRouter<ReqBody, E>) -> Self {
         // written using inner functions to generate less IR
+        #[track_caller]
         fn merge_inner<T>(name: &str, first: Option<T>, second: Option<T>) -> Option<T> {
             match (first, second) {
                 (Some(_), Some(_)) => panic!(
@@ -796,6 +802,7 @@ impl<ReqBody, E> MethodRouter<ReqBody, E> {
             }
         }
 
+        #[track_caller]
         fn merge_fallback<B, E>(
             fallback: Fallback<B, E>,
             fallback_other: Fallback<B, E>,
@@ -843,6 +850,7 @@ impl<ReqBody, E> MethodRouter<ReqBody, E> {
         self.layer(HandleErrorLayer::new(f))
     }
 
+    #[track_caller]
     fn on_service_boxed_response_body<S>(mut self, filter: MethodFilter, svc: S) -> Self
     where
         S: Service<Request<ReqBody>, Error = E> + Clone + Send + 'static,

--- a/axum/src/routing/mod.rs
+++ b/axum/src/routing/mod.rs
@@ -114,6 +114,7 @@ where
     }
 
     #[doc = include_str!("../docs/routing/route.md")]
+    #[track_caller]
     pub fn route<T>(mut self, path: &str, service: T) -> Self
     where
         T: Service<Request<B>, Error = Infallible> + Clone + Send + 'static,
@@ -167,6 +168,7 @@ where
         self
     }
 
+    #[track_caller]
     fn set_node(&mut self, path: &str, id: RouteId) {
         let mut node =
             Arc::try_unwrap(Arc::clone(&self.node)).unwrap_or_else(|node| (*node).clone());
@@ -177,6 +179,7 @@ where
     }
 
     #[doc = include_str!("../docs/routing/nest.md")]
+    #[track_caller]
     pub fn nest<T>(mut self, mut path: &str, svc: T) -> Self
     where
         T: Service<Request<B>, Error = Infallible> + Clone + Send + 'static,
@@ -216,6 +219,7 @@ where
     }
 
     #[doc = include_str!("../docs/routing/merge.md")]
+    #[track_caller]
     pub fn merge<R>(mut self, other: R) -> Self
     where
         R: Into<Router<B>>,


### PR DESCRIPTION
This annotates panicking functions with `#[track_caller]` so the error message points to where the user added the invalid router, rather than somewhere internally in axum.

Before:

```
thread 'routing::tests::foobar' panicked at 'Invalid route "/:b": insertion failed due to conflict with previously registered route: /:a', axum/src/routing/mod.rs:174:13
```

After

```
thread 'routing::tests::foobar' panicked at 'Invalid route "/:b": insertion failed due to conflict with previously registered route: /:a', axum/src/routing/tests/mod.rs:667:10
```

This should make it even easier to hunt down which route actually causes the conflict.