### PR TITLE
feat: Add axum-casbin-auth and axum-middleware-example

### DIFF
--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -23,6 +23,7 @@ If your project isn't listed here and you would like it to be, please feel free 
 - [axum-streams](https://github.com/abdolence/axum-streams-rs): Streaming HTTP body with different formats: JSON, CSV, Protobuf.
 - [axum-template](https://github.com/Altair-Bueno/axum-template): Layers, extractors and template engine wrappers for axum based Web MVC applications
 - [axum-guard-logic](https://github.com/sjud/axum_guard_logic): Use AND/OR logic to extract types and check their values against `Service` inputs.
+- [axum-casbin-auth](https://github.com/casbin-rs/axum-casbin-auth): Casbin access control middleware for axum framework
 
 ## Project showcase
 
@@ -45,6 +46,7 @@ If your project isn't listed here and you would like it to be, please feel free 
 - [axum_admin](https://github.com/lingdu1234/axum_admin): An admin panel built with **axum**, Sea-orm and Vue 3.
 - [rgit](https://git.inept.dev/~doyle/rgit.git/about): A blazingly fast Git repository browser, compatible with- and heavily inspired by cgit.
 - [Petclinic](https://github.com/danipardo/petclinic): A port of Spring Framework's Petclinic showcase project to Axum
+- [axum-middleware-example](https://github.com/casbin-rs/axum-middleware-example): A authorization application using Axum-web, Casbin and Diesel, with JWT support.
 
 [Realworld]: https://github.com/gothinkster/realworld
 [SQLx]: https://github.com/launchbadge/sqlx


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation
Currently, the rust version of Casbin is ready for production and we are developing the ecosystem around it. `axum-casbin-auth` uses Axum web framework to build a basic middleware which can handle requests with authorization control. It can basically read username, request path, request method and send enforce request to casbin enforcer for authorization.

`axum-middleware-example` is a simple example demonstrating the authorization using Casbin Axum Middleware.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution
I wish to showcase these developments under axum ecosystem so that open source community can take benefit from it. Hence I have added pointers to them in ECOSYSTEM.md
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
