### PR TITLE
Implement `IntoResponse` for `[u8; N]` and `&'static [u8; N]` (#1690)

### DIFF
--- a/axum-core/CHANGELOG.md
+++ b/axum-core/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
-- None.
+- **added** Implement IntoResponse for &'static [u8; N] and [u8; N] ([#1690])
 
 # 0.3.1 (9. January, 2023)
 
@@ -124,7 +124,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **added:** Add `response::ErrorResponse` and `response::Result` for
   `IntoResponse`-based error handling ([#921])
 
-[#921]: https://github.com/tokio-rs/axum/pull/921 
+[#921]: https://github.com/tokio-rs/axum/pull/921
 
 # 0.2.2 (19. April, 2022)
 

--- a/axum-core/CHANGELOG.md
+++ b/axum-core/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
-- **added** Implement IntoResponse for &'static [u8; N] and [u8; N] ([#1690](https://github.com/tokio-rs/axum/pull/1690))
+- **added** Implement IntoResponse for &'static [u8; N] and [u8; N] ([#1690])
+
+[#1690]: https://github.com/tokio-rs/axum/pull/1690
 
 # 0.3.1 (9. January, 2023)
 

--- a/axum-core/CHANGELOG.md
+++ b/axum-core/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
-- **added** Implement IntoResponse for &'static [u8; N] and [u8; N] ([#1690])
+- **added** Implement IntoResponse for &'static [u8; N] and [u8; N] [#1690](https://github.com/tokio-rs/axum/pull/1690)
 
 # 0.3.1 (9. January, 2023)
 

--- a/axum-core/CHANGELOG.md
+++ b/axum-core/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
-- **added** Implement IntoResponse for &'static [u8; N] and [u8; N] [(#1690)](https://github.com/tokio-rs/axum/pull/1690)
+- **added** Implement IntoResponse for &'static [u8; N] and [u8; N] ([#1690](https://github.com/tokio-rs/axum/pull/1690))
 
 # 0.3.1 (9. January, 2023)
 

--- a/axum-core/CHANGELOG.md
+++ b/axum-core/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
-- **added** Implement IntoResponse for &'static [u8; N] and [u8; N] [#1690](https://github.com/tokio-rs/axum/pull/1690)
+- **added** Implement IntoResponse for &'static [u8; N] and [u8; N] [(#1690)](https://github.com/tokio-rs/axum/pull/1690)
 
 # 0.3.1 (9. January, 2023)
 

--- a/axum-core/src/response/into_response.rs
+++ b/axum-core/src/response/into_response.rs
@@ -350,13 +350,13 @@ impl IntoResponse for &'static [u8] {
 
 impl<const N: usize> IntoResponse for &'static [u8; N] {
     fn into_response(self) -> Response {
-        Cow::Borrowed(self.as_slice()).into_response()
+        self.as_slice().into_response()
     }
 }
 
 impl<const N: usize> IntoResponse for [u8; N] {
     fn into_response(self) -> Response {
-        self.to_vec().into_response()
+        self.into_response()
     }
 }
 

--- a/axum-core/src/response/into_response.rs
+++ b/axum-core/src/response/into_response.rs
@@ -356,7 +356,7 @@ impl<const N: usize> IntoResponse for &'static [u8; N] {
 
 impl<const N: usize> IntoResponse for [u8; N] {
     fn into_response(self) -> Response {
-        self.into_response()
+        self.to_vec().into_response()
     }
 }
 

--- a/axum-core/src/response/into_response.rs
+++ b/axum-core/src/response/into_response.rs
@@ -348,6 +348,18 @@ impl IntoResponse for &'static [u8] {
     }
 }
 
+impl<const N: usize> IntoResponse for &'static [u8; N] {
+    fn into_response(self) -> Response {
+        Cow::Borrowed(self.as_slice()).into_response()
+    }
+}
+
+impl<const N: usize> IntoResponse for [u8; N] {
+    fn into_response(self) -> Response {
+        self.to_vec().into_response()
+    }
+}
+
 impl IntoResponse for Vec<u8> {
     fn into_response(self) -> Response {
         Cow::<'static, [u8]>::Owned(self).into_response()

--- a/axum-macros/tests/debug_handler/fail/wrong_return_type.stderr
+++ b/axum-macros/tests/debug_handler/fail/wrong_return_type.stderr
@@ -5,6 +5,7 @@ error[E0277]: the trait bound `bool: IntoResponse` is not satisfied
   |                       ^^^^ the trait `IntoResponse` is not implemented for `bool`
   |
   = help: the following other types implement trait `IntoResponse`:
+            &'static [u8; N]
             &'static [u8]
             &'static str
             ()
@@ -12,8 +13,7 @@ error[E0277]: the trait bound `bool: IntoResponse` is not satisfied
             (Response<()>, T1, R)
             (Response<()>, T1, T2, R)
             (Response<()>, T1, T2, T3, R)
-            (Response<()>, T1, T2, T3, T4, R)
-          and 120 others
+          and 122 others
 note: required by a bound in `__axum_macros_check_handler_into_response::{closure#0}::check`
  --> tests/debug_handler/fail/wrong_return_type.rs:4:23
   |

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
-- None.
+- - **added** Implement IntoResponse for &'static [u8; N] and [u8; N] ([#1690])
 
 # 0.6.2 (9. January, 2023)
 
@@ -48,7 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ```rust
   // this time without a fallback
   let api_router = Router::new().route("/users", get(|| { ... }));
-  
+
   let app = Router::new()
       .nest("/api", api_router)
       // `api_router` will inherit this fallback
@@ -198,9 +198,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   let app = Router::new()
       .route("/", get(handler))
       .layer(Extension(AppState {}));
-  
+
   async fn handler(Extension(app_state): Extension<AppState>) {}
-  
+
   #[derive(Clone)]
   struct AppState {}
   ```
@@ -213,9 +213,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   let app = Router::new()
       .route("/", get(handler))
       .with_state(AppState {});
-  
+
   async fn handler(State(app_state): State<AppState>) {}
-  
+
   #[derive(Clone)]
   struct AppState {}
   ```
@@ -232,22 +232,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   };
 
   let app = Router::new().route("/", get(handler)).with_state(state);
-  
+
   async fn handler(
       State(client): State<HttpClient>,
       State(database): State<Database>,
   ) {}
-  
+
   // the derive requires enabling the "macros" feature
   #[derive(Clone, FromRef)]
   struct AppState {
       client: HttpClient,
       database: Database,
   }
-  
+
   #[derive(Clone)]
   struct HttpClient {}
-  
+
   #[derive(Clone)]
   struct Database {}
   ```
@@ -301,7 +301,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
       B: Send,
   {
       type Rejection = StatusCode;
-  
+
       async fn from_request(req: &mut RequestParts<B>) -> Result<Self, Self::Rejection> {
           // ...
       }
@@ -326,7 +326,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
       S: Send + Sync,
   {
       type Rejection = StatusCode;
-  
+
       async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
           // ...
       }
@@ -340,7 +340,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
       B: Send + 'static,
   {
       type Rejection = StatusCode;
-  
+
       async fn from_request(req: Request<B>, state: &S) -> Result<Self, Self::Rejection> {
           // ...
       }
@@ -775,9 +775,9 @@ Yanked, as it didn't compile in release mode.
   let app = Router::new()
       .route("/", get(handler))
       .layer(Extension(AppState {}));
-  
+
   async fn handler(Extension(app_state): Extension<AppState>) {}
-  
+
   #[derive(Clone)]
   struct AppState {}
   ```
@@ -789,9 +789,9 @@ Yanked, as it didn't compile in release mode.
 
   let app = Router::with_state(AppState {})
       .route("/", get(handler));
-  
+
   async fn handler(State(app_state): State<AppState>) {}
-  
+
   #[derive(Clone)]
   struct AppState {}
   ```
@@ -808,30 +808,30 @@ Yanked, as it didn't compile in release mode.
   };
 
   let app = Router::with_state(state).route("/", get(handler));
-  
+
   async fn handler(
       State(client): State<HttpClient>,
       State(database): State<Database>,
   ) {}
-  
+
   #[derive(Clone)]
   struct AppState {
       client: HttpClient,
       database: Database,
   }
-  
+
   #[derive(Clone)]
   struct HttpClient {}
-  
+
   impl FromRef<AppState> for HttpClient {
       fn from_ref(state: &AppState) -> Self {
           state.client.clone()
       }
   }
-  
+
   #[derive(Clone)]
   struct Database {}
-  
+
   impl FromRef<AppState> for Database {
       fn from_ref(state: &AppState) -> Self {
           state.database.clone()
@@ -887,7 +887,7 @@ Yanked, as it didn't compile in release mode.
       B: Send,
   {
       type Rejection = StatusCode;
-  
+
       async fn from_request(req: &mut RequestParts<B>) -> Result<Self, Self::Rejection> {
           // ...
       }
@@ -912,7 +912,7 @@ Yanked, as it didn't compile in release mode.
       S: Send + Sync,
   {
       type Rejection = StatusCode;
-  
+
       async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
           // ...
       }
@@ -926,7 +926,7 @@ Yanked, as it didn't compile in release mode.
       B: Send + 'static,
   {
       type Rejection = StatusCode;
-  
+
       async fn from_request(req: Request<B>, state: &S) -> Result<Self, Self::Rejection> {
           // ...
       }

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
-- - **added** Implement IntoResponse for &'static [u8; N] and [u8; N] ([#1690])
+- - **added** Implement IntoResponse for &'static [u8; N] and [u8; N] ([#1690](https://github.com/tokio-rs/axum/pull/1690))
 
 # 0.6.2 (9. January, 2023)
 

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
-- - **added** Implement IntoResponse for &'static [u8; N] and [u8; N] ([#1690](https://github.com/tokio-rs/axum/pull/1690))
+- - **added** Implement IntoResponse for &'static [u8; N] and [u8; N] ([#1690])
+
+[#1690]: https://github.com/tokio-rs/axum/pull/1690
 
 # 0.6.2 (9. January, 2023)
 


### PR DESCRIPTION
## Motivation

I was trying to return an include_bytes! and axum doesn't actually have IntoResponse for its return type

## Solution

Implement IntoResponse for `&'static [u8; N]` and (inefficiently) for `[u8; N]`.
