### PR TITLE
Add support for nested fields in query strings and forms

### DIFF
--- a/axum/Cargo.toml
+++ b/axum/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/tokio-rs/axum"
 
 [features]
 default = ["form", "http1", "json", "matched-path", "original-uri", "query", "tokio", "tower-log"]
-form = ["dep:serde_urlencoded"]
+form = ["dep:serde_qs"]
 http1 = ["hyper/http1"]
 http2 = ["hyper/http2"]
 json = ["dep:serde_json", "dep:serde_path_to_error"]
@@ -21,7 +21,7 @@ macros = ["dep:axum-macros"]
 matched-path = []
 multipart = ["dep:multer"]
 original-uri = []
-query = ["dep:serde_urlencoded"]
+query = ["dep:serde_qs"]
 tokio = ["dep:tokio", "hyper/server", "hyper/tcp", "hyper/runtime", "tower/make"]
 tower-log = ["tower/log"]
 ws = ["tokio", "dep:tokio-tungstenite", "dep:sha1", "dep:base64"]
@@ -58,7 +58,7 @@ headers = { version = "0.3.7", optional = true }
 multer = { version = "2.0.0", optional = true }
 serde_json = { version = "1.0", features = ["raw_value"], optional = true }
 serde_path_to_error = { version = "0.1.8", optional = true }
-serde_urlencoded = { version = "0.7", optional = true }
+serde_qs = { version = "0.11", optional = true }
 sha1 = { version = "0.10", optional = true }
 tokio = { package = "tokio", version = "1.21", features = ["time"], optional = true }
 tokio-tungstenite = { version = "0.18.0", optional = true }

--- a/axum/src/extract/query.rs
+++ b/axum/src/extract/query.rs
@@ -127,6 +127,20 @@ mod tests {
     }
 
     #[crate::test]
+    async fn query_nested_fields() {
+        #[derive(Debug, PartialEq, Deserialize)]
+        struct Query {
+            foo: (u32, u32),
+        }
+
+        check(
+            "http://example.com/test?foo[0]=0&foo[1]=0",
+            Query { foo: (0, 0) },
+        )
+        .await;
+    }
+
+    #[crate::test]
     async fn correct_rejection_status_code() {
         #[derive(Deserialize)]
         #[allow(dead_code)]

--- a/axum/src/extract/query.rs
+++ b/axum/src/extract/query.rs
@@ -59,8 +59,7 @@ where
 
     async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
         let query = parts.uri.query().unwrap_or_default();
-        let value =
-            serde_urlencoded::from_str(query).map_err(FailedToDeserializeQueryString::from_err)?;
+        let value = serde_qs::from_str(query).map_err(FailedToDeserializeQueryString::from_err)?;
         Ok(Query(value))
     }
 }

--- a/axum/src/form.rs
+++ b/axum/src/form.rs
@@ -180,6 +180,20 @@ mod tests {
     }
 
     #[crate::test]
+    async fn form_query_nested_fields() {
+        #[derive(Debug, PartialEq, Deserialize)]
+        struct Query {
+            foo: (u32, u32),
+        }
+
+        check_query(
+            "http://example.com/test?foo[0]=0&foo[1]=0",
+            Query { foo: (0, 0) },
+        )
+        .await;
+    }
+
+    #[crate::test]
     async fn test_form_body() {
         check_body(Pagination {
             size: None,


### PR DESCRIPTION
## Motivation

Axum currently uses [serde_urlencoded](https://crates.io/crates/serde_urlencoded) to parse query strings in queries and forms. `serde_urlencoded` explicitly does not support nested fields. This means that Axum's `Form` and `Query` extractors cannot parse types like this:

```rust
// query: foo[0]=42&foo[1]=12
struct Query {
    foo: Vec<u32>,
}
```

## Solution

The [serde_qs](https://crates.io/crates/serde_qs) crate does support nested fields. This PR replaces `serde_urlencoded` with `serde_qs` to allow users to extract types with nested fields from forms.
