### PR TITLE
docs: Clarify that state parameters need to come before body too

### DIFF
--- a/axum/src/docs/extract.md
+++ b/axum/src/docs/extract.md
@@ -168,20 +168,26 @@ handler takes.
 For example
 
 ```rust
-use axum::http::{Method, HeaderMap};
+use axum::{extract::State, http::{Method, HeaderMap}};
+#
+# #[derive(Clone)]
+# struct AppState {
+# }
 
 async fn handler(
     // `Method` and `HeaderMap` don't consume the request body so they can
-    // put anywhere in the argument list
+    // put anywhere in the argument list (but before `body`)
     method: Method,
     headers: HeaderMap,
+    // `State` is also an extractor so it needs to be before `body`
+    State(state): State<AppState>,
     // `String` consumes the request body and thus must be the last extractor
     body: String,
 ) {
     // ...
 }
 #
-# let _: axum::routing::MethodRouter = axum::routing::get(handler);
+# let _: axum::routing::MethodRouter<AppState, String> = axum::routing::get(handler);
 ```
 
 We get a compile error if `String` isn't the last extractor:

--- a/axum/src/extract/state.rs
+++ b/axum/src/extract/state.rs
@@ -46,6 +46,11 @@ use std::{
 /// # let _: axum::Router = app;
 /// ```
 ///
+/// Note that `State` is an extractor, so be sure to put it before any body
+/// extractors, see ["the order of extractors"][order-of-extractors].
+///
+/// [order-of-extractors]: crate::extract#the-order-of-extractors
+///
 /// ## Combining stateful routers
 ///
 /// Multiple [`Router`]s can be combined with [`Router::nest`] or [`Router::merge`]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation

I used `axum` for the first time recently. I had a `state` parameter after `body` and got an inscrutable compile error (that I wrongly assumed was because of my complex return type) and it took me a good while to figure out what was wrong.

## Solution

I had read the section about order of extractors but in my mental model state wasn't extracting anything from the request. 

Mentioning it explicitly like I did in this PR would have helped me, and potentially others in the future.
