### PR TITLE
Support `deserialize_any` for `Path`

### DIFF
--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -8,8 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # Unreleased
 
 - - **added** Implement IntoResponse for &'static [u8; N] and [u8; N] ([#1690])
+- **fixed:** Make `Path` support types uses `serde::Deserializer::deserialize_any` ([#1693])
 
 [#1690]: https://github.com/tokio-rs/axum/pull/1690
+[#1693]: https://github.com/tokio-rs/axum/pull/1693
 
 # 0.6.2 (9. January, 2023)
 

--- a/axum/Cargo.toml
+++ b/axum/Cargo.toml
@@ -74,6 +74,7 @@ quickcheck_macros = "1.0"
 reqwest = { version = "0.11.11", default-features = false, features = ["json", "stream", "multipart"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+time = { version = "0.3", features = ["serde-human-readable"] }
 tokio = { package = "tokio", version = "1.21", features = ["macros", "rt", "rt-multi-thread", "net", "test-util"] }
 tokio-stream = "0.1"
 tracing = "0.1"

--- a/axum/src/extract/path/de.rs
+++ b/axum/src/extract/path/de.rs
@@ -56,7 +56,6 @@ impl<'de> PathDeserializer<'de> {
 impl<'de> Deserializer<'de> for PathDeserializer<'de> {
     type Error = PathDeserializationError;
 
-    unsupported_type!(deserialize_any);
     unsupported_type!(deserialize_bytes);
     unsupported_type!(deserialize_option);
     unsupported_type!(deserialize_identifier);
@@ -78,6 +77,13 @@ impl<'de> Deserializer<'de> for PathDeserializer<'de> {
     parse_single_value!(deserialize_string, visit_string, "String");
     parse_single_value!(deserialize_byte_buf, visit_string, "String");
     parse_single_value!(deserialize_char, visit_char, "char");
+
+    fn deserialize_any<V>(self, v: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_str(v)
+    }
 
     fn deserialize_str<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where

--- a/axum/src/extract/path/de.rs
+++ b/axum/src/extract/path/de.rs
@@ -334,7 +334,6 @@ struct ValueDeserializer<'de> {
 impl<'de> Deserializer<'de> for ValueDeserializer<'de> {
     type Error = PathDeserializationError;
 
-    unsupported_type!(deserialize_any);
     unsupported_type!(deserialize_map);
     unsupported_type!(deserialize_identifier);
 
@@ -354,6 +353,13 @@ impl<'de> Deserializer<'de> for ValueDeserializer<'de> {
     parse_value!(deserialize_string, visit_string, "String");
     parse_value!(deserialize_byte_buf, visit_string, "String");
     parse_value!(deserialize_char, visit_char, "char");
+
+    fn deserialize_any<V>(self, v: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_str(v)
+    }
 
     fn deserialize_str<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where

--- a/axum/src/extract/path/mod.rs
+++ b/axum/src/extract/path/mod.rs
@@ -693,4 +693,27 @@ mod tests {
             .await;
         assert_eq!(res.text().await, "struct: 2023-01-01 2023-01-02 2023-01-03");
     }
+
+    #[tokio::test]
+    async fn wrong_number_of_parameters_json() {
+        use serde_json::Value;
+
+        let app = Router::new()
+            .route("/one/:a", get(|_: Path<(Value, Value)>| async {}))
+            .route("/two/:a/:b", get(|_: Path<Value>| async {}));
+
+        let client = TestClient::new(app);
+
+        let res = client.get("/one/1").send().await;
+        assert!(res
+            .text()
+            .await
+            .starts_with("Wrong number of path arguments for `Path`. Expected 2 but got 1"));
+
+        let res = client.get("/two/1/2").send().await;
+        assert!(res
+            .text()
+            .await
+            .starts_with("Wrong number of path arguments for `Path`. Expected 1 but got 2"));
+    }
 }

--- a/axum/src/extract/path/mod.rs
+++ b/axum/src/extract/path/mod.rs
@@ -605,14 +605,18 @@ mod tests {
     #[tokio::test]
     async fn type_that_uses_deserialize_any() {
         let app = Router::new().route(
-            "/:date",
-            get(|Path(date): Path<time::Date>| async move { date.to_string() }),
+            "/:a/:b/:c",
+            get(
+                |Path((a, b, c)): Path<(time::Date, time::Date, time::Date)>| async move {
+                    format!("{a} {b} {c}")
+                },
+            ),
         );
 
         let client = TestClient::new(app);
 
-        let res = client.get("/2023-01-01").send().await;
-        assert_eq!(res.status(), StatusCode::OK);
-        assert_eq!(res.text().await, "2023-01-01");
+        let res = client.get("/2023-01-01/2023-01-02/2023-01-03").send().await;
+        // assert_eq!(res.status(), StatusCode::OK);
+        assert_eq!(res.text().await, "2023-01-01 2023-01-02 2023-01-03");
     }
 }


### PR DESCRIPTION
Forwarding to `deserialize_str` is probably gonna do the correct thing in most cases. It is also what `serde_urlencoded` does for values (https://github.com/nox/serde_urlencoded/blob/master/src/de.rs#L194-L202)

Fixes https://github.com/tokio-rs/axum/issues/1678