### PR TITLE
docs: Add jwt-authorizer to ECOSYSTEM.md

### DIFF
--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -30,6 +30,7 @@ If your project isn't listed here and you would like it to be, please feel free 
 - [axum-login](https://docs.rs/axum-login): Session-based user authentication for axum.
 - [axum-csrf-sync-pattern](https://crates.io/crates/axum-csrf-sync-pattern): A middleware implementing CSRF STP for AJAX backends and API endpoints.
 - [axum-otel-metrics](https://github.com/ttys3/axum-otel-metrics/): A axum OpenTelemetry Metrics middleware with prometheus exporter supported.
+- [jwt-authorizer](https://crates.io/crates/jwt-authorizer): JWT authorization layer for axum (oidc discovery, validation options, claims extraction, etc.) 
 
 ## Project showcase
 


### PR DESCRIPTION
The linked crate provides `jwt validation` middleware layer for axum. It supports many signature algorithms, provides signature key discovery, diverse acquisition and refresh modes.

## Motivation

Add `jwt-authorizer` to ECOSYSTEM.md, to indicate its existence to other axum users who might have a need for such middleware.

## Solution

This PR modifies ECOSYSTEM.md adding a link to the `jwt-validation` crate documentation.
