### PR TITLE
Improve `State` and `Router` docs

### DIFF
--- a/axum/src/docs/routing/merge.md
+++ b/axum/src/docs/routing/merge.md
@@ -43,9 +43,6 @@ When combining [`Router`]s with this function, each [`Router`] must have the
 same type of state. See ["Combining stateful routers"][combining-stateful-routers]
 for details.
 
-If you want to compose axum services with different types of state, use
-[`Router::nest_service`].
-
 # Panics
 
 - If two routers that each have a [fallback](Router::fallback) are merged. This

--- a/axum/src/docs/routing/merge.md
+++ b/axum/src/docs/routing/merge.md
@@ -37,7 +37,18 @@ let app = Router::new()
 # };
 ```
 
-## Panics
+# Merging routers with state
+
+When combining [`Router`]s with this function, each [`Router`] must have the
+same type of state. See ["Combining stateful routers"][combining-stateful-routers]
+for details.
+
+If you want to compose axum services with different types of state, use
+[`Router::nest_service`].
+
+# Panics
 
 - If two routers that each have a [fallback](Router::fallback) are merged. This
   is because `Router` only allows a single fallback.
+
+[combining-stateful-routers]: crate::extract::State#combining-stateful-routers

--- a/axum/src/docs/routing/nest.md
+++ b/axum/src/docs/routing/nest.md
@@ -1,4 +1,4 @@
-Nest a [`Service`] at some path.
+Nest a [`Router`] at some path.
 
 This allows you to break your application into smaller pieces and compose
 them together.
@@ -64,7 +64,7 @@ let app = Router::new().nest("/:version/api", users_api);
 # };
 ```
 
-# Differences to wildcard routes
+# Differences from wildcard routes
 
 Nested routes are similar to wildcard routes. The difference is that
 wildcard routes still see the whole URI whereas nested routes will have

--- a/axum/src/docs/routing/nest.md
+++ b/axum/src/docs/routing/nest.md
@@ -147,42 +147,14 @@ let app = Router::new()
 
 Here requests like `GET /api/not-found` will go to `api_fallback`.
 
-# Nesting a router with a different state type
+# Nesting routers with state
 
-By default `nest` requires a `Router` with the same state type as the outer
-`Router`. If you need to nest a `Router` with a different state type you can
-use [`Router::with_state`] and [`Router::nest_service`]:
+When combining [`Router`]s with this function, each [`Router`] must have the
+same type of state. See ["Combining stateful routers"][combining-stateful-routers]
+for details.
 
-```rust
-use axum::{
-    Router,
-    routing::get,
-    extract::State,
-};
-
-#[derive(Clone)]
-struct InnerState {}
-
-#[derive(Clone)]
-struct OuterState {}
-
-async fn inner_handler(state: State<InnerState>) {}
-
-let inner_router = Router::new()
-    .route("/bar", get(inner_handler))
-    .with_state(InnerState {});
-
-async fn outer_handler(state: State<OuterState>) {}
-
-let app = Router::new()
-    .route("/", get(outer_handler))
-    .nest_service("/foo", inner_router)
-    .with_state(OuterState {});
-# let _: axum::routing::RouterService = app;
-```
-
-Note that the inner router will still inherit the fallback from the outer
-router.
+If you want to compose axum services with different types of state, use
+[`Router::nest_service`].
 
 # Panics
 
@@ -193,3 +165,4 @@ for more details.
 
 [`OriginalUri`]: crate::extract::OriginalUri
 [fallbacks]: Router::fallback
+[combining-stateful-routers]: crate::extract::State#combining-stateful-routers

--- a/axum/src/extract/state.rs
+++ b/axum/src/extract/state.rs
@@ -46,14 +46,13 @@ use std::{
 /// # let _: axum::routing::RouterService = app;
 /// ```
 ///
-/// [`Router`][router]s that are combined with [`Router::nest`][router-nest]
-/// or [`Router::merge`][router-merge] generally require the same type of state.
-/// See [`Router::nest`][router-nest] for how to combine routers with different
-/// types of state.
-///
-/// [router]: crate::Router
-/// [router-nest]: crate::Router::nest
-/// [router-merge]: crate::Router::merge
+/// [`Router`]s that are combined with [`Router::nest`] or [`Router::merge`]
+/// generally require the same type of state. See [`Router::nest`] for how to
+/// combine routers with different types of state.
+/// 
+/// [`Router`]: crate::Router
+/// [`Router::nest`]: crate::Router::nest
+/// [`Router::merge`]: crate::Router::merge
 ///
 /// # With `MethodRouter`
 ///

--- a/axum/src/extract/state.rs
+++ b/axum/src/extract/state.rs
@@ -8,7 +8,7 @@ use std::{
 
 /// Extractor for state.
 ///
-/// See ["Accessing state in middleware"][state-from-middleware] for how to  
+/// See ["Accessing state in middleware"][state-from-middleware] for how to
 /// access state in middleware.
 ///
 /// [state-from-middleware]: crate::middleware#accessing-state-in-middleware
@@ -45,6 +45,15 @@ use std::{
 /// }
 /// # let _: axum::routing::RouterService = app;
 /// ```
+///
+/// [`Router`][router]s that are combined with [`Router::nest`][router-nest]
+/// or [`Router::merge`][router-merge] generally require the same type of state.
+/// See [`Router::nest`][router-nest] for how to combine routers with different
+/// types of state.
+///
+/// [router]: crate::Router
+/// [router-nest]: crate::Router::nest
+/// [router-merge]: crate::Router::merge
 ///
 /// # With `MethodRouter`
 ///

--- a/axum/src/lib.rs
+++ b/axum/src/lib.rs
@@ -164,11 +164,12 @@
 //!
 //! # Sharing state with handlers
 //!
-//! It is common to share some state between handlers for example to share a
-//! pool of database connections or clients to other services.
+//! It is common to share some state between handlers. For example, a
+//! pool of database connections or clients to other services may need to
+//! be shared.
 //!
 //! The three most common ways of doing that are:
-//! - Using the [`State`] extractor.
+//! - Using the [`State`] extractor
 //! - Using request extensions
 //! - Using closure captures
 //!

--- a/axum/src/routing/mod.rs
+++ b/axum/src/routing/mod.rs
@@ -212,6 +212,41 @@ where
     }
 
     /// Like [`nest`](Self::nest), but accepts an arbitrary `Service`.
+    ///
+    /// While [`nest`](Self::nest) requires [`Router`]s with the same type of
+    /// state, you can use this method to combine [`Router`]s with different
+    /// types of state:
+    ///
+    /// ```
+    /// use axum::{
+    ///     Router,
+    ///     routing::get,
+    ///     extract::State,
+    /// };
+    ///
+    /// #[derive(Clone)]
+    /// struct InnerState {}
+    ///
+    /// #[derive(Clone)]
+    /// struct OuterState {}
+    ///
+    /// async fn inner_handler(state: State<InnerState>) {}
+    ///
+    /// let inner_router = Router::new()
+    ///     .route("/bar", get(inner_handler))
+    ///     .with_state(InnerState {});
+    ///
+    /// async fn outer_handler(state: State<OuterState>) {}
+    ///
+    /// let app = Router::new()
+    ///     .route("/", get(outer_handler))
+    ///     .nest_service("/foo", inner_router)
+    ///     .with_state(OuterState {});
+    /// # let _: axum::routing::RouterService = app;
+    /// ```
+    ///
+    /// Note that the inner router will still inherit the fallback from the outer
+    /// router.
     #[track_caller]
     pub fn nest_service<T>(self, path: &str, svc: T) -> Self
     where


### PR DESCRIPTION
Per [my comment in #1313](https://github.com/tokio-rs/axum/issues/1313#issuecomment-1314955380), this improves discoverability of how `State` works with nested/merged `Router`s.

I made a few other minor documentation fixes while I was reading:

* Corrected the docs for `Router::nest` to say that it nests another `Router` rather than a `Service`. There is a separate function (`Router::nest_service`) for the latter.
* Changed one of the headings in nest.md to use more idiomatic English.
* Changed awkward phrasing under the "Sharing state with handlers" heading of the root documentation page.
* Removed a trailing period from one of three list items for consistency.