### PR TITLE
Add missing import of `http` in docs example

### DIFF
--- a/axum/src/middleware/from_fn.rs
+++ b/axum/src/middleware/from_fn.rs
@@ -29,7 +29,7 @@ use tower_service::Service;
 /// ```rust
 /// use axum::{
 ///     Router,
-///     http::{Request, StatusCode},
+///     http::{self, Request, StatusCode},
 ///     routing::get,
 ///     response::{IntoResponse, Response},
 ///     middleware::{self, Next},


### PR DESCRIPTION
Wouldn't compile without importing `self` for `http`