### PR TITLE
Misc documentation improvements

### DIFF
--- a/axum-core/Cargo.toml
+++ b/axum-core/Cargo.toml
@@ -25,7 +25,7 @@ tower-service = "0.3"
 rustversion = "1.0.9"
 
 [dev-dependencies]
-axum = { path = "../axum", version = "0.6.0" }
+axum = { path = "../axum", version = "0.6.0", features = ["headers"] }
 futures-util = "0.3"
 hyper = "0.14"
 tokio = { version = "1.0", features = ["macros"] }

--- a/axum/src/docs/routing/with_state.md
+++ b/axum/src/docs/routing/with_state.md
@@ -98,6 +98,13 @@ axum::Server::bind(&"0.0.0.0:3000".parse().unwrap())
 # };
 ```
 
+# State is global within the router
+
+The state passed to this method will be used for all requests this router
+receives. That means it is not suitable for holding state derived from a
+request, such as authorization data extracted in a middleware. Use [`Extension`]
+instead for such data.
+
 # What `S` in `Router<S>` means
 
 `Router<S>` means a router that is _missing_ a state of type `S` to be able to
@@ -234,3 +241,5 @@ which may impact performance and reduce allocations.
 
 Note that [`Router::into_make_service`] and [`Router::into_make_service_with_connect_info`]
 do this automatically.
+
+[`Extension`]: crate::Extension

--- a/axum/src/middleware/from_fn.rs
+++ b/axum/src/middleware/from_fn.rs
@@ -24,29 +24,66 @@ use tower_service::Service;
 /// 3. Take [`Next<B>`](Next) as the final argument.
 /// 4. Return something that implements [`IntoResponse`].
 ///
-/// Note that this function doesn't support extracting [`State`]. For that [`from_request_parts`].
+/// Note that this function doesn't support extracting [`State`]. For that [`from_fn_with_state`].
 ///
 /// # Example
 ///
 /// ```rust
 /// use axum::{
 ///     Router,
-///     http::{self, Request, StatusCode},
+///     http::{self, Request},
 ///     routing::get,
-///     response::{IntoResponse, Response},
+///     response::Response,
 ///     middleware::{self, Next},
 /// };
 ///
-/// async fn auth<B>(req: Request<B>, next: Next<B>) -> Result<Response, StatusCode> {
-///     let auth_header = req.headers()
-///         .get(http::header::AUTHORIZATION)
-///         .and_then(|header| header.to_str().ok());
+/// async fn my_middleware<B>(
+///     request: Request<B>,
+///     next: Next<B>,
+/// ) -> Response {
+///     // do something with `request`...
 ///
-///     match auth_header {
-///         Some(auth_header) if token_is_valid(auth_header) => {
-///             Ok(next.run(req).await)
-///         }
-///         _ => Err(StatusCode::UNAUTHORIZED),
+///     let response = next.run(request).await;
+///
+///     // do something with `response`...
+///
+///     response
+/// }
+///
+/// let app = Router::new()
+///     .route("/", get(|| async { /* ... */ }))
+///     .layer(middleware::from_fn(my_middleware));
+/// # let app: Router = app;
+/// ```
+///
+/// # Running extractors
+///
+/// ```rust
+/// use axum::{
+///     Router,
+///     extract::TypedHeader,
+///     http::StatusCode,
+///     headers::authorization::{Authorization, Bearer},
+///     http::Request,
+///     middleware::{self, Next},
+///     response::Response,
+///     routing::get,
+/// };
+///
+/// async fn auth<B>(
+///     // run the `TypedHeader` extractor
+///     TypedHeader(auth): TypedHeader<Authorization<Bearer>>,
+///     // you can also add more extractors here but the last
+///     // extractor must implement `FromRequest` which
+///     // `Request` does
+///     request: Request<B>,
+///     next: Next<B>,
+/// ) -> Result<Response, StatusCode> {
+///     if token_is_valid(auth.token()) {
+///         let response = next.run(request).await;
+///         Ok(response)
+///     } else {
+///         Err(StatusCode::UNAUTHORIZED)
 ///     }
 /// }
 ///
@@ -61,41 +98,8 @@ use tower_service::Service;
 /// # let app: Router = app;
 /// ```
 ///
-/// # Running extractors
-///
-/// ```rust
-/// use axum::{
-///     Router,
-///     extract::{TypedHeader, Query},
-///     headers::authorization::{Authorization, Bearer},
-///     http::Request,
-///     middleware::{self, Next},
-///     response::Response,
-///     routing::get,
-/// };
-/// use std::collections::HashMap;
-///
-/// async fn my_middleware<B>(
-///     TypedHeader(auth): TypedHeader<Authorization<Bearer>>,
-///     Query(query_params): Query<HashMap<String, String>>,
-///     // you can add more extractors here but the last
-///     // extractor must implement `FromRequest` which
-///     // `Request` does
-///     req: Request<B>,
-///     next: Next<B>,
-/// ) -> Response {
-///     // do something with `auth` and `query_params`...
-///
-///     next.run(req).await
-/// }
-///
-/// let app = Router::new()
-///     .route("/", get(|| async { /* ... */ }))
-///     .route_layer(middleware::from_fn(my_middleware));
-/// # let app: Router = app;
-/// ```
-///
 /// [extractors]: crate::extract::FromRequest
+/// [`State`]: crate::extract::State
 pub fn from_fn<F, T>(f: F) -> FromFnLayer<F, (), T> {
     from_fn_with_state((), f)
 }
@@ -124,13 +128,16 @@ pub fn from_fn<F, T>(f: F) -> FromFnLayer<F, (), T> {
 ///     // you can add more extractors here but the last
 ///     // extractor must implement `FromRequest` which
 ///     // `Request` does
-///     req: Request<B>,
+///     request: Request<B>,
 ///     next: Next<B>,
 /// ) -> Response {
-///     // do something with `req`...
-///     let res = next.run(req).await;
-///     // do something with `res`...
-///     res
+///     // do something with `request`...
+///
+///     let response = next.run(request).await;
+///
+///     // do something with `response`...
+///
+///     response
 /// }
 ///
 /// let state = AppState { /* ... */ };

--- a/axum/src/middleware/from_fn.rs
+++ b/axum/src/middleware/from_fn.rs
@@ -24,6 +24,8 @@ use tower_service::Service;
 /// 3. Take [`Next<B>`](Next) as the final argument.
 /// 4. Return something that implements [`IntoResponse`].
 ///
+/// Note that this function doesn't support extracting [`State`]. For that [`from_request_parts`].
+///
 /// # Example
 ///
 /// ```rust

--- a/axum/src/middleware/from_fn.rs
+++ b/axum/src/middleware/from_fn.rs
@@ -24,7 +24,7 @@ use tower_service::Service;
 /// 3. Take [`Next<B>`](Next) as the final argument.
 /// 4. Return something that implements [`IntoResponse`].
 ///
-/// Note that this function doesn't support extracting [`State`]. For that [`from_fn_with_state`].
+/// Note that this function doesn't support extracting [`State`]. For that, use [`from_fn_with_state`].
 ///
 /// # Example
 ///


### PR DESCRIPTION
* Add examples to methods in `RequestPartsExt` and `RequestExt`
* Mention that `State` is global within the router
* Point to `from_fn_with_state` in `from_fn` docs
* Tweak `from_fn` examples a bit