### PR TITLE
Add hint for on further details for WebSocket

### DIFF
--- a/axum/src/extract/ws.rs
+++ b/axum/src/extract/ws.rs
@@ -438,6 +438,8 @@ fn header_contains(headers: &HeaderMap, key: HeaderName, value: &'static str) ->
 }
 
 /// A stream of WebSocket messages.
+///
+/// See [the module level documentation](self) for more details.
 #[derive(Debug)]
 pub struct WebSocket {
     inner: WebSocketStream<Upgraded>,


### PR DESCRIPTION
## Motivation

I actually had a hard time figuring out the `WebSocket` API. I noticed in the examples that `split` is used and was going to leave a reference to it in the documentation.

While editing `ws.rs`, I noticed other mentions of `split` and finally noticed that there was more documentation on the `WebSocket` in the module level docs.

## Solution

Leave a hint on where to find more information for the `WebSocket`. Hopefully this'll help the next lost soul find their way around better.
