### PR TITLE
Reorder arguments to `Handler`

### DIFF
--- a/axum/src/handler/into_service.rs
+++ b/axum/src/handler/into_service.rs
@@ -88,7 +88,7 @@ where
         use futures_util::future::FutureExt;
 
         let handler = self.handler.clone();
-        let future = Handler::call(handler, Arc::clone(&self.state), req);
+        let future = Handler::call(handler, req, Arc::clone(&self.state));
         let future = future.map(Ok as _);
 
         super::future::IntoServiceFuture::new(future)

--- a/axum/src/handler/into_service_state_in_extension.rs
+++ b/axum/src/handler/into_service_state_in_extension.rs
@@ -78,7 +78,7 @@ where
             .expect("state extension missing. This is a bug in axum, please file an issue");
 
         let handler = self.handler.clone();
-        let future = Handler::call(handler, state, req);
+        let future = Handler::call(handler, req, state);
         let future = future.map(Ok as _);
 
         super::future::IntoServiceFuture::new(future)

--- a/axum/src/handler/mod.rs
+++ b/axum/src/handler/mod.rs
@@ -100,7 +100,7 @@ pub trait Handler<T, S = (), B = Body>: Clone + Send + Sized + 'static {
     type Future: Future<Output = Response> + Send + 'static;
 
     /// Call the handler with the given request.
-    fn call(self, state: Arc<S>, req: Request<B>) -> Self::Future;
+    fn call(self, req: Request<B>, state: Arc<S>) -> Self::Future;
 
     /// Apply a [`tower::Layer`] to the handler.
     ///
@@ -171,7 +171,7 @@ where
 {
     type Future = Pin<Box<dyn Future<Output = Response> + Send>>;
 
-    fn call(self, _state: Arc<S>, _req: Request<B>) -> Self::Future {
+    fn call(self, _req: Request<B>, _state: Arc<S>) -> Self::Future {
         Box::pin(async move { self().await.into_response() })
     }
 }
@@ -193,7 +193,7 @@ macro_rules! impl_handler {
         {
             type Future = Pin<Box<dyn Future<Output = Response> + Send>>;
 
-            fn call(self, state: Arc<S>, req: Request<B>) -> Self::Future {
+            fn call(self, req: Request<B>, state: Arc<S>) -> Self::Future {
                 Box::pin(async move {
                     let (mut parts, body) = req.into_parts();
                     let state = &state;
@@ -294,7 +294,7 @@ where
 {
     type Future = future::LayeredFuture<B, L::Service>;
 
-    fn call(self, state: Arc<S>, req: Request<B>) -> Self::Future {
+    fn call(self, req: Request<B>, state: Arc<S>) -> Self::Future {
         use futures_util::future::{FutureExt, Map};
 
         let svc = self.handler.with_state_arc(state);


### PR DESCRIPTION
I think `Request<B>, Arc<S>` is better since its consistent with `FromRequest` and `FromRequestParts`.