### PR TITLE
Update out of date `Router::nest` docs

### DIFF
--- a/axum/src/docs/routing/nest.md
+++ b/axum/src/docs/routing/nest.md
@@ -146,8 +146,6 @@ let app = Router::new()
 for more details.
 - If the route contains a wildcard (`*`).
 - If `path` is empty.
-- If the nested router has a [fallback](Router::fallback). This is because
-  `Router` only allows a single fallback.
 
 [`OriginalUri`]: crate::extract::OriginalUri
 [fallbacks]: Router::fallback


### PR DESCRIPTION
`Router::nest` no longer panics if the inner router has a fallback.

Fixes https://github.com/tokio-rs/axum/issues/1319