### PR TITLE
Limit size of request bodies in `Bytes` extractor

### DIFF
--- a/axum-core/CHANGELOG.md
+++ b/axum-core/CHANGELOG.md
@@ -7,7 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
-- None.
+- **breaking:** Added default limit to how much data `Bytes::from_request` will
+  consume. Previously it would attempt to consume the entire request body
+  without checking its length. This meant if a malicious peer sent an large (or
+  infinite) request body your server might run out of memory and crash.
+
+  The default limit is at 2 MB and can be disabled by adding the new
+  `DefaultBodyLimit::disable()` middleware. See its documentation for more
+  details.
+
+  This also applies to `String` which used `Bytes::from_request` internally.
+
+  ([#1346])
+
+[#1346]: https://github.com/tokio-rs/axum/pull/1346
 
 # 0.3.0-rc.1 (23. August, 2022)
 

--- a/axum-core/Cargo.toml
+++ b/axum-core/Cargo.toml
@@ -18,6 +18,8 @@ futures-util = { version = "0.3", default-features = false, features = ["alloc"]
 http = "0.2.7"
 http-body = "0.4.5"
 mime = "0.3.16"
+tower-layer = "0.3"
+tower-service = "0.3"
 
 [dev-dependencies]
 axum = { path = "../axum", version = "0.6.0-rc.1" }

--- a/axum-core/Cargo.toml
+++ b/axum-core/Cargo.toml
@@ -26,3 +26,4 @@ axum = { path = "../axum", version = "0.6.0-rc.1" }
 futures-util = "0.3"
 hyper = "0.14"
 tokio = { version = "1.0", features = ["macros"] }
+tower-http = { version = "0.3.4", features = ["limit"] }

--- a/axum-core/src/extract/default_body_limit.rs
+++ b/axum-core/src/extract/default_body_limit.rs
@@ -1,0 +1,52 @@
+#![allow(missing_docs)]
+
+use http::Request;
+use std::task::Context;
+use tower_layer::Layer;
+use tower_service::Service;
+
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct DefaultBodyLimit;
+
+impl DefaultBodyLimit {
+    pub fn disable() -> Self {
+        Self
+    }
+}
+
+impl<S> Layer<S> for DefaultBodyLimit {
+    type Service = DefaultBodyLimitService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        DefaultBodyLimitService { inner }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct DefaultBodyLimitService<S> {
+    pub(super) inner: S,
+}
+
+impl<B, S> Service<Request<B>> for DefaultBodyLimitService<S>
+where
+    S: Service<Request<B>>,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = S::Future;
+
+    #[inline]
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> std::task::Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    #[inline]
+    fn call(&mut self, mut req: Request<B>) -> Self::Future {
+        req.extensions_mut().insert(DefaultBodyLimitDisabled);
+        self.inner.call(req)
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+pub(crate) struct DefaultBodyLimitDisabled;

--- a/axum-core/src/extract/default_body_limit.rs
+++ b/axum-core/src/extract/default_body_limit.rs
@@ -1,15 +1,57 @@
-#![allow(missing_docs)]
-
-use http::Request;
-use std::task::Context;
+use self::private::DefaultBodyLimitService;
 use tower_layer::Layer;
-use tower_service::Service;
 
+/// Layer for configuring the default request body limit.
+///
+/// For security reasons, [`Bytes`] will, by default, not accept bodies larger than 2MB. This also
+/// applies to extractors that uses [`Bytes`] internally such as `String`, [`Json`], and [`Form`].
+///
+/// This middleware provides ways to configure that.
+///
+/// Note that if an extractor consumes the body directly with [`Body::data`], or similar, the
+/// default limit is _not_ applied.
+///
+/// [`Body::data`]: http_body::Body::data
+/// [`Bytes`]: bytes::Bytes
+/// [`Json`]: https://docs.rs/axum/0.6.0-rc.1/axum/struct.Json.html
+/// [`Form`]: https://docs.rs/axum/0.6.0-rc.1/axum/struct.Form.html
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct DefaultBodyLimit;
 
 impl DefaultBodyLimit {
+    /// Disable the default request body limit.
+    ///
+    /// This must be used to receive bodies larger than the default limit of 2MB using [`Bytes`] or
+    /// an extractor built on it such as `String`, [`Json`], [`Form`].
+    ///
+    /// Note that if you're accepting data from untrusted remotes it is recommend to add your own
+    /// limit such as [`tower_http::limit`].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use axum::{
+    ///     Router,
+    ///     routing::get,
+    ///     body::{Bytes, Body},
+    ///     extract::DefaultBodyLimit,
+    /// };
+    /// use tower_http::limit::RequestBodyLimitLayer;
+    /// use http_body::Limited;
+    ///
+    /// let app: Router<_, Limited<Body>> = Router::new()
+    ///     .route("/", get(|body: Bytes| async {}))
+    ///     // Disable the default limit
+    ///     .layer(DefaultBodyLimit::disable())
+    ///     // Set a different limit
+    ///     .layer(RequestBodyLimitLayer::new(10 * 1000 * 1000));
+    /// ```
+    ///
+    /// [`tower_http::limit`]: https://docs.rs/tower-http/0.3.4/tower_http/limit/index.html
+    /// [`Bytes`]: bytes::Bytes
+    /// [`Json`]: https://docs.rs/axum/0.6.0-rc.1/axum/struct.Json.html
+    /// [`Form`]: https://docs.rs/axum/0.6.0-rc.1/axum/struct.Form.html
     pub fn disable() -> Self {
         Self
     }
@@ -23,30 +65,37 @@ impl<S> Layer<S> for DefaultBodyLimit {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
-pub struct DefaultBodyLimitService<S> {
-    pub(super) inner: S,
-}
-
-impl<B, S> Service<Request<B>> for DefaultBodyLimitService<S>
-where
-    S: Service<Request<B>>,
-{
-    type Response = S::Response;
-    type Error = S::Error;
-    type Future = S::Future;
-
-    #[inline]
-    fn poll_ready(&mut self, cx: &mut Context<'_>) -> std::task::Poll<Result<(), Self::Error>> {
-        self.inner.poll_ready(cx)
-    }
-
-    #[inline]
-    fn call(&mut self, mut req: Request<B>) -> Self::Future {
-        req.extensions_mut().insert(DefaultBodyLimitDisabled);
-        self.inner.call(req)
-    }
-}
-
 #[derive(Copy, Clone, Debug)]
 pub(crate) struct DefaultBodyLimitDisabled;
+
+mod private {
+    use super::DefaultBodyLimitDisabled;
+    use http::Request;
+    use std::task::Context;
+    use tower_service::Service;
+
+    #[derive(Debug, Clone, Copy)]
+    pub struct DefaultBodyLimitService<S> {
+        pub(super) inner: S,
+    }
+
+    impl<B, S> Service<Request<B>> for DefaultBodyLimitService<S>
+    where
+        S: Service<Request<B>>,
+    {
+        type Response = S::Response;
+        type Error = S::Error;
+        type Future = S::Future;
+
+        #[inline]
+        fn poll_ready(&mut self, cx: &mut Context<'_>) -> std::task::Poll<Result<(), Self::Error>> {
+            self.inner.poll_ready(cx)
+        }
+
+        #[inline]
+        fn call(&mut self, mut req: Request<B>) -> Self::Future {
+            req.extensions_mut().insert(DefaultBodyLimitDisabled);
+            self.inner.call(req)
+        }
+    }
+}

--- a/axum-core/src/extract/mod.rs
+++ b/axum-core/src/extract/mod.rs
@@ -11,11 +11,15 @@ use std::convert::Infallible;
 
 pub mod rejection;
 
+mod default_body_limit;
 mod from_ref;
 mod request_parts;
 mod tuple;
 
-pub use self::from_ref::FromRef;
+pub use self::{
+    default_body_limit::{DefaultBodyLimit, DefaultBodyLimitService},
+    from_ref::FromRef,
+};
 
 mod private {
     #[derive(Debug, Clone, Copy)]

--- a/axum-core/src/extract/mod.rs
+++ b/axum-core/src/extract/mod.rs
@@ -16,10 +16,7 @@ mod from_ref;
 mod request_parts;
 mod tuple;
 
-pub use self::{
-    default_body_limit::{DefaultBodyLimit, DefaultBodyLimitService},
-    from_ref::FromRef,
-};
+pub use self::{default_body_limit::DefaultBodyLimit, from_ref::FromRef};
 
 mod private {
     #[derive(Debug, Clone, Copy)]

--- a/axum-core/src/extract/request_parts.rs
+++ b/axum-core/src/extract/request_parts.rs
@@ -84,6 +84,8 @@ where
     type Rejection = BytesRejection;
 
     async fn from_request(req: Request<B>, _: &S) -> Result<Self, Self::Rejection> {
+        // update docs in `axum-core/src/extract/default_body_limit.rs` and
+        // `axum/src/docs/extract.md` if this changes
         const DEFAULT_LIMIT: usize = 2_097_152; // 2 mb
 
         let bytes = if req.extensions().get::<DefaultBodyLimitDisabled>().is_some() {

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
+## Security
+
+- **breaking:** Added default limit to how much data `Bytes::from_request` will
+  consume. Previously it would attempt to consume the entire request body
+  without checking its length. This meant if a malicious peer sent an large (or
+  infinite) request body your server might run out of memory and crash.
+
+  The default limit is at 2 MB and can be disabled by adding the new
+  `DefaultBodyLimit::disable()` middleware. See its documentation for more
+  details.
+
+  This also applies to these extractors which used `Bytes::from_request`
+  internally:
+  - `Form`
+  - `Json`
+  - `String`
+
+  ([#1346])
+
 ## Routing
 
 - **breaking:** Adding a `.route_layer` onto a `Router` or `MethodRouter`
@@ -21,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [#1327]: https://github.com/tokio-rs/axum/pull/1327
 [#1342]: https://github.com/tokio-rs/axum/pull/1342
+[#1346]: https://github.com/tokio-rs/axum/pull/1346
 
 # 0.6.0-rc.1 (23. August, 2022)
 

--- a/axum/src/docs/extract.md
+++ b/axum/src/docs/extract.md
@@ -11,6 +11,7 @@ Types and traits for extracting data from requests.
 - [Accessing inner errors](#accessing-inner-errors)
 - [Defining custom extractors](#defining-custom-extractors)
 - [Accessing other extractors in `FromRequest` or `FromRequestParts` implementations](#accessing-other-extractors-in-fromrequest-or-fromrequestparts-implementations)
+- [Request body limits](#request-body-limits)
 - [Request body extractors](#request-body-extractors)
 - [Running extractors from middleware](#running-extractors-from-middleware)
 - [Wrapping extractors](#wrapping-extractors)
@@ -620,6 +621,14 @@ let app = Router::new().route("/", get(handler)).layer(Extension(state));
 # };
 ```
 
+# Request body limits
+
+For security reasons, [`Bytes`] will, by default, not accept bodies larger than
+2MB. This also applies to extractors that uses [`Bytes`] internally such as
+`String`, [`Json`], and [`Form`].
+
+For more details, including how to disable this limit, see [`DefaultBodyLimit`].
+
 # Request body extractors
 
 Most of the time your request body type will be [`body::Body`] (a re-export
@@ -816,6 +825,7 @@ async fn handler(
 ```
 
 [`body::Body`]: crate::body::Body
+[`Bytes`]: crate::body::Bytes
 [customize-extractor-error]: https://github.com/tokio-rs/axum/blob/main/examples/customize-extractor-error/src/main.rs
 [`HeaderMap`]: https://docs.rs/http/latest/http/header/struct.HeaderMap.html
 [`Request`]: https://docs.rs/http/latest/http/struct.Request.html

--- a/axum/src/extract/mod.rs
+++ b/axum/src/extract/mod.rs
@@ -16,7 +16,7 @@ mod request_parts;
 mod state;
 
 #[doc(inline)]
-pub use axum_core::extract::{FromRef, FromRequest, FromRequestParts};
+pub use axum_core::extract::{DefaultBodyLimit, FromRef, FromRequest, FromRequestParts};
 
 #[doc(inline)]
 #[allow(deprecated)]


### PR DESCRIPTION
## Motivation

We recently received a report of a vulnerability in axum caused by `Bytes::from_request` calling [`hyper::body::into_bytes`](https://docs.rs/hyper/latest/hyper/body/fn.to_bytes.html) directly without setting a limit. This meant if someone sent an infinite request body the server would attempt to buffer the whole thing in memory and eventually OOM.

This also applies to extractors that calls `Bytes::from_request` internally like `String`, `Json`, and `Form`.

## Solution

I think the right move is to set a default limit on how much `Bytes::from_request` will consume. I don't think just documenting it is enough since users might not notice.

This PR fixes it by wrapping the body in [`http_body::Limited`](https://docs.rs/http-body/latest/http_body/struct.Limited.html) before calling `into_bytes`. This can be disabled by adding the new `DefaultBodyLimit::disable()` middleware. That sets a private extension which `Bytes::from_request` looks for.

Once this is merged I'll backport this to 0.5