### PR TITLE
Enable the runtime feature of hyper when using tokio

### DIFF
--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -8,8 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # Unreleased
 
 - **added:** Add `body_text` and `status` methods to built-in rejections ([#1612])
+- **added:** Enable the `runtime` feature of `hyper` when using `tokio` ([#1671])
 
 [#1612]: https://github.com/tokio-rs/axum/pull/1612
+[#1671]: https://github.com/tokio-rs/axum/pull/1671
+
 
 # 0.6.1 (29. November, 2022)
 

--- a/axum/Cargo.toml
+++ b/axum/Cargo.toml
@@ -22,7 +22,7 @@ matched-path = []
 multipart = ["dep:multer"]
 original-uri = []
 query = ["dep:serde_urlencoded"]
-tokio = ["dep:tokio", "hyper/server", "hyper/tcp", "tower/make"]
+tokio = ["dep:tokio", "hyper/server", "hyper/tcp", "hyper/runtime", "tower/make"]
 tower-log = ["tower/log"]
 ws = ["tokio", "dep:tokio-tungstenite", "dep:sha1", "dep:base64"]
 


### PR DESCRIPTION
## Motivation

Currently axum never enables the `runtime` feature of hyper, which gates functions like [`Server::http1_header_read_timeout`](https://docs.rs/hyper/latest/hyper/server/struct.Builder.html#method.http1_header_read_timeout)

## Solution

This makes axum enable the runtime `feature`. The alternative is to import hyper and enable the feature but then Rust Analyzer imports things from hyper instead of axum, which is very annoying.
