### PR TITLE
Don't internally `Arc` the state

### DIFF
--- a/axum-extra/src/handler/or.rs
+++ b/axum-extra/src/handler/or.rs
@@ -7,7 +7,7 @@ use axum::{
     response::{IntoResponse, Response},
 };
 use futures_util::future::{BoxFuture, Either as EitherFuture, FutureExt, Map};
-use std::{future::Future, marker::PhantomData, sync::Arc};
+use std::{future::Future, marker::PhantomData};
 
 /// [`Handler`] that runs one [`Handler`] and if that rejects it'll fallback to another
 /// [`Handler`].
@@ -37,7 +37,7 @@ where
     fn call(
         self,
         extractors: Either<Lt, Rt>,
-        state: Arc<S>,
+        state: S,
     ) -> <Self as HandlerCallWithExtractors<Either<Lt, Rt>, S, B>>::Future {
         match extractors {
             Either::E1(lt) => self
@@ -68,7 +68,7 @@ where
     // this puts `futures_util` in our public API but thats fine in axum-extra
     type Future = BoxFuture<'static, Response>;
 
-    fn call(self, req: Request<B>, state: Arc<S>) -> Self::Future {
+    fn call(self, req: Request<B>, state: S) -> Self::Future {
         Box::pin(async move {
             let (mut parts, body) = req.into_parts();
 

--- a/axum-extra/src/routing/mod.rs
+++ b/axum-extra/src/routing/mod.rs
@@ -178,7 +178,7 @@ pub trait RouterExt<S, B>: sealed::Sealed {
 impl<S, B> RouterExt<S, B> for Router<S, B>
 where
     B: axum::body::HttpBody + Send + 'static,
-    S: Send + Sync + 'static,
+    S: Clone + Send + Sync + 'static,
 {
     #[cfg(feature = "typed-routing")]
     fn typed_get<H, T, P>(self, handler: H) -> Self

--- a/axum-extra/src/routing/resource.rs
+++ b/axum-extra/src/routing/resource.rs
@@ -53,7 +53,7 @@ where
 impl<S, B> Resource<S, B>
 where
     B: axum::body::HttpBody + Send + 'static,
-    S: Send + Sync + 'static,
+    S: Clone + Send + Sync + 'static,
 {
     /// Create a `Resource` with the given name and state.
     ///

--- a/axum-macros/tests/from_request/pass/state_explicit_parts.rs
+++ b/axum-macros/tests/from_request/pass/state_explicit_parts.rs
@@ -18,7 +18,7 @@ struct Extractor {
     other: Query<HashMap<String, String>>,
 }
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 struct AppState {
     inner: InnerState,
 }

--- a/axum/src/handler/into_service_state_in_extension.rs
+++ b/axum/src/handler/into_service_state_in_extension.rs
@@ -5,7 +5,6 @@ use std::{
     convert::Infallible,
     fmt,
     marker::PhantomData,
-    sync::Arc,
     task::{Context, Poll},
 };
 use tower_service::Service;
@@ -73,7 +72,7 @@ where
 
         let state = req
             .extensions_mut()
-            .remove::<Arc<S>>()
+            .remove::<S>()
             .expect("state extension missing. This is a bug in axum, please file an issue");
 
         let handler = self.handler.clone();

--- a/axum/src/middleware/from_extractor.rs
+++ b/axum/src/middleware/from_extractor.rs
@@ -10,7 +10,6 @@ use std::{
     future::Future,
     marker::PhantomData,
     pin::Pin,
-    sync::Arc,
     task::{Context, Poll},
 };
 use tower_layer::Layer;
@@ -99,13 +98,6 @@ pub fn from_extractor<E>() -> FromExtractorLayer<E, ()> {
 ///
 /// See [`State`](crate::extract::State) for more details about accessing state.
 pub fn from_extractor_with_state<E, S>(state: S) -> FromExtractorLayer<E, S> {
-    from_extractor_with_state_arc(Arc::new(state))
-}
-
-/// Create a middleware from an extractor with the given [`Arc`]'ed state.
-///
-/// See [`State`](crate::extract::State) for more details about accessing state.
-pub fn from_extractor_with_state_arc<E, S>(state: Arc<S>) -> FromExtractorLayer<E, S> {
     FromExtractorLayer {
         state,
         _marker: PhantomData,
@@ -119,14 +111,17 @@ pub fn from_extractor_with_state_arc<E, S>(state: Arc<S>) -> FromExtractorLayer<
 ///
 /// [`Layer`]: tower::Layer
 pub struct FromExtractorLayer<E, S> {
-    state: Arc<S>,
+    state: S,
     _marker: PhantomData<fn() -> E>,
 }
 
-impl<E, S> Clone for FromExtractorLayer<E, S> {
+impl<E, S> Clone for FromExtractorLayer<E, S>
+where
+    S: Clone,
+{
     fn clone(&self) -> Self {
         Self {
-            state: Arc::clone(&self.state),
+            state: self.state.clone(),
             _marker: PhantomData,
         }
     }
@@ -144,13 +139,16 @@ where
     }
 }
 
-impl<E, T, S> Layer<T> for FromExtractorLayer<E, S> {
+impl<E, T, S> Layer<T> for FromExtractorLayer<E, S>
+where
+    S: Clone,
+{
     type Service = FromExtractor<T, E, S>;
 
     fn layer(&self, inner: T) -> Self::Service {
         FromExtractor {
             inner,
-            state: Arc::clone(&self.state),
+            state: self.state.clone(),
             _extractor: PhantomData,
         }
     }
@@ -161,7 +159,7 @@ impl<E, T, S> Layer<T> for FromExtractorLayer<E, S> {
 /// See [`from_extractor`] for more details.
 pub struct FromExtractor<T, E, S> {
     inner: T,
-    state: Arc<S>,
+    state: S,
     _extractor: PhantomData<fn() -> E>,
 }
 
@@ -175,11 +173,12 @@ fn traits() {
 impl<T, E, S> Clone for FromExtractor<T, E, S>
 where
     T: Clone,
+    S: Clone,
 {
     fn clone(&self) -> Self {
         Self {
             inner: self.inner.clone(),
-            state: Arc::clone(&self.state),
+            state: self.state.clone(),
             _extractor: PhantomData,
         }
     }
@@ -205,7 +204,7 @@ where
     B: Default + Send + 'static,
     T: Service<Request<B>> + Clone,
     T::Response: IntoResponse,
-    S: Send + Sync + 'static,
+    S: Clone + Send + Sync + 'static,
 {
     type Response = Response;
     type Error = T::Error;
@@ -217,7 +216,7 @@ where
     }
 
     fn call(&mut self, req: Request<B>) -> Self::Future {
-        let state = Arc::clone(&self.state);
+        let state = self.state.clone();
         let extract_future = Box::pin(async move {
             let (mut parts, body) = req.into_parts();
             let extracted = E::from_request_parts(&mut parts, &state).await;

--- a/axum/src/middleware/mod.rs
+++ b/axum/src/middleware/mod.rs
@@ -8,19 +8,14 @@ mod map_request;
 mod map_response;
 
 pub use self::from_extractor::{
-    from_extractor, from_extractor_with_state, from_extractor_with_state_arc, FromExtractor,
-    FromExtractorLayer,
+    from_extractor, from_extractor_with_state, FromExtractor, FromExtractorLayer,
 };
-pub use self::from_fn::{
-    from_fn, from_fn_with_state, from_fn_with_state_arc, FromFn, FromFnLayer, Next,
-};
+pub use self::from_fn::{from_fn, from_fn_with_state, FromFn, FromFnLayer, Next};
 pub use self::map_request::{
-    map_request, map_request_with_state, map_request_with_state_arc, IntoMapRequestResult,
-    MapRequest, MapRequestLayer,
+    map_request, map_request_with_state, IntoMapRequestResult, MapRequest, MapRequestLayer,
 };
 pub use self::map_response::{
-    map_response, map_response_with_state, map_response_with_state_arc, MapResponse,
-    MapResponseLayer,
+    map_response, map_response_with_state, MapResponse, MapResponseLayer,
 };
 pub use crate::extension::AddExtension;
 

--- a/axum/src/routing/service.rs
+++ b/axum/src/routing/service.rs
@@ -33,7 +33,7 @@ where
     #[track_caller]
     pub(super) fn new<S>(router: Router<S, B>) -> Self
     where
-        S: Send + Sync + 'static,
+        S: Clone + Send + Sync + 'static,
     {
         let state = router
             .state
@@ -45,7 +45,7 @@ where
             .map(|(route_id, endpoint)| {
                 let route = match endpoint {
                     Endpoint::MethodRouter(method_router) => {
-                        Route::new(method_router.with_state_arc(Arc::clone(&state)))
+                        Route::new(method_router.with_state(state.clone()))
                     }
                     Endpoint::Route(route) => route,
                 };

--- a/axum/src/test_helpers/test_client.rs
+++ b/axum/src/test_helpers/test_client.rs
@@ -17,7 +17,7 @@ pub(crate) struct TestClient {
 impl TestClient {
     pub(crate) fn new<S>(router: Router<S, Body>) -> Self
     where
-        S: Send + Sync + 'static,
+        S: Clone + Send + Sync + 'static,
     {
         Self::from_service(router.into_service())
     }


### PR DESCRIPTION
The fact that the state is `Arc`'ed internally in `Router` has caused confusion for several people. I've been thinking about and think we should remove the `Arc` and give the users the choice to `Arc` things or not.