### PR TITLE
Require `StreamBody` to be infallible, add `TryStreamBody`

### DIFF
--- a/axum-extra/CHANGELOG.md
+++ b/axum-extra/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning].
 
 # Unreleased
 
-- None.
+- **added:** Support setting a callback to call on errors with `JsonLines` and `AsyncReadBody`
 
 # 0.6.0 (24. February, 2022)
 

--- a/axum-extra/Cargo.toml
+++ b/axum-extra/Cargo.toml
@@ -22,12 +22,12 @@ cookie-key-expansion = ["cookie", "cookie?/key-expansion"]
 erased-json = ["dep:serde_json", "dep:serde"]
 form = ["dep:serde", "dep:serde_html_form"]
 json-lines = [
-    "dep:serde_json",
     "dep:serde",
-    "dep:tokio-util",
+    "dep:serde_json",
     "dep:tokio-stream",
+    "dep:tokio-util",
+    "tokio-stream?/io-util",
     "tokio-util?/io",
-    "tokio-stream?/io-util"
 ]
 protobuf = ["dep:prost"]
 query = ["dep:serde", "dep:serde_html_form"]

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **breaking:** Change `sse::Event::json_data` to use `axum_core::Error` as its error type ([#1762])
 - **breaking:** Rename `DefaultOnFailedUpdgrade` to `DefaultOnFailedUpgrade` ([#1664])
 - **breaking:** Rename `OnFailedUpdgrade` to `OnFailedUpgrade` ([#1664])
+- **breaking:** Don't allow `StreamBody` to yield `Result`. Require `impl
+  Into<Bytes>`. Use `TryStreamBody` if you fallible streams
+- **added:** Add `TryStreamBody` for converting fallible streams into bodies
 
 [#1762]: https://github.com/tokio-rs/axum/pull/1762
 [#1664]: https://github.com/tokio-rs/axum/pull/1664

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -8,8 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # Unreleased
 
 - **breaking:** Change `sse::Event::json_data` to use `axum_core::Error` as its error type ([#1762])
+- **breaking:** Rename `DefaultOnFailedUpdgrade` to `DefaultOnFailedUpgrade` ([#1664])
+- **breaking:** Rename `OnFailedUpdgrade` to `OnFailedUpgrade` ([#1664])
 
 [#1762]: https://github.com/tokio-rs/axum/pull/1762
+[#1664]: https://github.com/tokio-rs/axum/pull/1664
 
 # 0.6.9 (24. February, 2023)
 

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
-- None.
+- **breaking:** Change `sse::Event::json_data` to use `axum_core::Error` as its error type ([#1762])
+
+[#1762]: https://github.com/tokio-rs/axum/pull/1762
 
 # 0.6.9 (24. February, 2023)
 

--- a/axum/Cargo.toml
+++ b/axum/Cargo.toml
@@ -183,7 +183,6 @@ allowed = [
     "http_body",
     "hyper",
     "serde",
-    "serde_json",
     "tower_layer",
     "tower_service",
 ]

--- a/axum/src/body/mod.rs
+++ b/axum/src/body/mod.rs
@@ -1,8 +1,8 @@
 //! HTTP body utilities.
 
-mod stream_body;
+pub mod stream_body;
 
-pub use self::stream_body::StreamBody;
+pub use self::stream_body::{StreamBody, TryStreamBody};
 
 #[doc(no_inline)]
 pub use http_body::{Body as HttpBody, Empty, Full};

--- a/axum/src/body/stream_body.rs
+++ b/axum/src/body/stream_body.rs
@@ -1,15 +1,18 @@
+//! Streaming bodies.
+
 use crate::{
     body::{self, Bytes, HttpBody},
     response::{IntoResponse, Response},
-    BoxError, Error,
+    Error,
 };
 use futures_util::{
     ready,
-    stream::{self, TryStream},
+    stream::{self, Stream, TryStream},
 };
 use http::HeaderMap;
 use pin_project_lite::pin_project;
 use std::{
+    convert::Infallible,
     fmt,
     pin::Pin,
     task::{Context, Poll},
@@ -23,6 +26,9 @@ pin_project! {
     /// extract the request body as a stream consider using
     /// [`BodyStream`](crate::extract::BodyStream).
     ///
+    /// Note the inner stream must yield `impl Into<Bytes>`. If you need `Result` use
+    /// [`TryStreamBody`] instead.
+    ///
     /// # Example
     ///
     /// ```
@@ -30,19 +36,14 @@ pin_project! {
     ///     Router,
     ///     routing::get,
     ///     body::StreamBody,
-    ///     response::IntoResponse,
+    ///     response::{IntoResponse, Response},
     /// };
     /// use futures::stream::{self, Stream};
-    /// use std::io;
     ///
-    /// async fn handler() -> StreamBody<impl Stream<Item = io::Result<&'static str>>> {
-    ///     let chunks: Vec<io::Result<_>> = vec![
-    ///         Ok("Hello,"),
-    ///         Ok(" "),
-    ///         Ok("world!"),
-    ///     ];
+    /// async fn handler() -> Response {
+    ///     let chunks = Vec::from(["Hello,", " ", "world!"]);
     ///     let stream = stream::iter(chunks);
-    ///     StreamBody::new(stream)
+    ///     StreamBody::new(stream).into_response()
     /// }
     ///
     /// let app = Router::new().route("/", get(handler));
@@ -60,9 +61,8 @@ pin_project! {
 
 impl<S> From<S> for StreamBody<S>
 where
-    S: TryStream + Send + 'static,
-    S::Ok: Into<Bytes>,
-    S::Error: Into<BoxError>,
+    S: Stream,
+    S::Item: Into<Bytes>,
 {
     fn from(stream: S) -> Self {
         Self::new(stream)
@@ -75,9 +75,8 @@ impl<S> StreamBody<S> {
     /// [`Stream`]: futures_util::stream::Stream
     pub fn new(stream: S) -> Self
     where
-        S: TryStream + Send + 'static,
-        S::Ok: Into<Bytes>,
-        S::Error: Into<BoxError>,
+        S: Stream,
+        S::Item: Into<Bytes>,
     {
         Self {
             stream: SyncWrapper::new(stream),
@@ -87,16 +86,15 @@ impl<S> StreamBody<S> {
 
 impl<S> IntoResponse for StreamBody<S>
 where
-    S: TryStream + Send + 'static,
-    S::Ok: Into<Bytes>,
-    S::Error: Into<BoxError>,
+    S: Stream + Send + 'static,
+    S::Item: Into<Bytes>,
 {
     fn into_response(self) -> Response {
         Response::new(body::boxed(self))
     }
 }
 
-impl Default for StreamBody<futures_util::stream::Empty<Result<Bytes, Error>>> {
+impl Default for StreamBody<futures_util::stream::Empty<Bytes>> {
     fn default() -> Self {
         Self::new(stream::empty())
     }
@@ -110,21 +108,177 @@ impl<S> fmt::Debug for StreamBody<S> {
 
 impl<S> HttpBody for StreamBody<S>
 where
-    S: TryStream,
-    S::Ok: Into<Bytes>,
-    S::Error: Into<BoxError>,
+    S: Stream,
+    S::Item: Into<Bytes>,
 {
     type Data = Bytes;
-    type Error = Error;
+    type Error = Infallible;
 
     fn poll_data(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Option<Result<Self::Data, Self::Error>>> {
-        let stream = self.project().stream.get_pin_mut();
+        self.poll_next(cx).map(|option_chunk| option_chunk.map(Ok))
+    }
+
+    fn poll_trailers(
+        self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+    ) -> Poll<Result<Option<HeaderMap>, Self::Error>> {
+        Poll::Ready(Ok(None))
+    }
+}
+
+impl<S> Stream for StreamBody<S>
+where
+    S: Stream,
+    S::Item: Into<Bytes>,
+{
+    type Item = Bytes;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.project()
+            .stream
+            .get_pin_mut()
+            .poll_next(cx)
+            .map(|option_chunk| option_chunk.map(Into::into))
+    }
+}
+
+pin_project! {
+    /// An [`http_body::Body`] created from a fallible [`Stream`].
+    ///
+    /// The purpose of this type is to be used in responses. If you want to
+    /// extract the request body as a stream consider using
+    /// [`BodyStream`](crate::extract::BodyStream).
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use axum::{
+    ///     Router,
+    ///     routing::get,
+    ///     body::{TryStreamBody, Bytes},
+    ///     response::{IntoResponse, Response},
+    /// };
+    /// use futures::stream::{self, Stream};
+    /// use std::io;
+    ///
+    /// async fn handler() -> Response {
+    ///     TryStreamBody::new(some_fallible_stream())
+    ///         .on_error(on_stream_error)
+    ///         .into_response()
+    /// }
+    ///
+    /// fn some_fallible_stream() -> impl Stream<Item = Result<Bytes, io::Error>> + Send + 'static {
+    ///     // ...
+    ///     # futures_util::stream::empty()
+    /// }
+    ///
+    /// fn on_stream_error(err: io::Error) {
+    ///     // ...
+    /// }
+    ///
+    /// let app = Router::new().route("/", get(handler));
+    /// # async {
+    /// # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
+    /// # };
+    /// ```
+    ///
+    /// [`Stream`]: futures_util::stream::Stream
+    pub struct TryStreamBody<S, T = DefaultOnError> {
+        #[pin]
+        stream: SyncWrapper<S>,
+        on_error: T,
+    }
+}
+
+impl<S> From<S> for TryStreamBody<S, DefaultOnError>
+where
+    S: TryStream,
+    S::Ok: Into<Bytes>,
+{
+    fn from(stream: S) -> Self {
+        Self::new(stream)
+    }
+}
+
+impl<S> TryStreamBody<S, DefaultOnError> {
+    /// Create a new `TryStreamBody` from a [`Stream`].
+    ///
+    /// [`Stream`]: futures_util::stream::Stream
+    pub fn new(stream: S) -> Self
+    where
+        S: TryStream,
+        S::Ok: Into<Bytes>,
+    {
+        Self {
+            stream: SyncWrapper::new(stream),
+            on_error: DefaultOnError,
+        }
+    }
+}
+
+impl<S, T> TryStreamBody<S, T> {
+    /// Provide a callback to call if the underlying stream produces an error.
+    ///
+    /// By default any errors will be silently ignored.
+    pub fn on_error<C>(self, callback: C) -> TryStreamBody<S, C>
+    where
+        S: TryStream,
+        C: OnError<S::Error>,
+    {
+        TryStreamBody {
+            stream: self.stream,
+            on_error: callback,
+        }
+    }
+}
+
+impl<S, T> IntoResponse for TryStreamBody<S, T>
+where
+    S: TryStream + Send + 'static,
+    S::Ok: Into<Bytes>,
+    T: OnError<S::Error> + Send + 'static,
+{
+    fn into_response(self) -> Response {
+        Response::new(body::boxed(self))
+    }
+}
+
+impl Default for TryStreamBody<futures_util::stream::Empty<Result<Bytes, Error>>, DefaultOnError> {
+    fn default() -> Self {
+        Self::new(stream::empty())
+    }
+}
+
+impl<S, T> fmt::Debug for TryStreamBody<S, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TryStreamBody").finish_non_exhaustive()
+    }
+}
+
+impl<S, T> HttpBody for TryStreamBody<S, T>
+where
+    S: TryStream,
+    S::Ok: Into<Bytes>,
+    T: OnError<S::Error>,
+{
+    type Data = Bytes;
+    type Error = Infallible;
+
+    fn poll_data(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Self::Data, Self::Error>>> {
+        let this = self.project();
+        let stream = this.stream.get_pin_mut();
         match ready!(stream.try_poll_next(cx)) {
             Some(Ok(chunk)) => Poll::Ready(Some(Ok(chunk.into()))),
-            Some(Err(err)) => Poll::Ready(Some(Err(Error::new(err)))),
+            Some(Err(err)) => {
+                this.on_error.call(err);
+                Poll::Ready(None)
+            }
             None => Poll::Ready(None),
         }
     }
@@ -137,11 +291,60 @@ where
     }
 }
 
+impl<S, T> Stream for TryStreamBody<S, T>
+where
+    S: TryStream,
+    S::Ok: Into<Bytes>,
+    T: OnError<S::Error>,
+{
+    type Item = Bytes;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.project();
+        let stream = this.stream.get_pin_mut();
+        match ready!(stream.try_poll_next(cx)) {
+            Some(Ok(chunk)) => Poll::Ready(Some(chunk.into())),
+            Some(Err(err)) => {
+                this.on_error.call(err);
+                Poll::Ready(None)
+            }
+            None => Poll::Ready(None),
+        }
+    }
+}
+
+/// What to do when a stream produces an error.
+///
+/// See [`TryStreamBody`] for more details.
+pub trait OnError<E> {
+    /// Call the callback.
+    fn call(&mut self, error: E);
+}
+
+/// The default `OnError` used by `TryStreamBody`.
+///
+/// It simply ignores the error.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct DefaultOnError;
+
+impl<E> OnError<E> for DefaultOnError {
+    fn call(&mut self, _error: E) {}
+}
+
+impl<E, F> OnError<E> for F
+where
+    F: FnMut(E) + Send + 'static,
+{
+    fn call(&mut self, error: E) {
+        self(error)
+    }
+}
+
 #[test]
 fn stream_body_traits() {
     use futures_util::stream::Empty;
 
-    type EmptyStream = StreamBody<Empty<Result<Bytes, BoxError>>>;
+    type EmptyStream = StreamBody<Empty<Result<Bytes, crate::BoxError>>>;
 
     crate::test_helpers::assert_send::<EmptyStream>();
     crate::test_helpers::assert_sync::<EmptyStream>();

--- a/axum/src/extract/ws.rs
+++ b/axum/src/extract/ws.rs
@@ -135,7 +135,7 @@ use tokio_tungstenite::{
 ///
 /// See the [module docs](self) for an example.
 #[cfg_attr(docsrs, doc(cfg(feature = "ws")))]
-pub struct WebSocketUpgrade<F = DefaultOnFailedUpdgrade> {
+pub struct WebSocketUpgrade<F = DefaultOnFailedUpgrade> {
     config: WebSocketConfig,
     /// The chosen protocol sent in the `Sec-WebSocket-Protocol` header of the response.
     protocol: Option<HeaderValue>,
@@ -268,7 +268,7 @@ impl<F> WebSocketUpgrade<F> {
     /// ```
     pub fn on_failed_upgrade<C>(self, callback: C) -> WebSocketUpgrade<C>
     where
-        C: OnFailedUpdgrade,
+        C: OnFailedUpgrade,
     {
         WebSocketUpgrade {
             config: self.config,
@@ -290,7 +290,7 @@ impl<F> WebSocketUpgrade<F> {
     where
         C: FnOnce(WebSocket) -> Fut + Send + 'static,
         Fut: Future<Output = ()> + Send + 'static,
-        F: OnFailedUpdgrade,
+        F: OnFailedUpgrade,
     {
         let on_upgrade = self.on_upgrade;
         let config = self.config;
@@ -342,12 +342,12 @@ impl<F> WebSocketUpgrade<F> {
 /// What to do when a connection upgrade fails.
 ///
 /// See [`WebSocketUpgrade::on_failed_upgrade`] for more details.
-pub trait OnFailedUpdgrade: Send + 'static {
+pub trait OnFailedUpgrade: Send + 'static {
     /// Call the callback.
     fn call(self, error: Error);
 }
 
-impl<F> OnFailedUpdgrade for F
+impl<F> OnFailedUpgrade for F
 where
     F: FnOnce(Error) + Send + 'static,
 {
@@ -356,20 +356,20 @@ where
     }
 }
 
-/// The default `OnFailedUpdgrade` used by `WebSocketUpgrade`.
+/// The default `OnFailedUpgrade` used by `WebSocketUpgrade`.
 ///
 /// It simply ignores the error.
 #[non_exhaustive]
 #[derive(Debug)]
-pub struct DefaultOnFailedUpdgrade;
+pub struct DefaultOnFailedUpgrade;
 
-impl OnFailedUpdgrade for DefaultOnFailedUpdgrade {
+impl OnFailedUpgrade for DefaultOnFailedUpgrade {
     #[inline]
     fn call(self, _error: Error) {}
 }
 
 #[async_trait]
-impl<S> FromRequestParts<S> for WebSocketUpgrade<DefaultOnFailedUpdgrade>
+impl<S> FromRequestParts<S> for WebSocketUpgrade<DefaultOnFailedUpgrade>
 where
     S: Send + Sync,
 {
@@ -410,7 +410,7 @@ where
             sec_websocket_key,
             on_upgrade,
             sec_websocket_protocol,
-            on_failed_upgrade: DefaultOnFailedUpdgrade,
+            on_failed_upgrade: DefaultOnFailedUpgrade,
         })
     }
 }

--- a/axum/src/response/sse.rs
+++ b/axum/src/response/sse.rs
@@ -210,7 +210,7 @@ impl Event {
     ///
     /// [`MessageEvent`'s data field]: https://developer.mozilla.org/en-US/docs/Web/API/MessageEvent/data
     #[cfg(feature = "json")]
-    pub fn json_data<T>(mut self, data: T) -> serde_json::Result<Event>
+    pub fn json_data<T>(mut self, data: T) -> Result<Event, axum_core::Error>
     where
         T: serde::Serialize,
     {
@@ -219,7 +219,7 @@ impl Event {
         }
 
         self.buffer.extend_from_slice(b"data:");
-        serde_json::to_writer((&mut self.buffer).writer(), &data)?;
+        serde_json::to_writer((&mut self.buffer).writer(), &data).map_err(axum_core::Error::new)?;
         self.buffer.put_u8(b'\n');
 
         self.flags.insert(EventFlags::HAS_DATA);


### PR DESCRIPTION
I've been thinking some more about #1699 and I think this approach makes sense.

This changes `StreamBody` to always require the underlying stream to be infallible, i.e. it must yield `impl Into<Bytes>`. `Result`s are not allowed. That is because hyper will silently ignore body errors, so its kind of a footgun.

Additionally I think we can provide a `TryStreamBody` that allows `Result`s but also a callback to call on errors. Then we can use `TryStreamBody` in `JsonLines` and `AsyncReadBody` which don't have a good way to surface errors otherwise.