### PR TITLE
Panic when attempting to add a route_layer to an empty router

### DIFF
--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -7,7 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
-- None
+## Routing
+
+- **breaking:** Adding a `.route_layer` onto a `Router` or `MethodRouter`
+  without any routes will now result in a panic. Previously, this just did
+  nothing. [#1327]
+
+[#1327]: https://github.com/tokio-rs/axum/pull/1327
 
 # 0.6.0-rc.1 (23. August, 2022)
 

--- a/axum/src/routing/mod.rs
+++ b/axum/src/routing/mod.rs
@@ -352,6 +352,7 @@ where
     }
 
     #[doc = include_str!("../docs/routing/route_layer.md")]
+    #[track_caller]
     pub fn route_layer<L>(self, layer: L) -> Self
     where
         L: Layer<Route<B>>,
@@ -360,6 +361,13 @@ where
         <L::Service as Service<Request<B>>>::Error: Into<Infallible> + 'static,
         <L::Service as Service<Request<B>>>::Future: Send + 'static,
     {
+        if self.routes.is_empty() {
+            panic!(
+                "Adding a route_layer before any routes is a no-op. \
+                 Add the routes you want the layer to apply to first."
+            );
+        }
+
         let layer = ServiceBuilder::new()
             .map_err(Into::into)
             .layer(MapResponseLayer::new(IntoResponse::into_response))


### PR DESCRIPTION
Maybe we should also disallow / heavily discourage routers that only consist of a fallback and panic in the `layer` methods as well?