### PR TITLE
Avoid unnecessary clones of state in MethodRouter

### DIFF
--- a/axum/src/routing/method_routing.rs
+++ b/axum/src/routing/method_routing.rs
@@ -734,14 +734,14 @@ where
     /// Provide the state for the router.
     pub fn with_state<S2>(self, state: S) -> MethodRouter<S2, B, E> {
         MethodRouter {
-            get: self.get.with_state(state.clone()),
-            head: self.head.with_state(state.clone()),
-            delete: self.delete.with_state(state.clone()),
-            options: self.options.with_state(state.clone()),
-            patch: self.patch.with_state(state.clone()),
-            post: self.post.with_state(state.clone()),
-            put: self.put.with_state(state.clone()),
-            trace: self.trace.with_state(state.clone()),
+            get: self.get.with_state(&state),
+            head: self.head.with_state(&state),
+            delete: self.delete.with_state(&state),
+            options: self.options.with_state(&state),
+            patch: self.patch.with_state(&state),
+            post: self.post.with_state(&state),
+            put: self.put.with_state(&state),
+            trace: self.trace.with_state(&state),
             allow_header: self.allow_header,
             fallback: self.fallback.with_state(state),
         }
@@ -1217,12 +1217,12 @@ where
         }
     }
 
-    fn with_state<S2>(self, state: S) -> MethodEndpoint<S2, B, E> {
+    fn with_state<S2>(self, state: &S) -> MethodEndpoint<S2, B, E> {
         match self {
             MethodEndpoint::None => MethodEndpoint::None,
             MethodEndpoint::Route(route) => MethodEndpoint::Route(route),
             MethodEndpoint::BoxedHandler(handler) => {
-                MethodEndpoint::Route(handler.into_route(state))
+                MethodEndpoint::Route(handler.into_route(state.clone()))
             }
         }
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

I noticed that a state type was getting cloned a lot more than I expected it to be on a server with just two endpoints. This turned out to be due to MethodRouter cloning the state for every single possible method endpoint, even those which didn't exist. Since it's relatively uncommon for every single route to have a handler for every single HTTP method, this is just wasted work.

Of course generally state will be wrapped in something like an Arc, so the amount of wasted work will be small, but reducing the number of clones is easy enough to justify here I think.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
MethodEndpoint is private, so changing its with_state method to take a reference it can clone lazily is easy and not a breaking change. This still results in 4 clones for 2 endpoints (one for each MethodRouter, and one for each MethodEndpoint), but that's much better than the 18 I was seeing previously