### PR TITLE
Support streaming/chunked requests in `ContentLengthLimit`

### DIFF
--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -12,9 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `serde_json::Error` ([#1371])
 - **added**: `JsonRejection` now displays the path at which a deserialization
   error occurred too ([#1371])
-- **fixed:** Support streaming/chunked requests in `ContentLengthLimit`
+- **fixed:** Support streaming/chunked requests in `ContentLengthLimit` ([#1389])
 
 [#1371]: https://github.com/tokio-rs/axum/pull/1371
+[#1389]: https://github.com/tokio-rs/axum/pull/1389
 
 # 0.6.0-rc.2 (10. September, 2022)
 

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `serde_json::Error` ([#1371])
 - **added**: `JsonRejection` now displays the path at which a deserialization
   error occurred too ([#1371])
+- **fixed:** Support streaming/chunked requests in `ContentLengthLimit`
 
 [#1371]: https://github.com/tokio-rs/axum/pull/1371
 


### PR DESCRIPTION
Now that `FromRequest` gets an owned `Request<B>` we can change the body type before calling some other extractor. Then `ContentLengthLimit` can apply `http_body::Limited` and limit the size of streaming/chunked requests which it previously couldn't.

Related to https://github.com/tokio-rs/axum/issues/1110#issuecomment-1248368803