### PR TITLE
axum-extra doesn't need to depend on axum-core

### DIFF
--- a/axum-core/Cargo.toml
+++ b/axum-core/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 name = "axum-core"
 readme = "README.md"
 repository = "https://github.com/tokio-rs/axum"
-version = "0.2.6" # remember to also bump the version that axum and axum-extra depend on
+version = "0.2.6" # remember to also bump the version that axum depends on
 
 [dependencies]
 async-trait = "0.1"

--- a/axum-extra/Cargo.toml
+++ b/axum-extra/Cargo.toml
@@ -35,7 +35,6 @@ typed-routing = ["dep:axum-macros", "dep:serde", "dep:percent-encoding"]
 
 [dependencies]
 axum = { path = "../axum", version = "0.5", default-features = false }
-axum-core = { path = "../axum-core", version = "0.2", default-features = false }
 bytes = "1.1.0"
 futures-util = { version = "0.3", default-features = false, features = ["alloc"] }
 http = "0.2"


### PR DESCRIPTION
Missed this in https://github.com/tokio-rs/axum/pull/1287