### PR TITLE
refactor(json): json content type checker

### DIFF
--- a/axum/src/json.rs
+++ b/axum/src/json.rs
@@ -146,40 +146,28 @@ where
 
 fn json_content_type(headers: &HeaderMap) -> Option<mime::Mime> {
     headers
-    .get(header::CONTENT_TYPE)
-    .map(|x| {
-        x.to_str().unwrap()
-    })
-    .and_then(|x| {
-        x.parse::<mime::Mime>().ok()
-    })
-    .and_then(|m| {
-        let suffix = m
-        .suffix()
-        .map_or(false, |name| {
-            name.eq(&mime::JSON)
+        .get(header::CONTENT_TYPE)
+        .map(|x| x.to_str().unwrap())
+        .and_then(|x| x.parse::<mime::Mime>().ok())
+        .and_then(|m| {
+            let suffix = m
+                .suffix()
+                .map_or(false, |name| name.eq(&mime::JSON))
+                .then_some(mime::JSON);
+
+            let type_ = m
+                .type_()
+                .eq(&mime::APPLICATION)
+                .then_some(mime::APPLICATION_JSON);
+
+            let subtype = m.subtype().eq(&mime::JSON).then_some(mime::JSON);
+
+            [subtype, suffix]
+                .iter()
+                .any(|x| x.is_some())
+                .then_some(type_)
+                .flatten()
         })
-        .then_some(mime::JSON);
-
-        let type_ = m
-        .type_()
-        .eq(&mime::APPLICATION)
-        .then_some(mime::APPLICATION_JSON);
-
-        let subtype = m
-        .subtype()
-        .eq(&mime::JSON)
-        .then_some(mime::JSON);
-
-        [
-            subtype,
-            suffix,
-        ]
-        .iter()
-        .any(|x| x.is_some())
-        .then_some(type_)
-        .flatten()
-    })
 }
 
 impl<T> Deref for Json<T> {

--- a/axum/src/json.rs
+++ b/axum/src/json.rs
@@ -153,19 +153,19 @@ fn json_content_type(headers: &HeaderMap) -> Option<mime::Mime> {
             let suffix = m
                 .suffix()
                 .map_or(false, |name| name.eq(&mime::JSON))
-                .then_some(mime::JSON);
+                .then(|| mime::JSON);
 
             let type_ = m
                 .type_()
                 .eq(&mime::APPLICATION)
-                .then_some(mime::APPLICATION_JSON);
+                .then(|| mime::APPLICATION_JSON);
 
-            let subtype = m.subtype().eq(&mime::JSON).then_some(mime::JSON);
+            let subtype = m.subtype().eq(&mime::JSON).then(|| mime::JSON);
 
             [subtype, suffix]
                 .iter()
                 .any(|x| x.is_some())
-                .then_some(type_)
+                .then(|| type_)
                 .flatten()
         })
 }


### PR DESCRIPTION
It started with me thinking I would minimize the code and I guess arguable write it more rusty.

It turns out it become a bit more code and I ... no string matching, no flag behavior and no branching.
I like it.

In the end it is about twice as fast,
measuring using basic `Instant::now`.

