### PR TITLE
Rework `Form` and `Query` rejections

### DIFF
--- a/axum-extra/src/extract/mod.rs
+++ b/axum-extra/src/extract/mod.rs
@@ -28,7 +28,7 @@ pub use self::cookie::SignedCookieJar;
 pub use self::form::{Form, FormRejection};
 
 #[cfg(feature = "query")]
-pub use self::query::Query;
+pub use self::query::{Query, QueryRejection};
 
 #[cfg(feature = "json-lines")]
 #[doc(no_inline)]

--- a/axum-extra/src/extract/mod.rs
+++ b/axum-extra/src/extract/mod.rs
@@ -25,7 +25,7 @@ pub use self::cookie::PrivateCookieJar;
 pub use self::cookie::SignedCookieJar;
 
 #[cfg(feature = "form")]
-pub use self::form::Form;
+pub use self::form::{Form, FormRejection};
 
 #[cfg(feature = "query")]
 pub use self::query::Query;

--- a/axum-macros/tests/debug_handler/fail/wrong_return_type.stderr
+++ b/axum-macros/tests/debug_handler/fail/wrong_return_type.stderr
@@ -13,7 +13,7 @@ error[E0277]: the trait bound `bool: IntoResponse` is not satisfied
             (Response<()>, T1, T2, R)
             (Response<()>, T1, T2, T3, R)
             (Response<()>, T1, T2, T3, T4, R)
-          and 119 others
+          and 120 others
 note: required by a bound in `__axum_macros_check_handler_into_response::{closure#0}::check`
  --> tests/debug_handler/fail/wrong_return_type.rs:4:23
   |

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -48,7 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   [`axum-macros`] behind the `macros` feature ([#1352])
 - **added:** Add `extract::RawForm` for accessing raw urlencoded query bytes or request body ([#1487])
 - **breaking:** Rename `FormRejection::FailedToDeserializeQueryString` to
-  `FormRejection::FailedToDeserializeForm`
+  `FormRejection::FailedToDeserializeForm` ([#1496])
 
 [#1352]: https://github.com/tokio-rs/axum/pull/1352
 [#1368]: https://github.com/tokio-rs/axum/pull/1368
@@ -65,6 +65,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#1420]: https://github.com/tokio-rs/axum/pull/1420
 [#1421]: https://github.com/tokio-rs/axum/pull/1421
 [#1487]: https://github.com/tokio-rs/axum/pull/1487
+[#1496]: https://github.com/tokio-rs/axum/pull/1496
 
 # 0.6.0-rc.2 (10. September, 2022)
 

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -47,6 +47,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **added:** `FromRequest` and `FromRequestParts` derive macro re-exports from
   [`axum-macros`] behind the `macros` feature ([#1352])
 - **added:** Add `extract::RawForm` for accessing raw urlencoded query bytes or request body ([#1487])
+- **breaking:** Rename `FormRejection::FailedToDeserializeQueryString` to
+  `FormRejection::FailedToDeserializeForm`
 
 [#1352]: https://github.com/tokio-rs/axum/pull/1352
 [#1368]: https://github.com/tokio-rs/axum/pull/1368

--- a/axum/src/extract/query.rs
+++ b/axum/src/extract/query.rs
@@ -59,8 +59,8 @@ where
 
     async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
         let query = parts.uri.query().unwrap_or_default();
-        let value = serde_urlencoded::from_str(query)
-            .map_err(FailedToDeserializeQueryString::__private_new)?;
+        let value =
+            serde_urlencoded::from_str(query).map_err(FailedToDeserializeQueryString::from_err)?;
         Ok(Query(value))
     }
 }

--- a/axum/src/extract/rejection.rs
+++ b/axum/src/extract/rejection.rs
@@ -1,8 +1,5 @@
 //! Rejection response types.
 
-use crate::{BoxError, Error};
-use axum_core::response::{IntoResponse, Response};
-
 pub use crate::extract::path::FailedToDeserializePathParams;
 pub use axum_core::extract::rejection::*;
 
@@ -81,38 +78,13 @@ define_rejection! {
     pub struct FailedToDeserializeForm(Error);
 }
 
-/// Rejection type for extractors that deserialize query strings if the input
-/// couldn't be deserialized into the target type.
-#[derive(Debug)]
-pub struct FailedToDeserializeQueryString {
-    error: Error,
+define_rejection! {
+    #[status = BAD_REQUEST]
+    #[body = "Failed to deserialize query string"]
+    /// Rejection type used if the [`Query`](super::Query) extractor is unable to
+    /// deserialize the form into the target type.
+    pub struct FailedToDeserializeQueryString(Error);
 }
-
-impl FailedToDeserializeQueryString {
-    #[doc(hidden)]
-    pub fn __private_new<E>(error: E) -> Self
-    where
-        E: Into<BoxError>,
-    {
-        FailedToDeserializeQueryString {
-            error: Error::new(error),
-        }
-    }
-}
-
-impl IntoResponse for FailedToDeserializeQueryString {
-    fn into_response(self) -> Response {
-        (http::StatusCode::BAD_REQUEST, self.to_string()).into_response()
-    }
-}
-
-impl std::fmt::Display for FailedToDeserializeQueryString {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "Failed to deserialize query string: {}", self.error,)
-    }
-}
-
-impl std::error::Error for FailedToDeserializeQueryString {}
 
 composite_rejection! {
     /// Rejection used for [`Query`](super::Query).

--- a/axum/src/extract/rejection.rs
+++ b/axum/src/extract/rejection.rs
@@ -73,6 +73,14 @@ define_rejection! {
     pub struct FailedToResolveHost;
 }
 
+define_rejection! {
+    #[status = BAD_REQUEST]
+    #[body = "Failed to deserialize form"]
+    /// Rejection type used if the [`Form`](super::Form) extractor is unable to
+    /// deserialize the form into the target type.
+    pub struct FailedToDeserializeForm(Error);
+}
+
 /// Rejection type for extractors that deserialize query strings if the input
 /// couldn't be deserialized into the target type.
 #[derive(Debug)]
@@ -123,7 +131,7 @@ composite_rejection! {
     /// can fail.
     pub enum FormRejection {
         InvalidFormContentType,
-        FailedToDeserializeQueryString,
+        FailedToDeserializeForm,
         BytesRejection,
     }
 }

--- a/axum/src/form.rs
+++ b/axum/src/form.rs
@@ -76,7 +76,7 @@ where
         match req.extract().await {
             Ok(RawForm(bytes)) => {
                 let value = serde_urlencoded::from_bytes(&bytes)
-                    .map_err(FailedToDeserializeQueryString::__private_new)?;
+                    .map_err(FailedToDeserializeForm::from_err)?;
                 Ok(Form(value))
             }
             Err(RawFormRejection::BytesRejection(r)) => Err(FormRejection::BytesRejection(r)),


### PR DESCRIPTION
- Rename some rejections.
- Make dedicated rejections for axum-extra's `Form` and `Query` extractors.