### PR TITLE
Gracefully handle missing headers

### DIFF
--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -8,11 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # Unreleased
 
 - **fixed:** Add `#[must_use]` to `WebSocketUpgrade::on_upgrade` ([#1801])
-
-[#1801]: https://github.com/tokio-rs/axum/pull/1801
-
 - **fixed:** Gracefully handle missing headers in the `TypedHeader` extractor ([#1810])
 
+[#1801]: https://github.com/tokio-rs/axum/pull/1801
 [#1810]: https://github.com/tokio-rs/axum/pull/1810
 
 # 0.6.9 (24. February, 2023)

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [#1801]: https://github.com/tokio-rs/axum/pull/1801
 
+- **fixed:** Gracefully handle missing headers in the `TypedHeader` extractor ([#1810])
+
+[#1810]: https://github.com/tokio-rs/axum/pull/1810
+
 # 0.6.9 (24. February, 2023)
 
 - **changed:** Update to tower-http 0.4. axum is still compatible with tower-http 0.3 ([#1783])


### PR DESCRIPTION
Reports a missing header rejection only if the header's decoder didn't return a default value.

I've also added a regression test by using Cookie as an example: missing Cookie should be treated in the same way as empty Cookie header, but before this PR would reject the entire request. Now it's going to be handled correctly.

Closes #1781.