### PR TITLE
axum-extra: Add serde_json as dev-dependency

### DIFF
--- a/axum-extra/Cargo.toml
+++ b/axum-extra/Cargo.toml
@@ -64,6 +64,7 @@ futures = "0.3"
 hyper = "0.14"
 reqwest = { version = "0.11", default-features = false, features = ["json", "stream", "multipart"] }
 serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0.71"
 tokio = { version = "1.14", features = ["full"] }
 tower = { version = "0.4", features = ["util"] }
 


### PR DESCRIPTION
## Motivation

`cargo test` compile fail because documentation code use `serde_json` which is an optional dependency.

## Solution

Add `serde_json` as dev-dependency.