### PR TITLE
Refactor `all_the_tuples!` macros

### DIFF
--- a/axum-core/src/extract/tuple.rs
+++ b/axum-core/src/extract/tuple.rs
@@ -74,31 +74,7 @@ macro_rules! impl_from_request {
     };
 }
 
-impl_from_request!([], T1);
-impl_from_request!([T1], T2);
-impl_from_request!([T1, T2], T3);
-impl_from_request!([T1, T2, T3], T4);
-impl_from_request!([T1, T2, T3, T4], T5);
-impl_from_request!([T1, T2, T3, T4, T5], T6);
-impl_from_request!([T1, T2, T3, T4, T5, T6], T7);
-impl_from_request!([T1, T2, T3, T4, T5, T6, T7], T8);
-impl_from_request!([T1, T2, T3, T4, T5, T6, T7, T8], T9);
-impl_from_request!([T1, T2, T3, T4, T5, T6, T7, T8, T9], T10);
-impl_from_request!([T1, T2, T3, T4, T5, T6, T7, T8, T9, T10], T11);
-impl_from_request!([T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11], T12);
-impl_from_request!([T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12], T13);
-impl_from_request!(
-    [T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13],
-    T14
-);
-impl_from_request!(
-    [T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14],
-    T15
-);
-impl_from_request!(
-    [T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15],
-    T16
-);
+all_the_tuples!(impl_from_request);
 
 #[cfg(test)]
 mod tests {

--- a/axum-core/src/macros.rs
+++ b/axum-core/src/macros.rs
@@ -102,6 +102,36 @@ macro_rules! composite_rejection {
 
 macro_rules! all_the_tuples {
     ($name:ident) => {
+        $name!([], T1);
+        $name!([T1], T2);
+        $name!([T1, T2], T3);
+        $name!([T1, T2, T3], T4);
+        $name!([T1, T2, T3, T4], T5);
+        $name!([T1, T2, T3, T4, T5], T6);
+        $name!([T1, T2, T3, T4, T5, T6], T7);
+        $name!([T1, T2, T3, T4, T5, T6, T7], T8);
+        $name!([T1, T2, T3, T4, T5, T6, T7, T8], T9);
+        $name!([T1, T2, T3, T4, T5, T6, T7, T8, T9], T10);
+        $name!([T1, T2, T3, T4, T5, T6, T7, T8, T9, T10], T11);
+        $name!([T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11], T12);
+        $name!([T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12], T13);
+        $name!(
+            [T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13],
+            T14
+        );
+        $name!(
+            [T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14],
+            T15
+        );
+        $name!(
+            [T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15],
+            T16
+        );
+    };
+}
+
+macro_rules! all_the_tuples_no_last_special_case {
+    ($name:ident) => {
         $name!(T1);
         $name!(T1, T2);
         $name!(T1, T2, T3);

--- a/axum-core/src/macros.rs
+++ b/axum-core/src/macros.rs
@@ -100,6 +100,7 @@ macro_rules! composite_rejection {
     };
 }
 
+#[rustfmt::skip]
 macro_rules! all_the_tuples {
     ($name:ident) => {
         $name!([], T1);
@@ -115,18 +116,9 @@ macro_rules! all_the_tuples {
         $name!([T1, T2, T3, T4, T5, T6, T7, T8, T9, T10], T11);
         $name!([T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11], T12);
         $name!([T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12], T13);
-        $name!(
-            [T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13],
-            T14
-        );
-        $name!(
-            [T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14],
-            T15
-        );
-        $name!(
-            [T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15],
-            T16
-        );
+        $name!([T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13], T14);
+        $name!([T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14], T15);
+        $name!([T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15], T16);
     };
 }
 

--- a/axum-core/src/response/into_response.rs
+++ b/axum-core/src/response/into_response.rs
@@ -516,4 +516,4 @@ macro_rules! impl_into_response {
     }
 }
 
-all_the_tuples!(impl_into_response);
+all_the_tuples_no_last_special_case!(impl_into_response);

--- a/axum-core/src/response/into_response_parts.rs
+++ b/axum-core/src/response/into_response_parts.rs
@@ -248,7 +248,7 @@ macro_rules! impl_into_response_parts {
     }
 }
 
-all_the_tuples!(impl_into_response_parts);
+all_the_tuples_no_last_special_case!(impl_into_response_parts);
 
 impl IntoResponseParts for Extensions {
     type Error = Infallible;

--- a/axum/src/error_handling/mod.rs
+++ b/axum/src/error_handling/mod.rs
@@ -204,7 +204,22 @@ macro_rules! impl_service {
     }
 }
 
-all_the_tuples!(impl_service);
+impl_service!(T1);
+impl_service!(T1, T2);
+impl_service!(T1, T2, T3);
+impl_service!(T1, T2, T3, T4);
+impl_service!(T1, T2, T3, T4, T5);
+impl_service!(T1, T2, T3, T4, T5, T6);
+impl_service!(T1, T2, T3, T4, T5, T6, T7);
+impl_service!(T1, T2, T3, T4, T5, T6, T7, T8);
+impl_service!(T1, T2, T3, T4, T5, T6, T7, T8, T9);
+impl_service!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10);
+impl_service!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11);
+impl_service!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12);
+impl_service!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13);
+impl_service!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14);
+impl_service!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15);
+impl_service!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16);
 
 pub mod future {
     //! Future types.

--- a/axum/src/handler/mod.rs
+++ b/axum/src/handler/mod.rs
@@ -224,31 +224,7 @@ macro_rules! impl_handler {
     };
 }
 
-impl_handler!([], T1);
-impl_handler!([T1], T2);
-impl_handler!([T1, T2], T3);
-impl_handler!([T1, T2, T3], T4);
-impl_handler!([T1, T2, T3, T4], T5);
-impl_handler!([T1, T2, T3, T4, T5], T6);
-impl_handler!([T1, T2, T3, T4, T5, T6], T7);
-impl_handler!([T1, T2, T3, T4, T5, T6, T7], T8);
-impl_handler!([T1, T2, T3, T4, T5, T6, T7, T8], T9);
-impl_handler!([T1, T2, T3, T4, T5, T6, T7, T8, T9], T10);
-impl_handler!([T1, T2, T3, T4, T5, T6, T7, T8, T9, T10], T11);
-impl_handler!([T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11], T12);
-impl_handler!([T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12], T13);
-impl_handler!(
-    [T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13],
-    T14
-);
-impl_handler!(
-    [T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14],
-    T15
-);
-impl_handler!(
-    [T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15],
-    T16
-);
+all_the_tuples!(impl_handler);
 
 /// A [`Service`] created from a [`Handler`] by applying a Tower middleware.
 ///

--- a/axum/src/macros.rs
+++ b/axum/src/macros.rs
@@ -180,21 +180,30 @@ macro_rules! composite_rejection {
 
 macro_rules! all_the_tuples {
     ($name:ident) => {
-        $name!(T1);
-        $name!(T1, T2);
-        $name!(T1, T2, T3);
-        $name!(T1, T2, T3, T4);
-        $name!(T1, T2, T3, T4, T5);
-        $name!(T1, T2, T3, T4, T5, T6);
-        $name!(T1, T2, T3, T4, T5, T6, T7);
-        $name!(T1, T2, T3, T4, T5, T6, T7, T8);
-        $name!(T1, T2, T3, T4, T5, T6, T7, T8, T9);
-        $name!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10);
-        $name!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11);
-        $name!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12);
-        $name!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13);
-        $name!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14);
-        $name!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15);
-        $name!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16);
+        $name!([], T1);
+        $name!([T1], T2);
+        $name!([T1, T2], T3);
+        $name!([T1, T2, T3], T4);
+        $name!([T1, T2, T3, T4], T5);
+        $name!([T1, T2, T3, T4, T5], T6);
+        $name!([T1, T2, T3, T4, T5, T6], T7);
+        $name!([T1, T2, T3, T4, T5, T6, T7], T8);
+        $name!([T1, T2, T3, T4, T5, T6, T7, T8], T9);
+        $name!([T1, T2, T3, T4, T5, T6, T7, T8, T9], T10);
+        $name!([T1, T2, T3, T4, T5, T6, T7, T8, T9, T10], T11);
+        $name!([T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11], T12);
+        $name!([T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12], T13);
+        $name!(
+            [T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13],
+            T14
+        );
+        $name!(
+            [T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14],
+            T15
+        );
+        $name!(
+            [T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15],
+            T16
+        );
     };
 }

--- a/axum/src/middleware/from_fn.rs
+++ b/axum/src/middleware/from_fn.rs
@@ -304,31 +304,7 @@ macro_rules! impl_service {
     };
 }
 
-impl_service!([], T1);
-impl_service!([T1], T2);
-impl_service!([T1, T2], T3);
-impl_service!([T1, T2, T3], T4);
-impl_service!([T1, T2, T3, T4], T5);
-impl_service!([T1, T2, T3, T4, T5], T6);
-impl_service!([T1, T2, T3, T4, T5, T6], T7);
-impl_service!([T1, T2, T3, T4, T5, T6, T7], T8);
-impl_service!([T1, T2, T3, T4, T5, T6, T7, T8], T9);
-impl_service!([T1, T2, T3, T4, T5, T6, T7, T8, T9], T10);
-impl_service!([T1, T2, T3, T4, T5, T6, T7, T8, T9, T10], T11);
-impl_service!([T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11], T12);
-impl_service!([T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12], T13);
-impl_service!(
-    [T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13],
-    T14
-);
-impl_service!(
-    [T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14],
-    T15
-);
-impl_service!(
-    [T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15],
-    T16
-);
+all_the_tuples!(impl_service);
 
 impl<F, S, I, T> fmt::Debug for FromFn<F, S, I, T>
 where

--- a/axum/src/middleware/map_request.rs
+++ b/axum/src/middleware/map_request.rs
@@ -319,31 +319,7 @@ macro_rules! impl_service {
     };
 }
 
-impl_service!([], T1);
-impl_service!([T1], T2);
-impl_service!([T1, T2], T3);
-impl_service!([T1, T2, T3], T4);
-impl_service!([T1, T2, T3, T4], T5);
-impl_service!([T1, T2, T3, T4, T5], T6);
-impl_service!([T1, T2, T3, T4, T5, T6], T7);
-impl_service!([T1, T2, T3, T4, T5, T6, T7], T8);
-impl_service!([T1, T2, T3, T4, T5, T6, T7, T8], T9);
-impl_service!([T1, T2, T3, T4, T5, T6, T7, T8, T9], T10);
-impl_service!([T1, T2, T3, T4, T5, T6, T7, T8, T9, T10], T11);
-impl_service!([T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11], T12);
-impl_service!([T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12], T13);
-impl_service!(
-    [T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13],
-    T14
-);
-impl_service!(
-    [T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14],
-    T15
-);
-impl_service!(
-    [T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15],
-    T16
-);
+all_the_tuples!(impl_service);
 
 impl<F, S, I, T> fmt::Debug for MapRequest<F, S, I, T>
 where


### PR DESCRIPTION
Changes `all_the_tuples` to use the array/last special casing by default.