### PR TITLE
[doc] Added notes about extractor precedence

### DIFF
--- a/axum/src/extract/content_length_limit.rs
+++ b/axum/src/extract/content_length_limit.rs
@@ -6,8 +6,16 @@ use std::ops::Deref;
 
 /// Extractor that will reject requests with a body larger than some size.
 ///
+///
 /// `GET`, `HEAD`, and `OPTIONS` requests are rejected if they have a `Content-Length` header,
 /// otherwise they're accepted without the body being checked.
+///
+/// Note: `ContentLengthLimit` can wrap types that extract the body (for example, Form or Json)
+/// if that is the case, the inner type will consume the request's body, which means the
+/// ContentLengthLimit must come *last* if the handler uses several extractors. See
+/// ["the order of extractors"][order-of-extractors]
+///
+/// [order-of-extractors]: crate::extract#the-order-of-extractors
 ///
 /// # Example
 ///

--- a/axum/src/extract/content_length_limit.rs
+++ b/axum/src/extract/content_length_limit.rs
@@ -6,7 +6,6 @@ use std::ops::Deref;
 
 /// Extractor that will reject requests with a body larger than some size.
 ///
-///
 /// `GET`, `HEAD`, and `OPTIONS` requests are rejected if they have a `Content-Length` header,
 /// otherwise they're accepted without the body being checked.
 ///

--- a/axum/src/extract/content_length_limit.rs
+++ b/axum/src/extract/content_length_limit.rs
@@ -15,6 +15,8 @@ use std::ops::Deref;
 /// ["the order of extractors"][order-of-extractors]
 ///
 /// [order-of-extractors]: crate::extract#the-order-of-extractors
+/// [`Form`]: crate::form::Form
+/// [`Json`]: crate::json::Json
 ///
 /// # Example
 ///

--- a/axum/src/extract/content_length_limit.rs
+++ b/axum/src/extract/content_length_limit.rs
@@ -9,9 +9,9 @@ use std::ops::Deref;
 /// `GET`, `HEAD`, and `OPTIONS` requests are rejected if they have a `Content-Length` header,
 /// otherwise they're accepted without the body being checked.
 ///
-/// Note: `ContentLengthLimit` can wrap types that extract the body (for example, Form or Json)
+/// Note: `ContentLengthLimit` can wrap types that extract the body (for example, [`Form`] or [`Json`])
 /// if that is the case, the inner type will consume the request's body, which means the
-/// ContentLengthLimit must come *last* if the handler uses several extractors. See
+/// `ContentLengthLimit` must come *last* if the handler uses several extractors. See
 /// ["the order of extractors"][order-of-extractors]
 ///
 /// [order-of-extractors]: crate::extract#the-order-of-extractors

--- a/axum/src/extract/multipart.rs
+++ b/axum/src/extract/multipart.rs
@@ -17,7 +17,7 @@ use std::{
 
 /// Extractor that parses `multipart/form-data` requests (commonly used with file uploads).
 ///
-/// Since extracting multipart form data from the request requires consuming it, the
+/// Since extracting multipart form data from the request requires consuming the body, the
 /// `Multipart` extractor must be *last* if there are multiple extractors in a handler.
 /// See ["the order of extractors"][order-of-extractors]
 ///

--- a/axum/src/extract/multipart.rs
+++ b/axum/src/extract/multipart.rs
@@ -17,6 +17,12 @@ use std::{
 
 /// Extractor that parses `multipart/form-data` requests (commonly used with file uploads).
 ///
+/// Since extracting multipart form data from the request requires consuming it, the 
+/// `Multipart` extractor must be *last* if there are multiple extractors in a handler. 
+/// See ["the order of extractors"][order-of-extractors]
+///
+/// [order-of-extractors]: crate::extract#the-order-of-extractors
+/// 
 /// # Example
 ///
 /// ```rust,no_run

--- a/axum/src/extract/multipart.rs
+++ b/axum/src/extract/multipart.rs
@@ -17,12 +17,12 @@ use std::{
 
 /// Extractor that parses `multipart/form-data` requests (commonly used with file uploads).
 ///
-/// Since extracting multipart form data from the request requires consuming it, the 
-/// `Multipart` extractor must be *last* if there are multiple extractors in a handler. 
+/// Since extracting multipart form data from the request requires consuming it, the
+/// `Multipart` extractor must be *last* if there are multiple extractors in a handler.
 /// See ["the order of extractors"][order-of-extractors]
 ///
 /// [order-of-extractors]: crate::extract#the-order-of-extractors
-/// 
+///
 /// # Example
 ///
 /// ```rust,no_run

--- a/axum/src/extract/request_parts.rs
+++ b/axum/src/extract/request_parts.rs
@@ -103,6 +103,12 @@ where
 
 /// Extractor that extracts the request body as a [`Stream`].
 ///
+/// Since extracting the request body requires consuming it, the `BodyStream` extractor must be
+/// *last* if there are multiple extractors in a handler.
+/// See ["the order of extractors"][order-of-extractors]
+///
+/// [order-of-extractors]: crate::extract#the-order-of-extractors
+///
 /// # Example
 ///
 /// ```rust,no_run
@@ -172,6 +178,11 @@ fn body_stream_traits() {
 }
 
 /// Extractor that extracts the raw request body.
+///
+/// Since extracting the raw request body requires consuming it, the `RawBody` extractor must be
+/// *last* if there are multiple extractors in a handler. See ["the order of extractors"][order-of-extractors]
+///
+/// [order-of-extractors]: crate::extract#the-order-of-extractors
 ///
 /// # Example
 ///

--- a/axum/src/extract/state.rs
+++ b/axum/src/extract/state.rs
@@ -11,7 +11,7 @@ use std::{
 /// Note this extractor is not available to middleware. See ["Accessing state in
 /// middleware"][state-from-middleware] for how to access state in middleware.
 ///
-/// [state-from-middleware]: ../middleware/index.html#accessing-state-in-middleware
+/// [state-from-middleware]: crate::middleware#accessing-state-in-middleware
 ///
 /// # With `Router`
 ///
@@ -22,6 +22,7 @@ use std::{
 /// //
 /// // here you can put configuration, database connection pools, or whatever
 /// // state you need
+/// // Note: the application state *must* derive `Clone` (or be wrapped in e.g. `Arc`)
 /// #[derive(Clone)]
 /// struct AppState {}
 ///

--- a/axum/src/form.rs
+++ b/axum/src/form.rs
@@ -19,7 +19,7 @@ use std::ops::Deref;
 /// Since parsing form data requires consuming the request body, the `Form` extractor must be
 /// *last* if there are multiple extractors in a handler. See ["the order of extractors"][order-of-extractors]
 ///
-/// [order-of-extractors]: extract/index.html#the-order-of-extractors
+/// [order-of-extractors]: crate::extract#the-order-of-extractors
 ///
 /// ```rust
 /// use axum::Form;

--- a/axum/src/form.rs
+++ b/axum/src/form.rs
@@ -16,6 +16,11 @@ use std::ops::Deref;
 /// If used as an extractor `Form` will deserialize `application/x-www-form-urlencoded` request
 /// bodies into some target type via [`serde::Deserialize`].
 ///
+/// Since parsing form data requires consuming the request body, the `Form` extractor must be
+/// *last* if there are multiple extractors in a handler. See ["the order of extractors"][order-of-extractors]
+///
+/// [order-of-extractors]: extract/index.html#the-order-of-extractors
+///
 /// ```rust
 /// use axum::Form;
 /// use serde::Deserialize;

--- a/axum/src/json.rs
+++ b/axum/src/json.rs
@@ -25,6 +25,11 @@ use std::ops::{Deref, DerefMut};
 /// type.
 /// - Buffering the request body fails.
 ///
+/// Since parsing JSON requires consuming the request body, the `Json` extractor must be
+/// *last* if there are multiple extractors in a handler. See ["the order of extractors"][order-of-extractors]
+///
+/// [order-of-extractors]: extract/index.html#the-order-of-extractors
+///
 /// See [`JsonRejection`] for more details.
 ///
 /// # Extractor example

--- a/axum/src/json.rs
+++ b/axum/src/json.rs
@@ -26,9 +26,10 @@ use std::ops::{Deref, DerefMut};
 /// - Buffering the request body fails.
 ///
 /// Since parsing JSON requires consuming the request body, the `Json` extractor must be
-/// *last* if there are multiple extractors in a handler. See ["the order of extractors"][order-of-extractors]
+/// *last* if there are multiple extractors in a handler.
+/// See ["the order of extractors"][order-of-extractors]
 ///
-/// [order-of-extractors]: extract/index.html#the-order-of-extractors
+/// [order-of-extractors]: crate::extract#the-order-of-extractors
 ///
 /// See [`JsonRejection`] for more details.
 ///


### PR DESCRIPTION
Added a note in the structs docs  pointing to the relevant part of the documentation regarding extractor precedence.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation

During discussion of a slightly unrelated problem (https://github.com/tokio-rs/axum/issues/1321), it was discovered that my example was ordering the extractors wrong, causing a compile-time problem.

## Solution

This PR should hopefully make the solution for the above problem (reordering extractors) a little bit more discoverable.
