### PR TITLE
Port axum-extra

### DIFF
--- a/axum-core/Cargo.toml
+++ b/axum-core/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 name = "axum-core"
 readme = "README.md"
 repository = "https://github.com/tokio-rs/axum"
-version = "0.2.6" # remember to also bump the version that axum and axum-extra depends on
+version = "0.2.6" # remember to also bump the version that axum and axum-extra depend on
 
 [dependencies]
 async-trait = "0.1"

--- a/axum-core/Cargo.toml
+++ b/axum-core/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 name = "axum-core"
 readme = "README.md"
 repository = "https://github.com/tokio-rs/axum"
-version = "0.2.6" # remember to also bump the version that axum depends on
+version = "0.2.6" # remember to also bump the version that axum and axum-extra depends on
 
 [dependencies]
 async-trait = "0.1"

--- a/axum-extra/Cargo.toml
+++ b/axum-extra/Cargo.toml
@@ -35,6 +35,7 @@ typed-routing = ["dep:axum-macros", "dep:serde", "dep:percent-encoding"]
 
 [dependencies]
 axum = { path = "../axum", version = "0.5", default-features = false }
+axum-core = { path = "../axum-core", version = "0.2", default-features = false }
 bytes = "1.1.0"
 futures-util = { version = "0.3", default-features = false, features = ["alloc"] }
 http = "0.2"

--- a/axum-extra/src/extract/cached.rs
+++ b/axum-extra/src/extract/cached.rs
@@ -21,24 +21,23 @@ use std::ops::{Deref, DerefMut};
 /// use axum_extra::extract::Cached;
 /// use axum::{
 ///     async_trait,
-///     extract::{FromRequest, RequestParts},
+///     extract::FromRequestParts,
 ///     body::BoxBody,
 ///     response::{IntoResponse, Response},
-///     http::StatusCode,
+///     http::{StatusCode, request::Parts},
 /// };
 ///
 /// #[derive(Clone)]
 /// struct Session { /* ... */ }
 ///
 /// #[async_trait]
-/// impl<S, B> FromRequest<S, B> for Session
+/// impl<S> FromRequestParts<S> for Session
 /// where
-///     B: Send,
 ///     S: Send + Sync,
 /// {
 ///     type Rejection = (StatusCode, String);
 ///
-///     async fn from_request(req: &mut RequestParts<S, B>) -> Result<Self, Self::Rejection> {
+///     async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
 ///         // load session...
 ///         # unimplemented!()
 ///     }
@@ -47,19 +46,18 @@ use std::ops::{Deref, DerefMut};
 /// struct CurrentUser { /* ... */ }
 ///
 /// #[async_trait]
-/// impl<S, B> FromRequest<S, B> for CurrentUser
+/// impl<S> FromRequestParts<S> for CurrentUser
 /// where
-///     B: Send,
 ///     S: Send + Sync,
 /// {
 ///     type Rejection = Response;
 ///
-///     async fn from_request(req: &mut RequestParts<S, B>) -> Result<Self, Self::Rejection> {
+///     async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
 ///         // loading a `CurrentUser` requires first loading the `Session`
 ///         //
 ///         // by using `Cached<Session>` we avoid extracting the session more than
 ///         // once, in case other extractors for the same request also loads the session
-///         let session: Session = Cached::<Session>::from_request(req)
+///         let session: Session = Cached::<Session>::from_request_parts(parts, state)
 ///             .await
 ///             .map_err(|err| err.into_response())?
 ///             .0;

--- a/axum-extra/src/handler/mod.rs
+++ b/axum-extra/src/handler/mod.rs
@@ -1,208 +1,203 @@
 //! Additional handler utilities.
 
-// NOTE: bringing this back requires fixing `axum-core/src/extract/tuple.rs`
+use axum::{
+    extract::FromRequest,
+    handler::Handler,
+    response::{IntoResponse, Response},
+};
+use futures_util::future::{BoxFuture, FutureExt, Map};
+use std::{future::Future, marker::PhantomData, sync::Arc};
 
-// use axum::{
-//     extract::{FromRequest, RequestParts},
-//     handler::Handler,
-//     response::{IntoResponse, Response},
-// };
-// use futures_util::future::{BoxFuture, FutureExt, Map};
-// use std::{future::Future, marker::PhantomData, sync::Arc};
-//
-// mod or;
-//
-// pub use self::or::Or;
-//
-// /// Trait for async functions that can be used to handle requests.
-// ///
-// /// This trait is similar to [`Handler`] but rather than taking the request it takes the extracted
-// /// inputs.
-// ///
-// /// The drawbacks of this trait is that you cannot apply middleware to individual handlers like you
-// /// can with [`Handler::layer`].
-// pub trait HandlerCallWithExtractors<T, S, B>: Sized {
-//     /// The type of future calling this handler returns.
-//     type Future: Future<Output = Response> + Send + 'static;
-//
-//     /// Call the handler with the extracted inputs.
-//     fn call(
-//         self,
-//         state: Arc<S>,
-//         extractors: T,
-//     ) -> <Self as HandlerCallWithExtractors<T, S, B>>::Future;
-//
-//     /// Conver this `HandlerCallWithExtractors` into [`Handler`].
-//     fn into_handler(self) -> IntoHandler<Self, T, S, B> {
-//         IntoHandler {
-//             handler: self,
-//             _marker: PhantomData,
-//         }
-//     }
-//
-//     /// Chain two handlers together, running the second one if the first one rejects.
-//     ///
-//     /// Note that this only moves to the next handler if an extractor fails. The response from
-//     /// handlers are not considered.
-//     ///
-//     /// # Example
-//     ///
-//     /// ```
-//     /// use axum_extra::handler::HandlerCallWithExtractors;
-//     /// use axum::{
-//     ///     Router,
-//     ///     async_trait,
-//     ///     routing::get,
-//     ///     extract::FromRequest,
-//     /// };
-//     ///
-//     /// // handlers for varying levels of access
-//     /// async fn admin(admin: AdminPermissions) {
-//     ///     // request came from an admin
-//     /// }
-//     ///
-//     /// async fn user(user: User) {
-//     ///     // we have a `User`
-//     /// }
-//     ///
-//     /// async fn guest() {
-//     ///     // `AdminPermissions` and `User` failed, so we're just a guest
-//     /// }
-//     ///
-//     /// // extractors for checking permissions
-//     /// struct AdminPermissions {}
-//     ///
-//     /// #[async_trait]
-//     /// impl<S, B> FromRequest<S, B> for AdminPermissions
-//     /// where
-//     ///     B: Send,
-//     ///     S: Send + Sync,
-//     /// {
-//     ///     // check for admin permissions...
-//     ///     # type Rejection = ();
-//     ///     # async fn from_request(req: &mut axum::extract::RequestParts<S, B>) -> Result<Self, Self::Rejection> {
-//     ///     #     todo!()
-//     ///     # }
-//     /// }
-//     ///
-//     /// struct User {}
-//     ///
-//     /// #[async_trait]
-//     /// impl<S, B> FromRequest<S, B> for User
-//     /// where
-//     ///     B: Send,
-//     ///     S: Send + Sync,
-//     /// {
-//     ///     // check for a logged in user...
-//     ///     # type Rejection = ();
-//     ///     # async fn from_request(req: &mut axum::extract::RequestParts<S, B>) -> Result<Self, Self::Rejection> {
-//     ///     #     todo!()
-//     ///     # }
-//     /// }
-//     ///
-//     /// let app = Router::new().route(
-//     ///     "/users/:id",
-//     ///     get(
-//     ///         // first try `admin`, if that rejects run `user`, finally falling back
-//     ///         // to `guest`
-//     ///         admin.or(user).or(guest)
-//     ///     )
-//     /// );
-//     /// # let _: Router = app;
-//     /// ```
-//     fn or<R, Rt>(self, rhs: R) -> Or<Self, R, T, Rt, S, B>
-//     where
-//         R: HandlerCallWithExtractors<Rt, S, B>,
-//     {
-//         Or {
-//             lhs: self,
-//             rhs,
-//             _marker: PhantomData,
-//         }
-//     }
-// }
-//
-// macro_rules! impl_handler_call_with {
-//     ( $($ty:ident),* $(,)? ) => {
-//         #[allow(non_snake_case)]
-//         impl<F, Fut, S, B, $($ty,)*> HandlerCallWithExtractors<($($ty,)*), S, B> for F
-//         where
-//             F: FnOnce($($ty,)*) -> Fut,
-//             Fut: Future + Send + 'static,
-//             Fut::Output: IntoResponse,
-//         {
-//             // this puts `futures_util` in our public API but thats fine in axum-extra
-//             type Future = Map<Fut, fn(Fut::Output) -> Response>;
-//
-//             fn call(
-//                 self,
-//                 _state: Arc<S>,
-//                 ($($ty,)*): ($($ty,)*),
-//             ) -> <Self as HandlerCallWithExtractors<($($ty,)*), S, B>>::Future {
-//                 self($($ty,)*).map(IntoResponse::into_response)
-//             }
-//         }
-//     };
-// }
-//
-// impl_handler_call_with!();
-// impl_handler_call_with!(T1);
-// impl_handler_call_with!(T1, T2);
-// impl_handler_call_with!(T1, T2, T3);
-// impl_handler_call_with!(T1, T2, T3, T4);
-// impl_handler_call_with!(T1, T2, T3, T4, T5);
-// impl_handler_call_with!(T1, T2, T3, T4, T5, T6);
-// impl_handler_call_with!(T1, T2, T3, T4, T5, T6, T7);
-// impl_handler_call_with!(T1, T2, T3, T4, T5, T6, T7, T8);
-// impl_handler_call_with!(T1, T2, T3, T4, T5, T6, T7, T8, T9);
-// impl_handler_call_with!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10);
-// impl_handler_call_with!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11);
-// impl_handler_call_with!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12);
-// impl_handler_call_with!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13);
-// impl_handler_call_with!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14);
-// impl_handler_call_with!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15);
-// impl_handler_call_with!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16);
-//
-// /// A [`Handler`] created from a [`HandlerCallWithExtractors`].
-// ///
-// /// Created with [`HandlerCallWithExtractors::into_handler`].
-// #[allow(missing_debug_implementations)]
-// pub struct IntoHandler<H, T, S, B> {
-//     handler: H,
-//     _marker: PhantomData<fn() -> (T, S, B)>,
-// }
-//
-// impl<H, T, S, B> Handler<T, S, B> for IntoHandler<H, T, S, B>
-// where
-//     H: HandlerCallWithExtractors<T, S, B> + Clone + Send + 'static,
-//     T: FromRequest<S, B> + Send + 'static,
-//     T::Rejection: Send,
-//     B: Send + 'static,
-//     S: Send + Sync + 'static,
-// {
-//     type Future = BoxFuture<'static, Response>;
-//
-//     fn call(self, state: Arc<S>, req: http::Request<B>) -> Self::Future {
-//         Box::pin(async move {
-//             let mut req = RequestParts::with_state_arc(Arc::clone(&state), req);
-//             match req.extract::<T>().await {
-//                 Ok(t) => self.handler.call(state, t).await,
-//                 Err(rejection) => rejection.into_response(),
-//             }
-//         })
-//     }
-// }
-//
-// impl<H, T, S, B> Copy for IntoHandler<H, T, S, B> where H: Copy {}
-//
-// impl<H, T, S, B> Clone for IntoHandler<H, T, S, B>
-// where
-//     H: Clone,
-// {
-//     fn clone(&self) -> Self {
-//         Self {
-//             handler: self.handler.clone(),
-//             _marker: self._marker,
-//         }
-//     }
-// }
+mod or;
+
+pub use self::or::Or;
+
+/// Trait for async functions that can be used to handle requests.
+///
+/// This trait is similar to [`Handler`] but rather than taking the request it takes the extracted
+/// inputs.
+///
+/// The drawbacks of this trait is that you cannot apply middleware to individual handlers like you
+/// can with [`Handler::layer`].
+pub trait HandlerCallWithExtractors<T, S, B>: Sized {
+    /// The type of future calling this handler returns.
+    type Future: Future<Output = Response> + Send + 'static;
+
+    /// Call the handler with the extracted inputs.
+    fn call(
+        self,
+        extractors: T,
+        state: Arc<S>,
+    ) -> <Self as HandlerCallWithExtractors<T, S, B>>::Future;
+
+    /// Conver this `HandlerCallWithExtractors` into [`Handler`].
+    fn into_handler(self) -> IntoHandler<Self, T, S, B> {
+        IntoHandler {
+            handler: self,
+            _marker: PhantomData,
+        }
+    }
+
+    /// Chain two handlers together, running the second one if the first one rejects.
+    ///
+    /// Note that this only moves to the next handler if an extractor fails. The response from
+    /// handlers are not considered.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use axum_extra::handler::HandlerCallWithExtractors;
+    /// use axum::{
+    ///     Router,
+    ///     async_trait,
+    ///     routing::get,
+    ///     extract::FromRequestParts,
+    /// };
+    ///
+    /// // handlers for varying levels of access
+    /// async fn admin(admin: AdminPermissions) {
+    ///     // request came from an admin
+    /// }
+    ///
+    /// async fn user(user: User) {
+    ///     // we have a `User`
+    /// }
+    ///
+    /// async fn guest() {
+    ///     // `AdminPermissions` and `User` failed, so we're just a guest
+    /// }
+    ///
+    /// // extractors for checking permissions
+    /// struct AdminPermissions {}
+    ///
+    /// #[async_trait]
+    /// impl<S> FromRequestParts<S> for AdminPermissions
+    /// where
+    ///     S: Send + Sync,
+    /// {
+    ///     // check for admin permissions...
+    ///     # type Rejection = ();
+    ///     # async fn from_request_parts(parts: &mut http::request::Parts, state: &S) -> Result<Self, Self::Rejection> {
+    ///     #     todo!()
+    ///     # }
+    /// }
+    ///
+    /// struct User {}
+    ///
+    /// #[async_trait]
+    /// impl<S> FromRequestParts<S> for User
+    /// where
+    ///     S: Send + Sync,
+    /// {
+    ///     // check for a logged in user...
+    ///     # type Rejection = ();
+    ///     # async fn from_request_parts(parts: &mut http::request::Parts, state: &S) -> Result<Self, Self::Rejection> {
+    ///     #     todo!()
+    ///     # }
+    /// }
+    ///
+    /// let app = Router::new().route(
+    ///     "/users/:id",
+    ///     get(
+    ///         // first try `admin`, if that rejects run `user`, finally falling back
+    ///         // to `guest`
+    ///         admin.or(user).or(guest)
+    ///     )
+    /// );
+    /// # let _: Router = app;
+    /// ```
+    fn or<R, Rt>(self, rhs: R) -> Or<Self, R, T, Rt, S, B>
+    where
+        R: HandlerCallWithExtractors<Rt, S, B>,
+    {
+        Or {
+            lhs: self,
+            rhs,
+            _marker: PhantomData,
+        }
+    }
+}
+
+macro_rules! impl_handler_call_with {
+     ( $($ty:ident),* $(,)? ) => {
+         #[allow(non_snake_case)]
+         impl<F, Fut, S, B, $($ty,)*> HandlerCallWithExtractors<($($ty,)*), S, B> for F
+         where
+             F: FnOnce($($ty,)*) -> Fut,
+             Fut: Future + Send + 'static,
+             Fut::Output: IntoResponse,
+         {
+             // this puts `futures_util` in our public API but thats fine in axum-extra
+             type Future = Map<Fut, fn(Fut::Output) -> Response>;
+
+             fn call(
+                 self,
+                 ($($ty,)*): ($($ty,)*),
+                 _state: Arc<S>,
+             ) -> <Self as HandlerCallWithExtractors<($($ty,)*), S, B>>::Future {
+                 self($($ty,)*).map(IntoResponse::into_response)
+             }
+         }
+     };
+ }
+
+impl_handler_call_with!();
+impl_handler_call_with!(T1);
+impl_handler_call_with!(T1, T2);
+impl_handler_call_with!(T1, T2, T3);
+impl_handler_call_with!(T1, T2, T3, T4);
+impl_handler_call_with!(T1, T2, T3, T4, T5);
+impl_handler_call_with!(T1, T2, T3, T4, T5, T6);
+impl_handler_call_with!(T1, T2, T3, T4, T5, T6, T7);
+impl_handler_call_with!(T1, T2, T3, T4, T5, T6, T7, T8);
+impl_handler_call_with!(T1, T2, T3, T4, T5, T6, T7, T8, T9);
+impl_handler_call_with!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10);
+impl_handler_call_with!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11);
+impl_handler_call_with!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12);
+impl_handler_call_with!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13);
+impl_handler_call_with!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14);
+impl_handler_call_with!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15);
+impl_handler_call_with!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16);
+
+/// A [`Handler`] created from a [`HandlerCallWithExtractors`].
+///
+/// Created with [`HandlerCallWithExtractors::into_handler`].
+#[allow(missing_debug_implementations)]
+pub struct IntoHandler<H, T, S, B> {
+    handler: H,
+    _marker: PhantomData<fn() -> (T, S, B)>,
+}
+
+impl<H, T, S, B> Handler<T, S, B> for IntoHandler<H, T, S, B>
+where
+    H: HandlerCallWithExtractors<T, S, B> + Clone + Send + 'static,
+    T: FromRequest<S, B> + Send + 'static,
+    T::Rejection: Send,
+    B: Send + 'static,
+    S: Send + Sync + 'static,
+{
+    type Future = BoxFuture<'static, Response>;
+
+    fn call(self, req: http::Request<B>, state: Arc<S>) -> Self::Future {
+        Box::pin(async move {
+            match T::from_request(req, &state).await {
+                Ok(t) => self.handler.call(t, state).await,
+                Err(rejection) => rejection.into_response(),
+            }
+        })
+    }
+}
+
+impl<H, T, S, B> Copy for IntoHandler<H, T, S, B> where H: Copy {}
+
+impl<H, T, S, B> Clone for IntoHandler<H, T, S, B>
+where
+    H: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            handler: self.handler.clone(),
+            _marker: self._marker,
+        }
+    }
+}

--- a/axum-extra/src/handler/or.rs
+++ b/axum-extra/src/handler/or.rs
@@ -1,153 +1,153 @@
-// use super::HandlerCallWithExtractors;
-// use crate::either::Either;
-// use axum::{
-//     extract::{FromRequest, RequestParts},
-//     handler::Handler,
-//     http::Request,
-//     response::{IntoResponse, Response},
-// };
-// use futures_util::future::{BoxFuture, Either as EitherFuture, FutureExt, Map};
-// use http::StatusCode;
-// use std::{future::Future, marker::PhantomData, sync::Arc};
-// 
-// /// [`Handler`] that runs one [`Handler`] and if that rejects it'll fallback to another
-// /// [`Handler`].
-// ///
-// /// Created with [`HandlerCallWithExtractors::or`](super::HandlerCallWithExtractors::or).
-// #[allow(missing_debug_implementations)]
-// pub struct Or<L, R, Lt, Rt, S, B> {
-//     pub(super) lhs: L,
-//     pub(super) rhs: R,
-//     pub(super) _marker: PhantomData<fn() -> (Lt, Rt, S, B)>,
-// }
-// 
-// impl<S, B, L, R, Lt, Rt> HandlerCallWithExtractors<Either<Lt, Rt>, S, B> for Or<L, R, Lt, Rt, S, B>
-// where
-//     L: HandlerCallWithExtractors<Lt, S, B> + Send + 'static,
-//     R: HandlerCallWithExtractors<Rt, S, B> + Send + 'static,
-//     Rt: Send + 'static,
-//     Lt: Send + 'static,
-//     B: Send + 'static,
-// {
-//     // this puts `futures_util` in our public API but thats fine in axum-extra
-//     type Future = EitherFuture<
-//         Map<L::Future, fn(<L::Future as Future>::Output) -> Response>,
-//         Map<R::Future, fn(<R::Future as Future>::Output) -> Response>,
-//     >;
-// 
-//     fn call(
-//         self,
-//         state: Arc<S>,
-//         extractors: Either<Lt, Rt>,
-//     ) -> <Self as HandlerCallWithExtractors<Either<Lt, Rt>, S, B>>::Future {
-//         match extractors {
-//             Either::E1(lt) => self
-//                 .lhs
-//                 .call(state, lt)
-//                 .map(IntoResponse::into_response as _)
-//                 .left_future(),
-//             Either::E2(rt) => self
-//                 .rhs
-//                 .call(state, rt)
-//                 .map(IntoResponse::into_response as _)
-//                 .right_future(),
-//         }
-//     }
-// }
-// 
-// impl<S, B, L, R, Lt, Rt> Handler<(Lt, Rt), S, B> for Or<L, R, Lt, Rt, S, B>
-// where
-//     L: HandlerCallWithExtractors<Lt, S, B> + Clone + Send + 'static,
-//     R: HandlerCallWithExtractors<Rt, S, B> + Clone + Send + 'static,
-//     Lt: FromRequest<S, B> + Send + 'static,
-//     Rt: FromRequest<S, B> + Send + 'static,
-//     Lt::Rejection: Send,
-//     Rt::Rejection: Send,
-//     B: Send + 'static,
-//     S: Send + Sync + 'static,
-// {
-//     // this puts `futures_util` in our public API but thats fine in axum-extra
-//     type Future = BoxFuture<'static, Response>;
-// 
-//     fn call(self, state: Arc<S>, req: Request<B>) -> Self::Future {
-//         Box::pin(async move {
-//             let mut req = RequestParts::with_state_arc(Arc::clone(&state), req);
-// 
-//             if let Ok(lt) = req.extract::<Lt>().await {
-//                 return self.lhs.call(state, lt).await;
-//             }
-// 
-//             if let Ok(rt) = req.extract::<Rt>().await {
-//                 return self.rhs.call(state, rt).await;
-//             }
-// 
-//             StatusCode::NOT_FOUND.into_response()
-//         })
-//     }
-// }
-// 
-// impl<L, R, Lt, Rt, S, B> Copy for Or<L, R, Lt, Rt, S, B>
-// where
-//     L: Copy,
-//     R: Copy,
-// {
-// }
-// 
-// impl<L, R, Lt, Rt, S, B> Clone for Or<L, R, Lt, Rt, S, B>
-// where
-//     L: Clone,
-//     R: Clone,
-// {
-//     fn clone(&self) -> Self {
-//         Self {
-//             lhs: self.lhs.clone(),
-//             rhs: self.rhs.clone(),
-//             _marker: self._marker,
-//         }
-//     }
-// }
-// 
-// #[cfg(test)]
-// mod tests {
-//     use super::*;
-//     use crate::test_helpers::*;
-//     use axum::{
-//         extract::{Path, Query},
-//         routing::get,
-//         Router,
-//     };
-//     use serde::Deserialize;
-// 
-//     #[tokio::test]
-//     async fn works() {
-//         #[derive(Deserialize)]
-//         struct Params {
-//             a: String,
-//         }
-// 
-//         async fn one(Path(id): Path<u32>) -> String {
-//             id.to_string()
-//         }
-// 
-//         async fn two(Query(params): Query<Params>) -> String {
-//             params.a
-//         }
-// 
-//         async fn three() -> &'static str {
-//             "fallback"
-//         }
-// 
-//         let app = Router::new().route("/:id", get(one.or(two).or(three)));
-// 
-//         let client = TestClient::new(app);
-// 
-//         let res = client.get("/123").send().await;
-//         assert_eq!(res.text().await, "123");
-// 
-//         let res = client.get("/foo?a=bar").send().await;
-//         assert_eq!(res.text().await, "bar");
-// 
-//         let res = client.get("/foo").send().await;
-//         assert_eq!(res.text().await, "fallback");
-//     }
-// }
+use super::HandlerCallWithExtractors;
+use crate::either::Either;
+use axum::{
+    extract::{FromRequest, FromRequestParts},
+    handler::Handler,
+    http::Request,
+    response::{IntoResponse, Response},
+};
+use futures_util::future::{BoxFuture, Either as EitherFuture, FutureExt, Map};
+use std::{future::Future, marker::PhantomData, sync::Arc};
+
+/// [`Handler`] that runs one [`Handler`] and if that rejects it'll fallback to another
+/// [`Handler`].
+///
+/// Created with [`HandlerCallWithExtractors::or`](super::HandlerCallWithExtractors::or).
+#[allow(missing_debug_implementations)]
+pub struct Or<L, R, Lt, Rt, S, B> {
+    pub(super) lhs: L,
+    pub(super) rhs: R,
+    pub(super) _marker: PhantomData<fn() -> (Lt, Rt, S, B)>,
+}
+
+impl<S, B, L, R, Lt, Rt> HandlerCallWithExtractors<Either<Lt, Rt>, S, B> for Or<L, R, Lt, Rt, S, B>
+where
+    L: HandlerCallWithExtractors<Lt, S, B> + Send + 'static,
+    R: HandlerCallWithExtractors<Rt, S, B> + Send + 'static,
+    Rt: Send + 'static,
+    Lt: Send + 'static,
+    B: Send + 'static,
+{
+    // this puts `futures_util` in our public API but thats fine in axum-extra
+    type Future = EitherFuture<
+        Map<L::Future, fn(<L::Future as Future>::Output) -> Response>,
+        Map<R::Future, fn(<R::Future as Future>::Output) -> Response>,
+    >;
+
+    fn call(
+        self,
+        extractors: Either<Lt, Rt>,
+        state: Arc<S>,
+    ) -> <Self as HandlerCallWithExtractors<Either<Lt, Rt>, S, B>>::Future {
+        match extractors {
+            Either::E1(lt) => self
+                .lhs
+                .call(lt, state)
+                .map(IntoResponse::into_response as _)
+                .left_future(),
+            Either::E2(rt) => self
+                .rhs
+                .call(rt, state)
+                .map(IntoResponse::into_response as _)
+                .right_future(),
+        }
+    }
+}
+
+impl<S, B, L, R, Lt, Rt, M> Handler<(M, Lt, Rt), S, B> for Or<L, R, Lt, Rt, S, B>
+where
+    L: HandlerCallWithExtractors<Lt, S, B> + Clone + Send + 'static,
+    R: HandlerCallWithExtractors<Rt, S, B> + Clone + Send + 'static,
+    Lt: FromRequestParts<S> + Send + 'static,
+    Rt: FromRequest<S, B, M> + Send + 'static,
+    Lt::Rejection: Send,
+    Rt::Rejection: Send,
+    B: Send + 'static,
+    S: Send + Sync + 'static,
+{
+    // this puts `futures_util` in our public API but thats fine in axum-extra
+    type Future = BoxFuture<'static, Response>;
+
+    fn call(self, req: Request<B>, state: Arc<S>) -> Self::Future {
+        Box::pin(async move {
+            let (mut parts, body) = req.into_parts();
+
+            if let Ok(lt) = Lt::from_request_parts(&mut parts, &state).await {
+                return self.lhs.call(lt, state).await;
+            }
+
+            let req = Request::from_parts(parts, body);
+
+            match Rt::from_request(req, &state).await {
+                Ok(rt) => self.rhs.call(rt, state).await,
+                Err(rejection) => rejection.into_response(),
+            }
+        })
+    }
+}
+
+impl<L, R, Lt, Rt, S, B> Copy for Or<L, R, Lt, Rt, S, B>
+where
+    L: Copy,
+    R: Copy,
+{
+}
+
+impl<L, R, Lt, Rt, S, B> Clone for Or<L, R, Lt, Rt, S, B>
+where
+    L: Clone,
+    R: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            lhs: self.lhs.clone(),
+            rhs: self.rhs.clone(),
+            _marker: self._marker,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_helpers::*;
+    use axum::{
+        extract::{Path, Query},
+        routing::get,
+        Router,
+    };
+    use serde::Deserialize;
+
+    #[tokio::test]
+    async fn works() {
+        #[derive(Deserialize)]
+        struct Params {
+            a: String,
+        }
+
+        async fn one(Path(id): Path<u32>) -> String {
+            id.to_string()
+        }
+
+        async fn two(Query(params): Query<Params>) -> String {
+            params.a
+        }
+
+        async fn three() -> &'static str {
+            "fallback"
+        }
+
+        let app = Router::new().route("/:id", get(one.or(two).or(three)));
+
+        let client = TestClient::new(app);
+
+        let res = client.get("/123").send().await;
+        assert_eq!(res.text().await, "123");
+
+        let res = client.get("/foo?a=bar").send().await;
+        assert_eq!(res.text().await, "bar");
+
+        let res = client.get("/foo").send().await;
+        assert_eq!(res.text().await, "fallback");
+    }
+}

--- a/axum/src/routing/tests/mod.rs
+++ b/axum/src/routing/tests/mod.rs
@@ -8,7 +8,7 @@ use crate::{
     test_helpers::*,
     BoxError, Json, Router,
 };
-use http::{header::CONTENT_LENGTH, HeaderMap, Request, Response, StatusCode, Uri};
+use http::{header::CONTENT_LENGTH, HeaderMap, Method, Request, Response, StatusCode, Uri};
 use hyper::Body;
 use serde_json::json;
 use std::{


### PR DESCRIPTION
This ports the code and docs in axum-extra. `cargo t --all-features -p axum-extra` now passes. Getting closer 😊