### PR TITLE
feat: failable state extraction using TryState and TryFromRef

### DIFF
--- a/axum-core/src/extract/from_ref.rs
+++ b/axum-core/src/extract/from_ref.rs
@@ -1,3 +1,7 @@
+use std::convert::Infallible;
+
+use crate::response::IntoResponse;
+
 /// Used to do reference-to-value conversions thus not consuming the input value.
 ///
 /// This is mainly used with [`State`] to extract "substates" from a reference to main application
@@ -21,5 +25,25 @@ where
 {
     fn from_ref(input: &T) -> Self {
         input.clone()
+    }
+}
+
+pub trait TryFromRef<T> {
+    type Rejection: IntoResponse;
+
+    /// Converts to this type from a reference to the input type.
+    fn try_from_ref(input: &T) -> Result<Self, Self::Rejection>
+    where
+        Self: Sized;
+}
+
+impl<T> TryFromRef<T> for T
+where
+    T: Clone,
+{
+    type Rejection = Infallible;
+
+    fn try_from_ref(input: &T) -> Result<Self, Self::Rejection> {
+        Ok(input.clone())
     }
 }

--- a/axum-core/src/extract/from_ref.rs
+++ b/axum-core/src/extract/from_ref.rs
@@ -28,7 +28,19 @@ where
     }
 }
 
+/// Used to do reference-to-value conversions (which might fail) thus not consuming the input value.
+///
+/// This is mainly used with [`TryState`] to extract "substates" from a reference to main application
+/// state.
+///
+/// See [`TryState`] for more details on how library authors should use this trait.
+///
+/// [`TryState`]: https://docs.rs/axum/0.6/axum/extract/struct.TryState.html
+// NOTE: This trait is defined in axum-core, even though it is mainly used with `TryState` which is
+// defined in axum. That allows crate authors to use it when implementing extractors.
 pub trait TryFromRef<T> {
+    /// If the conversion fails it'll use this "rejection" type. A rejection is
+    /// a kind of error that can be converted into a response.
     type Rejection: IntoResponse;
 
     /// Converts to this type from a reference to the input type.

--- a/axum-core/src/extract/mod.rs
+++ b/axum-core/src/extract/mod.rs
@@ -17,7 +17,10 @@ mod request_parts;
 mod tuple;
 
 pub(crate) use self::default_body_limit::DefaultBodyLimitKind;
-pub use self::{default_body_limit::DefaultBodyLimit, from_ref::FromRef};
+pub use self::{
+    default_body_limit::DefaultBodyLimit,
+    from_ref::{FromRef, TryFromRef},
+};
 
 mod private {
     #[derive(Debug, Clone, Copy)]

--- a/axum/src/extract/mod.rs
+++ b/axum/src/extract/mod.rs
@@ -17,7 +17,9 @@ mod request_parts;
 mod state;
 
 #[doc(inline)]
-pub use axum_core::extract::{DefaultBodyLimit, FromRef, FromRequest, FromRequestParts};
+pub use axum_core::extract::{
+    DefaultBodyLimit, FromRef, FromRequest, FromRequestParts, TryFromRef,
+};
 
 #[cfg(feature = "macros")]
 pub use axum_macros::{FromRef, FromRequest, FromRequestParts};
@@ -30,7 +32,7 @@ pub use self::{
     raw_form::RawForm,
     raw_query::RawQuery,
     request_parts::{BodyStream, RawBody},
-    state::State,
+    state::{State, TryState},
 };
 
 #[doc(inline)]

--- a/axum/src/extract/state.rs
+++ b/axum/src/extract/state.rs
@@ -329,6 +329,11 @@ impl<S> DerefMut for State<S> {
     }
 }
 
+/// Extractor for state that my fail.
+///
+/// If the extraction fails the [FromRequestParts::Rejection] type is returned.
+///
+/// Otherwise it behaves similarly to [State].
 #[derive(Debug, Default, Clone, Copy)]
 pub struct TryState<S>(pub S);
 


### PR DESCRIPTION
I've been migrating my application in the last two days to Axum and I really like it :)

One thing I found missing, is the possibility to extract state in a way that can fail.
In my case I want to get a db connection from a connection pool that is part of the global state.
As shown in the example below one can obviously just extract the pool an get a connection manually (handler1) or implement `FromRef` for the Result of the connection retrieval (handler2). However,  this is unergonomic and has to be done in every handler.
To solve this I added `TryFromRef` and `TryState`. By implementing `TryFromRef` for the db connection and using `TryState` as the extractor, the handler gets the db connection directly and does not have to deal with the connection pool (handler3).
Currently `TryState` is used in order to not introduce breaking changes. In the next release (v0.7), `TryState` could be removed, `FromRequestParts` implemented for `State` if the inner state implements `TryFromRef` and a blanket impl added for `FromRef` for `TryFromRef`.

As I already said, I've been using axum only for two days, so please forgive me if there is already a (more elegant) way of accomplishing this. If so I would be interested in how to do it. 

```rust
use axum::{
    extract::{FromRef, State, TryFromRef, TryState},
    http::StatusCode,
    routing::get,
    Router,
};

#[derive(Clone)]
struct DbPool;

impl DbPool {
    fn get_connection(&self) -> Result<DbConn, ()> {
        // this might fail
        Ok(DbConn)
    }
}

#[derive(Clone, Debug)]
struct DbConn;

impl FromRef<DbPool> for Result<DbConn, ()> {
    fn from_ref(pool: &DbPool) -> Self {
        pool.get_connection()
    }
}

impl TryFromRef<DbPool> for DbConn {
    type Rejection = StatusCode;

    fn try_from_ref(pool: &DbPool) -> Result<Self, Self::Rejection> {
        let db_conn = pool
            .get_connection()
            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;

        Ok(db_conn)
    }
}

#[tokio::main]
async fn main() {
    let state = DbPool;

    let app = Router::new()
        .route("/1", get(handler1))
        .route("/2", get(handler2))
        .route("/3", get(handler3))
        .with_state(state);

    axum::Server::bind(&"0.0.0.0:3000".parse().unwrap())
        .serve(app.into_make_service())
        .await
        .unwrap();
}

/// works but is unergonomic
async fn handler1(State(db_pool): State<DbPool>) -> Result<String, StatusCode> {
    let db_conn = db_pool
        .get_connection()
        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;

    Ok(format!("handler1 extracted {db_conn:?} successfully"))
}

/// still not really better
async fn handler2(State(db_conn_result): State<Result<DbConn, ()>>) -> Result<String, StatusCode> {
    let db_conn = db_conn_result.map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;

    Ok(format!("handler2 extracted {db_conn:?} successfully"))
}

/// much better
async fn handler3(TryState(db_conn): TryState<DbConn>) -> Result<String, StatusCode> {
    Ok(format!("handler3 extracted {db_conn:?} successfully"))
}
```
