### PR TITLE
Enforce Sync for inner services and handlers

### DIFF
--- a/axum-extra/src/handler/mod.rs
+++ b/axum-extra/src/handler/mod.rs
@@ -166,7 +166,7 @@ pub struct IntoHandler<H, T, S, B> {
 
 impl<H, T, S, B> Handler<T, S, B> for IntoHandler<H, T, S, B>
 where
-    H: HandlerCallWithExtractors<T, S, B> + Clone + Send + 'static,
+    H: HandlerCallWithExtractors<T, S, B> + Clone + Send + Sync + 'static,
     T: FromRequest<S, B> + Send + 'static,
     T::Rejection: Send,
     B: Send + 'static,

--- a/axum-extra/src/handler/or.rs
+++ b/axum-extra/src/handler/or.rs
@@ -56,8 +56,8 @@ where
 
 impl<S, B, L, R, Lt, Rt, M> Handler<(M, Lt, Rt), S, B> for Or<L, R, Lt, Rt, S, B>
 where
-    L: HandlerCallWithExtractors<Lt, S, B> + Clone + Send + 'static,
-    R: HandlerCallWithExtractors<Rt, S, B> + Clone + Send + 'static,
+    L: HandlerCallWithExtractors<Lt, S, B> + Clone + Send + Sync + 'static,
+    R: HandlerCallWithExtractors<Rt, S, B> + Clone + Send + Sync + 'static,
     Lt: FromRequestParts<S> + Send + 'static,
     Rt: FromRequest<S, B, M> + Send + 'static,
     Lt::Rejection: Send,

--- a/axum-extra/src/routing/mod.rs
+++ b/axum-extra/src/routing/mod.rs
@@ -169,7 +169,7 @@ pub trait RouterExt<S, B>: sealed::Sealed {
     /// This works like [`RouterExt::route_with_tsr`] but accepts any [`Service`].
     fn route_service_with_tsr<T>(self, path: &str, service: T) -> Self
     where
-        T: Service<Request<B>, Error = Infallible> + Clone + Send + 'static,
+        T: Service<Request<B>, Error = Infallible> + Clone + Send + Sync + 'static,
         T::Response: IntoResponse,
         T::Future: Send + 'static,
         Self: Sized;
@@ -282,7 +282,7 @@ where
     #[track_caller]
     fn route_service_with_tsr<T>(mut self, path: &str, service: T) -> Self
     where
-        T: Service<Request<B>, Error = Infallible> + Clone + Send + 'static,
+        T: Service<Request<B>, Error = Infallible> + Clone + Send + Sync + 'static,
         T::Response: IntoResponse,
         T::Future: Send + 'static,
         Self: Sized,

--- a/axum/src/handler/mod.rs
+++ b/axum/src/handler/mod.rs
@@ -99,7 +99,7 @@ pub use self::service::HandlerService;
         note = "Consider using `#[axum::debug_handler]` to improve the error message"
     )
 )]
-pub trait Handler<T, S, B = Body>: Clone + Send + Sized + 'static {
+pub trait Handler<T, S, B = Body>: Clone + Send + Sync + Sized + 'static {
     /// The type of future calling this handler returns.
     type Future: Future<Output = Response> + Send + 'static;
 
@@ -162,7 +162,7 @@ pub trait Handler<T, S, B = Body>: Clone + Send + Sized + 'static {
 
 impl<F, Fut, Res, S, B> Handler<((),), S, B> for F
 where
-    F: FnOnce() -> Fut + Clone + Send + 'static,
+    F: FnOnce() -> Fut + Clone + Send + Sync + 'static,
     Fut: Future<Output = Res> + Send,
     Res: IntoResponse,
     B: Send + 'static,
@@ -181,7 +181,7 @@ macro_rules! impl_handler {
         #[allow(non_snake_case, unused_mut)]
         impl<F, Fut, S, B, Res, M, $($ty,)* $last> Handler<(M, $($ty,)* $last,), S, B> for F
         where
-            F: FnOnce($($ty,)* $last,) -> Fut + Clone + Send + 'static,
+            F: FnOnce($($ty,)* $last,) -> Fut + Clone + Send + Sync + 'static,
             Fut: Future<Output = Res> + Send,
             B: Send + 'static,
             S: Send + Sync + 'static,
@@ -257,7 +257,7 @@ where
 
 impl<H, S, T, L, B, B2> Handler<T, S, B2> for Layered<L, H, T, S, B, B2>
 where
-    L: Layer<HandlerService<H, T, S, B>> + Clone + Send + 'static,
+    L: Layer<HandlerService<H, T, S, B>> + Clone + Send + Sync + 'static,
     H: Handler<T, S, B>,
     L::Service: Service<Request<B2>, Error = Infallible> + Clone + Send + 'static,
     <L::Service as Service<Request<B2>>>::Response: IntoResponse,

--- a/axum/src/routing/method_routing.rs
+++ b/axum/src/routing/method_routing.rs
@@ -80,7 +80,7 @@ macro_rules! top_level_service_fn {
         $(#[$m])+
         pub fn $name<T, S, B>(svc: T) -> MethodRouter<S, B, T::Error>
         where
-            T: Service<Request<B>> + Clone + Send + 'static,
+            T: Service<Request<B>> + Clone + Send + Sync + 'static,
             T::Response: IntoResponse + 'static,
             T::Future: Send + 'static,
             B: HttpBody + Send + 'static,
@@ -218,6 +218,7 @@ macro_rules! chained_service_fn {
             T: Service<Request<B>, Error = E>
                 + Clone
                 + Send
+                + Sync
                 + 'static,
             T::Response: IntoResponse + 'static,
             T::Future: Send + 'static,
@@ -324,7 +325,7 @@ top_level_service_fn!(trace_service, TRACE);
 /// ```
 pub fn on_service<T, S, B>(filter: MethodFilter, svc: T) -> MethodRouter<S, B, T::Error>
 where
-    T: Service<Request<B>> + Clone + Send + 'static,
+    T: Service<Request<B>> + Clone + Send + Sync + 'static,
     T::Response: IntoResponse + 'static,
     T::Future: Send + 'static,
     B: HttpBody + Send + 'static,
@@ -388,7 +389,7 @@ where
 /// ```
 pub fn any_service<T, S, B>(svc: T) -> MethodRouter<S, B, T::Error>
 where
-    T: Service<Request<B>> + Clone + Send + 'static,
+    T: Service<Request<B>> + Clone + Send + Sync + 'static,
     T::Response: IntoResponse + 'static,
     T::Future: Send + 'static,
     B: HttpBody + Send + 'static,
@@ -775,7 +776,7 @@ where
     #[track_caller]
     pub fn on_service<T>(self, filter: MethodFilter, svc: T) -> Self
     where
-        T: Service<Request<B>, Error = E> + Clone + Send + 'static,
+        T: Service<Request<B>, Error = E> + Clone + Send + Sync + 'static,
         T::Response: IntoResponse + 'static,
         T::Future: Send + 'static,
     {
@@ -907,7 +908,7 @@ where
     #[doc = include_str!("../docs/method_routing/fallback.md")]
     pub fn fallback_service<T>(mut self, svc: T) -> Self
     where
-        T: Service<Request<B>, Error = E> + Clone + Send + 'static,
+        T: Service<Request<B>, Error = E> + Clone + Send + Sync + 'static,
         T::Response: IntoResponse + 'static,
         T::Future: Send + 'static,
     {
@@ -918,8 +919,8 @@ where
     #[doc = include_str!("../docs/method_routing/layer.md")]
     pub fn layer<L, NewReqBody, NewError>(self, layer: L) -> MethodRouter<S, NewReqBody, NewError>
     where
-        L: Layer<Route<B, E>> + Clone + Send + 'static,
-        L::Service: Service<Request<NewReqBody>> + Clone + Send + 'static,
+        L: Layer<Route<B, E>> + Clone + Send + Sync + 'static,
+        L::Service: Service<Request<NewReqBody>> + Clone + Send + Sync + 'static,
         <L::Service as Service<Request<NewReqBody>>>::Response: IntoResponse + 'static,
         <L::Service as Service<Request<NewReqBody>>>::Error: Into<NewError> + 'static,
         <L::Service as Service<Request<NewReqBody>>>::Future: Send + 'static,
@@ -948,8 +949,8 @@ where
     #[track_caller]
     pub fn route_layer<L>(mut self, layer: L) -> MethodRouter<S, B, E>
     where
-        L: Layer<Route<B, E>> + Clone + Send + 'static,
-        L::Service: Service<Request<B>, Error = E> + Clone + Send + 'static,
+        L: Layer<Route<B, E>> + Clone + Send + Sync + 'static,
+        L::Service: Service<Request<B>, Error = E> + Clone + Send + Sync + 'static,
         <L::Service as Service<Request<B>>>::Response: IntoResponse + 'static,
         <L::Service as Service<Request<B>>>::Future: Send + 'static,
         E: 'static,
@@ -1206,7 +1207,7 @@ where
         S: 'static,
         B: 'static,
         E: 'static,
-        F: FnOnce(Route<B, E>) -> Route<B2, E2> + Clone + Send + 'static,
+        F: FnOnce(Route<B, E>) -> Route<B2, E2> + Clone + Send + Sync + 'static,
         B2: HttpBody + 'static,
         E2: 'static,
     {

--- a/axum/src/routing/mod.rs
+++ b/axum/src/routing/mod.rs
@@ -164,7 +164,7 @@ where
     #[doc = include_str!("../docs/routing/route_service.md")]
     pub fn route_service<T>(self, path: &str, service: T) -> Self
     where
-        T: Service<Request<B>, Error = Infallible> + Clone + Send + 'static,
+        T: Service<Request<B>, Error = Infallible> + Clone + Send + Sync + 'static,
         T::Response: IntoResponse,
         T::Future: Send + 'static,
     {
@@ -215,7 +215,7 @@ where
     #[track_caller]
     pub fn nest_service<T>(self, path: &str, svc: T) -> Self
     where
-        T: Service<Request<B>, Error = Infallible> + Clone + Send + 'static,
+        T: Service<Request<B>, Error = Infallible> + Clone + Send + Sync + 'static,
         T::Response: IntoResponse,
         T::Future: Send + 'static,
     {
@@ -229,7 +229,7 @@ where
         router_or_service: RouterOrService<S, B, T>,
     ) -> Self
     where
-        T: Service<Request<B>, Error = Infallible> + Clone + Send + 'static,
+        T: Service<Request<B>, Error = Infallible> + Clone + Send + Sync + 'static,
         T::Response: IntoResponse,
         T::Future: Send + 'static,
     {
@@ -313,8 +313,8 @@ where
     #[doc = include_str!("../docs/routing/layer.md")]
     pub fn layer<L, NewReqBody>(self, layer: L) -> Router<S, NewReqBody>
     where
-        L: Layer<Route<B>> + Clone + Send + 'static,
-        L::Service: Service<Request<NewReqBody>> + Clone + Send + 'static,
+        L: Layer<Route<B>> + Clone + Send + Sync + 'static,
+        L::Service: Service<Request<NewReqBody>> + Clone + Send + Sync + 'static,
         <L::Service as Service<Request<NewReqBody>>>::Response: IntoResponse + 'static,
         <L::Service as Service<Request<NewReqBody>>>::Error: Into<Infallible> + 'static,
         <L::Service as Service<Request<NewReqBody>>>::Future: Send + 'static,
@@ -342,8 +342,8 @@ where
     #[track_caller]
     pub fn route_layer<L>(self, layer: L) -> Self
     where
-        L: Layer<Route<B>> + Clone + Send + 'static,
-        L::Service: Service<Request<B>> + Clone + Send + 'static,
+        L: Layer<Route<B>> + Clone + Send + Sync + 'static,
+        L::Service: Service<Request<B>> + Clone + Send + Sync + 'static,
         <L::Service as Service<Request<B>>>::Response: IntoResponse + 'static,
         <L::Service as Service<Request<B>>>::Error: Into<Infallible> + 'static,
         <L::Service as Service<Request<B>>>::Future: Send + 'static,
@@ -386,7 +386,7 @@ where
     /// See [`Router::fallback`] for more details.
     pub fn fallback_service<T>(mut self, svc: T) -> Self
     where
-        T: Service<Request<B>, Error = Infallible> + Clone + Send + 'static,
+        T: Service<Request<B>, Error = Infallible> + Clone + Send + Sync + 'static,
         T::Response: IntoResponse,
         T::Future: Send + 'static,
     {
@@ -633,7 +633,7 @@ where
         S: 'static,
         B: 'static,
         E: 'static,
-        F: FnOnce(Route<B, E>) -> Route<B2, E2> + Clone + Send + 'static,
+        F: FnOnce(Route<B, E>) -> Route<B2, E2> + Clone + Send + Sync + 'static,
         B2: HttpBody + 'static,
         E2: 'static,
     {
@@ -687,8 +687,8 @@ where
 {
     fn layer<L, NewReqBody>(self, layer: L) -> Endpoint<S, NewReqBody>
     where
-        L: Layer<Route<B>> + Clone + Send + 'static,
-        L::Service: Service<Request<NewReqBody>> + Clone + Send + 'static,
+        L: Layer<Route<B>> + Clone + Send + Sync + 'static,
+        L::Service: Service<Request<NewReqBody>> + Clone + Send + Sync + 'static,
         <L::Service as Service<Request<NewReqBody>>>::Response: IntoResponse + 'static,
         <L::Service as Service<Request<NewReqBody>>>::Error: Into<Infallible> + 'static,
         <L::Service as Service<Request<NewReqBody>>>::Future: Send + 'static,

--- a/axum/src/routing/mod.rs
+++ b/axum/src/routing/mod.rs
@@ -743,4 +743,5 @@ struct SuperFallback<B>(SyncWrapper<Route<B>>);
 fn traits() {
     use crate::test_helpers::*;
     assert_send::<Router<(), ()>>();
+    assert_sync::<Router<(), ()>>();
 }

--- a/axum/src/util/box_clone_sync_service.rs
+++ b/axum/src/util/box_clone_sync_service.rs
@@ -1,0 +1,83 @@
+use futures_util::future::BoxFuture;
+use std::{
+    fmt,
+    task::{Context, Poll},
+};
+use tower::ServiceExt;
+use tower_service::Service;
+
+pub(crate) struct BoxCloneSyncService<T, U, E>(
+    Box<
+        dyn CloneSyncService<T, Response = U, Error = E, Future = BoxFuture<'static, Result<U, E>>>
+            + Send
+            + Sync,
+    >,
+);
+
+impl<T, U, E> BoxCloneSyncService<T, U, E> {
+    pub(crate) fn new<S>(inner: S) -> Self
+    where
+        S: Service<T, Response = U, Error = E> + Clone + Send + Sync + 'static,
+        S::Future: Send + 'static,
+    {
+        let inner = inner.map_future(|f| Box::pin(f) as _);
+        BoxCloneSyncService(Box::new(inner))
+    }
+}
+
+impl<T, U, E> Service<T> for BoxCloneSyncService<T, U, E> {
+    type Response = U;
+    type Error = E;
+    type Future = BoxFuture<'static, Result<U, E>>;
+
+    #[inline]
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), E>> {
+        self.0.poll_ready(cx)
+    }
+
+    #[inline]
+    fn call(&mut self, request: T) -> Self::Future {
+        self.0.call(request)
+    }
+}
+
+impl<T, U, E> Clone for BoxCloneSyncService<T, U, E> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone_box())
+    }
+}
+
+trait CloneSyncService<R>: Service<R> {
+    fn clone_box(
+        &self,
+    ) -> Box<
+        dyn CloneSyncService<
+                R,
+                Response = Self::Response,
+                Error = Self::Error,
+                Future = Self::Future,
+            > + Send
+            + Sync,
+    >;
+}
+
+impl<R, T> CloneSyncService<R> for T
+where
+    T: Service<R> + Send + Sync + Clone + 'static,
+{
+    fn clone_box(
+        &self,
+    ) -> Box<
+        dyn CloneSyncService<R, Response = T::Response, Error = T::Error, Future = T::Future>
+            + Send
+            + Sync,
+    > {
+        Box::new(self.clone())
+    }
+}
+
+impl<T, U, E> fmt::Debug for BoxCloneSyncService<T, U, E> {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.debug_struct("BoxCloneSyncService").finish()
+    }
+}

--- a/axum/src/util/mod.rs
+++ b/axum/src/util/mod.rs
@@ -1,6 +1,10 @@
 use pin_project_lite::pin_project;
 use std::{ops::Deref, sync::Arc};
 
+mod box_clone_sync_service;
+
+pub(crate) use box_clone_sync_service::BoxCloneSyncService;
+
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub(crate) struct PercentDecodedStr(Arc<str>);
 


### PR DESCRIPTION
**Motivation:** Makes `Router` and `RouterService` `Sync`.

The `box_clone_sync_service` is copied from tower and adjusted to include `Sync`, none of the docs since it is private. It could probably be upstreamed into tower if we decide that we want this.