### PR TITLE
Improve opaque error message for `Handler::layer`

### DIFF
--- a/axum/src/handler/mod.rs
+++ b/axum/src/handler/mod.rs
@@ -140,7 +140,7 @@ pub trait Handler<T, S, B = Body>: Clone + Send + Sized + 'static {
     /// ```
     fn layer<L>(self, layer: L) -> Layered<L, Self, T, S, B>
     where
-        L: Layer<WithState<Self, T, S, B>>,
+        L: Layer<WithState<Self, T, S, B>> + Clone,
     {
         Layered {
             layer,


### PR DESCRIPTION
Layers applied with `Hander::layer` must implement `Clone`. If they don't you get the familiar "Handler not implemented ..." error. Other methods like `Router::layer` doesn't require this and its pretty confusing why a layer would work on a router but not on a handler. I just spent an hour helping someone on Discord track this down 😅

The reason the `Handler::layer` requires `L: Clone` is that layers can only be applied to `Service`s and turning a `Handler` into a `Service` requires the state. We don't have the state yet in `Handler::layer` so instead we store the layer with the handler and apply the layer in `<Layered as Handler>::call`.