### PR TITLE
Add `Body::from_stream`

### DIFF
--- a/axum-core/CHANGELOG.md
+++ b/axum-core/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
-- None.
+- **added:** Add `Body::from_stream` ([#1752])
+
+[#1752]: https://github.com/tokio-rs/axum/pull/1752
 
 # 0.3.2 (20. January, 2023)
 

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
-- None.
+- **added:** Add `Body::from_stream` ([#1752])
+
+[#1752]: https://github.com/tokio-rs/axum/pull/1752
 
 # 0.6.6 (12. February, 2023)
 


### PR DESCRIPTION
Inspired by hyper's `Body::wrap_stream`.

With this we can remove [`StreamBody`](https://docs.rs/axum/latest/axum/body/struct.StreamBody.html) but I think I'll do that in another PR as it impacts things like `AsyncReadBody`.

Maybe we could also add `Body::from_async_read`? Though that'd require axum-core to depend on tokio-util 🤔 