### PR TITLE
Show path in panic message when merging overlapping `MethodRouter`s

### DIFF
--- a/axum/src/routing/mod.rs
+++ b/axum/src/routing/mod.rs
@@ -173,7 +173,11 @@ where
         {
             // if we're adding a new `MethodRouter` to a route that already has one just
             // merge them. This makes `.route("/", get(_)).route("/", post(_))` work
-            let service = Endpoint::MethodRouter(prev_method_router.clone().merge(method_router));
+            let service = Endpoint::MethodRouter(
+                prev_method_router
+                    .clone()
+                    .merge_for_path(Some(path), method_router),
+            );
             self.routes.insert(route_id, service);
             return self;
         } else {

--- a/axum/src/routing/tests/mod.rs
+++ b/axum/src/routing/tests/mod.rs
@@ -504,6 +504,23 @@ async fn merging_routers_with_fallbacks_panics() {
     TestClient::new(one.merge(two));
 }
 
+#[test]
+#[should_panic(expected = "Overlapping method route. Handler for `GET /foo/bar` already exists")]
+fn routes_with_overlapping_method_routes() {
+    async fn handler() {}
+    let _: Router = Router::new()
+        .route("/foo/bar", get(handler))
+        .route("/foo/bar", get(handler));
+}
+
+#[test]
+#[should_panic(expected = "Overlapping method route. Handler for `GET /foo/bar` already exists")]
+fn merging_with_overlapping_method_routes() {
+    async fn handler() {}
+    let app: Router = Router::new().route("/foo/bar", get(handler));
+    app.clone().merge(app);
+}
+
 #[tokio::test]
 async fn merging_routers_with_same_paths_but_different_methods() {
     let one = Router::new().route("/", get(|| async { "GET" }));


### PR DESCRIPTION
When you do

```rust
Router::new()
    .route("/foo/bar", get(handler))
    .route("/foo/bar", get(handler));
```

or

```rust
Router::new().route("/foo/bar", get(handler)).merge(
    Router::new().route("/foo/bar", get(handler))
);
```

The panic message will now contain the path (`/foo/bar`) so the error is hopefully easier to track down. Example:

```
Overlapping method route. Handler for `GET /foo/bar` already exists
```

It doesn't work for

```rust
Router::new().route("/foo/bar", get(handler).get(handler));
```

because the `get(_).get(_)` panics before `Router::route` is called so we don't know the path at that point.