### PR TITLE
rmv claim that state can't be passed to middleware

### DIFF
--- a/axum/src/extract/state.rs
+++ b/axum/src/extract/state.rs
@@ -8,8 +8,8 @@ use std::{
 
 /// Extractor for state.
 ///
-/// Note this extractor is not available to middleware. See ["Accessing state in
-/// middleware"][state-from-middleware] for how to access state in middleware.
+/// See ["Accessing state in middleware"][state-from-middleware] for how to  
+/// access state in middleware.
 ///
 /// [state-from-middleware]: crate::middleware#accessing-state-in-middleware
 ///


### PR DESCRIPTION
axum::middleware::from_fn_with_state now allows middleware to access application state.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation
The docs currently state that the State extractor cannot be passed to middleware. axum::middleware::from_fn_with_state allows state to be passed to middleware, so the statement is either incorrect or at the least confusing. 
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution
Removed the statement.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
