### PR TITLE
Always store state in an `Arc`

### DIFF
--- a/axum-core/src/extract/request_parts.rs
+++ b/axum-core/src/extract/request_parts.rs
@@ -9,7 +9,7 @@ use std::{convert::Infallible, sync::Arc};
 impl<S, B> FromRequest<S, B> for Request<B>
 where
     B: Send,
-    S: Clone + Send + Sync,
+    S: Send + Sync,
 {
     type Rejection = BodyAlreadyExtracted;
 

--- a/axum-core/src/extract/request_parts.rs
+++ b/axum-core/src/extract/request_parts.rs
@@ -9,7 +9,7 @@ use std::convert::Infallible;
 impl<S, B> FromRequest<S, B> for Request<B>
 where
     B: Send,
-    S: Clone + Send,
+    S: Clone + Send + Sync,
 {
     type Rejection = BodyAlreadyExtracted;
 
@@ -17,7 +17,7 @@ where
         let req = std::mem::replace(
             req,
             RequestParts {
-                state: req.state().clone(),
+                state: req.state.clone(),
                 method: req.method.clone(),
                 version: req.version,
                 uri: req.uri.clone(),
@@ -35,7 +35,7 @@ where
 impl<S, B> FromRequest<S, B> for Method
 where
     B: Send,
-    S: Send,
+    S: Send + Sync,
 {
     type Rejection = Infallible;
 
@@ -48,7 +48,7 @@ where
 impl<S, B> FromRequest<S, B> for Uri
 where
     B: Send,
-    S: Send,
+    S: Send + Sync,
 {
     type Rejection = Infallible;
 
@@ -61,7 +61,7 @@ where
 impl<S, B> FromRequest<S, B> for Version
 where
     B: Send,
-    S: Send,
+    S: Send + Sync,
 {
     type Rejection = Infallible;
 
@@ -79,7 +79,7 @@ where
 impl<S, B> FromRequest<S, B> for HeaderMap
 where
     B: Send,
-    S: Send,
+    S: Send + Sync,
 {
     type Rejection = Infallible;
 
@@ -94,7 +94,7 @@ where
     B: http_body::Body + Send,
     B::Data: Send,
     B::Error: Into<BoxError>,
-    S: Send,
+    S: Send + Sync,
 {
     type Rejection = BytesRejection;
 
@@ -115,7 +115,7 @@ where
     B: http_body::Body + Send,
     B::Data: Send,
     B::Error: Into<BoxError>,
-    S: Send,
+    S: Send + Sync,
 {
     type Rejection = StringRejection;
 
@@ -137,7 +137,7 @@ where
 impl<S, B> FromRequest<S, B> for http::request::Parts
 where
     B: Send,
-    S: Send,
+    S: Send + Sync,
 {
     type Rejection = Infallible;
 

--- a/axum-core/src/extract/request_parts.rs
+++ b/axum-core/src/extract/request_parts.rs
@@ -3,7 +3,7 @@ use crate::BoxError;
 use async_trait::async_trait;
 use bytes::Bytes;
 use http::{Extensions, HeaderMap, Method, Request, Uri, Version};
-use std::convert::Infallible;
+use std::{convert::Infallible, sync::Arc};
 
 #[async_trait]
 impl<S, B> FromRequest<S, B> for Request<B>
@@ -17,7 +17,7 @@ where
         let req = std::mem::replace(
             req,
             RequestParts {
-                state: req.state.clone(),
+                state: Arc::clone(&req.state),
                 method: req.method.clone(),
                 version: req.version,
                 uri: req.uri.clone(),

--- a/axum-core/src/extract/tuple.rs
+++ b/axum-core/src/extract/tuple.rs
@@ -7,7 +7,7 @@ use std::convert::Infallible;
 impl<S, B> FromRequest<S, B> for ()
 where
     B: Send,
-    S: Send,
+    S: Send + Sync,
 {
     type Rejection = Infallible;
 
@@ -26,7 +26,7 @@ macro_rules! impl_from_request {
         where
             $( $ty: FromRequest<S, B> + Send, )*
             B: Send,
-            S: Send,
+            S: Send + Sync,
         {
             type Rejection = Response;
 

--- a/axum-extra/src/either.rs
+++ b/axum-extra/src/either.rs
@@ -195,7 +195,7 @@ macro_rules! impl_traits_for_either {
             $($ident: FromRequest<S, B>),*,
             $last: FromRequest<S, B>,
             B: Send,
-            S: Send,
+            S: Send + Sync,
         {
             type Rejection = $last::Rejection;
 

--- a/axum-extra/src/extract/cached.rs
+++ b/axum-extra/src/extract/cached.rs
@@ -33,7 +33,7 @@ use std::ops::{Deref, DerefMut};
 /// impl<S, B> FromRequest<S, B> for Session
 /// where
 ///     B: Send,
-///     S: Send,
+///     S: Send + Sync,
 /// {
 ///     type Rejection = (StatusCode, String);
 ///
@@ -49,7 +49,7 @@ use std::ops::{Deref, DerefMut};
 /// impl<S, B> FromRequest<S, B> for CurrentUser
 /// where
 ///     B: Send,
-///     S: Send,
+///     S: Send + Sync,
 /// {
 ///     type Rejection = Response;
 ///
@@ -93,7 +93,7 @@ struct CachedEntry<T>(T);
 impl<S, B, T> FromRequest<S, B> for Cached<T>
 where
     B: Send,
-    S: Send,
+    S: Send + Sync,
     T: FromRequest<S, B> + Clone + Send + Sync + 'static,
 {
     type Rejection = T::Rejection;
@@ -145,7 +145,7 @@ mod tests {
         impl<S, B> FromRequest<S, B> for Extractor
         where
             B: Send,
-            S: Send,
+            S: Send + Sync,
         {
             type Rejection = Infallible;
 

--- a/axum-extra/src/extract/cookie/mod.rs
+++ b/axum-extra/src/extract/cookie/mod.rs
@@ -91,7 +91,7 @@ pub struct CookieJar {
 impl<S, B> FromRequest<S, B> for CookieJar
 where
     B: Send,
-    S: Send,
+    S: Send + Sync,
 {
     type Rejection = Infallible;
 

--- a/axum-extra/src/extract/cookie/private.rs
+++ b/axum-extra/src/extract/cookie/private.rs
@@ -90,7 +90,7 @@ impl<K> fmt::Debug for PrivateCookieJar<K> {
 impl<S, B, K> FromRequest<S, B> for PrivateCookieJar<K>
 where
     B: Send,
-    S: Send,
+    S: Send + Sync,
     K: FromRef<S> + Into<Key>,
 {
     type Rejection = Infallible;

--- a/axum-extra/src/extract/cookie/signed.rs
+++ b/axum-extra/src/extract/cookie/signed.rs
@@ -108,7 +108,7 @@ impl<K> fmt::Debug for SignedCookieJar<K> {
 impl<S, B, K> FromRequest<S, B> for SignedCookieJar<K>
 where
     B: Send,
-    S: Send,
+    S: Send + Sync,
     K: FromRef<S> + Into<Key>,
 {
     type Rejection = Infallible;

--- a/axum-extra/src/extract/form.rs
+++ b/axum-extra/src/extract/form.rs
@@ -61,7 +61,7 @@ where
     B: HttpBody + Send,
     B::Data: Send,
     B::Error: Into<BoxError>,
-    S: Send,
+    S: Send + Sync,
 {
     type Rejection = FormRejection;
 

--- a/axum-extra/src/extract/query.rs
+++ b/axum-extra/src/extract/query.rs
@@ -62,7 +62,7 @@ impl<T, S, B> FromRequest<S, B> for Query<T>
 where
     T: DeserializeOwned,
     B: Send,
-    S: Send,
+    S: Send + Sync,
 {
     type Rejection = QueryRejection;
 

--- a/axum-extra/src/extract/with_rejection.rs
+++ b/axum-extra/src/extract/with_rejection.rs
@@ -110,7 +110,7 @@ impl<E, R> DerefMut for WithRejection<E, R> {
 impl<B, E, R, S> FromRequest<S, B> for WithRejection<E, R>
 where
     B: Send,
-    S: Send,
+    S: Send + Sync,
     E: FromRequest<S, B>,
     R: From<E::Rejection> + IntoResponse,
 {
@@ -138,7 +138,7 @@ mod tests {
         impl<S, B> FromRequest<S, B> for TestExtractor
         where
             B: Send,
-            S: Send,
+            S: Send + Sync,
         {
             type Rejection = ();
 

--- a/axum-extra/src/handler/mod.rs
+++ b/axum-extra/src/handler/mod.rs
@@ -6,7 +6,7 @@ use axum::{
     response::{IntoResponse, Response},
 };
 use futures_util::future::{BoxFuture, FutureExt, Map};
-use std::{future::Future, marker::PhantomData};
+use std::{future::Future, marker::PhantomData, sync::Arc};
 
 mod or;
 
@@ -24,7 +24,11 @@ pub trait HandlerCallWithExtractors<T, S, B>: Sized {
     type Future: Future<Output = Response> + Send + 'static;
 
     /// Call the handler with the extracted inputs.
-    fn call(self, state: S, extractors: T) -> <Self as HandlerCallWithExtractors<T, S, B>>::Future;
+    fn call(
+        self,
+        state: Arc<S>,
+        extractors: T,
+    ) -> <Self as HandlerCallWithExtractors<T, S, B>>::Future;
 
     /// Conver this `HandlerCallWithExtractors` into [`Handler`].
     fn into_handler(self) -> IntoHandler<Self, T, S, B> {
@@ -130,7 +134,7 @@ macro_rules! impl_handler_call_with {
 
             fn call(
                 self,
-                _state: S,
+                _state: Arc<S>,
                 ($($ty,)*): ($($ty,)*),
             ) -> <Self as HandlerCallWithExtractors<($($ty,)*), S, B>>::Future {
                 self($($ty,)*).map(IntoResponse::into_response)
@@ -176,9 +180,9 @@ where
 {
     type Future = BoxFuture<'static, Response>;
 
-    fn call(self, state: S, req: http::Request<B>) -> Self::Future {
+    fn call(self, state: Arc<S>, req: http::Request<B>) -> Self::Future {
         Box::pin(async move {
-            let mut req = RequestParts::with_state(state.clone(), req);
+            let mut req = RequestParts::with_state_arc(Arc::clone(&state), req);
             match req.extract::<T>().await {
                 Ok(t) => self.handler.call(state, t).await,
                 Err(rejection) => rejection.into_response(),

--- a/axum-extra/src/handler/mod.rs
+++ b/axum-extra/src/handler/mod.rs
@@ -70,7 +70,7 @@ pub trait HandlerCallWithExtractors<T, S, B>: Sized {
     /// impl<S, B> FromRequest<S, B> for AdminPermissions
     /// where
     ///     B: Send,
-    ///     S: Send,
+    ///     S: Send + Sync,
     /// {
     ///     // check for admin permissions...
     ///     # type Rejection = ();
@@ -85,7 +85,7 @@ pub trait HandlerCallWithExtractors<T, S, B>: Sized {
     /// impl<S, B> FromRequest<S, B> for User
     /// where
     ///     B: Send,
-    ///     S: Send,
+    ///     S: Send + Sync,
     /// {
     ///     // check for a logged in user...
     ///     # type Rejection = ();
@@ -172,7 +172,7 @@ where
     T: FromRequest<S, B> + Send + 'static,
     T::Rejection: Send,
     B: Send + 'static,
-    S: Clone + Send + 'static,
+    S: Clone + Send + Sync + 'static,
 {
     type Future = BoxFuture<'static, Response>;
 

--- a/axum-extra/src/handler/mod.rs
+++ b/axum-extra/src/handler/mod.rs
@@ -176,7 +176,7 @@ where
     T: FromRequest<S, B> + Send + 'static,
     T::Rejection: Send,
     B: Send + 'static,
-    S: Clone + Send + Sync + 'static,
+    S: Send + Sync + 'static,
 {
     type Future = BoxFuture<'static, Response>;
 

--- a/axum-extra/src/handler/or.rs
+++ b/axum-extra/src/handler/or.rs
@@ -64,7 +64,7 @@ where
     Lt::Rejection: Send,
     Rt::Rejection: Send,
     B: Send + 'static,
-    S: Clone + Send + 'static,
+    S: Clone + Send + Sync + 'static,
 {
     // this puts `futures_util` in our public API but thats fine in axum-extra
     type Future = BoxFuture<'static, Response>;

--- a/axum-extra/src/handler/or.rs
+++ b/axum-extra/src/handler/or.rs
@@ -8,7 +8,7 @@ use axum::{
 };
 use futures_util::future::{BoxFuture, Either as EitherFuture, FutureExt, Map};
 use http::StatusCode;
-use std::{future::Future, marker::PhantomData};
+use std::{future::Future, marker::PhantomData, sync::Arc};
 
 /// [`Handler`] that runs one [`Handler`] and if that rejects it'll fallback to another
 /// [`Handler`].
@@ -37,7 +37,7 @@ where
 
     fn call(
         self,
-        state: S,
+        state: Arc<S>,
         extractors: Either<Lt, Rt>,
     ) -> <Self as HandlerCallWithExtractors<Either<Lt, Rt>, S, B>>::Future {
         match extractors {
@@ -64,14 +64,14 @@ where
     Lt::Rejection: Send,
     Rt::Rejection: Send,
     B: Send + 'static,
-    S: Clone + Send + Sync + 'static,
+    S: Send + Sync + 'static,
 {
     // this puts `futures_util` in our public API but thats fine in axum-extra
     type Future = BoxFuture<'static, Response>;
 
-    fn call(self, state: S, req: Request<B>) -> Self::Future {
+    fn call(self, state: Arc<S>, req: Request<B>) -> Self::Future {
         Box::pin(async move {
-            let mut req = RequestParts::with_state(state.clone(), req);
+            let mut req = RequestParts::with_state_arc(Arc::clone(&state), req);
 
             if let Ok(lt) = req.extract::<Lt>().await {
                 return self.lhs.call(state, lt).await;

--- a/axum-extra/src/json_lines.rs
+++ b/axum-extra/src/json_lines.rs
@@ -104,7 +104,7 @@ where
     B::Data: Into<Bytes>,
     B::Error: Into<BoxError>,
     T: DeserializeOwned,
-    S: Send,
+    S: Send + Sync,
 {
     type Rejection = BodyAlreadyExtracted;
 

--- a/axum-extra/src/protobuf.rs
+++ b/axum-extra/src/protobuf.rs
@@ -103,7 +103,7 @@ where
     B: HttpBody + Send,
     B::Data: Send,
     B::Error: Into<BoxError>,
-    S: Send,
+    S: Send + Sync,
 {
     type Rejection = ProtoBufRejection;
 

--- a/axum-extra/src/routing/mod.rs
+++ b/axum-extra/src/routing/mod.rs
@@ -178,7 +178,7 @@ pub trait RouterExt<S, B>: sealed::Sealed {
 impl<S, B> RouterExt<S, B> for Router<S, B>
 where
     B: axum::body::HttpBody + Send + 'static,
-    S: Clone + Send + Sync + 'static,
+    S: Send + Sync + 'static,
 {
     #[cfg(feature = "typed-routing")]
     fn typed_get<H, T, P>(self, handler: H) -> Self

--- a/axum-extra/src/routing/resource.rs
+++ b/axum-extra/src/routing/resource.rs
@@ -53,7 +53,7 @@ where
 impl<S, B> Resource<S, B>
 where
     B: axum::body::HttpBody + Send + 'static,
-    S: Clone + Send + Sync + 'static,
+    S: Send + Sync + 'static,
 {
     /// Create a `Resource` with the given name and state.
     ///

--- a/axum-macros/src/from_request.rs
+++ b/axum-macros/src/from_request.rs
@@ -223,7 +223,7 @@ fn impl_struct_by_extracting_each_field(
             B: ::axum::body::HttpBody + ::std::marker::Send + 'static,
             B::Data: ::std::marker::Send,
             B::Error: ::std::convert::Into<::axum::BoxError>,
-            S: Send,
+            S: ::std::marker::Send + ::std::marker::Sync,
         {
             type Rejection = #rejection_ident;
 
@@ -659,7 +659,7 @@ fn impl_struct_by_extracting_all_at_once(
             #path<#via_type_generics>: ::axum::extract::FromRequest<S, B>,
             #rejection_bound
             B: ::std::marker::Send,
-            S: ::std::marker::Send,
+            S: ::std::marker::Send + ::std::marker::Sync,
         {
             type Rejection = #associated_rejection_type;
 
@@ -725,7 +725,7 @@ fn impl_enum_by_extracting_all_at_once(
             B: ::axum::body::HttpBody + ::std::marker::Send + 'static,
             B::Data: ::std::marker::Send,
             B::Error: ::std::convert::Into<::axum::BoxError>,
-            S: ::std::marker::Send,
+            S: ::std::marker::Send + ::std::marker::Sync,
         {
             type Rejection = #associated_rejection_type;
 

--- a/axum-macros/src/lib.rs
+++ b/axum-macros/src/lib.rs
@@ -226,7 +226,7 @@ mod typed_path;
 /// impl<S, B> FromRequest<S, B> for OtherExtractor
 /// where
 ///     B: Send,
-///     S: Send,
+///     S: Send + Sync,
 /// {
 ///     // this rejection doesn't implement `Display` and `Error`
 ///     type Rejection = (StatusCode, String);

--- a/axum-macros/src/typed_path.rs
+++ b/axum-macros/src/typed_path.rs
@@ -130,7 +130,7 @@ fn expand_named_fields(
         impl<S, B> ::axum::extract::FromRequest<S, B> for #ident
         where
             B: Send,
-            S: Send,
+            S: Send + Sync,
         {
             type Rejection = #rejection_assoc_type;
 
@@ -233,7 +233,7 @@ fn expand_unnamed_fields(
         impl<S, B> ::axum::extract::FromRequest<S, B> for #ident
         where
             B: Send,
-            S: Send,
+            S: Send + Sync,
         {
             type Rejection = #rejection_assoc_type;
 
@@ -315,7 +315,7 @@ fn expand_unit_fields(
         impl<S, B> ::axum::extract::FromRequest<S, B> for #ident
         where
             B: Send,
-            S: Send,
+            S: Send + Sync,
         {
             type Rejection = #rejection_assoc_type;
 

--- a/axum-macros/tests/debug_handler/fail/extract_self_mut.rs
+++ b/axum-macros/tests/debug_handler/fail/extract_self_mut.rs
@@ -10,7 +10,7 @@ struct A;
 impl<S, B> FromRequest<S, B> for A
 where
     B: Send,
-    S: Send,
+    S: Send + Sync,
 {
     type Rejection = ();
 

--- a/axum-macros/tests/debug_handler/fail/extract_self_ref.rs
+++ b/axum-macros/tests/debug_handler/fail/extract_self_ref.rs
@@ -10,7 +10,7 @@ struct A;
 impl<S, B> FromRequest<S, B> for A
 where
     B: Send,
-    S: Send,
+    S: Send + Sync,
 {
     type Rejection = ();
 

--- a/axum-macros/tests/debug_handler/pass/result_impl_into_response.rs
+++ b/axum-macros/tests/debug_handler/pass/result_impl_into_response.rs
@@ -123,7 +123,7 @@ impl A {
 impl<S, B> FromRequest<S, B> for A
 where
     B: Send,
-    S: Send,
+    S: Send + Sync,
 {
     type Rejection = ();
 

--- a/axum-macros/tests/debug_handler/pass/self_receiver.rs
+++ b/axum-macros/tests/debug_handler/pass/self_receiver.rs
@@ -10,7 +10,7 @@ struct A;
 impl<S, B> FromRequest<S, B> for A
 where
     B: Send,
-    S: Send,
+    S: Send + Sync,
 {
     type Rejection = ();
 

--- a/axum-macros/tests/from_request/pass/derive_opt_out.rs
+++ b/axum-macros/tests/from_request/pass/derive_opt_out.rs
@@ -17,7 +17,7 @@ struct OtherExtractor;
 impl<S, B> FromRequest<S, B> for OtherExtractor
 where
     B: Send,
-    S: Send,
+    S: Send + Sync,
 {
     type Rejection = OtherExtractorRejection;
 

--- a/axum-macros/tests/from_request/pass/override_rejection.rs
+++ b/axum-macros/tests/from_request/pass/override_rejection.rs
@@ -31,7 +31,7 @@ struct OtherExtractor;
 impl<S, B> FromRequest<S, B> for OtherExtractor
 where
     B: Send + 'static,
-    S: Send,
+    S: Send + Sync,
 {
     // this rejection doesn't implement `Display` and `Error`
     type Rejection = (StatusCode, String);

--- a/axum/src/docs/extract.md
+++ b/axum/src/docs/extract.md
@@ -424,7 +424,7 @@ struct ExtractUserAgent(HeaderValue);
 impl<S, B> FromRequest<S, B> for ExtractUserAgent
 where
     B: Send,
-    S: Send,
+    S: Send + Sync,
 {
     type Rejection = (StatusCode, &'static str);
 
@@ -476,7 +476,7 @@ struct AuthenticatedUser {
 impl<S, B> FromRequest<S, B> for AuthenticatedUser
 where
     B: Send,
-    S: Send,
+    S: Send + Sync,
 {
     type Rejection = Response;
 

--- a/axum/src/extension.rs
+++ b/axum/src/extension.rs
@@ -77,7 +77,7 @@ impl<T, S, B> FromRequest<S, B> for Extension<T>
 where
     T: Clone + Send + Sync + 'static,
     B: Send,
-    S: Send,
+    S: Send + Sync,
 {
     type Rejection = ExtensionRejection;
 

--- a/axum/src/extract/connect_info.rs
+++ b/axum/src/extract/connect_info.rs
@@ -131,7 +131,7 @@ pub struct ConnectInfo<T>(pub T);
 impl<S, B, T> FromRequest<S, B> for ConnectInfo<T>
 where
     B: Send,
-    S: Send,
+    S: Send + Sync,
     T: Clone + Send + Sync + 'static,
 {
     type Rejection = <Extension<Self> as FromRequest<S, B>>::Rejection;

--- a/axum/src/extract/content_length_limit.rs
+++ b/axum/src/extract/content_length_limit.rs
@@ -41,7 +41,7 @@ where
     T: FromRequest<S, B>,
     T::Rejection: IntoResponse,
     B: Send,
-    S: Send,
+    S: Send + Sync,
 {
     type Rejection = ContentLengthLimitRejection<T::Rejection>;
 

--- a/axum/src/extract/host.rs
+++ b/axum/src/extract/host.rs
@@ -24,7 +24,7 @@ pub struct Host(pub String);
 impl<S, B> FromRequest<S, B> for Host
 where
     B: Send,
-    S: Send,
+    S: Send + Sync,
 {
     type Rejection = HostRejection;
 

--- a/axum/src/extract/matched_path.rs
+++ b/axum/src/extract/matched_path.rs
@@ -67,7 +67,7 @@ impl MatchedPath {
 impl<S, B> FromRequest<S, B> for MatchedPath
 where
     B: Send,
-    S: Send,
+    S: Send + Sync,
 {
     type Rejection = MatchedPathRejection;
 

--- a/axum/src/extract/multipart.rs
+++ b/axum/src/extract/multipart.rs
@@ -54,7 +54,7 @@ impl<S, B> FromRequest<S, B> for Multipart
 where
     B: HttpBody<Data = Bytes> + Default + Unpin + Send + 'static,
     B::Error: Into<BoxError>,
-    S: Send,
+    S: Send + Sync,
 {
     type Rejection = MultipartRejection;
 

--- a/axum/src/extract/path/mod.rs
+++ b/axum/src/extract/path/mod.rs
@@ -167,7 +167,7 @@ impl<T, S, B> FromRequest<S, B> for Path<T>
 where
     T: DeserializeOwned + Send,
     B: Send,
-    S: Send,
+    S: Send + Sync,
 {
     type Rejection = PathRejection;
 

--- a/axum/src/extract/query.rs
+++ b/axum/src/extract/query.rs
@@ -53,7 +53,7 @@ impl<T, S, B> FromRequest<S, B> for Query<T>
 where
     T: DeserializeOwned,
     B: Send,
-    S: Send,
+    S: Send + Sync,
 {
     type Rejection = QueryRejection;
 

--- a/axum/src/extract/raw_query.rs
+++ b/axum/src/extract/raw_query.rs
@@ -30,7 +30,7 @@ pub struct RawQuery(pub Option<String>);
 impl<S, B> FromRequest<S, B> for RawQuery
 where
     B: Send,
-    S: Send,
+    S: Send + Sync,
 {
     type Rejection = Infallible;
 

--- a/axum/src/extract/request_parts.rs
+++ b/axum/src/extract/request_parts.rs
@@ -89,7 +89,7 @@ pub struct OriginalUri(pub Uri);
 impl<S, B> FromRequest<S, B> for OriginalUri
 where
     B: Send,
-    S: Send,
+    S: Send + Sync,
 {
     type Rejection = Infallible;
 
@@ -146,7 +146,7 @@ where
     B: HttpBody + Send + 'static,
     B::Data: Into<Bytes>,
     B::Error: Into<BoxError>,
-    S: Send,
+    S: Send + Sync,
 {
     type Rejection = BodyAlreadyExtracted;
 
@@ -201,7 +201,7 @@ pub struct RawBody<B = Body>(pub B);
 impl<S, B> FromRequest<S, B> for RawBody<B>
 where
     B: Send,
-    S: Send,
+    S: Send + Sync,
 {
     type Rejection = BodyAlreadyExtracted;
 

--- a/axum/src/extract/state.rs
+++ b/axum/src/extract/state.rs
@@ -153,7 +153,7 @@ use std::{
 ///     // keep `S` generic but require that it can produce a `MyLibraryState`
 ///     // this means users will have to implement `FromRef<UserState> for MyLibraryState`
 ///     MyLibraryState: FromRef<S>,
-///     S: Send,
+///     S: Send + Sync,
 /// {
 ///     type Rejection = Infallible;
 ///
@@ -182,7 +182,7 @@ impl<B, OuterState, InnerState> FromRequest<OuterState, B> for State<InnerState>
 where
     B: Send,
     InnerState: FromRef<OuterState>,
-    OuterState: Send,
+    OuterState: Send + Sync,
 {
     type Rejection = Infallible;
 

--- a/axum/src/extract/ws.rs
+++ b/axum/src/extract/ws.rs
@@ -278,7 +278,7 @@ impl WebSocketUpgrade {
 impl<S, B> FromRequest<S, B> for WebSocketUpgrade
 where
     B: Send,
-    S: Send,
+    S: Send + Sync,
 {
     type Rejection = WebSocketUpgradeRejection;
 

--- a/axum/src/form.rs
+++ b/axum/src/form.rs
@@ -62,7 +62,7 @@ where
     B: HttpBody + Send,
     B::Data: Send,
     B::Error: Into<BoxError>,
-    S: Send,
+    S: Send + Sync,
 {
     type Rejection = FormRejection;
 

--- a/axum/src/handler/into_service_state_in_extension.rs
+++ b/axum/src/handler/into_service_state_in_extension.rs
@@ -5,6 +5,7 @@ use std::{
     convert::Infallible,
     fmt,
     marker::PhantomData,
+    sync::Arc,
     task::{Context, Poll},
 };
 use tower_service::Service;
@@ -54,7 +55,7 @@ impl<H, T, S, B> Service<Request<B>> for IntoServiceStateInExtension<H, T, S, B>
 where
     H: Handler<T, S, B> + Clone + Send + 'static,
     B: Send + 'static,
-    S: Clone + Send + Sync + 'static,
+    S: Send + Sync + 'static,
 {
     type Response = Response;
     type Error = Infallible;
@@ -73,7 +74,7 @@ where
 
         let state = req
             .extensions_mut()
-            .remove::<S>()
+            .remove::<Arc<S>>()
             .expect("state extension missing. This is a bug in axum, please file an issue");
 
         let handler = self.handler.clone();

--- a/axum/src/handler/mod.rs
+++ b/axum/src/handler/mod.rs
@@ -179,7 +179,7 @@ macro_rules! impl_handler {
             F: FnOnce($($ty,)*) -> Fut + Clone + Send + 'static,
             Fut: Future<Output = Res> + Send,
             B: Send + 'static,
-            S: Send + 'static,
+            S: Send + Sync + 'static,
             Res: IntoResponse,
             $( $ty: FromRequest<S, B> + Send,)*
         {

--- a/axum/src/handler/with_state.rs
+++ b/axum/src/handler/with_state.rs
@@ -37,7 +37,6 @@ impl<H, T, S, B> WithState<H, T, S, B> {
     /// };
     /// use std::net::SocketAddr;
     ///
-    /// #[derive(Clone)]
     /// struct AppState {}
     ///
     /// async fn handler(State(state): State<AppState>) {
@@ -73,7 +72,6 @@ impl<H, T, S, B> WithState<H, T, S, B> {
     /// };
     /// use std::net::SocketAddr;
     ///
-    /// #[derive(Clone)]
     /// struct AppState {};
     ///
     /// async fn handler(
@@ -106,7 +104,7 @@ impl<H, T, S, B> Service<Request<B>> for WithState<H, T, S, B>
 where
     H: Handler<T, S, B> + Clone + Send + 'static,
     B: Send + 'static,
-    S: Clone,
+    S: Send + Sync,
 {
     type Response = <IntoService<H, T, S, B> as Service<Request<B>>>::Response;
     type Error = <IntoService<H, T, S, B> as Service<Request<B>>>::Error;
@@ -134,7 +132,6 @@ impl<H, T, S, B> std::fmt::Debug for WithState<H, T, S, B> {
 impl<H, T, S, B> Clone for WithState<H, T, S, B>
 where
     H: Clone,
-    S: Clone,
 {
     fn clone(&self) -> Self {
         Self {

--- a/axum/src/handler/with_state.rs
+++ b/axum/src/handler/with_state.rs
@@ -37,6 +37,7 @@ impl<H, T, S, B> WithState<H, T, S, B> {
     /// };
     /// use std::net::SocketAddr;
     ///
+    /// #[derive(Clone)]
     /// struct AppState {}
     ///
     /// async fn handler(State(state): State<AppState>) {
@@ -72,6 +73,7 @@ impl<H, T, S, B> WithState<H, T, S, B> {
     /// };
     /// use std::net::SocketAddr;
     ///
+    /// #[derive(Clone)]
     /// struct AppState {};
     ///
     /// async fn handler(

--- a/axum/src/json.rs
+++ b/axum/src/json.rs
@@ -100,7 +100,7 @@ where
     B: HttpBody + Send,
     B::Data: Send,
     B::Error: Into<BoxError>,
-    S: Send,
+    S: Send + Sync,
 {
     type Rejection = JsonRejection;
 

--- a/axum/src/middleware/from_extractor.rs
+++ b/axum/src/middleware/from_extractor.rs
@@ -48,7 +48,7 @@ use tower_service::Service;
 /// impl<S, B> FromRequest<S, B> for RequireAuth
 /// where
 ///     B: Send,
-///     S: Send,
+///     S: Send + Sync,
 /// {
 ///     type Rejection = StatusCode;
 ///
@@ -283,7 +283,7 @@ mod tests {
         impl<S, B> FromRequest<S, B> for RequireAuth
         where
             B: Send,
-            S: Send,
+            S: Send + Sync,
         {
             type Rejection = StatusCode;
 

--- a/axum/src/routing/method_routing.rs
+++ b/axum/src/routing/method_routing.rs
@@ -144,7 +144,7 @@ macro_rules! top_level_handler_fn {
             H: Handler<T, S, B>,
             B: Send + 'static,
             T: 'static,
-            S: Clone + Send + Sync + 'static,
+            S: Send + Sync + 'static,
         {
             on(MethodFilter::$method, handler)
         }
@@ -280,7 +280,7 @@ macro_rules! chained_handler_fn {
         where
             H: Handler<T, S, B>,
             T: 'static,
-            S: Clone + Send + Sync + 'static,
+            S: Send + Sync + 'static,
         {
             self.on(MethodFilter::$method, handler)
         }
@@ -429,7 +429,7 @@ where
     H: Handler<T, S, B>,
     B: Send + 'static,
     T: 'static,
-    S: Clone + Send + Sync + 'static,
+    S: Send + Sync + 'static,
 {
     MethodRouter::new().on(filter, handler)
 }
@@ -476,7 +476,7 @@ where
     H: Handler<T, S, B>,
     B: Send + 'static,
     T: 'static,
-    S: Clone + Send + Sync + 'static,
+    S: Send + Sync + 'static,
 {
     MethodRouter::new()
         .fallback_boxed_response_body(IntoServiceStateInExtension::new(handler))
@@ -600,7 +600,7 @@ where
     where
         H: Handler<T, S, B>,
         T: 'static,
-        S: Clone + Send + Sync + 'static,
+        S: Send + Sync + 'static,
     {
         self.on_service_boxed_response_body(filter, IntoServiceStateInExtension::new(handler))
     }
@@ -619,7 +619,7 @@ where
     where
         H: Handler<T, S, B>,
         T: 'static,
-        S: Clone + Send + Sync + 'static,
+        S: Send + Sync + 'static,
     {
         self.fallback_service(IntoServiceStateInExtension::new(handler))
     }

--- a/axum/src/routing/method_routing.rs
+++ b/axum/src/routing/method_routing.rs
@@ -16,6 +16,7 @@ use std::{
     convert::Infallible,
     fmt,
     marker::PhantomData,
+    sync::Arc,
     task::{Context, Poll},
 };
 use tower::{service_fn, util::MapResponseLayer};
@@ -727,6 +728,13 @@ where
     ///
     /// See [`State`](crate::extract::State) for more details about accessing state.
     pub fn with_state(self, state: S) -> WithState<S, B, E> {
+        self.with_state_arc(Arc::new(state))
+    }
+
+    /// Provide the [`Arc`]'ed state.
+    ///
+    /// See [`State`](crate::extract::State) for more details about accessing state.
+    pub fn with_state_arc(self, state: Arc<S>) -> WithState<S, B, E> {
         WithState {
             method_router: self,
             state,
@@ -1127,7 +1135,7 @@ where
 /// Created with [`MethodRouter::with_state`]
 pub struct WithState<S, B, E> {
     method_router: MethodRouter<S, B, E>,
-    state: S,
+    state: Arc<S>,
 }
 
 impl<S, B, E> WithState<S, B, E> {
@@ -1156,14 +1164,11 @@ impl<S, B, E> WithState<S, B, E> {
     }
 }
 
-impl<S, B, E> Clone for WithState<S, B, E>
-where
-    S: Clone,
-{
+impl<S, B, E> Clone for WithState<S, B, E> {
     fn clone(&self) -> Self {
         Self {
             method_router: self.method_router.clone(),
-            state: self.state.clone(),
+            state: Arc::clone(&self.state),
         }
     }
 }
@@ -1183,7 +1188,7 @@ where
 impl<S, B, E> Service<Request<B>> for WithState<S, B, E>
 where
     B: HttpBody,
-    S: Clone + Send + Sync + 'static,
+    S: Send + Sync + 'static,
 {
     type Response = Response;
     type Error = E;
@@ -1232,7 +1237,7 @@ where
                 },
         } = self;
 
-        req.extensions_mut().insert(state.clone());
+        req.extensions_mut().insert(Arc::clone(state));
 
         call!(req, method, HEAD, head);
         call!(req, method, HEAD, get);

--- a/axum/src/typed_header.rs
+++ b/axum/src/typed_header.rs
@@ -56,7 +56,7 @@ impl<T, S, B> FromRequest<S, B> for TypedHeader<T>
 where
     T: headers::Header,
     B: Send,
-    S: Send,
+    S: Send + Sync,
 {
     type Rejection = TypedHeaderRejection;
 

--- a/examples/consume-body-in-extractor-or-middleware/src/main.rs
+++ b/examples/consume-body-in-extractor-or-middleware/src/main.rs
@@ -82,7 +82,7 @@ struct PrintRequestBody;
 #[async_trait]
 impl<S> FromRequest<S, BoxBody> for PrintRequestBody
 where
-    S: Send + Clone,
+    S: Clone + Send + Sync,
 {
     type Rejection = Response;
 

--- a/examples/customize-extractor-error/src/main.rs
+++ b/examples/customize-extractor-error/src/main.rs
@@ -58,7 +58,7 @@ struct Json<T>(T);
 #[async_trait]
 impl<S, B, T> FromRequest<S, B> for Json<T>
 where
-    S: Send,
+    S: Send + Sync,
     // these trait bounds are copied from `impl FromRequest for axum::Json`
     T: DeserializeOwned,
     B: axum::body::HttpBody + Send,

--- a/examples/customize-path-rejection/src/main.rs
+++ b/examples/customize-path-rejection/src/main.rs
@@ -57,7 +57,7 @@ where
     // these trait bounds are copied from `impl FromRequest for axum::extract::path::Path`
     T: DeserializeOwned + Send,
     B: Send,
-    S: Send,
+    S: Send + Sync,
 {
     type Rejection = (StatusCode, axum::Json<PathError>);
 

--- a/examples/jwt/src/main.rs
+++ b/examples/jwt/src/main.rs
@@ -124,7 +124,7 @@ impl AuthBody {
 #[async_trait]
 impl<S, B> FromRequest<S, B> for Claims
 where
-    S: Send,
+    S: Send + Sync,
     B: Send,
 {
     type Rejection = AuthError;

--- a/examples/validator/src/main.rs
+++ b/examples/validator/src/main.rs
@@ -63,7 +63,7 @@ pub struct ValidatedForm<T>(pub T);
 impl<T, S, B> FromRequest<S, B> for ValidatedForm<T>
 where
     T: DeserializeOwned + Validate,
-    S: Send,
+    S: Send + Sync,
     B: http_body::Body + Send,
     B::Data: Send,
     B::Error: Into<BoxError>,

--- a/examples/versioning/src/main.rs
+++ b/examples/versioning/src/main.rs
@@ -51,7 +51,7 @@ enum Version {
 impl<S, B> FromRequest<S, B> for Version
 where
     B: Send,
-    S: Send,
+    S: Send + Sync,
 {
     type Rejection = Response;
 


### PR DESCRIPTION
Fixes https://github.com/tokio-rs/axum/issues/1269

Could remove the `S: Clone` bound but had to add `S: Sync` since `Arc<S>` is only `Send` if `S: Sync`.

## Benchmark results

### Baseline

```
Running "extension" benchmark
  Beginning round 1...
  Benchmarking 10 connections @ http://0.0.0.0:62118 for 10 second(s)
    Latencies:
      Avg      Stdev    Min      Max
      0.06ms   0.02ms   0.02ms   1.03ms
    Requests:
      Total: 1555665 Req/Sec: 155558.87
    Transfer:
      Total: 111.27 MB Transfer Rate: 11.13 MB/Sec
```

```
Running "state" benchmark
  Beginning round 1...
  Benchmarking 10 connections @ http://0.0.0.0:62129 for 10 second(s)
    Latencies:
      Avg      Stdev    Min      Max
      0.06ms   0.02ms   0.02ms   1.77ms
    Requests:
      Total: 1716178 Req/Sec: 171604.66
    Transfer:
      Total: 122.75 MB Transfer Rate: 12.27 MB/Sec
```

### With `Arc<S>`

```
Running "state" benchmark
  Beginning round 1...
  Benchmarking 10 connections @ http://0.0.0.0:62551 for 10 second(s)
    Latencies:
      Avg      Stdev    Min      Max
      0.06ms   0.02ms   0.01ms   0.73ms
    Requests:
      Total: 1744483 Req/Sec: 174435.79
    Transfer:
      Total: 124.78 MB Transfer Rate: 12.48 MB/Sec
```

So a relatively small increase of 1.6% but the state is only cloned once (and only if its actually extracted) instead of four times previously before the `Arc`.