### PR TITLE
Start second server on different port for metrics endpoint

### DIFF
--- a/examples/prometheus-metrics/src/main.rs
+++ b/examples/prometheus-metrics/src/main.rs
@@ -23,6 +23,48 @@ use std::{
 };
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
+fn metrics_app() -> Router {
+    let recorder_handle = setup_metrics_recorder();
+    Router::new()
+        .route("/metrics", get(move || ready(recorder_handle.render())))
+        .route_layer(middleware::from_fn(track_metrics))
+}
+
+fn main_app() -> Router {
+    Router::new()
+        .route("/fast", get(|| async {}))
+        .route(
+            "/slow",
+            get(|| async {
+                tokio::time::sleep(Duration::from_secs(1)).await;
+            }),
+        )
+        .route_layer(middleware::from_fn(track_metrics))
+}
+
+async fn start_main_server() {
+    let app = main_app();
+
+    let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
+    tracing::debug!("listening on {}", addr);
+    axum::Server::bind(&addr)
+        .serve(app.into_make_service())
+        .await
+        .unwrap()
+}
+
+async fn start_metrics_server() {
+    let app = metrics_app();
+
+    // NOTE: expose metrics enpoint on a different port
+    let addr = SocketAddr::from(([127, 0, 0, 1], 3001));
+    tracing::debug!("listening on {}", addr);
+    axum::Server::bind(&addr)
+        .serve(app.into_make_service())
+        .await
+        .unwrap()
+}
+
 #[tokio::main]
 async fn main() {
     tracing_subscriber::registry()
@@ -33,25 +75,10 @@ async fn main() {
         .with(tracing_subscriber::fmt::layer())
         .init();
 
-    let recorder_handle = setup_metrics_recorder();
-
-    let app = Router::new()
-        .route("/fast", get(|| async {}))
-        .route(
-            "/slow",
-            get(|| async {
-                tokio::time::sleep(Duration::from_secs(1)).await;
-            }),
-        )
-        .route("/metrics", get(move || ready(recorder_handle.render())))
-        .route_layer(middleware::from_fn(track_metrics));
-
-    let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
-    tracing::debug!("listening on {}", addr);
-    axum::Server::bind(&addr)
-        .serve(app.into_make_service())
-        .await
-        .unwrap();
+    // The `/metrics` endpoint should not be publicly available. If behind a reverse proxy, this
+    // can be achieved by rejecting requests to `/metrics`. In this example, a second server is
+    // started on another port to expose `/metrics`.
+    let (_main_server, _metrics_server) = tokio::join!(start_main_server(), start_metrics_server());
 }
 
 fn setup_metrics_recorder() -> PrometheusHandle {

--- a/examples/prometheus-metrics/src/main.rs
+++ b/examples/prometheus-metrics/src/main.rs
@@ -25,9 +25,7 @@ use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 fn metrics_app() -> Router {
     let recorder_handle = setup_metrics_recorder();
-    Router::new()
-        .route("/metrics", get(move || ready(recorder_handle.render())))
-        .route_layer(middleware::from_fn(track_metrics))
+    Router::new().route("/metrics", get(move || ready(recorder_handle.render())))
 }
 
 fn main_app() -> Router {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation

The `prometheus-metrics` example makes the `/metrics` endpoint publicly available.


## Solution

As discussed in #1443, this change starts a second server on a different port for the `/metrics` endpoint.
