### PR TITLE
Add `#[non_exhaustive]` to `ProtoBufRejection`

### DIFF
--- a/axum-extra/src/protobuf.rs
+++ b/axum-extra/src/protobuf.rs
@@ -188,6 +188,7 @@ impl IntoResponse for ProtoBufDecodeError {
 /// Contains one variant for each way the [`ProtoBuf`] extractor
 /// can fail.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum ProtoBufRejection {
     #[allow(missing_docs)]
     ProtoBufDecodeError(ProtoBufDecodeError),


### PR DESCRIPTION
Our `composite_rejection!` macro does this, but we cannot use that in axum-extra, and so we missed it. I think for forwards compatibility reasons we should add it.

cc @Altair-Bueno