### PR TITLE
Explicitely point out example's dependency

### DIFF
--- a/axum/src/extract/path/mod.rs
+++ b/axum/src/extract/path/mod.rs
@@ -25,6 +25,8 @@ use std::{
 ///
 /// # Example
 ///
+/// These examples assume the "serde" feature of the `uuid` crate is enabled.
+///
 /// ```rust,no_run
 /// use axum::{
 ///     extract::Path,


### PR DESCRIPTION
## Motivation

While adopting Axum, I started by building a simple handler parsing Uuids from the path, as per the example. I spend a bit of time trying to figure out why the provided example doesn't compile: `uuid::Uuid` only implements `serde::Deserialize` if one enables the "serde" feature of the crate (which is not enabled by default).


## Solution

The error message generated is relatively opaque for an axum newbie, so this pull request adds a simple documentation update to point them in the right direction (and save them the trouble from using `axum-macros::debug_handler` themselves).
