### PR TITLE
Replace weird doc paragraph by compiler-checked must_use attribute

### DIFF
--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
-- None.
+- **fixed:** Add `#[must_use]` to `WebSocketUpgrade::on_upgrade` ([#1801])
+
+[#1801]: https://github.com/tokio-rs/axum/pull/1801
 
 # 0.6.9 (24. February, 2023)
 

--- a/axum/src/extract/ws.rs
+++ b/axum/src/extract/ws.rs
@@ -282,7 +282,7 @@ impl<F> WebSocketUpgrade<F> {
 
     /// Finalize upgrading the connection and call the provided callback with
     /// the stream.
-    #[must_use]
+    #[must_use = "to setup the WebSocket connection, this response must be returned"]
     pub fn on_upgrade<C, Fut>(self, callback: C) -> Response
     where
         C: FnOnce(WebSocket) -> Fut + Send + 'static,

--- a/axum/src/extract/ws.rs
+++ b/axum/src/extract/ws.rs
@@ -282,10 +282,7 @@ impl<F> WebSocketUpgrade<F> {
 
     /// Finalize upgrading the connection and call the provided callback with
     /// the stream.
-    ///
-    /// When using `WebSocketUpgrade`, the response produced by this method
-    /// should be returned from the handler. See the [module docs](self) for an
-    /// example.
+    #[must_use]
     pub fn on_upgrade<C, Fut>(self, callback: C) -> Response
     where
         C: FnOnce(WebSocket) -> Fut + Send + 'static,


### PR DESCRIPTION
Very lazy fix for making it harder to accidentally discard the `Response` generated by `WebSocketUpgrade::on_upgrade`. Feel free to improve by prodiving a message (`#[must_use = "message"]` or restoring a more useful version of the docs I deleted.