### PR TITLE
FromRequestParts does not have a 'B' type

### DIFF
--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -313,7 +313,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   impl<S> FromRequestParts<S> for MyExtractor
   where
       S: Send + Sync,
-      B: Send + 'static,
   {
       type Rejection = StatusCode;
   


### PR DESCRIPTION
## Motivation

The release notes for 0.6-rc.1 contains the following code:
```
// implement `FromRequestParts` if you don't need to consume the request body
#[async_trait]
impl<S> FromRequestParts<S> for MyExtractor
where
    S: Send + Sync,
    B: Send + 'static,
{
    type Rejection = StatusCode;

    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
        // ...
    }
}
```

`B: Send + 'static` cannot compile as `B` is not known for this implementation.

## Solution

Remove `B: Send + 'static`.