### PR TITLE
Add tests for the Allow header when returning 405 METHOD NOT ALLOWED

### DIFF
--- a/axum/src/routing/tests/mod.rs
+++ b/axum/src/routing/tests/mod.rs
@@ -9,7 +9,7 @@ use crate::{
     BoxError, Json, Router,
 };
 use futures_util::stream::StreamExt;
-use http::{header::CONTENT_LENGTH, HeaderMap, Request, Response, StatusCode, Uri};
+use http::{header::ALLOW, header::CONTENT_LENGTH, HeaderMap, Request, Response, StatusCode, Uri};
 use hyper::Body;
 use serde_json::json;
 use std::{
@@ -217,12 +217,14 @@ async fn wrong_method_handler() {
 
     let res = client.patch("/").send().await;
     assert_eq!(res.status(), StatusCode::METHOD_NOT_ALLOWED);
+    assert_eq!(res.headers()[ALLOW], "GET,HEAD,POST");
 
     let res = client.patch("/foo").send().await;
     assert_eq!(res.status(), StatusCode::OK);
 
     let res = client.post("/foo").send().await;
     assert_eq!(res.status(), StatusCode::METHOD_NOT_ALLOWED);
+    assert_eq!(res.headers()[ALLOW], "PATCH");
 
     let res = client.get("/bar").send().await;
     assert_eq!(res.status(), StatusCode::NOT_FOUND);
@@ -255,12 +257,14 @@ async fn wrong_method_service() {
 
     let res = client.patch("/").send().await;
     assert_eq!(res.status(), StatusCode::METHOD_NOT_ALLOWED);
+    assert_eq!(res.headers()[ALLOW], "GET,HEAD,POST");
 
     let res = client.patch("/foo").send().await;
     assert_eq!(res.status(), StatusCode::OK);
 
     let res = client.post("/foo").send().await;
     assert_eq!(res.status(), StatusCode::METHOD_NOT_ALLOWED);
+    assert_eq!(res.headers()[ALLOW], "PATCH");
 
     let res = client.get("/bar").send().await;
     assert_eq!(res.status(), StatusCode::NOT_FOUND);

--- a/axum/src/routing/tests/nest.rs
+++ b/axum/src/routing/tests/nest.rs
@@ -70,6 +70,7 @@ async fn wrong_method_nest() {
 
     let res = client.post("/").send().await;
     assert_eq!(res.status(), StatusCode::METHOD_NOT_ALLOWED);
+    assert_eq!(res.headers()[ALLOW], "GET,HEAD");
 
     let res = client.patch("/foo").send().await;
     assert_eq!(res.status(), StatusCode::NOT_FOUND);


### PR DESCRIPTION
In #1525 I vowed to write tests for the allow header. This PR fulfills my obligation.

If I failed to adhere to some facet of the [contributing guidelines](https://github.com/tokio-rs/axum/blob/main/CONTRIBUTING.md) or I made any other kind of error, I am happy to make changes.

Refs: #1525, #733