### PR TITLE
Fix missing `Allow` when middleware are applied to `MethodRouter`

### DIFF
--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
-- None.
+- **fixed:** Fix `Allow` missing from routers with middleware
 
 # 0.6.7 (17. February, 2023)
 

--- a/axum/Cargo.toml
+++ b/axum/Cargo.toml
@@ -35,10 +35,10 @@ axum-core = { path = "../axum-core", version = "0.3.2" }
 bitflags = "1.0"
 bytes = "1.0"
 futures-util = { version = "0.3", default-features = false, features = ["alloc"] }
-http = "0.2.5"
+http = "0.2.9"
 http-body = "0.4.4"
-hyper = { version = "0.14.14", features = ["stream"] }
-itoa = "1.0.1"
+hyper = { version = "0.14.24", features = ["stream"] }
+itoa = "=1.0.5"
 matchit = "0.7"
 memchr = "2.4.1"
 mime = "0.3.16"
@@ -72,7 +72,7 @@ axum-macros = { path = "../axum-macros", version = "0.3.4", features = ["__priva
 futures = "0.3"
 quickcheck = "1.0"
 quickcheck_macros = "1.0"
-reqwest = { version = "0.11.11", default-features = false, features = ["json", "stream", "multipart"] }
+reqwest = { version = "0.11.14", default-features = false, features = ["json", "stream", "multipart"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 time = { version = "0.3", features = ["serde-human-readable"] }

--- a/axum/src/routing/method_routing.rs
+++ b/axum/src/routing/method_routing.rs
@@ -1488,6 +1488,17 @@ mod tests {
     }
 
     #[crate::test]
+    async fn allow_header_noop_middleware() {
+        let mut svc = MethodRouter::new()
+            .get(ok)
+            .layer(tower::layer::util::Identity::new());
+
+        let (status, headers, _) = call(Method::DELETE, &mut svc).await;
+        assert_eq!(status, StatusCode::METHOD_NOT_ALLOWED);
+        assert_eq!(headers[ALLOW], "GET,HEAD");
+    }
+
+    #[crate::test]
     #[should_panic(
         expected = "Overlapping method route. Cannot add two method routes that both handle `GET`"
     )]

--- a/axum/src/routing/route.rs
+++ b/axum/src/routing/route.rs
@@ -155,9 +155,6 @@ where
 
     #[inline]
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        #[derive(Clone, Copy)]
-        struct AlreadyPassedThroughRouteFuture;
-
         let this = self.project();
 
         let mut res = match this.kind.project() {
@@ -170,16 +167,6 @@ where
                 response.take().expect("future polled after completion")
             }
         };
-
-        if res
-            .extensions()
-            .get::<AlreadyPassedThroughRouteFuture>()
-            .is_some()
-        {
-            return Poll::Ready(Ok(res));
-        } else {
-            res.extensions_mut().insert(AlreadyPassedThroughRouteFuture);
-        }
 
         set_allow_header(res.headers_mut(), this.allow_header);
 


### PR DESCRIPTION
Fixes https://github.com/tokio-rs/axum/issues/1770

To be totally honest I don't understand why this fixes the issue. I also noticed some weirdness in this piece of the code in https://github.com/tokio-rs/axum/pull/1711/files#r1082406463. Removing it doesn't seem to break anything else, and the bug it was originally added to fix doesn't occur anymore.

The reason its pretty hard to follow I think is that we wrap things in `Route` quite a bit, which also wraps the response future in `RouteFuture`. So there are several layers of `RouteFuture` being called and previously mutating the response.