### PR TITLE
Support `State` with `#[derive(FromRequest[Parts])]`

### DIFF
--- a/axum-macros/Cargo.toml
+++ b/axum-macros/Cargo.toml
@@ -26,7 +26,7 @@ syn = { version = "1.0", features = [
 
 [dev-dependencies]
 axum = { path = "../axum", version = "0.6.0-rc.2", features = ["headers"] }
-axum-extra = { path = "../axum-extra", version = "0.4.0-rc.1", features = ["typed-routing"] }
+axum-extra = { path = "../axum-extra", version = "0.4.0-rc.1", features = ["typed-routing", "cookie-private"] }
 rustversion = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/axum-macros/src/from_request/attr.rs
+++ b/axum-macros/src/from_request/attr.rs
@@ -7,18 +7,21 @@ use syn::{
 pub(crate) mod kw {
     syn::custom_keyword!(via);
     syn::custom_keyword!(rejection);
+    syn::custom_keyword!(state);
 }
 
 #[derive(Default)]
 pub(super) struct FromRequestContainerAttrs {
     pub(super) via: Option<(kw::via, syn::Path)>,
     pub(super) rejection: Option<(kw::rejection, syn::Path)>,
+    pub(super) state: Option<(kw::state, syn::Type)>,
 }
 
 impl Parse for FromRequestContainerAttrs {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         let mut via = None;
         let mut rejection = None;
+        let mut state = None;
 
         while !input.is_empty() {
             let lh = input.lookahead1();
@@ -26,6 +29,8 @@ impl Parse for FromRequestContainerAttrs {
                 parse_parenthesized_attribute(input, &mut via)?;
             } else if lh.peek(kw::rejection) {
                 parse_parenthesized_attribute(input, &mut rejection)?;
+            } else if lh.peek(kw::state) {
+                parse_parenthesized_attribute(input, &mut state)?;
             } else {
                 return Err(lh.error());
             }
@@ -33,15 +38,24 @@ impl Parse for FromRequestContainerAttrs {
             let _ = input.parse::<Token![,]>();
         }
 
-        Ok(Self { via, rejection })
+        Ok(Self {
+            via,
+            rejection,
+            state,
+        })
     }
 }
 
 impl Combine for FromRequestContainerAttrs {
     fn combine(mut self, other: Self) -> syn::Result<Self> {
-        let Self { via, rejection } = other;
+        let Self {
+            via,
+            rejection,
+            state,
+        } = other;
         combine_attribute(&mut self.via, via)?;
         combine_attribute(&mut self.rejection, rejection)?;
+        combine_attribute(&mut self.state, state)?;
         Ok(self)
     }
 }

--- a/axum-macros/tests/from_request/fail/state_infer_multiple_different_types.rs
+++ b/axum-macros/tests/from_request/fail/state_infer_multiple_different_types.rs
@@ -1,0 +1,22 @@
+use axum_macros::FromRequest;
+use axum::extract::State;
+
+#[derive(FromRequest)]
+struct Extractor {
+    inner_state: State<AppState>,
+    other_state: State<OtherState>,
+}
+
+#[derive(Clone)]
+struct AppState {}
+
+#[derive(Clone)]
+struct OtherState {}
+
+fn assert_from_request()
+where
+    Extractor: axum::extract::FromRequest<AppState, axum::body::Body, Rejection = axum::response::Response>,
+{
+}
+
+fn main() {}

--- a/axum-macros/tests/from_request/fail/state_infer_multiple_different_types.stderr
+++ b/axum-macros/tests/from_request/fail/state_infer_multiple_different_types.stderr
@@ -1,0 +1,23 @@
+error[E0277]: the trait bound `AppState: FromRef<S>` is not satisfied
+ --> tests/from_request/fail/state_infer_multiple_different_types.rs:6:18
+  |
+6 |     inner_state: State<AppState>,
+  |                  ^^^^^ the trait `FromRef<S>` is not implemented for `AppState`
+  |
+  = note: required because of the requirements on the impl of `FromRequestParts<S>` for `State<AppState>`
+help: consider extending the `where` clause, but there might be an alternative better way to express this requirement
+  |
+4 | #[derive(FromRequest, AppState: FromRef<S>)]
+  |                     ++++++++++++++++++++++
+
+error[E0277]: the trait bound `OtherState: FromRef<S>` is not satisfied
+ --> tests/from_request/fail/state_infer_multiple_different_types.rs:7:18
+  |
+7 |     other_state: State<OtherState>,
+  |                  ^^^^^ the trait `FromRef<S>` is not implemented for `OtherState`
+  |
+  = note: required because of the requirements on the impl of `FromRequestParts<S>` for `State<OtherState>`
+help: consider extending the `where` clause, but there might be an alternative better way to express this requirement
+  |
+4 | #[derive(FromRequest, OtherState: FromRef<S>)]
+  |                     ++++++++++++++++++++++++

--- a/axum-macros/tests/from_request/fail/unknown_attr_container.stderr
+++ b/axum-macros/tests/from_request/fail/unknown_attr_container.stderr
@@ -1,4 +1,4 @@
-error: expected `via` or `rejection`
+error: expected one of: `via`, `rejection`, `state`
  --> tests/from_request/fail/unknown_attr_container.rs:4:16
   |
 4 | #[from_request(foo)]

--- a/axum-macros/tests/from_request/pass/state_cookie.rs
+++ b/axum-macros/tests/from_request/pass/state_cookie.rs
@@ -1,0 +1,27 @@
+use axum_macros::FromRequest;
+use axum::extract::FromRef;
+use axum_extra::extract::cookie::{PrivateCookieJar, Key};
+
+#[derive(FromRequest)]
+#[from_request(state(AppState))]
+struct Extractor {
+    cookies: PrivateCookieJar,
+}
+
+struct AppState {
+    key: Key,
+}
+
+impl FromRef<AppState> for Key {
+    fn from_ref(input: &AppState) -> Self {
+        input.key.clone()
+    }
+}
+
+fn assert_from_request()
+where
+    Extractor: axum::extract::FromRequest<AppState, axum::body::Body, Rejection = axum::response::Response>,
+{
+}
+
+fn main() {}

--- a/axum-macros/tests/from_request/pass/state_enum_via.rs
+++ b/axum-macros/tests/from_request/pass/state_enum_via.rs
@@ -1,0 +1,35 @@
+use axum::{
+    extract::{State, FromRef},
+    routing::get,
+    Router,
+};
+use axum_macros::FromRequest;
+
+#[tokio::main]
+async fn main() {
+    let _: Router<AppState> = Router::with_state(AppState::default())
+        .route("/a", get(|_: AppState| async {}))
+        .route("/b", get(|_: InnerState| async {}));
+}
+
+#[derive(Clone, FromRequest)]
+#[from_request(via(State))]
+enum AppState {
+    One,
+}
+
+impl Default for AppState {
+    fn default() -> AppState {
+        Self::One
+    }
+}
+
+#[derive(FromRequest)]
+#[from_request(via(State), state(AppState))]
+enum InnerState {}
+
+impl FromRef<AppState> for InnerState {
+    fn from_ref(_: &AppState) -> Self {
+        todo!(":shrug:")
+    }
+}

--- a/axum-macros/tests/from_request/pass/state_enum_via.rs
+++ b/axum-macros/tests/from_request/pass/state_enum_via.rs
@@ -5,8 +5,7 @@ use axum::{
 };
 use axum_macros::FromRequest;
 
-#[tokio::main]
-async fn main() {
+fn main() {
     let _: Router<AppState> = Router::with_state(AppState::default())
         .route("/a", get(|_: AppState| async {}))
         .route("/b", get(|_: InnerState| async {}));

--- a/axum-macros/tests/from_request/pass/state_enum_via_parts.rs
+++ b/axum-macros/tests/from_request/pass/state_enum_via_parts.rs
@@ -5,8 +5,7 @@ use axum::{
 };
 use axum_macros::FromRequestParts;
 
-#[tokio::main]
-async fn main() {
+fn main() {
     let _: Router<AppState> = Router::with_state(AppState::default())
         .route("/a", get(|_: AppState| async {}))
         .route("/b", get(|_: InnerState| async {}))

--- a/axum-macros/tests/from_request/pass/state_enum_via_parts.rs
+++ b/axum-macros/tests/from_request/pass/state_enum_via_parts.rs
@@ -1,0 +1,36 @@
+use axum::{
+    extract::{State, FromRef},
+    routing::get,
+    Router,
+};
+use axum_macros::FromRequestParts;
+
+#[tokio::main]
+async fn main() {
+    let _: Router<AppState> = Router::with_state(AppState::default())
+        .route("/a", get(|_: AppState| async {}))
+        .route("/b", get(|_: InnerState| async {}))
+        .route("/c", get(|_: AppState, _: InnerState| async {}));
+}
+
+#[derive(Clone, FromRequestParts)]
+#[from_request(via(State))]
+enum AppState {
+    One,
+}
+
+impl Default for AppState {
+    fn default() -> AppState {
+        Self::One
+    }
+}
+
+#[derive(FromRequestParts)]
+#[from_request(via(State), state(AppState))]
+enum InnerState {}
+
+impl FromRef<AppState> for InnerState {
+    fn from_ref(_: &AppState) -> Self {
+        todo!(":shrug:")
+    }
+}

--- a/axum-macros/tests/from_request/pass/state_explicit.rs
+++ b/axum-macros/tests/from_request/pass/state_explicit.rs
@@ -5,8 +5,7 @@ use axum::{
     routing::get,
 };
 
-#[tokio::main]
-async fn main() {
+fn main() {
     let _: Router<AppState> = Router::with_state(AppState::default())
         .route("/b", get(|_: Extractor| async {}));
 }

--- a/axum-macros/tests/from_request/pass/state_explicit.rs
+++ b/axum-macros/tests/from_request/pass/state_explicit.rs
@@ -1,5 +1,15 @@
 use axum_macros::FromRequest;
-use axum::extract::{FromRef, State};
+use axum::{
+    extract::{FromRef, State},
+    Router,
+    routing::get,
+};
+
+#[tokio::main]
+async fn main() {
+    let _: Router<AppState> = Router::with_state(AppState::default())
+        .route("/b", get(|_: Extractor| async {}));
+}
 
 #[derive(FromRequest)]
 #[from_request(state(AppState))]
@@ -7,15 +17,16 @@ struct Extractor {
     app_state: State<AppState>,
     one: State<One>,
     two: State<Two>,
+    other_extractor: String,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 struct AppState {
     one: One,
     two: Two,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 struct One {}
 
 impl FromRef<AppState> for One {
@@ -24,7 +35,7 @@ impl FromRef<AppState> for One {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 struct Two {}
 
 impl FromRef<AppState> for Two {
@@ -32,11 +43,3 @@ impl FromRef<AppState> for Two {
         input.two.clone()
     }
 }
-
-fn assert_from_request()
-where
-    Extractor: axum::extract::FromRequest<AppState, axum::body::Body, Rejection = axum::response::Response>,
-{
-}
-
-fn main() {}

--- a/axum-macros/tests/from_request/pass/state_explicit.rs
+++ b/axum-macros/tests/from_request/pass/state_explicit.rs
@@ -1,0 +1,42 @@
+use axum_macros::FromRequest;
+use axum::extract::{FromRef, State};
+
+#[derive(FromRequest)]
+#[from_request(state(AppState))]
+struct Extractor {
+    app_state: State<AppState>,
+    one: State<One>,
+    two: State<Two>,
+}
+
+#[derive(Clone)]
+struct AppState {
+    one: One,
+    two: Two,
+}
+
+#[derive(Clone)]
+struct One {}
+
+impl FromRef<AppState> for One {
+    fn from_ref(input: &AppState) -> Self {
+        input.one.clone()
+    }
+}
+
+#[derive(Clone)]
+struct Two {}
+
+impl FromRef<AppState> for Two {
+    fn from_ref(input: &AppState) -> Self {
+        input.two.clone()
+    }
+}
+
+fn assert_from_request()
+where
+    Extractor: axum::extract::FromRequest<AppState, axum::body::Body, Rejection = axum::response::Response>,
+{
+}
+
+fn main() {}

--- a/axum-macros/tests/from_request/pass/state_explicit_parts.rs
+++ b/axum-macros/tests/from_request/pass/state_explicit_parts.rs
@@ -1,0 +1,29 @@
+use axum_macros::FromRequestParts;
+use axum::extract::{FromRef, State};
+
+#[derive(FromRequestParts)]
+#[from_request(state(AppState))]
+struct Extractor {
+    inner_state: State<InnerState>,
+}
+
+struct AppState {
+    inner: InnerState,
+}
+
+#[derive(Clone)]
+struct InnerState {}
+
+impl FromRef<AppState> for InnerState {
+    fn from_ref(input: &AppState) -> Self {
+        input.inner.clone()
+    }
+}
+
+fn assert_from_request()
+where
+    Extractor: axum::extract::FromRequestParts<AppState, Rejection = axum::response::Response>,
+{
+}
+
+fn main() {}

--- a/axum-macros/tests/from_request/pass/state_explicit_parts.rs
+++ b/axum-macros/tests/from_request/pass/state_explicit_parts.rs
@@ -6,8 +6,7 @@ use axum::{
 };
 use std::collections::HashMap;
 
-#[tokio::main]
-async fn main() {
+fn main() {
     let _: Router<AppState> = Router::with_state(AppState::default())
         .route("/b", get(|_: Extractor| async {}));
 }

--- a/axum-macros/tests/from_request/pass/state_explicit_parts.rs
+++ b/axum-macros/tests/from_request/pass/state_explicit_parts.rs
@@ -1,17 +1,30 @@
 use axum_macros::FromRequestParts;
-use axum::extract::{FromRef, State};
+use axum::{
+    extract::{FromRef, State, Query},
+    Router,
+    routing::get,
+};
+use std::collections::HashMap;
+
+#[tokio::main]
+async fn main() {
+    let _: Router<AppState> = Router::with_state(AppState::default())
+        .route("/b", get(|_: Extractor| async {}));
+}
 
 #[derive(FromRequestParts)]
 #[from_request(state(AppState))]
 struct Extractor {
     inner_state: State<InnerState>,
+    other: Query<HashMap<String, String>>,
 }
 
+#[derive(Default)]
 struct AppState {
     inner: InnerState,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 struct InnerState {}
 
 impl FromRef<AppState> for InnerState {
@@ -19,11 +32,3 @@ impl FromRef<AppState> for InnerState {
         input.inner.clone()
     }
 }
-
-fn assert_from_request()
-where
-    Extractor: axum::extract::FromRequestParts<AppState, Rejection = axum::response::Response>,
-{
-}
-
-fn main() {}

--- a/axum-macros/tests/from_request/pass/state_field_explicit.rs
+++ b/axum-macros/tests/from_request/pass/state_field_explicit.rs
@@ -5,8 +5,7 @@ use axum::{
 };
 use axum_macros::FromRequest;
 
-#[tokio::main]
-async fn main() {
+fn main() {
     let _: Router<AppState> = Router::with_state(AppState::default())
         .route("/", get(|_: Extractor| async {}));
 }

--- a/axum-macros/tests/from_request/pass/state_field_explicit.rs
+++ b/axum-macros/tests/from_request/pass/state_field_explicit.rs
@@ -1,0 +1,35 @@
+use axum::{
+    extract::{State, FromRef},
+    routing::get,
+    Router,
+};
+use axum_macros::FromRequest;
+
+#[tokio::main]
+async fn main() {
+    let _: Router<AppState> = Router::with_state(AppState::default())
+        .route("/", get(|_: Extractor| async {}));
+}
+
+#[derive(FromRequest)]
+#[from_request(state(AppState))]
+struct Extractor {
+    #[from_request(via(State))]
+    state: AppState,
+    #[from_request(via(State))]
+    inner: InnerState,
+}
+
+#[derive(Clone, Default)]
+struct AppState {
+    inner: InnerState,
+}
+
+#[derive(Clone, Default)]
+struct InnerState {}
+
+impl FromRef<AppState> for InnerState {
+    fn from_ref(input: &AppState) -> Self {
+        input.inner.clone()
+    }
+}

--- a/axum-macros/tests/from_request/pass/state_field_infer.rs
+++ b/axum-macros/tests/from_request/pass/state_field_infer.rs
@@ -1,0 +1,21 @@
+use axum::{
+    extract::State,
+    routing::get,
+    Router,
+};
+use axum_macros::FromRequest;
+
+#[tokio::main]
+async fn main() {
+    let _: Router<AppState> = Router::with_state(AppState::default())
+        .route("/", get(|_: Extractor| async {}));
+}
+
+#[derive(FromRequest)]
+struct Extractor {
+    #[from_request(via(State))]
+    state: AppState,
+}
+
+#[derive(Clone, Default)]
+struct AppState {}

--- a/axum-macros/tests/from_request/pass/state_field_infer.rs
+++ b/axum-macros/tests/from_request/pass/state_field_infer.rs
@@ -5,8 +5,7 @@ use axum::{
 };
 use axum_macros::FromRequest;
 
-#[tokio::main]
-async fn main() {
+fn main() {
     let _: Router<AppState> = Router::with_state(AppState::default())
         .route("/", get(|_: Extractor| async {}));
 }

--- a/axum-macros/tests/from_request/pass/state_infer.rs
+++ b/axum-macros/tests/from_request/pass/state_infer.rs
@@ -1,0 +1,18 @@
+use axum_macros::FromRequest;
+use axum::extract::State;
+
+#[derive(FromRequest)]
+struct Extractor {
+    inner_state: State<AppState>,
+}
+
+#[derive(Clone)]
+struct AppState {}
+
+fn assert_from_request()
+where
+    Extractor: axum::extract::FromRequest<AppState, axum::body::Body, Rejection = axum::response::Response>,
+{
+}
+
+fn main() {}

--- a/axum-macros/tests/from_request/pass/state_infer_multiple.rs
+++ b/axum-macros/tests/from_request/pass/state_infer_multiple.rs
@@ -1,0 +1,19 @@
+use axum_macros::FromRequest;
+use axum::extract::State;
+
+#[derive(FromRequest)]
+struct Extractor {
+    inner_state: State<AppState>,
+    also_inner_state: State<AppState>,
+}
+
+#[derive(Clone)]
+struct AppState {}
+
+fn assert_from_request()
+where
+    Extractor: axum::extract::FromRequest<AppState, axum::body::Body, Rejection = axum::response::Response>,
+{
+}
+
+fn main() {}

--- a/axum-macros/tests/from_request/pass/state_infer_parts.rs
+++ b/axum-macros/tests/from_request/pass/state_infer_parts.rs
@@ -1,0 +1,18 @@
+use axum_macros::FromRequestParts;
+use axum::extract::State;
+
+#[derive(FromRequestParts)]
+struct Extractor {
+    inner_state: State<AppState>,
+}
+
+#[derive(Clone)]
+struct AppState {}
+
+fn assert_from_request()
+where
+    Extractor: axum::extract::FromRequestParts<AppState, Rejection = axum::response::Response>,
+{
+}
+
+fn main() {}

--- a/axum-macros/tests/from_request/pass/state_via.rs
+++ b/axum-macros/tests/from_request/pass/state_via.rs
@@ -5,8 +5,7 @@ use axum::{
 };
 use axum_macros::FromRequest;
 
-#[tokio::main]
-async fn main() {
+fn main() {
     let _: Router<AppState> = Router::with_state(AppState::default())
         .route("/b", get(|_: (), _: AppState| async {}))
         .route("/c", get(|_: (), _: InnerState| async {}));

--- a/axum-macros/tests/from_request/pass/state_via.rs
+++ b/axum-macros/tests/from_request/pass/state_via.rs
@@ -1,0 +1,29 @@
+use axum::{
+    extract::{FromRef, State},
+    routing::get,
+    Router,
+};
+use axum_macros::FromRequest;
+
+#[tokio::main]
+async fn main() {
+    let _: Router<AppState> = Router::with_state(AppState::default())
+        .route("/b", get(|_: (), _: AppState| async {}))
+        .route("/c", get(|_: (), _: InnerState| async {}));
+}
+
+#[derive(Clone, Default, FromRequest)]
+#[from_request(via(State), state(AppState))]
+struct AppState {
+    inner: InnerState,
+}
+
+#[derive(Clone, Default, FromRequest)]
+#[from_request(via(State), state(AppState))]
+struct InnerState {}
+
+impl FromRef<AppState> for InnerState {
+    fn from_ref(input: &AppState) -> Self {
+        input.inner.clone()
+    }
+}

--- a/axum-macros/tests/from_request/pass/state_via_infer.rs
+++ b/axum-macros/tests/from_request/pass/state_via_infer.rs
@@ -5,8 +5,7 @@ use axum::{
 };
 use axum_macros::FromRequest;
 
-#[tokio::main]
-async fn main() {
+fn main() {
     let _: Router<AppState> = Router::with_state(AppState::default())
         .route("/b", get(|_: AppState| async {}));
 }

--- a/axum-macros/tests/from_request/pass/state_via_infer.rs
+++ b/axum-macros/tests/from_request/pass/state_via_infer.rs
@@ -1,0 +1,18 @@
+use axum::{
+    extract::State,
+    routing::get,
+    Router,
+};
+use axum_macros::FromRequest;
+
+#[tokio::main]
+async fn main() {
+    let _: Router<AppState> = Router::with_state(AppState::default())
+        .route("/b", get(|_: AppState| async {}));
+}
+
+// if we're extract "via" `State<AppState>` and not specifying state
+// assume `AppState` is the state
+#[derive(Clone, Default, FromRequest)]
+#[from_request(via(State))]
+struct AppState {}

--- a/axum-macros/tests/from_request/pass/state_via_parts.rs
+++ b/axum-macros/tests/from_request/pass/state_via_parts.rs
@@ -5,8 +5,7 @@ use axum::{
 };
 use axum_macros::FromRequestParts;
 
-#[tokio::main]
-async fn main() {
+fn main() {
     let _: Router<AppState> = Router::with_state(AppState::default())
         .route("/a", get(|_: AppState, _: InnerState, _: String| async {}))
         .route("/b", get(|_: AppState, _: String| async {}))

--- a/axum-macros/tests/from_request/pass/state_via_parts.rs
+++ b/axum-macros/tests/from_request/pass/state_via_parts.rs
@@ -8,9 +8,9 @@ use axum_macros::FromRequestParts;
 #[tokio::main]
 async fn main() {
     let _: Router<AppState> = Router::with_state(AppState::default())
-        .route("/a", get(|_: AppState, _: InnerState| async {}))
-        .route("/b", get(|_: AppState| async {}))
-        .route("/c", get(|_: InnerState| async {}));
+        .route("/a", get(|_: AppState, _: InnerState, _: String| async {}))
+        .route("/b", get(|_: AppState, _: String| async {}))
+        .route("/c", get(|_: InnerState, _: String| async {}));
 }
 
 #[derive(Clone, Default, FromRequestParts)]

--- a/axum-macros/tests/from_request/pass/state_via_parts.rs
+++ b/axum-macros/tests/from_request/pass/state_via_parts.rs
@@ -1,0 +1,30 @@
+use axum::{
+    extract::{FromRef, State},
+    routing::get,
+    Router,
+};
+use axum_macros::FromRequestParts;
+
+#[tokio::main]
+async fn main() {
+    let _: Router<AppState> = Router::with_state(AppState::default())
+        .route("/a", get(|_: AppState, _: InnerState| async {}))
+        .route("/b", get(|_: AppState| async {}))
+        .route("/c", get(|_: InnerState| async {}));
+}
+
+#[derive(Clone, Default, FromRequestParts)]
+#[from_request(via(State))]
+struct AppState {
+    inner: InnerState,
+}
+
+#[derive(Clone, Default, FromRequestParts)]
+#[from_request(via(State), state(AppState))]
+struct InnerState {}
+
+impl FromRef<AppState> for InnerState {
+    fn from_ref(input: &AppState) -> Self {
+        input.inner.clone()
+    }
+}

--- a/axum-macros/tests/from_request/pass/state_with_rejection.rs
+++ b/axum-macros/tests/from_request/pass/state_with_rejection.rs
@@ -7,8 +7,7 @@ use axum::{
 };
 use axum_macros::FromRequest;
 
-#[tokio::main]
-async fn main() {
+fn main() {
     let _: Router<AppState> =
         Router::with_state(AppState::default()).route("/a", get(|_: Extractor| async {}));
 }

--- a/axum-macros/tests/from_request/pass/state_with_rejection.rs
+++ b/axum-macros/tests/from_request/pass/state_with_rejection.rs
@@ -1,0 +1,37 @@
+use std::convert::Infallible;
+use axum::{
+    extract::State,
+    response::{IntoResponse, Response},
+    routing::get,
+    Router,
+};
+use axum_macros::FromRequest;
+
+#[tokio::main]
+async fn main() {
+    let _: Router<AppState> =
+        Router::with_state(AppState::default()).route("/a", get(|_: Extractor| async {}));
+}
+
+#[derive(Clone, Default, FromRequest)]
+#[from_request(rejection(MyRejection))]
+struct Extractor {
+    state: State<AppState>,
+}
+
+#[derive(Clone, Default)]
+struct AppState {}
+
+struct MyRejection {}
+
+impl From<Infallible> for MyRejection {
+    fn from(err: Infallible) -> Self {
+        match err {}
+    }
+}
+
+impl IntoResponse for MyRejection {
+    fn into_response(self) -> Response {
+        ().into_response()
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/tokio-rs/axum/issues/1314

This makes it possible to extract things via `State` in `#[derive(FromRequet)]`:

```rust
#[derive(FromRequet)]
#[from_request(state(AppState))]
struct Foo {
    state: State<AppState>,
}
```

The state can also be inferred in a lot of cases so you only need to write:

```rust
#[derive(FromRequet)]
struct Foo {
    // since we're using `State<AppState>` we know the state has to be
    // `AppState`
    state: State<AppState>,
}
```

Same for

```rust
#[derive(FromRequet)]
struct Foo {
    #[from_request(via(State))]
    state: AppState,
}
```

And

```rust
#[derive(FromRequet)]
#[from_request(via(State))]
struct AppState {}
```

I think I've covered all the edge cases but there are (unsurprisingly) a few.

## Todo

- [x] Test that these extractors can be combined with others in the same handler, ie that we don't get errors because of `M`