### PR TITLE
Example of optional Path extractor added

### DIFF
--- a/axum/src/docs/extract.md
+++ b/axum/src/docs/extract.md
@@ -251,10 +251,8 @@ let app = Router::new().route("/users", post(create_user));
 # };
 ```
 
-For `Path` extractors you would need to define separate routes with the same 
-handler to benefit from the optional extractor, but doing so with an `Option`
-wrapper is discouraged since the extractor may fail in other ways than because
-of a missing parameter. See below for an example of how to handle this.
+`Path` extractors have a specific behaviour and should only be used with `Result`
+wrapper, see [`path`](`Path`#optional-path-parameters) module doc for details.
 
 Wrapping extractors in `Result` makes them optional and gives you the reason
 the extraction failed:
@@ -293,43 +291,6 @@ async fn create_user(payload: Result<Json<Value>, JsonRejection>) {
 }
 
 let app = Router::new().route("/users", post(create_user));
-# async {
-# axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
-# };
-```
-
-Using separate routes to allow for the same function to handle both present
-and missing `Path` parameters, as well as bad requests:
-
-```rust,no_run
-use axum::{
-    extract::{Path, rejection::PathRejection},
-    routing::get,
-    Router,
-};
-
-async fn get_user(id: Result<Path<u128>, PathRejection>) {
-    match parameter {
-        Ok(Path(_)) => {
-            // Route with a valid path parameter was used
-        }
-        Err(PathRejection::MissingPathParams(_)) => {
-            // Route without a path parameter was used
-        }
-        Err(PathRejection::FailedToDeserializePathParams(_)) => {
-            // Route with an invalid path parameter was used
-        }
-        Err(_) => {
-            // `PathRejection` is marked `#[non_exhaustive]` so match must
-            // include a catch-all case.
-        }
-    }
-}
-
-let app = Router::new()
-    .route("/users/:id", get(get_user))
-    .route("/users", get(get_user));
-
 # async {
 # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
 # };

--- a/axum/src/docs/extract.md
+++ b/axum/src/docs/extract.md
@@ -250,6 +250,31 @@ let app = Router::new().route("/users", post(create_user));
 # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
 # };
 ```
+For `Path` extractors you would need to define separate routes with the same 
+handler to benefit from optional extractor:
+```rust,no_run
+use axum::{
+    extract::Path,
+    routing::get,
+    Router,
+};
+
+async fn get_user(id: Option<Path<String>>) {
+    if let Some(Path(id)) = id {
+        // route with a path parameter was used
+    } else {
+        // route without a path parameter was used
+    }
+}
+
+let app = Router::new()
+    .route("/users/:id", get(get_user))
+    .route("/users", get(get_user));
+
+# async {
+# axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
+# };
+```
 
 Wrapping extractors in `Result` makes them optional and gives you the reason
 the extraction failed:


### PR DESCRIPTION
An example of how a route handler with an `Option<Path<_>>` should be used is added. This should allow for a better understanding of how to idiomatically use multiple paths with the same handler, and allow new users not to stumble upon rejections for a seemingly optional parameter missing

Refs: #1662

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation

For me as a new Axum user, the documentation was not clear as to how to define an optional path parameter.  After creating an issue and seeing a response from maintainers on how this should have been done, it became apparent that having a path parameter extractor optional is not enough as we'd need to somehow guess what the route would look like in such a case. Nevertheless, I find it possible that there will be others like me, who will lack the necessary insight and be puzzled by rejected requests.

I assume that this could be mitigated by stating the fact that Path extractors are a special case of optional extractors, and new users could benefit from an example of how those should be used. 

## Solution

A basic example of how a handler with an optional path parameter extractor could be used for handling several routes
