### PR TITLE
Add `option_layer`

### DIFF
--- a/axum-extra/CHANGELOG.md
+++ b/axum-extra/CHANGELOG.md
@@ -7,7 +7,10 @@ and this project adheres to [Semantic Versioning].
 
 # Unreleased
 
-- None.
+- **added:** Add `option_layer` for converting an `Option<Layer>` into a `Layer` ([#1696])
+- **added:** Implement `Layer` and `Service` for `Either` ([#1696])
+
+[#1696]: https://github.com/tokio-rs/axum/pull/1696
 
 # 0.4.2 (02. December, 2022)
 

--- a/axum-extra/Cargo.toml
+++ b/axum-extra/Cargo.toml
@@ -67,6 +67,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.71"
 tokio = { version = "1.14", features = ["full"] }
 tower = { version = "0.4", features = ["util"] }
+tower-http = { version = "0.3", features = ["map-response-body", "timeout"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/axum-extra/src/lib.rs
+++ b/axum-extra/src/lib.rs
@@ -69,6 +69,7 @@ pub mod body;
 pub mod either;
 pub mod extract;
 pub mod handler;
+pub mod middleware;
 pub mod response;
 pub mod routing;
 

--- a/axum-extra/src/middleware.rs
+++ b/axum-extra/src/middleware.rs
@@ -1,0 +1,44 @@
+//! Additional middleware utilities.
+
+use crate::either::Either;
+use tower_layer::Identity;
+
+/// Convert an `Option<Layer>` into a [`Layer`].
+///
+/// If the layer is a `Some` it'll be applied, otherwise not.
+///
+/// # Example
+///
+/// ```
+/// use axum_extra::either::option_layer;
+/// use axum::{Router, routing::get};
+/// use std::time::Duration;
+/// use tower_http::timeout::TimeoutLayer;
+///
+/// # let option_timeout = Some(Duration::new(10, 0));
+/// let timeout_layer = option_timeout.map(TimeoutLayer::new);
+///
+/// let app = Router::new()
+///     .route("/", get(|| async {}))
+///     .layer(option_layer(timeout_layer));
+/// # let _: Router = app;
+/// ```
+///
+/// # Difference between this and [`tower::util::option_layer`]
+///
+/// [`tower::util::option_layer`] always changes the error type to [`BoxError`] which requires
+/// using [`HandleErrorLayer`] when used with axum, even if the layer you're applying uses
+/// [`Infallible`].
+///
+/// `axum_extra::middleware::option_layer` on the other hand doesn't change the error type so can
+/// be applied directly.
+///
+/// [`Layer`]: tower_layer::Layer
+/// [`BoxError`]: tower::BoxError
+/// [`HandleErrorLayer`]: axum::error_handling::HandleErrorLayer
+/// [`Infallible`]: std::convert::Infallible
+pub fn option_layer<L>(layer: Option<L>) -> Either<L, Identity> {
+    layer
+        .map(Either::E1)
+        .unwrap_or_else(|| Either::E2(Identity::new()))
+}

--- a/axum-extra/src/middleware.rs
+++ b/axum-extra/src/middleware.rs
@@ -10,7 +10,7 @@ use tower_layer::Identity;
 /// # Example
 ///
 /// ```
-/// use axum_extra::either::option_layer;
+/// use axum_extra::middleware::option_layer;
 /// use axum::{Router, routing::get};
 /// use std::time::Duration;
 /// use tower_http::timeout::TimeoutLayer;


### PR DESCRIPTION
Tower already has `option_layer` for conditionally applying a `Layer` but since it uses `tower::util::Either` it always changes the error type to `BoxError`. That requires using `HandleErrorLayer` which is inconvenient for axum users.

That has been changed in tower
(https://github.com/tower-rs/tower/pull/637) but still has some issues (https://github.com/tower-rs/tower/issues/665). Its also a breaking change so hasn't been released yet.

In the meantime I figure we can provide our own thing in axum-extra, since we already have an `Either` type there.