### PR TITLE
Document the fact that `debug_handler` doesn't work within impl blocks

### DIFF
--- a/axum-macros/src/lib.rs
+++ b/axum-macros/src/lib.rs
@@ -542,14 +542,17 @@ pub fn derive_from_request_parts(item: TokenStream) -> TokenStream {
 ///
 /// # Limitations
 ///
-/// This macro does not work for associated functions — functions defined in an impl block.
+/// This macro does not work for associated functions — functions defined in an `impl` block that
+/// don't take `self`:
 ///
-/// ```
+/// ```compile_fail
 /// use axum::{debug_handler, extract::Path};
+///
 /// struct App {}
-/// #[debug_handler]
+///
 /// impl App {
-///     pub async fn handler(Path(_): Path(String)) {}
+///     #[debug_handler]
+///     async fn handler(Path(_): Path<String>) {}
 /// }
 /// ```
 ///

--- a/axum-macros/src/lib.rs
+++ b/axum-macros/src/lib.rs
@@ -540,6 +540,29 @@ pub fn derive_from_request_parts(item: TokenStream) -> TokenStream {
 /// }
 /// ```
 ///
+/// # Limitations
+///
+/// This macro does not work for associated functions — functions defined in an impl block.
+///
+/// ```
+/// use axum::{debug_handler, extract::Path};
+/// struct App {}
+/// #[debug_handler]
+/// impl App {
+///     pub async fn handler(Path(_): Path(String)) {}
+/// }
+/// ```
+///
+/// This will yield an error similar to this:
+///
+/// ```text
+/// error[E0425]: cannot find function `__axum_macros_check_handler_0_from_request_check` in this scope
+//    --> src/main.rs:xx:xx
+//     |
+//  xx |     pub async fn handler(Path(_): Path<String>)  {}
+//     |                                   ^^^^ not found in this scope
+/// ```
+///
 /// # Performance
 ///
 /// This macro has no effect when compiled with the release profile. (eg. `cargo build --release`)


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation

When upgrading from from axum 0.5.x to 0.6.x I encountered a breaking change to how the `debug_handler` macro works. 

In 0.5.x, an associated function (not a method) could be used with `debug_handler`. In 0.6.x this yields confusing compilation errors. 

As per @davidpdrsn on Discord: 

> ah yes I see why now. Basically in 0.6 FromRequest got a new (secret) type param M, which is used to work around some otherwise overlapping impls. But because of this we need to generate slightly different code in debug_handler, which doesn't work we're inside an impl would be good to document. 

## Solution

This PR attempts to document this behavior.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
