### PR TITLE
Update deny.toml bans

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -16,9 +16,9 @@ confidence-threshold = 0.8
 multiple-versions = "deny"
 highlight = "all"
 skip-tree = [
-    # currently duplicated through mio & parking_lot_core
-    # https://github.com/tokio-rs/mio/pull/1624 will fix that
-    { name = "windows-sys" },
+    # currently duplicated through header, reqwest, tower-http and cookie
+    # C.f. https://github.com/tokio-rs/axum/pull/1641
+    { name = "base64" },
 ]
 
 [sources]


### PR DESCRIPTION
## Motivation

CI on `main` currently fails due to a duplicate dependency in the tree. This can't be fixed here, we need the headers crate (and tower-http) to release new versions that depend on base64 but headers in particular isn't very actively maintained.

## Solution

Add an exception for the duplicate dependency (and remove an older exception that is no longer needed).