### PR TITLE
Update documentation for `FailedToDeserializeQueryString` response type

### DIFF
--- a/axum-extra/src/extract/query.rs
+++ b/axum-extra/src/extract/query.rs
@@ -46,8 +46,8 @@ use std::{fmt, ops::Deref};
 /// # };
 /// ```
 ///
-/// If the query string cannot be parsed it will reject the request with a `422
-/// Unprocessable Entity` response.
+/// If the query string cannot be parsed it will reject the request with a `400
+/// Bad Request` response.
 ///
 /// For handling values being empty vs missing see the [query-params-with-empty-strings][example]
 /// example.

--- a/axum/src/extract/query.rs
+++ b/axum/src/extract/query.rs
@@ -38,8 +38,8 @@ use std::ops::Deref;
 /// # };
 /// ```
 ///
-/// If the query string cannot be parsed it will reject the request with a `422
-/// Unprocessable Entity` response.
+/// If the query string cannot be parsed it will reject the request with a `400
+/// Bad Request` response.
 ///
 /// For handling values being empty vs missing see the [query-params-with-empty-strings][example]
 /// example.


### PR DESCRIPTION
I believe this was just an oversight from #1387.

Changes the stated return type from `422 Unprocessable Entity` to `400 Bad Request`.