### PR TITLE
Add Error::into_inner

### DIFF
--- a/axum-core/CHANGELOG.md
+++ b/axum-core/CHANGELOG.md
@@ -8,8 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # Unreleased
 
 - **added:** Add `DefaultBodyLimit::max` for changing the default body limit ([#1397])
+- **added:** Add `Error::into_inner` for converting `Error` to `BoxError` without allocating ([#1476])
 
 [#1397]: https://github.com/tokio-rs/axum/pull/1397
+[#1476]: https://github.com/tokio-rs/axum/pull/1476
 
 # 0.3.0-rc.2 (10. September, 2022)
 

--- a/axum-core/src/error.rs
+++ b/axum-core/src/error.rs
@@ -14,6 +14,11 @@ impl Error {
             inner: error.into(),
         }
     }
+
+    /// Convert an `Error` back into the underlying boxed trait object.
+    pub fn into_inner(self) -> BoxError {
+        self.inner
+    }
 }
 
 impl fmt::Display for Error {


### PR DESCRIPTION
## Motivation

Allows one to convert `axum::response::Response` to a similar boxed-body response type not tied to axum-core (if you want to be able to bump axum without that being a breaking change) without allocating.
