### PR TITLE
Add sync constructors to `CookieJar`, `SignedCookieJar`, and `PrivateCookieJar`

### DIFF
--- a/axum-extra/CHANGELOG.md
+++ b/axum-extra/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning].
 - **added:** Support chaining handlers with `HandlerCallWithExtractors::or` ([#1170])
 - **change:** axum-extra's MSRV is now 1.60 ([#1239])
 - **added:** Add Protocol Buffer extractor and response ([#1239])
+- **added:** Add sync constructors to `CookieJar`, `PrivateCookieJar`, and
+  `SignedCookieJar` so they're easier to use in custom middleware
 
 [#1086]: https://github.com/tokio-rs/axum/pull/1086
 [#1119]: https://github.com/tokio-rs/axum/pull/1119

--- a/axum-extra/src/extract/cookie/private.rs
+++ b/axum-extra/src/extract/cookie/private.rs
@@ -6,6 +6,7 @@ use axum::{
     Extension,
 };
 use cookie::PrivateJar;
+use http::HeaderMap;
 use std::{convert::Infallible, fmt, marker::PhantomData};
 
 /// Extractor that grabs private cookies from the request and manages the jar.
@@ -83,20 +84,52 @@ where
 
     async fn from_request(req: &mut RequestParts<B>) -> Result<Self, Self::Rejection> {
         let key = Extension::<K>::from_request(req).await?.0.into();
+        let PrivateCookieJar {
+            jar,
+            key,
+            _marker: _,
+        } = PrivateCookieJar::from_headers(req.headers(), key);
+        Ok(PrivateCookieJar {
+            jar,
+            key,
+            _marker: PhantomData,
+        })
+    }
+}
 
+impl PrivateCookieJar {
+    /// Create a new `PrivateCookieJar` from a map of request headers.
+    ///
+    /// The valid cookies in `headers` will be added to the jar.
+    ///
+    /// This is inteded to be used in middleware and other where places it might be difficult to
+    /// run extractors. Normally you should create `PrivateCookieJar`s through [`FromRequest`].
+    pub fn from_headers(headers: &HeaderMap, key: Key) -> Self {
         let mut jar = cookie::CookieJar::new();
         let mut private_jar = jar.private_mut(&key);
-        for cookie in cookies_from_request(req) {
+        for cookie in cookies_from_request(headers) {
             if let Some(cookie) = private_jar.decrypt(cookie) {
                 private_jar.add_original(cookie);
             }
         }
 
-        Ok(Self {
+        Self {
             jar,
             key,
             _marker: PhantomData,
-        })
+        }
+    }
+
+    /// Create a new empty `PrivateCookieJarIter`.
+    ///
+    /// This is inteded to be used in middleware and other places where it might be difficult to
+    /// run extractors. Normally you should create `PrivateCookieJar`s through [`FromRequest`].
+    pub fn new(key: Key) -> Self {
+        Self {
+            jar: Default::default(),
+            key,
+            _marker: PhantomData,
+        }
     }
 }
 

--- a/axum-extra/src/extract/cookie/private.rs
+++ b/axum-extra/src/extract/cookie/private.rs
@@ -83,7 +83,7 @@ where
     type Rejection = <axum::Extension<K> as FromRequest<B>>::Rejection;
 
     async fn from_request(req: &mut RequestParts<B>) -> Result<Self, Self::Rejection> {
-        let key = Extension::<K>::from_request(req).await?.0.into();
+        let key = req.extract::<Extension<K>>().await?.0.into();
         let PrivateCookieJar {
             jar,
             key,

--- a/axum-extra/src/extract/cookie/signed.rs
+++ b/axum-extra/src/extract/cookie/signed.rs
@@ -101,7 +101,7 @@ where
     type Rejection = <axum::Extension<K> as FromRequest<B>>::Rejection;
 
     async fn from_request(req: &mut RequestParts<B>) -> Result<Self, Self::Rejection> {
-        let key = Extension::<K>::from_request(req).await?.0.into();
+        let key = req.extract::<Extension<K>>().await?.0.into();
         let SignedCookieJar {
             jar,
             key,

--- a/axum-extra/src/extract/cookie/signed.rs
+++ b/axum-extra/src/extract/cookie/signed.rs
@@ -7,6 +7,7 @@ use axum::{
 };
 use cookie::SignedJar;
 use cookie::{Cookie, Key};
+use http::HeaderMap;
 use std::{convert::Infallible, fmt, marker::PhantomData};
 
 /// Extractor that grabs signed cookies from the request and manages the jar.
@@ -101,20 +102,52 @@ where
 
     async fn from_request(req: &mut RequestParts<B>) -> Result<Self, Self::Rejection> {
         let key = Extension::<K>::from_request(req).await?.0.into();
+        let SignedCookieJar {
+            jar,
+            key,
+            _marker: _,
+        } = SignedCookieJar::from_headers(req.headers(), key);
+        Ok(SignedCookieJar {
+            jar,
+            key,
+            _marker: PhantomData,
+        })
+    }
+}
 
+impl SignedCookieJar {
+    /// Create a new `SignedCookieJar` from a map of request headers.
+    ///
+    /// The valid cookies in `headers` will be added to the jar.
+    ///
+    /// This is inteded to be used in middleware and other places where it might be difficult to
+    /// run extractors. Normally you should create `SignedCookieJar`s through [`FromRequest`].
+    pub fn from_headers(headers: &HeaderMap, key: Key) -> Self {
         let mut jar = cookie::CookieJar::new();
         let mut signed_jar = jar.signed_mut(&key);
-        for cookie in cookies_from_request(req) {
+        for cookie in cookies_from_request(headers) {
             if let Some(cookie) = signed_jar.verify(cookie) {
                 signed_jar.add_original(cookie);
             }
         }
 
-        Ok(Self {
+        Self {
             jar,
             key,
             _marker: PhantomData,
-        })
+        }
+    }
+
+    /// Create a new empty `SignedCookieJar`.
+    ///
+    /// This is inteded to be used in middleware and other places where it might be difficult to
+    /// run extractors. Normally you should create `SignedCookieJar`s through [`FromRequest`].
+    pub fn new(key: Key) -> Self {
+        Self {
+            jar: Default::default(),
+            key,
+            _marker: PhantomData,
+        }
     }
 }
 


### PR DESCRIPTION
This makes them easier to use in middleware which I think is a use case we should support.