### PR TITLE
Release axum, axum-core, and axum-macros

### DIFF
--- a/axum-core/CHANGELOG.md
+++ b/axum-core/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
+- None.
+
+# 0.3.1 (9. January, 2023)
+
 - **added:** Add `body_text` and `status` methods to built-in rejections ([#1612])
 
 [#1612]: https://github.com/tokio-rs/axum/pull/1612

--- a/axum-core/Cargo.toml
+++ b/axum-core/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 name = "axum-core"
 readme = "README.md"
 repository = "https://github.com/tokio-rs/axum"
-version = "0.3.0" # remember to also bump the version that axum depends on
+version = "0.3.1" # remember to also bump the version that axum depends on
 
 [dependencies]
 async-trait = "0.1"

--- a/axum-extra/Cargo.toml
+++ b/axum-extra/Cargo.toml
@@ -48,7 +48,7 @@ tower-layer = "0.3"
 tower-service = "0.3"
 
 # optional dependencies
-axum-macros = { path = "../axum-macros", version = "0.3.0", optional = true }
+axum-macros = { path = "../axum-macros", version = "0.3.1", optional = true }
 cookie = { package = "cookie", version = "0.16", features = ["percent-encode"], optional = true }
 percent-encoding = { version = "2.1", optional = true }
 prost = { version = "0.11", optional = true }

--- a/axum-macros/CHANGELOG.md
+++ b/axum-macros/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - None.
 
+# 0.3.1 (9. January, 2022)
+
+- **fixed:** Fix warnings for cloning references in generated code ([#1676])
+
+[#1676]: https://github.com/tokio-rs/axum/pull/1676
+
 # 0.3.0 (25. November, 2022)
 
 - **added:** Add `#[derive(FromRequestParts)]` for deriving an implementation of

--- a/axum-macros/Cargo.toml
+++ b/axum-macros/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 name = "axum-macros"
 readme = "README.md"
 repository = "https://github.com/tokio-rs/axum"
-version = "0.3.0" # remember to also bump the version that axum and axum-extra depends on
+version = "0.3.1" # remember to also bump the version that axum and axum-extra depends on
 
 [lib]
 proc-macro = true

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -7,12 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
+- None.
+
+# 0.6.2 (9. January, 2023)
+
 - **added:** Add `body_text` and `status` methods to built-in rejections ([#1612])
 - **added:** Enable the `runtime` feature of `hyper` when using `tokio` ([#1671])
 
 [#1612]: https://github.com/tokio-rs/axum/pull/1612
 [#1671]: https://github.com/tokio-rs/axum/pull/1671
-
 
 # 0.6.1 (29. November, 2022)
 

--- a/axum/Cargo.toml
+++ b/axum/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axum"
-version = "0.6.1"
+version = "0.6.2"
 categories = ["asynchronous", "network-programming", "web-programming::http-server"]
 description = "Web framework that focuses on ergonomics and modularity"
 edition = "2021"
@@ -31,7 +31,7 @@ __private_docs = ["tower/full", "tower-http/full"]
 
 [dependencies]
 async-trait = "0.1.43"
-axum-core = { path = "../axum-core", version = "0.3.0" }
+axum-core = { path = "../axum-core", version = "0.3.1" }
 bitflags = "1.0"
 bytes = "1.0"
 futures-util = { version = "0.3", default-features = false, features = ["alloc"] }
@@ -52,7 +52,7 @@ tower-layer = "0.3.2"
 tower-service = "0.3"
 
 # optional dependencies
-axum-macros = { path = "../axum-macros", version = "0.3.0", optional = true }
+axum-macros = { path = "../axum-macros", version = "0.3.1", optional = true }
 base64 = { version = "0.20", optional = true }
 headers = { version = "0.3.7", optional = true }
 multer = { version = "2.0.0", optional = true }


### PR DESCRIPTION
Someone on Discord needs the new `body_text` and `status` methods to lets :shipit: 