### PR TITLE
Change `sse::Event::json_data` to use `axum_core::Error` as its error type

### DIFF
--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
-- None.
+- **breaking:** Change `sse::Event::json_data` to use `axum_core::Error` as its error type ([#1762])
+
+[#1762]: https://github.com/tokio-rs/axum/pull/1762
 
 # 0.6.6 (12. February, 2023)
 

--- a/axum/Cargo.toml
+++ b/axum/Cargo.toml
@@ -122,7 +122,6 @@ allowed = [
     "http_body",
     "hyper",
     "serde",
-    "serde_json",
     "tower_layer",
     "tower_service",
 ]

--- a/axum/src/response/sse.rs
+++ b/axum/src/response/sse.rs
@@ -210,7 +210,7 @@ impl Event {
     ///
     /// [`MessageEvent`'s data field]: https://developer.mozilla.org/en-US/docs/Web/API/MessageEvent/data
     #[cfg(feature = "json")]
-    pub fn json_data<T>(mut self, data: T) -> serde_json::Result<Event>
+    pub fn json_data<T>(mut self, data: T) -> Result<Event, axum_core::Error>
     where
         T: serde::Serialize,
     {
@@ -219,7 +219,7 @@ impl Event {
         }
 
         self.buffer.extend_from_slice(b"data:");
-        serde_json::to_writer((&mut self.buffer).writer(), &data)?;
+        serde_json::to_writer((&mut self.buffer).writer(), &data).map_err(axum_core::Error::new)?;
         self.buffer.put_u8(b'\n');
 
         self.flags.insert(EventFlags::HAS_DATA);


### PR DESCRIPTION
I don't think it was intentional to use `serde_json::Error` here and we don't generally use that elsewhere we do JSON things.

Discovered this with <https://github.com/davidpdrsn/cargo-public-api-crates>