### PR TITLE
Remove debug_assert in matched_path

### DIFF
--- a/axum/src/extract/matched_path.rs
+++ b/axum/src/extract/matched_path.rs
@@ -143,6 +143,7 @@ pub(crate) fn set_matched_path_for_request(
 
     if matched_path.ends_with(NEST_TAIL_PARAM_CAPTURE) {
         extensions.insert(MatchedNestedPath(matched_path));
+        debug_assert!(matches!(extensions.remove::<MatchedPath>(), None));
     } else {
         extensions.insert(MatchedPath(matched_path));
         extensions.remove::<MatchedNestedPath>();

--- a/axum/src/extract/matched_path.rs
+++ b/axum/src/extract/matched_path.rs
@@ -143,7 +143,6 @@ pub(crate) fn set_matched_path_for_request(
 
     if matched_path.ends_with(NEST_TAIL_PARAM_CAPTURE) {
         extensions.insert(MatchedNestedPath(matched_path));
-        debug_assert!(matches!(dbg!(extensions.remove::<MatchedPath>()), None));
     } else {
         extensions.insert(MatchedPath(matched_path));
         extensions.remove::<MatchedNestedPath>();


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

The `debug_assert` prints a message normally instead of going through `tracing`, which looks weird.

![example](https://user-images.githubusercontent.com/17971474/201496678-01aa4003-4fed-463e-be27-28609f32ea77.png)

(image transcript):

```
[/home/bbaovanc/.local/share/cargo/registry/src/github.com-1ecc6299db9ec823/axum-0.6.0-rc.4/src/extract/matched_path.rs:146] extensions.remove::<MatchedPath>() = None
2022-11-12T21:20:55.448880Z  INFO request{method=DELETE uri=/api/v1/delete/04l5RCVD id="21f5752a-f61d-4337-8577-1f941fcf1438"}: tower_http::trace::on_request: started processing request
[/home/bbaovanc/.local/share/cargo/registry/src/github.com-1ecc6299db9ec823/axum-0.6.0-rc.4/src/extract/matched_path.rs:146] extensions.remove::<MatchedPath>() = None
2022-11-12T21:20:55.449682Z DEBUG request{method=DELETE uri=/api/v1/delete/04l5RCVD id="21f5752a-f61d-4337-8577-1f941fcf1438"}:delete{id="04l5RCVD" key="bQTqK3jrq1WFWF7KvFBMwInYpTGQqXgw"}: bobashare_web::api::v1::delete: reading upload metadata
2022-11-12T21:20:55.451297Z DEBUG request{method=DELETE uri=/api/v1/delete/04l5RCVD id="21f5752a-f61d-4337-8577-1f941fcf1438"}:delete{id="04l5RCVD" key="bQTqK3jrq1WFWF7KvFBMwInYpTGQqXgw"}: bobashare_web::api::v1::delete: delete key was correct; deleting upload
```

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Remove the assert since it was left in accidentally.