### PR TITLE
Refactor macro argument parsing code

### DIFF
--- a/axum-macros/src/debug_handler.rs
+++ b/axum-macros/src/debug_handler.rs
@@ -5,11 +5,7 @@ use crate::{
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote, quote_spanned};
 use std::collections::HashSet;
-use syn::{
-    parse::{Parse, ParseStream},
-    spanned::Spanned,
-    FnArg, ItemFn, Token, Type,
-};
+use syn::{parse::Parse, spanned::Spanned, FnArg, ItemFn, Token, Type};
 
 pub(crate) fn expand(mut attr: Attrs, item_fn: ItemFn) -> TokenStream {
     let check_extractor_count = check_extractor_count(&item_fn);

--- a/axum-macros/src/lib.rs
+++ b/axum-macros/src/lib.rs
@@ -86,7 +86,7 @@ macro_rules! parse_arg {
     ( $ident:ident: $kw:ident ( $arg:ty ) ) => {
         parse_arg!(@setup $ident: $kw = $arg);
 
-        impl Parse for $ident {
+        impl syn::parse::Parse for $ident {
             fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
                 let kw = input.parse::<$kw::$kw>()?;
                 let content;
@@ -111,8 +111,8 @@ macro_rules! parse_args_enum {
             $( $variant($variant), )*
         }
 
-        impl Parse for $ident {
-            fn parse(input: ParseStream) -> syn::Result<Self> {
+        impl syn::parse::Parse for $ident {
+            fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
                 let lh = input.lookahead1();
 
                 $(


### PR DESCRIPTION
Fixes https://github.com/tokio-rs/axum/issues/1284

This alignes how argument parsing is done in the four macros. It also makes it easier to add more arguments in the future (required for https://github.com/tokio-rs/axum/issues/1314)