### PR TITLE
Make `WithRejection::into_inner` public

### DIFF
--- a/axum-extra/src/extract/with_rejection.rs
+++ b/axum-extra/src/extract/with_rejection.rs
@@ -58,7 +58,7 @@ pub struct WithRejection<E, R>(pub E, pub PhantomData<R>);
 
 impl<E, R> WithRejection<E, R> {
     /// Returns the wrapped extractor
-    fn into_inner(self) -> E {
+    pub fn into_inner(self) -> E {
         self.0
     }
 }


### PR DESCRIPTION
Missed this in https://github.com/tokio-rs/axum/pull/1262