### PR TITLE
Add `status` and `body_text` methods to built-in rejections

### DIFF
--- a/axum-core/CHANGELOG.md
+++ b/axum-core/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
-- None.
+- **added:** Add `body_text` and `status` methods to built-in rejections
 
 # 0.3.0 (25. November, 2022)
 

--- a/axum-core/src/macros.rs
+++ b/axum-core/src/macros.rs
@@ -19,12 +19,21 @@ macro_rules! define_rejection {
             }
         }
 
+        impl $name {
+            /// Get the response body text used for this rejection.
+            pub fn body_text(&self) -> String {
+                format!(concat!($body, ": {}"), self.0).into()
+            }
+
+            /// Get the status code used for this rejection.
+            pub fn status(&self) -> http::StatusCode {
+                http::StatusCode::$status
+            }
+        }
+
         impl crate::response::IntoResponse for $name {
             fn into_response(self) -> $crate::response::Response {
-                (
-                    http::StatusCode::$status,
-                    format!(concat!($body, ": {}"), self.0)
-                ).into_response()
+                (self.status(), self.body_text()).into_response()
             }
         }
 
@@ -65,6 +74,26 @@ macro_rules! composite_rejection {
                 match self {
                     $(
                         Self::$variant(inner) => inner.into_response(),
+                    )+
+                }
+            }
+        }
+
+        impl $name {
+            /// Get the response body text used for this rejection.
+            pub fn body_text(&self) -> String {
+                match self {
+                    $(
+                        Self::$variant(inner) => inner.body_text(),
+                    )+
+                }
+            }
+
+            /// Get the status code used for this rejection.
+            pub fn status(&self) -> http::StatusCode {
+                match self {
+                    $(
+                        Self::$variant(inner) => inner.status(),
                     )+
                 }
             }

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
-- None.
+- **added:** Add `body_text` and `status` methods to built-in rejections
 
 # 0.6.1 (29. November, 2022)
 

--- a/axum/src/macros.rs
+++ b/axum/src/macros.rs
@@ -59,7 +59,19 @@ macro_rules! define_rejection {
 
         impl $crate::response::IntoResponse for $name {
             fn into_response(self) -> $crate::response::Response {
-                (http::StatusCode::$status, $body).into_response()
+                (self.status(), $body).into_response()
+            }
+        }
+
+        impl $name {
+            /// Get the response body text used for this rejection.
+            pub fn body_text(&self) -> String {
+                $body.into()
+            }
+
+            /// Get the status code used for this rejection.
+            pub fn status(&self) -> http::StatusCode {
+                http::StatusCode::$status
             }
         }
 
@@ -99,10 +111,19 @@ macro_rules! define_rejection {
 
         impl crate::response::IntoResponse for $name {
             fn into_response(self) -> $crate::response::Response {
-                (
-                    http::StatusCode::$status,
-                    format!(concat!($body, ": {}"), self.0),
-                ).into_response()
+                (self.status(), self.body_text()).into_response()
+            }
+        }
+
+        impl $name {
+            /// Get the response body text used for this rejection.
+            pub fn body_text(&self) -> String {
+                format!(concat!($body, ": {}"), self.0).into()
+            }
+
+            /// Get the status code used for this rejection.
+            pub fn status(&self) -> http::StatusCode {
+                http::StatusCode::$status
             }
         }
 
@@ -143,6 +164,26 @@ macro_rules! composite_rejection {
                 match self {
                     $(
                         Self::$variant(inner) => inner.into_response(),
+                    )+
+                }
+            }
+        }
+
+        impl $name {
+            /// Get the response body text used for this rejection.
+            pub fn body_text(&self) -> String {
+                match self {
+                    $(
+                        Self::$variant(inner) => inner.body_text(),
+                    )+
+                }
+            }
+
+            /// Get the status code used for this rejection.
+            pub fn status(&self) -> http::StatusCode {
+                match self {
+                    $(
+                        Self::$variant(inner) => inner.status(),
                     )+
                 }
             }


### PR DESCRIPTION
This should make it easier to customize a built-in rejection while preserving either the status or body.

Fixes https://github.com/tokio-rs/axum/issues/1611