### PR TITLE
Add example of static-file-server using serve dir with handler as service

### DIFF
--- a/examples/static-file-server/src/main.rs
+++ b/examples/static-file-server/src/main.rs
@@ -89,12 +89,12 @@ fn using_serve_dir_only_from_root_via_fallback() -> Router {
 }
 
 fn using_serve_dir_with_handler_as_service() -> Router {
-    // you can convert handler function to service
-    async fn handler_404() -> impl IntoResponse {
+    async fn handle_404() -> (StatusCode, &'static str) {
         (StatusCode::NOT_FOUND, "Not found")
     }
-    
-    let service = handler_404
+
+    // you can convert handler function to service
+    let service = handle_404
         .into_service()
         .map_err(|_| io::Error::from(io::ErrorKind::Other));
 

--- a/examples/static-file-server/src/main.rs
+++ b/examples/static-file-server/src/main.rs
@@ -103,7 +103,7 @@ fn using_serve_dir_with_handler_as_service() -> Router {
 
     Router::new()
         .route("/foo", get(|| async { "Hi from /foo" }))
-        .fallback_service(serve_dir)    
+        .fallback_service(serve_dir)
 }
 
 fn two_serve_dirs() -> Router {

--- a/examples/static-file-server/src/main.rs
+++ b/examples/static-file-server/src/main.rs
@@ -96,7 +96,7 @@ fn using_serve_dir_with_handler_as_service() -> Router {
     // you can convert handler function to service
     let service = handle_404
         .into_service()
-        .map_err(|_| io::Error::from(io::ErrorKind::Other));
+        .map_err(|err| -> std::io::Error { match err {} });
 
     let serve_dir = ServeDir::new("assets").not_found_service(service);
     let serve_dir = get_service(serve_dir).handle_error(handle_error);


### PR DESCRIPTION
This PR simply adds another case in static-file-server example showing how it is possible to use a handler function with ServeDir

