### PR TITLE
Add `DefaultBodyLimit::max` to change the body size limit

### DIFF
--- a/axum-core/CHANGELOG.md
+++ b/axum-core/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
-- None.
+- **added:** Add `DefaultBodyLimit::max` for changing the default body limit ([#1397])
+
+[#1397]: https://github.com/tokio-rs/axum/pull/1397
 
 # 0.3.0-rc.2 (10. September, 2022)
 

--- a/axum-core/src/extract/default_body_limit.rs
+++ b/axum-core/src/extract/default_body_limit.rs
@@ -88,6 +88,10 @@ impl DefaultBodyLimit {
     ///     // Replace the default of 2MB with 1024 bytes.
     ///     .layer(DefaultBodyLimit::max(1024));
     /// ```
+    ///
+    /// [`Bytes::from_request`]: bytes::Bytes
+    /// [`Json`]: https://docs.rs/axum/0.6.0-rc.2/axum/struct.Json.html
+    /// [`Form`]: https://docs.rs/axum/0.6.0-rc.2/axum/struct.Form.html
     pub fn max(limit: usize) -> Self {
         Self {
             kind: DefaultBodyLimitKind::Limit(limit),

--- a/axum-core/src/extract/default_body_limit.rs
+++ b/axum-core/src/extract/default_body_limit.rs
@@ -23,6 +23,7 @@ pub struct DefaultBodyLimit {
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum DefaultBodyLimitKind {
     Disable,
+    Limit(usize),
 }
 
 impl DefaultBodyLimit {
@@ -61,6 +62,35 @@ impl DefaultBodyLimit {
     pub fn disable() -> Self {
         Self {
             kind: DefaultBodyLimitKind::Disable,
+        }
+    }
+
+    /// Set the default request body limit.
+    ///
+    /// By default the limit of request body sizes that [`Bytes::from_request`] (and other
+    /// extractors built on top of it such as `String`, [`Json`], and [`Form`]) is 2MB. This method
+    /// can be used to change that limit.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use axum::{
+    ///     Router,
+    ///     routing::get,
+    ///     body::{Bytes, Body},
+    ///     extract::DefaultBodyLimit,
+    /// };
+    /// use tower_http::limit::RequestBodyLimitLayer;
+    /// use http_body::Limited;
+    ///
+    /// let app: Router<_, Limited<Body>> = Router::new()
+    ///     .route("/", get(|body: Bytes| async {}))
+    ///     // Replace the default of 2MB with 1024 bytes.
+    ///     .layer(DefaultBodyLimit::max(1024));
+    /// ```
+    pub fn max(limit: usize) -> Self {
+        Self {
+            kind: DefaultBodyLimitKind::Limit(limit),
         }
     }
 }

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -15,10 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **fixed:** Support streaming/chunked requests in `ContentLengthLimit` ([#1389])
 - **fixed:** Used `400 Bad Request` for `FailedToDeserializeQueryString`
   rejections, instead of `422 Unprocessable Entity` ([#1387])
+- **added:** Add `DefaultBodyLimit::max` for changing the default body limit ([#1397])
 
 [#1371]: https://github.com/tokio-rs/axum/pull/1371
 [#1387]: https://github.com/tokio-rs/axum/pull/1387
 [#1389]: https://github.com/tokio-rs/axum/pull/1389
+[#1397]: https://github.com/tokio-rs/axum/pull/1397
 
 # 0.6.0-rc.2 (10. September, 2022)
 

--- a/axum/src/routing/tests/mod.rs
+++ b/axum/src/routing/tests/mod.rs
@@ -672,6 +672,31 @@ async fn limited_body_with_content_length() {
 }
 
 #[tokio::test]
+async fn changing_the_default_limit() {
+    let new_limit = 2;
+
+    let app = Router::new()
+        .route("/", post(|_: Bytes| async {}))
+        .layer(DefaultBodyLimit::max(new_limit));
+
+    let client = TestClient::new(app);
+
+    let res = client
+        .post("/")
+        .body(Body::from("a".repeat(new_limit)))
+        .send()
+        .await;
+    assert_eq!(res.status(), StatusCode::OK);
+
+    let res = client
+        .post("/")
+        .body(Body::from("a".repeat(new_limit + 1)))
+        .send()
+        .await;
+    assert_eq!(res.status(), StatusCode::PAYLOAD_TOO_LARGE);
+}
+
+#[tokio::test]
 async fn limited_body_with_streaming_body() {
     const LIMIT: usize = 3;
 


### PR DESCRIPTION
Fixes https://github.com/tokio-rs/axum/issues/1370

We now have a few ways to set body limits:
- The new `DefaultBodyLimit::max`
- `ContentLengthLimit`
- `tower_http::limit::RequestBodyLimit` and `http_body::Limited`

I don't we should remove anything tower-http and http-body but I feel we should consider removing `ContentLengthLimit`. It can essentially be replaced with

```rust
Router::new().route(
    "/",
    post(handler.layer(DefaultBodyLimit::max(new_limit))),
);
```