### PR TITLE
expose FromRequest and FromRequestParts macros in axum

### DIFF
--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -13,6 +13,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   without any routes will now result in a panic. Previously, this just did
   nothing. [#1327]
 
+## Extractors
+
+- **added:** `FromRequest` and `FromRequestParts` derive macro re-exports from [`axum-macros`] behind the `macros` feature ([#1352])
+
+[`axum-macros`]: https://docs.rs/axum-macros/latest/axum_macros/
+[#1352]: https://github.com/tokio-rs/axum/pull/1352
+
 ## Middleware
 
 - **added**: Add `middleware::from_fn_with_state` and

--- a/axum/src/extract/mod.rs
+++ b/axum/src/extract/mod.rs
@@ -18,6 +18,9 @@ mod state;
 #[doc(inline)]
 pub use axum_core::extract::{FromRef, FromRequest, FromRequestParts};
 
+#[cfg(feature = "macros")]
+pub use axum_macros::{FromRequest, FromRequestParts};
+
 #[doc(inline)]
 #[allow(deprecated)]
 pub use self::{


### PR DESCRIPTION
I would expect to just `#[derive(FromRequest)]` if the `macros` feature is enabled, this tiny PR enables that.
