### PR TITLE
Add sample demonstrating static file served behind authentication

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,6 @@ members = [
     "axum",
     "axum-core",
     "axum-extra",
-    "axum-macros",
+    "axum-macros"
 ]
 resolver = "2"

--- a/examples/static-file-server/Cargo.toml
+++ b/examples/static-file-server/Cargo.toml
@@ -10,5 +10,6 @@ axum-extra = { path = "../../axum-extra", features = ["spa"] }
 tokio = { version = "1.0", features = ["full"] }
 tower = { version = "0.4", features = ["util"] }
 tower-http = { version = "0.3.0", features = ["fs", "trace"] }
+http = "0.2.8"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }


### PR DESCRIPTION
This change adds a sample, demonstrating how to use `ServeDir` (and `ServeFile`) inside a method handler.

The purpose is to be able to leverage other injection mechanisms (`FromRequest`, `FromRequestParts`, `Extension`, etc.).

My use case was to gate static files behind authentication.

## Motivation
As a rust newbie I invested quite some time to figure out how to do this, so I figure it could help someone else.
