### PR TITLE
axum-extra 0.4.0-rc.3

### DIFF
--- a/axum-extra/CHANGELOG.md
+++ b/axum-extra/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning].
 
 - None.
 
+# 0.4.0-rc.3 (19. November, 2022)
+
+- **breaking:** Depend axum 0.6.0-rc.5 and axum-macros 0.3.0-rc.3
+
 # 0.4.0-rc.2 (8. November, 2022)
 
 - **breaking:** `Form` has a new rejection type ([#1496])

--- a/axum-extra/Cargo.toml
+++ b/axum-extra/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 name = "axum-extra"
 readme = "README.md"
 repository = "https://github.com/tokio-rs/axum"
-version = "0.4.0-rc.2"
+version = "0.4.0-rc.3"
 
 [features]
 default = []
@@ -35,7 +35,7 @@ spa = ["tower-http/fs"]
 typed-routing = ["dep:axum-macros", "dep:serde", "dep:percent-encoding"]
 
 [dependencies]
-axum = { path = "../axum", version = "0.6.0-rc.2", default-features = false }
+axum = { path = "../axum", version = "=0.6.0-rc.5", default-features = false }
 bytes = "1.1.0"
 futures-util = { version = "0.3", default-features = false, features = ["alloc"] }
 http = "0.2"
@@ -48,7 +48,7 @@ tower-layer = "0.3"
 tower-service = "0.3"
 
 # optional dependencies
-axum-macros = { path = "../axum-macros", version = "0.3.0-rc.1", optional = true }
+axum-macros = { path = "../axum-macros", version = "=0.3.0-rc.3", optional = true }
 cookie = { package = "cookie", version = "0.16", features = ["percent-encode"], optional = true }
 percent-encoding = { version = "2.1", optional = true }
 prost = { version = "0.11", optional = true }
@@ -59,7 +59,7 @@ tokio-stream = { version = "0.1.9", optional = true }
 tokio-util = { version = "0.7", optional = true }
 
 [dev-dependencies]
-axum = { path = "../axum", version = "0.6.0-rc.2", features = ["headers"] }
+axum = { path = "../axum", version = "=0.6.0-rc.5", features = ["headers"] }
 futures = "0.3"
 hyper = "0.14"
 reqwest = { version = "0.11", default-features = false, features = ["json", "stream", "multipart"] }

--- a/axum-macros/Cargo.toml
+++ b/axum-macros/Cargo.toml
@@ -26,7 +26,7 @@ syn = { version = "1.0", features = [
 
 [dev-dependencies]
 axum = { path = "../axum", version = "=0.6.0-rc.5", features = ["headers", "macros"] }
-axum-extra = { path = "../axum-extra", version = "=0.4.0-rc.2", features = ["typed-routing", "cookie-private"] }
+axum-extra = { path = "../axum-extra", version = "=0.4.0-rc.3", features = ["typed-routing", "cookie-private"] }
 rustversion = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
axum-extra needs a new release because it uses the old state inheritance whic is removed in the latest rc.