### PR TITLE
Relax Multipart FromRequest implementation bounds

### DIFF
--- a/axum/src/extract/multipart.rs
+++ b/axum/src/extract/multipart.rs
@@ -249,7 +249,7 @@ define_rejection! {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{response::IntoResponse, routing::post, test_helpers::*, Router};
+    use crate::{body::Body, response::IntoResponse, routing::post, test_helpers::*, Router};
 
     #[tokio::test]
     async fn content_type_with_encoding() {
@@ -280,5 +280,11 @@ mod tests {
         );
 
         client.post("/").multipart(form).send().await;
+    }
+
+    // No need for this to be a #[test], we just want to make sure it compiles
+    fn _multipart_from_request_limited() {
+        async fn handler(_: Multipart) {}
+        let _app: Router<(), http_body::Limited<Body>> = Router::new().route("/", post(handler));
     }
 }

--- a/axum/src/extract/multipart.rs
+++ b/axum/src/extract/multipart.rs
@@ -59,7 +59,8 @@ pub struct Multipart {
 #[async_trait]
 impl<S, B> FromRequest<S, B> for Multipart
 where
-    B: HttpBody<Data = Bytes> + Send + 'static,
+    B: HttpBody + Send + 'static,
+    B::Data: Into<Bytes>,
     B::Error: Into<BoxError>,
     S: Send + Sync,
 {

--- a/axum/src/extract/multipart.rs
+++ b/axum/src/extract/multipart.rs
@@ -59,7 +59,7 @@ pub struct Multipart {
 #[async_trait]
 impl<S, B> FromRequest<S, B> for Multipart
 where
-    B: HttpBody<Data = Bytes> + Default + Unpin + Send + 'static,
+    B: HttpBody<Data = Bytes> + Send + 'static,
     B::Error: Into<BoxError>,
     S: Send + Sync,
 {


### PR DESCRIPTION
Without this, it was impossible to use [tower_http::limit](https://docs.rs/tower-http/latest/tower_http/limit/index.html) with `Multipart` because `http_body::Limited` doesn't implement `Default`.

The first commit is not a breaking change and can thus be backported to 0.5.