### PR TITLE
Use `400 Bad Request` for `FailedToDeserializeQueryString` rejections

### DIFF
--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -12,8 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `serde_json::Error` ([#1371])
 - **added**: `JsonRejection` now displays the path at which a deserialization
   error occurred too ([#1371])
+- **fixed:** Used `400 Bad Request` for `FailedToDeserializeQueryString`
+  rejections, instead of `422 Unprocessable Entity` ([#1387])
 
 [#1371]: https://github.com/tokio-rs/axum/pull/1371
+[#1387]: https://github.com/tokio-rs/axum/pull/1387
 
 # 0.6.0-rc.2 (10. September, 2022)
 

--- a/axum/src/extract/rejection.rs
+++ b/axum/src/extract/rejection.rs
@@ -116,7 +116,7 @@ impl FailedToDeserializeQueryString {
 
 impl IntoResponse for FailedToDeserializeQueryString {
     fn into_response(self) -> Response {
-        (http::StatusCode::UNPROCESSABLE_ENTITY, self.to_string()).into_response()
+        (http::StatusCode::BAD_REQUEST, self.to_string()).into_response()
     }
 }
 


### PR DESCRIPTION
Fixes https://github.com/tokio-rs/axum/issues/1378

From [the spec] about `422 Unprocessable Entity`:

> For example, this error condition may occur if an XML request body
> contains well-formed (i.e., syntactically correct), but semantically
> erroneous, XML instructions.

I understand this to mean that query params shouldn't use 422 because that is about the request body.

So this changes `FailedToDeserializeQueryString` from `422 Unprocessable Entity` to `400 Bad Request`.

[the spec]: https://datatracker.ietf.org/doc/html/rfc4918#section-11.2

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
