### PR TITLE
Support using a different rejection for `#[derive(FromRequest)]`

### DIFF
--- a/axum-macros/CHANGELOG.md
+++ b/axum-macros/CHANGELOG.md
@@ -8,8 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # Unreleased
 
 - **change:** axum-macro's MSRV is now 1.60 ([#1239])
+- **added:** Support using a different rejection for `#[derive(FromRequest)]`
+  with `#[from_request(rejection(MyRejection))]` ([#1256])
 
 [#1239]: https://github.com/tokio-rs/axum/pull/1239
+[#1256]: https://github.com/tokio-rs/axum/pull/1256
 
 # 0.2.3 (27. June, 2022)
 

--- a/axum-macros/Cargo.toml
+++ b/axum-macros/Cargo.toml
@@ -25,6 +25,7 @@ axum = { path = "../axum", version = "0.5", features = ["headers"] }
 axum-extra = { path = "../axum-extra", version = "0.3", features = ["typed-routing"] }
 rustversion = "1.0"
 serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 syn = { version = "1.0", features = ["full", "extra-traits"] }
 tokio = { version = "1.0", features = ["full"] }
 trybuild = "1.0.63"

--- a/axum-macros/src/from_request.rs
+++ b/axum-macros/src/from_request.rs
@@ -37,11 +37,13 @@ pub(crate) fn expand(item: syn::Item) -> syn::Result<TokenStream> {
                     )
                 }
                 FromRequestContainerAttr::RejectionDerive(_, opt_outs) => {
-                    // TODO(david): check `generic_ident`
+                    error_on_generic_ident(generic_ident)?;
+
                     impl_struct_by_extracting_each_field(ident, fields, vis, opt_outs, None)
                 }
                 FromRequestContainerAttr::Rejection(rejection) => {
-                    // TODO(david): check `generic_ident`
+                    error_on_generic_ident(generic_ident)?;
+
                     impl_struct_by_extracting_each_field(
                         ident,
                         fields,
@@ -51,7 +53,8 @@ pub(crate) fn expand(item: syn::Item) -> syn::Result<TokenStream> {
                     )
                 }
                 FromRequestContainerAttr::None => {
-                    // TODO(david): check `generic_ident`
+                    error_on_generic_ident(generic_ident)?;
+
                     impl_struct_by_extracting_each_field(
                         ident,
                         fields,
@@ -179,6 +182,17 @@ fn parse_single_generic_type_on_struct(
             generics,
             "#[derive(FromRequest)] only supports 0 or 1 generic type parameters",
         )),
+    }
+}
+
+fn error_on_generic_ident(generic_ident: Option<Ident>) -> syn::Result<()> {
+    if let Some(generic_ident) = generic_ident {
+        Err(syn::Error::new_spanned(
+            generic_ident,
+            "#[derive(FromRequest)] only supports generics when used with #[from_request(via)]",
+        ))
+    } else {
+        Ok(())
     }
 }
 

--- a/axum-macros/src/from_request.rs
+++ b/axum-macros/src/from_request.rs
@@ -614,8 +614,14 @@ fn impl_struct_by_extracting_all_at_once(
     };
 
     let rejection_bound = rejection.as_ref().map(|rejection| {
-        quote! {
-            #rejection: ::std::convert::From<<#path<T> as ::axum::extract::FromRequest<B>>::Rejection>,
+        if generic_ident.is_some() {
+            quote! {
+                #rejection: ::std::convert::From<<#path<T> as ::axum::extract::FromRequest<B>>::Rejection>,
+            }
+        } else {
+            quote! {
+                #rejection: ::std::convert::From<<#path<Self> as ::axum::extract::FromRequest<B>>::Rejection>,
+            }
         }
     }).unwrap_or_default();
 

--- a/axum-macros/src/from_request.rs
+++ b/axum-macros/src/from_request.rs
@@ -1,5 +1,3 @@
-#![allow(unused_variables, clippy::todo)]
-
 use self::attr::{
     parse_container_attrs, parse_field_attrs, FromRequestContainerAttr, FromRequestFieldAttr,
     RejectionDeriveOptOuts,
@@ -207,7 +205,6 @@ fn impl_struct_by_extracting_each_field(
 
     let (rejection_ident, rejection) = if let Some(rejection) = rejection {
         let rejection_ident = syn::parse_quote!(#rejection);
-        let rejection = quote! { #rejection };
         (rejection_ident, None)
     } else if has_no_fields(&fields) {
         (syn::parse_quote!(::std::convert::Infallible), None)
@@ -740,17 +737,8 @@ fn ui() {
     #[rustversion::stable]
     fn go() {
         let t = trybuild::TestCases::new();
-
-        if let Ok(var) = std::env::var("ONLY") {
-            if var.contains("pass") {
-                t.pass(var);
-            } else {
-                t.compile_fail(var);
-            }
-        } else {
-            t.compile_fail("tests/from_request/fail/*.rs");
-            t.pass("tests/from_request/pass/*.rs");
-        }
+        t.compile_fail("tests/from_request/fail/*.rs");
+        t.pass("tests/from_request/pass/*.rs");
     }
 
     #[rustversion::not(stable)]

--- a/axum-macros/src/from_request/attr.rs
+++ b/axum-macros/src/from_request/attr.rs
@@ -11,7 +11,11 @@ pub(crate) struct FromRequestFieldAttr {
 }
 
 pub(crate) enum FromRequestContainerAttr {
-    Via(syn::Path),
+    Via {
+        path: syn::Path,
+        rejection: Option<syn::Path>,
+    },
+    Rejection(syn::Path),
     RejectionDerive(kw::rejection_derive, RejectionDeriveOptOuts),
     None,
 }
@@ -19,6 +23,7 @@ pub(crate) enum FromRequestContainerAttr {
 pub(crate) mod kw {
     syn::custom_keyword!(via);
     syn::custom_keyword!(rejection_derive);
+    syn::custom_keyword!(rejection);
     syn::custom_keyword!(Display);
     syn::custom_keyword!(Debug);
     syn::custom_keyword!(Error);
@@ -51,6 +56,7 @@ pub(crate) fn parse_container_attrs(
 
     let mut out_via = None;
     let mut out_rejection_derive = None;
+    let mut out_rejection = None;
 
     // we track the index of the attribute to know which comes last
     // used to give more accurate error messages
@@ -73,11 +79,18 @@ pub(crate) fn parse_container_attrs(
                     out_rejection_derive = Some((idx, rejection_derive, opt_outs));
                 }
             }
+            ContainerAttr::Rejection { rejection, path } => {
+                if out_rejection.is_some() {
+                    return Err(double_attr_error("rejection", rejection));
+                } else {
+                    out_rejection = Some((idx, rejection, path));
+                }
+            }
         }
     }
 
-    match (out_via, out_rejection_derive) {
-        (Some((via_idx, via, _)), Some((rejection_derive_idx, rejection_derive, _))) => {
+    match (out_via, out_rejection_derive, out_rejection) {
+        (Some((via_idx, via, _)), Some((rejection_derive_idx, rejection_derive, _)), _) => {
             if via_idx > rejection_derive_idx {
                 Err(syn::Error::new_spanned(
                     via,
@@ -90,11 +103,41 @@ pub(crate) fn parse_container_attrs(
                 ))
             }
         }
-        (Some((_, _, path)), None) => Ok(FromRequestContainerAttr::Via(path)),
-        (None, Some((_, rejection_derive, opt_outs))) => Ok(
+
+        (
+            _,
+            Some((rejection_derive_idx, rejection_derive, _)),
+            Some((rejection_idx, rejection, _)),
+        ) => {
+            if rejection_idx > rejection_derive_idx {
+                Err(syn::Error::new_spanned(
+                    rejection,
+                    "cannot use both `rejection_derive` and `rejection`",
+                ))
+            } else {
+                Err(syn::Error::new_spanned(
+                    rejection_derive,
+                    "cannot use both `rejection` and `rejection_derive`",
+                ))
+            }
+        }
+
+        (Some((_, _, path)), None, None) => Ok(FromRequestContainerAttr::Via {
+            path,
+            rejection: None,
+        }),
+        (Some((_, _, path)), None, Some((_, _, rejection))) => Ok(FromRequestContainerAttr::Via {
+            path,
+            rejection: Some(rejection),
+        }),
+
+        (None, Some((_, rejection_derive, opt_outs)), _) => Ok(
             FromRequestContainerAttr::RejectionDerive(rejection_derive, opt_outs),
         ),
-        (None, None) => Ok(FromRequestContainerAttr::None),
+
+        (None, None, Some((_, _, rejection))) => Ok(FromRequestContainerAttr::Rejection(rejection)),
+
+        (None, None, None) => Ok(FromRequestContainerAttr::None),
     }
 }
 
@@ -125,6 +168,10 @@ enum ContainerAttr {
         via: kw::via,
         path: syn::Path,
     },
+    Rejection {
+        rejection: kw::rejection,
+        path: syn::Path,
+    },
     RejectionDerive {
         rejection_derive: kw::rejection_derive,
         opt_outs: RejectionDeriveOptOuts,
@@ -147,6 +194,13 @@ impl Parse for ContainerAttr {
                 rejection_derive,
                 opt_outs,
             })
+        } else if lh.peek(kw::rejection) {
+            let rejection = input.parse::<kw::rejection>()?;
+            let content;
+            syn::parenthesized!(content in input);
+            content
+                .parse()
+                .map(|path| Self::Rejection { rejection, path })
         } else {
             Err(lh.error())
         }

--- a/axum-macros/tests/from_request/fail/generic.stderr
+++ b/axum-macros/tests/from_request/fail/generic.stderr
@@ -1,5 +1,5 @@
-error: `#[derive(FromRequest)] doesn't support generics
- --> tests/from_request/fail/generic.rs:4:17
+error: #[derive(FromRequest)] only supports generics on tuple structs that have exactly one field of the generic type
+ --> tests/from_request/fail/generic.rs:4:21
   |
 4 | struct Extractor<T>(Option<T>);
-  |                 ^^^
+  |                     ^^^^^^^^^

--- a/axum-macros/tests/from_request/fail/generic_without_via.rs
+++ b/axum-macros/tests/from_request/fail/generic_without_via.rs
@@ -1,0 +1,11 @@
+use axum::{body::Body, routing::get, Extension, Router};
+use axum_macros::FromRequest;
+
+#[derive(FromRequest, Clone)]
+struct Extractor<T>(T);
+
+async fn foo(_: Extractor<()>) {}
+
+fn main() {
+    Router::<Body>::new().route("/", get(foo));
+}

--- a/axum-macros/tests/from_request/fail/generic_without_via.stderr
+++ b/axum-macros/tests/from_request/fail/generic_without_via.stderr
@@ -1,0 +1,29 @@
+error: #[derive(FromRequest)] only supports generics when used with #[from_request(via)]
+ --> tests/from_request/fail/generic_without_via.rs:5:18
+  |
+5 | struct Extractor<T>(T);
+  |                  ^
+
+warning: unused import: `Extension`
+ --> tests/from_request/fail/generic_without_via.rs:1:38
+  |
+1 | use axum::{body::Body, routing::get, Extension, Router};
+  |                                      ^^^^^^^^^
+  |
+  = note: `#[warn(unused_imports)]` on by default
+
+error[E0277]: the trait bound `fn(Extractor<()>) -> impl Future<Output = ()> {foo}: Handler<_, _>` is not satisfied
+   --> tests/from_request/fail/generic_without_via.rs:10:42
+    |
+10  |     Router::<Body>::new().route("/", get(foo));
+    |                                      --- ^^^ the trait `Handler<_, _>` is not implemented for `fn(Extractor<()>) -> impl Future<Output = ()> {foo}`
+    |                                      |
+    |                                      required by a bound introduced by this call
+    |
+    = help: the trait `Handler<T, ReqBody>` is implemented for `Layered<S, T>`
+note: required by a bound in `axum::routing::get`
+   --> $WORKSPACE/axum/src/routing/method_routing.rs
+    |
+    | top_level_handler_fn!(get, GET);
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `axum::routing::get`
+    = note: this error originates in the macro `top_level_handler_fn` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/axum-macros/tests/from_request/fail/generic_without_via_rejection.rs
+++ b/axum-macros/tests/from_request/fail/generic_without_via_rejection.rs
@@ -1,0 +1,12 @@
+use axum::{body::Body, routing::get, Extension, Router};
+use axum_macros::FromRequest;
+
+#[derive(FromRequest, Clone)]
+#[from_request(rejection(Foo))]
+struct Extractor<T>(T);
+
+async fn foo(_: Extractor<()>) {}
+
+fn main() {
+    Router::<Body>::new().route("/", get(foo));
+}

--- a/axum-macros/tests/from_request/fail/generic_without_via_rejection.stderr
+++ b/axum-macros/tests/from_request/fail/generic_without_via_rejection.stderr
@@ -1,0 +1,29 @@
+error: #[derive(FromRequest)] only supports generics when used with #[from_request(via)]
+ --> tests/from_request/fail/generic_without_via_rejection.rs:6:18
+  |
+6 | struct Extractor<T>(T);
+  |                  ^
+
+warning: unused import: `Extension`
+ --> tests/from_request/fail/generic_without_via_rejection.rs:1:38
+  |
+1 | use axum::{body::Body, routing::get, Extension, Router};
+  |                                      ^^^^^^^^^
+  |
+  = note: `#[warn(unused_imports)]` on by default
+
+error[E0277]: the trait bound `fn(Extractor<()>) -> impl Future<Output = ()> {foo}: Handler<_, _>` is not satisfied
+   --> tests/from_request/fail/generic_without_via_rejection.rs:11:42
+    |
+11  |     Router::<Body>::new().route("/", get(foo));
+    |                                      --- ^^^ the trait `Handler<_, _>` is not implemented for `fn(Extractor<()>) -> impl Future<Output = ()> {foo}`
+    |                                      |
+    |                                      required by a bound introduced by this call
+    |
+    = help: the trait `Handler<T, ReqBody>` is implemented for `Layered<S, T>`
+note: required by a bound in `axum::routing::get`
+   --> $WORKSPACE/axum/src/routing/method_routing.rs
+    |
+    | top_level_handler_fn!(get, GET);
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `axum::routing::get`
+    = note: this error originates in the macro `top_level_handler_fn` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/axum-macros/tests/from_request/fail/generic_without_via_rejection_derive.rs
+++ b/axum-macros/tests/from_request/fail/generic_without_via_rejection_derive.rs
@@ -1,0 +1,12 @@
+use axum::{body::Body, routing::get, Extension, Router};
+use axum_macros::FromRequest;
+
+#[derive(FromRequest, Clone)]
+#[from_request(rejection_derive(!Error))]
+struct Extractor<T>(T);
+
+async fn foo(_: Extractor<()>) {}
+
+fn main() {
+    Router::<Body>::new().route("/", get(foo));
+}

--- a/axum-macros/tests/from_request/fail/generic_without_via_rejection_derive.stderr
+++ b/axum-macros/tests/from_request/fail/generic_without_via_rejection_derive.stderr
@@ -1,0 +1,29 @@
+error: #[derive(FromRequest)] only supports generics when used with #[from_request(via)]
+ --> tests/from_request/fail/generic_without_via_rejection_derive.rs:6:18
+  |
+6 | struct Extractor<T>(T);
+  |                  ^
+
+warning: unused import: `Extension`
+ --> tests/from_request/fail/generic_without_via_rejection_derive.rs:1:38
+  |
+1 | use axum::{body::Body, routing::get, Extension, Router};
+  |                                      ^^^^^^^^^
+  |
+  = note: `#[warn(unused_imports)]` on by default
+
+error[E0277]: the trait bound `fn(Extractor<()>) -> impl Future<Output = ()> {foo}: Handler<_, _>` is not satisfied
+   --> tests/from_request/fail/generic_without_via_rejection_derive.rs:11:42
+    |
+11  |     Router::<Body>::new().route("/", get(foo));
+    |                                      --- ^^^ the trait `Handler<_, _>` is not implemented for `fn(Extractor<()>) -> impl Future<Output = ()> {foo}`
+    |                                      |
+    |                                      required by a bound introduced by this call
+    |
+    = help: the trait `Handler<T, ReqBody>` is implemented for `Layered<S, T>`
+note: required by a bound in `axum::routing::get`
+   --> $WORKSPACE/axum/src/routing/method_routing.rs
+    |
+    | top_level_handler_fn!(get, GET);
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `axum::routing::get`
+    = note: this error originates in the macro `top_level_handler_fn` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/axum-macros/tests/from_request/fail/override_rejection_on_enum_without_via.rs
+++ b/axum-macros/tests/from_request/fail/override_rejection_on_enum_without_via.rs
@@ -1,0 +1,33 @@
+use axum::{
+    extract::rejection::ExtensionRejection,
+    response::{IntoResponse, Response},
+    routing::get,
+    Router,
+};
+use axum_macros::FromRequest;
+
+fn main() {
+    let _: Router = Router::new().route("/", get(handler).post(handler_result));
+}
+
+async fn handler(_: MyExtractor) {}
+
+async fn handler_result(_: Result<MyExtractor, MyRejection>) {}
+
+#[derive(FromRequest, Clone)]
+#[from_request(rejection(MyRejection))]
+enum MyExtractor {}
+
+struct MyRejection {}
+
+impl From<ExtensionRejection> for MyRejection {
+    fn from(_: ExtensionRejection) -> Self {
+        todo!()
+    }
+}
+
+impl IntoResponse for MyRejection {
+    fn into_response(self) -> Response {
+        todo!()
+    }
+}

--- a/axum-macros/tests/from_request/fail/override_rejection_on_enum_without_via.stderr
+++ b/axum-macros/tests/from_request/fail/override_rejection_on_enum_without_via.stderr
@@ -1,0 +1,37 @@
+error: cannot use `rejection` without `via`
+  --> tests/from_request/fail/override_rejection_on_enum_without_via.rs:18:26
+   |
+18 | #[from_request(rejection(MyRejection))]
+   |                          ^^^^^^^^^^^
+
+error[E0277]: the trait bound `fn(MyExtractor) -> impl Future<Output = ()> {handler}: Handler<_, _>` is not satisfied
+   --> tests/from_request/fail/override_rejection_on_enum_without_via.rs:10:50
+    |
+10  |     let _: Router = Router::new().route("/", get(handler).post(handler_result));
+    |                                              --- ^^^^^^^ the trait `Handler<_, _>` is not implemented for `fn(MyExtractor) -> impl Future<Output = ()> {handler}`
+    |                                              |
+    |                                              required by a bound introduced by this call
+    |
+    = help: the trait `Handler<T, ReqBody>` is implemented for `Layered<S, T>`
+note: required by a bound in `axum::routing::get`
+   --> $WORKSPACE/axum/src/routing/method_routing.rs
+    |
+    | top_level_handler_fn!(get, GET);
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `axum::routing::get`
+    = note: this error originates in the macro `top_level_handler_fn` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `fn(Result<MyExtractor, MyRejection>) -> impl Future<Output = ()> {handler_result}: Handler<_, _>` is not satisfied
+   --> tests/from_request/fail/override_rejection_on_enum_without_via.rs:10:64
+    |
+10  |     let _: Router = Router::new().route("/", get(handler).post(handler_result));
+    |                                                           ---- ^^^^^^^^^^^^^^ the trait `Handler<_, _>` is not implemented for `fn(Result<MyExtractor, MyRejection>) -> impl Future<Output = ()> {handler_result}`
+    |                                                           |
+    |                                                           required by a bound introduced by this call
+    |
+    = help: the trait `Handler<T, ReqBody>` is implemented for `Layered<S, T>`
+note: required by a bound in `MethodRouter::<B>::post`
+   --> $WORKSPACE/axum/src/routing/method_routing.rs
+    |
+    |     chained_handler_fn!(post, POST);
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `MethodRouter::<B>::post`
+    = note: this error originates in the macro `chained_handler_fn` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/axum-macros/tests/from_request/fail/unknown_attr_container.stderr
+++ b/axum-macros/tests/from_request/fail/unknown_attr_container.stderr
@@ -1,4 +1,4 @@
-error: expected `via` or `rejection_derive`
+error: expected one of: `via`, `rejection_derive`, `rejection`
  --> tests/from_request/fail/unknown_attr_container.rs:4:16
   |
 4 | #[from_request(foo)]

--- a/axum-macros/tests/from_request/pass/override_rejection.rs
+++ b/axum-macros/tests/from_request/pass/override_rejection.rs
@@ -1,0 +1,41 @@
+use axum::{
+    extract::rejection::JsonRejection,
+    response::{IntoResponse, Response},
+    routing::get,
+    Router,
+};
+use axum_macros::FromRequest;
+use serde::Deserialize;
+
+fn main() {
+    let _: Router = Router::new().route("/", get(handler).post(handler_result));
+}
+
+#[derive(Deserialize)]
+struct Payload {}
+
+async fn handler(_: MyJson<Payload>) {}
+
+async fn handler_result(_: Result<MyJson<Payload>, MyJsonRejection>) {}
+
+#[derive(FromRequest)]
+#[from_request(
+    // TODO(david): `rejection(...)` without `via(...)`
+    via(axum::Json),
+    rejection(MyJsonRejection),
+)]
+struct MyJson<T>(T);
+
+struct MyJsonRejection {}
+
+impl From<JsonRejection> for MyJsonRejection {
+    fn from(_: JsonRejection) -> Self {
+        todo!()
+    }
+}
+
+impl IntoResponse for MyJsonRejection {
+    fn into_response(self) -> Response {
+        todo!()
+    }
+}

--- a/axum-macros/tests/from_request/pass/override_rejection_with_via_on_enum.rs
+++ b/axum-macros/tests/from_request/pass/override_rejection_with_via_on_enum.rs
@@ -1,0 +1,33 @@
+use axum::{
+    extract::rejection::ExtensionRejection,
+    response::{IntoResponse, Response},
+    routing::get,
+    Router,
+};
+use axum_macros::FromRequest;
+
+fn main() {
+    let _: Router = Router::new().route("/", get(handler).post(handler_result));
+}
+
+async fn handler(_: MyExtractor) {}
+
+async fn handler_result(_: Result<MyExtractor, MyRejection>) {}
+
+#[derive(FromRequest, Clone)]
+#[from_request(via(axum::Extension), rejection(MyRejection))]
+enum MyExtractor {}
+
+struct MyRejection {}
+
+impl From<ExtensionRejection> for MyRejection {
+    fn from(_: ExtensionRejection) -> Self {
+        todo!()
+    }
+}
+
+impl IntoResponse for MyRejection {
+    fn into_response(self) -> Response {
+        todo!()
+    }
+}

--- a/axum-macros/tests/from_request/pass/override_rejection_with_via_on_struct.rs
+++ b/axum-macros/tests/from_request/pass/override_rejection_with_via_on_struct.rs
@@ -20,7 +20,6 @@ async fn handler_result(_: Result<MyJson<Payload>, MyJsonRejection>) {}
 
 #[derive(FromRequest)]
 #[from_request(
-    // TODO(david): `rejection(...)` without `via(...)`
     via(axum::Json),
     rejection(MyJsonRejection),
 )]

--- a/axum-macros/tests/from_request/pass/override_rejection_with_via_on_struct.rs
+++ b/axum-macros/tests/from_request/pass/override_rejection_with_via_on_struct.rs
@@ -1,0 +1,41 @@
+use axum::{
+    extract::rejection::JsonRejection,
+    response::{IntoResponse, Response},
+    routing::get,
+    Router,
+};
+use axum_macros::FromRequest;
+use serde::Deserialize;
+
+fn main() {
+    let _: Router = Router::new().route("/", get(handler).post(handler_result));
+}
+
+#[derive(Deserialize)]
+struct Payload {}
+
+async fn handler(_: MyJson<Payload>) {}
+
+async fn handler_result(_: Result<MyJson<Payload>, MyJsonRejection>) {}
+
+#[derive(FromRequest)]
+#[from_request(
+    // TODO(david): `rejection(...)` without `via(...)`
+    via(axum::Json),
+    rejection(MyJsonRejection),
+)]
+struct MyJson<T>(T);
+
+struct MyJsonRejection {}
+
+impl From<JsonRejection> for MyJsonRejection {
+    fn from(_: JsonRejection) -> Self {
+        todo!()
+    }
+}
+
+impl IntoResponse for MyJsonRejection {
+    fn into_response(self) -> Response {
+        todo!()
+    }
+}


### PR DESCRIPTION
This implements the suggestion I made [here](https://github.com/tokio-rs/axum/issues/1116#issuecomment-1195392516). I.e. one can change the rejection type in `#[derive(FromRequest)]` like so:

```rust
#[derive(FromRequest)]
#[from_request(via(axum::Json), rejection(MyRejection))]
struct MyJson<T>(T);

struct MyRejection(Response);

impl From<JsonRejection> for MyRejection {
    fn from(rejection: JsonRejection) -> Self {
        let response = (
            StatusCode::INTERNAL_SERVER_ERROR,
            axum::Json(json!({ "error": rejection.to_string() })),
        ).into_response();

        MyRejection(response)
    }
}

impl IntoResponse for MyRejection {
    fn into_response(self) -> Response {
        self.0
    }
}

#[derive(Deserialize)]
struct Payload {}

async fn handler(MyJson(payload): MyJson<Payload>) {}
```

I like this quite a bit as it takes most of the boilerplate out of wrapping extractors and importantly doesn't require users write any complex trait bounds (like the ones `Json` requires).

It also supports a couple of more use cases which are shown in the docs.