### PR TITLE
Add `middleware::{from_fn_with_state, from_fn_with_state_arc}`

### DIFF
--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -17,9 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **added**: Add `middleware::from_fn_with_state` and
   `middleware::from_fn_with_state_arc` to enable running extractors that require
-  state
+  state ([#1342])
 
 [#1327]: https://github.com/tokio-rs/axum/pull/1327
+[#1342]: https://github.com/tokio-rs/axum/pull/1342
 
 # 0.6.0-rc.1 (23. August, 2022)
 

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   without any routes will now result in a panic. Previously, this just did
   nothing. [#1327]
 
+## Middleware
+
+- **added**: Add `middleware::from_fn_with_state` and
+  `middleware::from_fn_with_state_arc` to enable running extractors that require
+  state
+
 [#1327]: https://github.com/tokio-rs/axum/pull/1327
 
 # 0.6.0-rc.1 (23. August, 2022)

--- a/axum/src/middleware/mod.rs
+++ b/axum/src/middleware/mod.rs
@@ -6,7 +6,9 @@ mod from_extractor;
 mod from_fn;
 
 pub use self::from_extractor::{from_extractor, FromExtractor, FromExtractorLayer};
-pub use self::from_fn::{from_fn, FromFn, FromFnLayer, Next};
+pub use self::from_fn::{
+    from_fn, from_fn_with_state, from_fn_with_state_arc, FromFn, FromFnLayer, Next,
+};
 pub use crate::extension::AddExtension;
 
 pub mod future {


### PR DESCRIPTION
Makes running extractors like `PrivateCookieJar` and `State` easier from middleware created with async functions.