### PR TITLE
Add must_use attribute to Redirect type

### DIFF
--- a/axum/src/response/redirect.rs
+++ b/axum/src/response/redirect.rs
@@ -19,6 +19,7 @@ use http::{header::LOCATION, HeaderValue, StatusCode};
 /// # hyper::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
 /// # };
 /// ```
+#[must_use = "needs to be returned from a handler or otherwise turned into a Response to be useful"]
 #[derive(Debug, Clone)]
 pub struct Redirect {
     status_code: StatusCode,


### PR DESCRIPTION
## Motivation

I just had somebody ask me for help with a redirect that wasn't working, turns out they just didn't return the `Redirect` from the handler.

## Solution

Have the compiler emit a warning if a `Redirect` goes unused.