### PR TITLE
Guide people to the right places to ask questions

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,7 @@
+contact_links:
+  - name: Q&A (GitHub Discussions)
+    url: https://github.com/tokio-rs/axum/discussions/categories/q-a
+    about: Q&A all around axum usage
+  - name: Tokio Discord
+    url: https://discord.gg/tokio
+    about: Community chat for Tokio (axum channel is under libs)

--- a/axum/README.md
+++ b/axum/README.md
@@ -121,7 +121,7 @@ The [examples] folder contains various examples of how to use `axum`. The
 ## Getting Help
 
 In the `axum`'s repo we also have a [number of examples][examples] showing how
-to put everything together. Community-maintained [showcases] and [tutorials] also demonstrate how to use `axum` for real-world applications. You're also welcome to ask in the [Discord channel][chat] or open an [issue] with your question.
+to put everything together. Community-maintained [showcases] and [tutorials] also demonstrate how to use `axum` for real-world applications. You're also welcome to ask in the [Discord channel][chat] or open a [discussion] with your question.
 
 ## Community projects
 
@@ -153,7 +153,7 @@ additional terms or conditions.
 [`tonic`]: https://crates.io/crates/tonic
 [contributing]: https://github.com/tokio-rs/axum/blob/main/CONTRIBUTING.md
 [chat]: https://discord.gg/tokio
-[issue]: https://github.com/tokio-rs/axum/issues/new
+[discussion]: https://github.com/tokio-rs/axum/discussions/new?category=q-a
 [`tower::Service`]: https://docs.rs/tower/latest/tower/trait.Service.html
 [ecosystem]: https://github.com/tokio-rs/axum/blob/main/ECOSYSTEM.md
 [showcases]: https://github.com/tokio-rs/axum/blob/main/ECOSYSTEM.md#project-showcase


### PR DESCRIPTION
## Motivation

We're getting a lot of issues that are really just questions about how to use axum, even though we have better tools for Q&A.

## Solution

Don't recommend people use issues for questions in `README.md`. Also link to Discussions and Discord from the new issue page.