### PR TITLE
Update to tokio-tungstenite-0.18.0 and use sha1

### DIFF
--- a/axum/Cargo.toml
+++ b/axum/Cargo.toml
@@ -24,7 +24,7 @@ original-uri = []
 query = ["dep:serde_urlencoded"]
 tokio = ["dep:tokio", "hyper/server", "hyper/tcp", "tower/make"]
 tower-log = ["tower/log"]
-ws = ["tokio", "dep:tokio-tungstenite", "dep:sha-1", "dep:base64"]
+ws = ["tokio", "dep:tokio-tungstenite", "dep:sha1", "dep:base64"]
 
 # Required for intra-doc links to resolve correctly
 __private_docs = ["tower/full", "tower-http/full"]
@@ -59,9 +59,9 @@ multer = { version = "2.0.0", optional = true }
 serde_json = { version = "1.0", features = ["raw_value"], optional = true }
 serde_path_to_error = { version = "0.1.8", optional = true }
 serde_urlencoded = { version = "0.7", optional = true }
-sha-1 = { version = "0.10", optional = true }
+sha1 = { version = "0.10", optional = true }
 tokio = { package = "tokio", version = "1.21", features = ["time"], optional = true }
-tokio-tungstenite = { version = "0.17.2", optional = true }
+tokio-tungstenite = { version = "0.18.0", optional = true }
 
 [build-dependencies]
 rustversion = "1.0.9"


### PR DESCRIPTION
Updates to tokio-tungstenite 0.18.0.

This updates tungstenite version to 0.18.0 as dependency.

https://github.com/snapview/tokio-tungstenite/blob/v0.18.0/CHANGELOG.md#0180

This version of tungstenite uses sha1 instead of sha-1 because sha1 is transferred to https://github.com/RustCrypto (https://github.com/RustCrypto/hashes/pull/350) who owned sha-1 so it may be good to use sha1 in this change to avoid duplication.