### PR TITLE
[Fix] Allow `clone_on_copy` for `FromRef`

### DIFF
--- a/axum-macros/src/from_ref.rs
+++ b/axum-macros/src/from_ref.rs
@@ -44,6 +44,7 @@ fn expand_field(state: &Ident, idx: usize, field: &Field) -> TokenStream {
     };
 
     quote_spanned! {span=>
+        #[allow(clippy::clone_on_copy)]
         impl ::axum::extract::FromRef<#state> for #field_ty {
             fn from_ref(state: &#state) -> Self {
                 #body


### PR DESCRIPTION
There was a clippy warning if you derived a struct with `FromRef` that contains a type that derives `Copy` 

## Solution

As suggested in the issue, I added `#[allow(clippy::clone_on_copy)]` to the macro output

Fixes: #1737
