### PR TITLE
fix: warnings for cloning references

### DIFF
--- a/axum-macros/src/from_ref.rs
+++ b/axum-macros/src/from_ref.rs
@@ -3,7 +3,7 @@ use quote::quote_spanned;
 use syn::{
     parse::{Parse, ParseStream},
     spanned::Spanned,
-    Field, ItemStruct, Token,
+    Field, ItemStruct, Token, Type,
 };
 
 use crate::attr_parsing::{combine_unary_attribute, parse_attrs, Combine};
@@ -30,7 +30,11 @@ fn expand_field(state: &Ident, idx: usize, field: &Field) -> TokenStream {
     let span = field.ty.span();
 
     let body = if let Some(field_ident) = &field.ident {
-        quote_spanned! {span=> state.#field_ident.clone() }
+        if matches!(field_ty, Type::Reference(_)) {
+            quote_spanned! {span=> state.#field_ident }
+        } else {
+            quote_spanned! {span=> state.#field_ident.clone() }
+        }
     } else {
         let idx = syn::Index {
             index: idx as _,

--- a/axum-macros/tests/from_ref/pass/reference-types.rs
+++ b/axum-macros/tests/from_ref/pass/reference-types.rs
@@ -1,0 +1,10 @@
+#![deny(noop_method_call)]
+
+use axum_macros::FromRef;
+
+#[derive(FromRef)]
+struct State {
+    inner: &'static str,
+}
+
+fn main() {}


### PR DESCRIPTION
## Motivation

In #1674, it was pointed out that `axum-macros` causes some `clippy` warnings (and some `rustc` lints to fail) as the `FromRef` macro generates code which clones reference types unnecessarily.

## Solution

This seems to be when generating the body of the trait implementation, but since we have the type information from `syn` at that point it's relatively simple to resolve these.

This change:
* Avoids using `.clone` if we are generating the implementation for a reference type field
* Adds a simple UI test to ensure this compiles with the `rustc` lint set to deny

Fixes #1674.
