### PR TITLE
Add shared mutable state documentation

### DIFF
--- a/axum/src/docs/routing/with_state.md
+++ b/axum/src/docs/routing/with_state.md
@@ -105,14 +105,6 @@ receives. That means it is not suitable for holding state derived from a
 request, such as authorization data extracted in a middleware. Use [`Extension`]
 instead for such data.
 
-# Mutable state
-
-As state is used across routes it is not mutable by default. To mutate a state
-you will need to use an `Arc<Mutex>` or similar. Accessing mutable IO such as 
-a database connection requires an async mutex or similar. See the 
-[tokio discussion on sync vs async mutex](https://docs.rs/tokio/1.25.0/tokio/sync/struct.Mutex.html#which-kind-of-mutex-should-you-use). 
-
-
 # What `S` in `Router<S>` means
 
 `Router<S>` means a router that is _missing_ a state of type `S` to be able to

--- a/axum/src/docs/routing/with_state.md
+++ b/axum/src/docs/routing/with_state.md
@@ -108,37 +108,11 @@ instead for such data.
 # Mutable state
 
 As state is used across routes it is not mutable by default. To mutate a state
-you will need to use an `Arc<Mutex>` or similar. Note if accessing a mutable IO such as 
-a database connection using an async mutex is required. See 
-<a href="https://docs.rs/tokio/1.25.0/tokio/sync/struct.Mutex.html#which-kind-of-mutex-should-you-use">this</a>
-discussion for a more detailed conversation on the differences between an async mutex 
-and synchronous mutex. 
+you will need to use an `Arc<Mutex>` or similar. Accessing mutable IO such as 
+a database connection requires an async mutex or similar. See the
+<a href="https://docs.rs/tokio/1.25.0/tokio/sync/struct.Mutex.html#which-kind-of-mutex-should-you-use">
+tokio discussion on sync vs async mutex</a>. 
 
-For example:
-
-```rust
-# use axum::{Router, routing::get, extract::State, response::IntoResponse, http::StatusCode};
-use std::sync::{Arc, Mutex};
-// This AppState consists of a vec of mutable strings 
-#[derive(Clone)]
-struct AppState { mutable_state: Vec<String>, }
-async fn mutate_state(State(state): State<Arc<Mutex<AppState>>>) -> impl IntoResponse {
-    // Wait to get the state
-    let mutable_state = state.lock();
-    // Now the AppState can be mutated  
-    StatusCode::OK
-}
-// A mutable AppState
-let state = Arc::new(Mutex::new(AppState { mutable_state: Default::default(), } ));
-let router = Router::new()
-    .route("/", get(mutate_state))
-    .with_state(state);
-# async {
-axum::Server::bind( & "0.0.0.0:3000".parse().unwrap())
-    .serve(router.into_make_service())
-    .await;
-# };
-```
 
 # What `S` in `Router<S>` means
 

--- a/axum/src/docs/routing/with_state.md
+++ b/axum/src/docs/routing/with_state.md
@@ -108,22 +108,23 @@ instead for such data.
 # Mutable state
 
 As state is used across routes it is not mutable by default. To mutate a state
-you will need to use an `Arc<Mutex>` or similar. Note that the Mutex must
-support async locks.
+you will need to use an `Arc<Mutex>` or similar. Note if accessing a mutable IO such as 
+a database connection using an async mutex is required. See 
+<a href="https://docs.rs/tokio/1.25.0/tokio/sync/struct.Mutex.html#which-kind-of-mutex-should-you-use">this</a>
+discussion for a more detailed conversation on the differences between an async mutex 
+and synchronous mutex. 
 
 For example:
 
 ```rust
 # use axum::{Router, routing::get, extract::State, response::IntoResponse, http::StatusCode};
-// Note the use of the tokio Mutex
-use tokio::sync::Mutex;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 // This AppState consists of a vec of mutable strings 
 #[derive(Clone)]
 struct AppState { mutable_state: Vec<String>, }
 async fn mutate_state(State(state): State<Arc<Mutex<AppState>>>) -> impl IntoResponse {
     // Wait to get the state
-    let mutable_state = state.lock().await;
+    let mutable_state = state.lock();
     // Now the AppState can be mutated  
     StatusCode::OK
 }

--- a/axum/src/docs/routing/with_state.md
+++ b/axum/src/docs/routing/with_state.md
@@ -109,9 +109,8 @@ instead for such data.
 
 As state is used across routes it is not mutable by default. To mutate a state
 you will need to use an `Arc<Mutex>` or similar. Accessing mutable IO such as 
-a database connection requires an async mutex or similar. See the
-<a href="https://docs.rs/tokio/1.25.0/tokio/sync/struct.Mutex.html#which-kind-of-mutex-should-you-use">
-tokio discussion on sync vs async mutex</a>. 
+a database connection requires an async mutex or similar. See the 
+[tokio discussion on sync vs async mutex](https://docs.rs/tokio/1.25.0/tokio/sync/struct.Mutex.html#which-kind-of-mutex-should-you-use). 
 
 
 # What `S` in `Router<S>` means

--- a/axum/src/extract/state.rs
+++ b/axum/src/extract/state.rs
@@ -300,7 +300,7 @@ use std::{
 /// As state is used across routes it is not mutable by default. To mutate the state
 /// you will need to use an `Arc<Mutex>` or similar.
 /// You may have to use `tokio::sync::Mutex` instead of `std::sync::Mutex`,
-/// since `std::sync::Mutex` cannot be used across `.await` points,
+/// since `std::sync::Mutex` should not be locked across `.await` points,
 /// but this comes with performance cost.
 /// See the
 /// [tokio discussion on sync vs async mutex](https://docs.rs/tokio/1.25.0/tokio/sync/struct.Mutex.html#which-kind-of-mutex-should-you-use).

--- a/axum/src/extract/state.rs
+++ b/axum/src/extract/state.rs
@@ -300,9 +300,10 @@ use std::{
 /// As state is used across routes it is not mutable by default. To mutate the state
 /// you will need to use an `Arc<Mutex>` or similar.
 /// You may have to use `tokio::sync::Mutex` instead of `std::sync::Mutex`,
-/// since `std::sync::Mutex` is not safe for use across threads, but this comes
-/// with performance cost. See the
-// [tokio discussion on sync vs async mutex](https://docs.rs/tokio/1.25.0/tokio/sync/struct.Mutex.html#which-kind-of-mutex-should-you-use).
+/// since `std::sync::Mutex` cannot be used across `.await` points,
+/// but this comes with performance cost.
+/// See the
+/// [tokio discussion on sync vs async mutex](https://docs.rs/tokio/1.25.0/tokio/sync/struct.Mutex.html#which-kind-of-mutex-should-you-use).
 /// for a detailed comparison.
 ///
 /// Be aware that many tasks that require an asynchronous mutex can lead to deadlocks

--- a/axum/src/extract/state.rs
+++ b/axum/src/extract/state.rs
@@ -305,7 +305,7 @@ use std::{
 /// your use case. See [the tokio docs] for more details.
 ///
 /// Note that holding a locked `std::sync::Mutex` across `.await` points will result in `!Send`
-/// futures which are incompatible with axum. If you need to hold a mutex across `.await` points
+/// futures which are incompatible with axum. If you need to hold a mutex across `.await` points,
 /// consider using a `tokio::sync::Mutex` instead.
 ///
 /// ## Example

--- a/axum/src/extract/state.rs
+++ b/axum/src/extract/state.rs
@@ -297,17 +297,17 @@ use std::{
 /// potential type errors.
 ///
 /// # When mutable shared state is needed
-/// As state is used across routes it is not mutable by default. To mutate a state
+/// As state is used across routes it is not mutable by default. To mutate the state
 /// you will need to use an `Arc<Mutex>` or similar.
 /// You may have to use `tokio::sync::Mutex` instead of `std::sync::Mutex`,
-/// since `std::sync::Mutex` is not safe for use across threads but this comes
-/// with performance cost, See the
+/// since `std::sync::Mutex` is not safe for use across threads, but this comes
+/// with performance cost. See the
 // [tokio discussion on sync vs async mutex](https://docs.rs/tokio/1.25.0/tokio/sync/struct.Mutex.html#which-kind-of-mutex-should-you-use).
 /// for a detailed comparison.
 ///
 /// Be aware that many tasks that require an asynchronous mutex can lead to deadlocks
 /// if steps are not taken to prevent a situation where
-/// multiple tasks waiting for each other to release the resource.
+/// multiple tasks are waiting for each other to release the resource.
 ///
 /// ```
 /// use axum::extract::{State};
@@ -324,7 +324,8 @@ use std::{
 ///
 /// async fn handler(State(state): State<std::sync::Arc<tokio::sync::Mutex<AppState>>>) {
 ///     let mut guard = state.lock().await;
-///     let data = guard.deref_mut();
+///     let state = guard.deref_mut();
+///     state.data = "updated foo".to_string();
 ///     // ...
 /// }
 ///


### PR DESCRIPTION
## Motivation
I spent a lot of time trying to find documentation for creating a mutable state. I eventually found discussion #629 

## Solution

Added documentation for creating mutable state and wrote a small trivial example using a `Vec<String>` 