### PR TITLE
docs: add axum-otel-metrics to axum ecosystem

### DIFF
--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -29,6 +29,7 @@ If your project isn't listed here and you would like it to be, please feel free 
 - [axum-sessions](https://docs.rs/axum-sessions): Cookie-based sessions for axum via async-session.
 - [axum-login](https://docs.rs/axum-login): Session-based user authentication for axum.
 - [axum-csrf-sync-pattern](https://crates.io/crates/axum-csrf-sync-pattern): A middleware implementing CSRF STP for AJAX backends and API endpoints.
+- [axum-otel-metrics](https://github.com/ttys3/axum-otel-metrics/): A axum OpenTelemetry Metrics middleware with prometheus exporter supported.
 
 ## Project showcase
 


### PR DESCRIPTION
a http metrics middleware for axum which 

uses the opentelemetry Rust sdk auto record http requests metrics

and export the metrics data to Prometheus at `/metrics` endpoint.

it include two major metrics: a request duration `histogram` metric and a request `counter` metric

https://github.com/ttys3/axum-otel-metrics
