### PR TITLE
Port cookie extractors to use state to extract keys

### DIFF
--- a/axum-extra/CHANGELOG.md
+++ b/axum-extra/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning].
   literal `Response`
 - **added:** Support chaining handlers with `HandlerCallWithExtractors::or` ([#1170])
 - **change:** axum-extra's MSRV is now 1.60 ([#1239])
+- **breaking:** `SignedCookieJar` and `PrivateCookieJar` now extracts the keys
+  from the router's state, rather than extensions
 
 [#1086]: https://github.com/tokio-rs/axum/pull/1086
 [#1119]: https://github.com/tokio-rs/axum/pull/1119

--- a/axum-extra/src/extract/cookie/private.rs
+++ b/axum-extra/src/extract/cookie/private.rs
@@ -3,7 +3,6 @@ use axum::{
     async_trait,
     extract::{FromRequest, RequestParts},
     response::{IntoResponse, IntoResponseParts, Response, ResponseParts},
-    Extension,
 };
 use cookie::PrivateJar;
 use std::{convert::Infallible, fmt, marker::PhantomData};
@@ -22,7 +21,6 @@ use std::{convert::Infallible, fmt, marker::PhantomData};
 /// ```rust
 /// use axum::{
 ///     Router,
-///     Extension,
 ///     routing::{post, get},
 ///     extract::TypedHeader,
 ///     response::{IntoResponse, Redirect},
@@ -44,22 +42,36 @@ use std::{convert::Infallible, fmt, marker::PhantomData};
 ///     }
 /// }
 ///
-/// // Generate a secure key
-/// //
-/// // You probably don't wanna generate a new one each time the app starts though
-/// let key = Key::generate();
+/// // our application state
+/// #[derive(Clone)]
+/// struct AppState {
+///     // that holds the key used to sign cookies
+///     key: Key,
+/// }
 ///
-/// let app = Router::new()
+/// // this impl tells `SignedCookieJar` how to access the key from our state
+/// impl From<AppState> for Key {
+///     fn from(state: AppState) -> Self {
+///         state.key
+///     }
+/// }
+///
+/// let state = AppState {
+///     // Generate a secure key
+///     //
+///     // You probably don't wanna generate a new one each time the app starts though
+///     key: Key::generate(),
+/// };
+///
+/// let app = Router::with_state(state)
 ///     .route("/set", post(set_secret))
-///     .route("/get", get(get_secret))
-///     // add extension with the key so `PrivateCookieJar` can access it
-///     .layer(Extension(key));
-/// # let app: Router = app;
+///     .route("/get", get(get_secret));
+/// # let app: Router<_> = app;
 /// ```
 pub struct PrivateCookieJar<K = Key> {
     jar: cookie::CookieJar,
     key: Key,
-    // The key used to extract the key extension. Allows users to use multiple keys for different
+    // The key used to extract the key. Allows users to use multiple keys for different
     // jars. Maybe a library wants its own key.
     _marker: PhantomData<K>,
 }
@@ -77,13 +89,15 @@ impl<K> fmt::Debug for PrivateCookieJar<K> {
 impl<S, B, K> FromRequest<B, S> for PrivateCookieJar<K>
 where
     B: Send,
-    S: Send,
+    S: Into<K> + Clone + Send,
     K: Into<Key> + Clone + Send + Sync + 'static,
 {
-    type Rejection = <axum::Extension<K> as FromRequest<B, S>>::Rejection;
+    type Rejection = Infallible;
 
     async fn from_request(req: &mut RequestParts<B, S>) -> Result<Self, Self::Rejection> {
-        let key = Extension::<K>::from_request(req).await?.0.into();
+        let state = req.state().clone();
+        let key: K = state.into();
+        let key: Key = key.into();
 
         let mut jar = cookie::CookieJar::new();
         let mut private_jar = jar.private_mut(&key);

--- a/axum-extra/src/extract/cookie/signed.rs
+++ b/axum-extra/src/extract/cookie/signed.rs
@@ -3,7 +3,6 @@ use axum::{
     async_trait,
     extract::{FromRequest, RequestParts},
     response::{IntoResponse, IntoResponseParts, Response, ResponseParts},
-    Extension,
 };
 use cookie::SignedJar;
 use cookie::{Cookie, Key};
@@ -23,7 +22,6 @@ use std::{convert::Infallible, fmt, marker::PhantomData};
 /// ```rust
 /// use axum::{
 ///     Router,
-///     Extension,
 ///     routing::{post, get},
 ///     extract::TypedHeader,
 ///     response::{IntoResponse, Redirect},
@@ -62,22 +60,36 @@ use std::{convert::Infallible, fmt, marker::PhantomData};
 ///     # todo!()
 /// }
 ///
-/// // Generate a secure key
-/// //
-/// // You probably don't wanna generate a new one each time the app starts though
-/// let key = Key::generate();
+/// // our application state
+/// #[derive(Clone)]
+/// struct AppState {
+///     // that holds the key used to sign cookies
+///     key: Key,
+/// }
 ///
-/// let app = Router::new()
+/// // this impl tells `SignedCookieJar` how to access the key from our state
+/// impl From<AppState> for Key {
+///     fn from(state: AppState) -> Self {
+///         state.key
+///     }
+/// }
+///
+/// let state = AppState {
+///     // Generate a secure key
+///     //
+///     // You probably don't wanna generate a new one each time the app starts though
+///     key: Key::generate(),
+/// };
+///
+/// let app = Router::with_state(state)
 ///     .route("/sessions", post(create_session))
-///     .route("/me", get(me))
-///     // add extension with the key so `SignedCookieJar` can access it
-///     .layer(Extension(key));
-/// # let app: Router = app;
+///     .route("/me", get(me));
+/// # let app: Router<_> = app;
 /// ```
 pub struct SignedCookieJar<K = Key> {
     jar: cookie::CookieJar,
     key: Key,
-    // The key used to extract the key extension. Allows users to use multiple keys for different
+    // The key used to extract the key. Allows users to use multiple keys for different
     // jars. Maybe a library wants its own key.
     _marker: PhantomData<K>,
 }
@@ -95,13 +107,15 @@ impl<K> fmt::Debug for SignedCookieJar<K> {
 impl<S, B, K> FromRequest<B, S> for SignedCookieJar<K>
 where
     B: Send,
-    S: Send,
+    S: Into<K> + Clone + Send,
     K: Into<Key> + Clone + Send + Sync + 'static,
 {
-    type Rejection = <axum::Extension<K> as FromRequest<B, S>>::Rejection;
+    type Rejection = Infallible;
 
     async fn from_request(req: &mut RequestParts<B, S>) -> Result<Self, Self::Rejection> {
-        let key = Extension::<K>::from_request(req).await?.0.into();
+        let state = req.state().clone();
+        let key: K = state.into();
+        let key: Key = key.into();
 
         let mut jar = cookie::CookieJar::new();
         let mut signed_jar = jar.signed_mut(&key);


### PR DESCRIPTION
This PR builds on https://github.com/tokio-rs/axum/pull/1155 by porting `SignedCookieJar` and `PrivateCookieJar` to extract the keys via state rather than loosely typed extensions.