### PR TITLE
Use `JsonRejection::{status, body_text}` in customize extractor error example

### DIFF
--- a/examples/customize-extractor-error/src/custom_extractor.rs
+++ b/examples/customize-extractor-error/src/custom_extractor.rs
@@ -51,18 +51,12 @@ where
             // convert the error from `axum::Json` into whatever we want
             Err(rejection) => {
                 let payload = json!({
-                    "message": rejection.to_string(),
+                    "message": rejection.body_text(),
                     "origin": "custom_extractor",
                     "path": path,
                 });
 
-                let code = match rejection {
-                    JsonRejection::JsonDataError(_) => StatusCode::UNPROCESSABLE_ENTITY,
-                    JsonRejection::JsonSyntaxError(_) => StatusCode::BAD_REQUEST,
-                    JsonRejection::MissingJsonContentType(_) => StatusCode::UNSUPPORTED_MEDIA_TYPE,
-                    _ => StatusCode::INTERNAL_SERVER_ERROR,
-                };
-                Err((code, axum::Json(payload)))
+                Err((rejection.status(), axum::Json(payload)))
             }
         }
     }

--- a/examples/customize-extractor-error/src/derive_from_request.rs
+++ b/examples/customize-extractor-error/src/derive_from_request.rs
@@ -27,22 +27,16 @@ pub struct Json<T>(T);
 // We create our own rejection type
 #[derive(Debug)]
 pub struct ApiError {
-    code: StatusCode,
+    status: StatusCode,
     message: String,
 }
 
 // We implement `From<JsonRejection> for ApiError`
 impl From<JsonRejection> for ApiError {
     fn from(rejection: JsonRejection) -> Self {
-        let code = match rejection {
-            JsonRejection::JsonDataError(_) => StatusCode::UNPROCESSABLE_ENTITY,
-            JsonRejection::JsonSyntaxError(_) => StatusCode::BAD_REQUEST,
-            JsonRejection::MissingJsonContentType(_) => StatusCode::UNSUPPORTED_MEDIA_TYPE,
-            _ => StatusCode::INTERNAL_SERVER_ERROR,
-        };
         Self {
-            code,
-            message: rejection.to_string(),
+            status: rejection.status(),
+            message: rejection.body_text(),
         }
     }
 }
@@ -55,6 +49,6 @@ impl IntoResponse for ApiError {
             "origin": "derive_from_request"
         });
 
-        (self.code, axum::Json(payload)).into_response()
+        (self.status, axum::Json(payload)).into_response()
     }
 }


### PR DESCRIPTION
I think we should recommend people use these methods. Its simpler and likely to be more correct, or at least match what axum's built-in extractors do.