### PR TITLE
Add example for parsing body based on `Content-Type`

### DIFF
--- a/examples/parse-body-based-on-content-type/Cargo.toml
+++ b/examples/parse-body-based-on-content-type/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "example-parse-body-based-on-content-type"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+axum = { path = "../../axum" }
+serde = { version = "1.0", features = ["derive"] }
+tokio = { version = "1.0", features = ["full"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/parse-body-based-on-content-type/src/main.rs
+++ b/examples/parse-body-based-on-content-type/src/main.rs
@@ -1,16 +1,9 @@
 //! Provides a RESTful web server managing some Todos.
 //!
-//! API will be:
-//!
-//! - `GET /todos`: return a JSON list of Todos.
-//! - `POST /todos`: create a new Todo.
-//! - `PUT /todos/:id`: update a specific Todo.
-//! - `DELETE /todos/:id`: delete a specific Todo.
-//!
 //! Run with
 //!
 //! ```not_rust
-//! cd examples && cargo run -p example-todos
+//! cd examples && cargo run -p example-parse-body-based-on-content-type
 //! ```
 
 use axum::{

--- a/examples/parse-body-based-on-content-type/src/main.rs
+++ b/examples/parse-body-based-on-content-type/src/main.rs
@@ -57,14 +57,14 @@ enum JsonOrForm<T, K = T> {
 }
 
 #[async_trait]
-impl<S, B, T, K> FromRequest<S, B> for JsonOrForm<T, K>
+impl<S, B, T, U> FromRequest<S, B> for JsonOrForm<T, U>
 where
     B: Send + 'static,
     S: Send + Sync,
     Json<T>: FromRequest<(), B>,
-    Form<K>: FromRequest<(), B>,
+    Form<U>: FromRequest<(), B>,
     T: 'static,
-    K: 'static,
+    U: 'static,
 {
     type Rejection = Response;
 

--- a/examples/parse-body-based-on-content-type/src/main.rs
+++ b/examples/parse-body-based-on-content-type/src/main.rs
@@ -1,0 +1,97 @@
+//! Provides a RESTful web server managing some Todos.
+//!
+//! API will be:
+//!
+//! - `GET /todos`: return a JSON list of Todos.
+//! - `POST /todos`: create a new Todo.
+//! - `PUT /todos/:id`: update a specific Todo.
+//! - `DELETE /todos/:id`: delete a specific Todo.
+//!
+//! Run with
+//!
+//! ```not_rust
+//! cd examples && cargo run -p example-todos
+//! ```
+
+use axum::{
+    async_trait,
+    extract::FromRequest,
+    http::{header::CONTENT_TYPE, Request, StatusCode},
+    response::{IntoResponse, Response},
+    Form, Json, RequestExt, Router, routing::post,
+};
+use serde::{Deserialize, Serialize};
+use std::net::SocketAddr;
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::registry()
+        .with(tracing_subscriber::EnvFilter::new(
+            std::env::var("RUST_LOG").unwrap_or_else(|_| {
+                "example_parse_body_based_on_content_type=debug,tower_http=debug".into()
+            }),
+        ))
+        .with(tracing_subscriber::fmt::layer())
+        .init();
+
+    let app = Router::new().route("/", post(handler));
+
+    let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
+    tracing::debug!("listening on {}", addr);
+    axum::Server::bind(&addr)
+        .serve(app.into_make_service())
+        .await
+        .unwrap();
+}
+
+#[derive(Serialize, Deserialize)]
+struct Payload {
+    foo: String,
+}
+
+async fn handler(payload: JsonOrForm<Payload>) -> Response {
+    match payload {
+        JsonOrForm::Json(payload) => Json(payload).into_response(),
+        JsonOrForm::Form(payload) => Form(payload).into_response(),
+    }
+}
+
+enum JsonOrForm<T, K = T> {
+    Json(T),
+    Form(K),
+}
+
+#[async_trait]
+impl<S, B, T, K> FromRequest<S, B> for JsonOrForm<T, K>
+where
+    B: Send + 'static,
+    S: Send + Sync,
+    Json<T>: FromRequest<(), B>,
+    Form<K>: FromRequest<(), B>,
+    T: 'static,
+    K: 'static,
+{
+    type Rejection = Response;
+
+    async fn from_request(req: Request<B>, _state: &S) -> Result<Self, Self::Rejection> {
+        let content_type = req
+            .headers()
+            .get(CONTENT_TYPE)
+            .and_then(|value| value.to_str().ok())
+            .map(|value| value.to_owned())
+            .ok_or_else(|| StatusCode::UNSUPPORTED_MEDIA_TYPE.into_response())?;
+
+        if content_type.starts_with("application/json") {
+            let Json(payload) = req.extract().await.map_err(IntoResponse::into_response)?;
+            return Ok(Self::Json(payload));
+        }
+
+        if content_type.starts_with("application/x-www-form-urlencoded") {
+            let Form(payload) = req.extract().await.map_err(IntoResponse::into_response)?;
+            return Ok(Self::Form(payload));
+        }
+
+        Err(StatusCode::UNSUPPORTED_MEDIA_TYPE.into_response())
+    }
+}

--- a/examples/parse-body-based-on-content-type/src/main.rs
+++ b/examples/parse-body-based-on-content-type/src/main.rs
@@ -76,21 +76,19 @@ where
     type Rejection = Response;
 
     async fn from_request(req: Request<B>, _state: &S) -> Result<Self, Self::Rejection> {
-        let content_type = req
-            .headers()
-            .get(CONTENT_TYPE)
-            .and_then(|value| value.to_str().ok())
-            .map(|value| value.to_owned())
-            .ok_or_else(|| StatusCode::UNSUPPORTED_MEDIA_TYPE.into_response())?;
+        let content_type_header = req.headers().get(CONTENT_TYPE);
+        let content_type = content_type_header.and_then(|value| value.to_str().ok());
 
-        if content_type.starts_with("application/json") {
-            let Json(payload) = req.extract().await.map_err(IntoResponse::into_response)?;
-            return Ok(Self::Json(payload));
-        }
+        if let Some(content_type) = content_type {
+            if content_type.starts_with("application/json") {
+                let Json(payload) = req.extract().await.map_err(IntoResponse::into_response)?;
+                return Ok(Self::Json(payload));
+            }
 
-        if content_type.starts_with("application/x-www-form-urlencoded") {
-            let Form(payload) = req.extract().await.map_err(IntoResponse::into_response)?;
-            return Ok(Self::Form(payload));
+            if content_type.starts_with("application/x-www-form-urlencoded") {
+                let Form(payload) = req.extract().await.map_err(IntoResponse::into_response)?;
+                return Ok(Self::Form(payload));
+            }
         }
 
         Err(StatusCode::UNSUPPORTED_MEDIA_TYPE.into_response())

--- a/examples/parse-body-based-on-content-type/src/main.rs
+++ b/examples/parse-body-based-on-content-type/src/main.rs
@@ -18,7 +18,8 @@ use axum::{
     extract::FromRequest,
     http::{header::CONTENT_TYPE, Request, StatusCode},
     response::{IntoResponse, Response},
-    Form, Json, RequestExt, Router, routing::post,
+    routing::post,
+    Form, Json, RequestExt, Router,
 };
 use serde::{Deserialize, Serialize};
 use std::net::SocketAddr;


### PR DESCRIPTION
Gotten a few questions from people trying to do

```rust
async fn handler(
    form: Option<Form<BTreeMap<String, String>>>,
    multipart: Option<Multipart>,
) {
```

basically parse the body based on the content-type.

I think writing a custom extractor that inspects the content-type and delegates the corresponding extractor is a good way to solve it. So this adds an example for that.