### PR TITLE
docs/middleware: Add missing `Clone` derive on `MyLayer`

### DIFF
--- a/axum/src/docs/middleware.md
+++ b/axum/src/docs/middleware.md
@@ -229,6 +229,7 @@ use futures::future::BoxFuture;
 use tower::{Service, Layer};
 use std::task::{Context, Poll};
 
+#[derive(Clone)]
 struct MyLayer;
 
 impl<S> Layer<S> for MyLayer {
@@ -258,7 +259,7 @@ where
         self.inner.poll_ready(cx)
     }
 
-    fn call(&mut self, mut request: Request<Body>) -> Self::Future {
+    fn call(&mut self, request: Request<Body>) -> Self::Future {
         let future = self.inner.call(request);
         Box::pin(async move {
             let response: Response = future.await?;


### PR DESCRIPTION
## Motivation

Without this `Clone` implementation the compiler was showing errors on the `router.layer(middleware)` call. 

## Solution

Adding the `Clone` derive fixed the compiler error for me.

I've also removed an unnecessary `mut` keyword, that the compiler was warning about.