### PR TITLE
Fixed small typo

### DIFF
--- a/axum/src/extract/path/de.rs
+++ b/axum/src/extract/path/de.rs
@@ -340,7 +340,7 @@ impl<'de> Deserializer<'de> for ValueDeserializer<'de> {
     parse_value!(deserialize_bool, visit_bool, "bool");
     parse_value!(deserialize_i8, visit_i8, "i8");
     parse_value!(deserialize_i16, visit_i16, "i16");
-    parse_value!(deserialize_i32, visit_i32, "i16");
+    parse_value!(deserialize_i32, visit_i32, "i32");
     parse_value!(deserialize_i64, visit_i64, "i64");
     parse_value!(deserialize_i128, visit_i128, "i128");
     parse_value!(deserialize_u8, visit_u8, "u8");


### PR DESCRIPTION
## Motivation
``` rust
async fn handler(Path(p): Path<i32>) -> String {
    format!("{p}")
}
```
The above handler returns:

Invalid URL: Cannot parse value at index 0 with value "123123123123123" to a **i16**

It should return:

Invalid URL: Cannot parse value at index 0 with value "123123123123123" to a **i32**

