### PR TITLE
Add accept_unmasked_frames setting in WebSocketUpgrade

### DIFF
--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
-- None.
+- **added**: Add accept_unmasked_frames setting in WebSocketUpgrade ([#1529])
 
 # 0.6.0-rc.4 (9. November, 2022)
 

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
-- **added**: Add accept_unmasked_frames setting in WebSocketUpgrade ([#1529])
+- **added:** Add `accept_unmasked_frames` setting in WebSocketUpgrade ([#1529])
 
 # 0.6.0-rc.4 (9. November, 2022)
 

--- a/axum/src/extract/ws.rs
+++ b/axum/src/extract/ws.rs
@@ -164,6 +164,12 @@ impl WebSocketUpgrade {
         self
     }
 
+    /// Allow server to accept unmasked frames (defaults to false)
+    pub fn accept_unmasked_frames(mut self, accept: bool) -> Self {
+        self.config.accept_unmasked_frames = accept;
+        self
+    }
+
     /// Set the known protocols.
     ///
     /// If the protocol name specified by `Sec-WebSocket-Protocol` header


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation

I am working with some legacy websocket clients that do not follow RFC 6455 and is thus sending unmasked frames via websockets.  There isn't a way to change these clients, but tungstenite does expose an accept_unmasked_frames config option which can be set by axum.

## Solution

I've added accept_unmasked_frames to WebSocketUpgrade to set the underlying config setting and allow unmasked frames


Please let me know if anything needs to change
