### PR TITLE
Bug fixes for `RouterExt:{route_with_tsr, route_service_with_tsr}`

### DIFF
--- a/axum-extra/CHANGELOG.md
+++ b/axum-extra/CHANGELOG.md
@@ -7,7 +7,10 @@ and this project adheres to [Semantic Versioning].
 
 # Unreleased
 
-- None.
+- **fixed:** Bug fixes for `RouterExt:{route_with_tsr, route_service_with_tsr}`:
+  - Redirects to the correct URI if the route contains path parameters
+  - Keeps query parameters when redirecting
+  - Better improved error message if adding route for `/`
 
 # 0.4.1 (29. November, 2022)
 

--- a/axum-extra/CHANGELOG.md
+++ b/axum-extra/CHANGELOG.md
@@ -7,10 +7,12 @@ and this project adheres to [Semantic Versioning].
 
 # Unreleased
 
-- **fixed:** Bug fixes for `RouterExt:{route_with_tsr, route_service_with_tsr}`:
+- **fixed:** Bug fixes for `RouterExt:{route_with_tsr, route_service_with_tsr}` ([#1608]):
   - Redirects to the correct URI if the route contains path parameters
   - Keeps query parameters when redirecting
   - Better improved error message if adding route for `/`
+
+[#1608]: https://github.com/tokio-rs/axum/pull/1608
 
 # 0.4.1 (29. November, 2022)
 


### PR DESCRIPTION
- Redirects to the correct URI if the route contains path parameters
- Keeps query parameters when redirecting
- Better improved error message if adding route for `/`

Fixes https://github.com/tokio-rs/axum/issues/1605