### PR TITLE
Hide debug_handler generated functions from docs

### DIFF
--- a/axum-macros/src/debug_handler.rs
+++ b/axum-macros/src/debug_handler.rs
@@ -270,6 +270,7 @@ fn check_inputs_impls_from_request(
 
             quote_spanned! {span=>
                 #[allow(warnings)]
+                #[doc(hidden)]
                 fn #check_fn #check_fn_generics()
                 where
                     #from_request_bound,
@@ -278,6 +279,7 @@ fn check_inputs_impls_from_request(
                 // we have to call the function to actually trigger a compile error
                 // since the function is generic, just defining it is not enough
                 #[allow(warnings)]
+                #[doc(hidden)]
                 fn #call_check_fn()
                 {
                     #call_check_fn_body
@@ -417,6 +419,7 @@ fn check_output_impls_into_response(item_fn: &ItemFn) -> TokenStream {
     let make = if item_fn.sig.asyncness.is_some() {
         quote_spanned! {span=>
             #[allow(warnings)]
+            #[doc(hidden)]
             async fn #make_value_name() -> #ty {
                 #declare_inputs
                 #block
@@ -425,6 +428,7 @@ fn check_output_impls_into_response(item_fn: &ItemFn) -> TokenStream {
     } else {
         quote_spanned! {span=>
             #[allow(warnings)]
+            #[doc(hidden)]
             fn #make_value_name() -> #ty {
                 #declare_inputs
                 #block
@@ -439,6 +443,7 @@ fn check_output_impls_into_response(item_fn: &ItemFn) -> TokenStream {
             #make
 
             #[allow(warnings)]
+            #[doc(hidden)]
             async fn #name() {
                 let value = #receiver #make_value_name().await;
                 fn check<T>(_: T)
@@ -450,6 +455,7 @@ fn check_output_impls_into_response(item_fn: &ItemFn) -> TokenStream {
     } else {
         quote_spanned! {span=>
             #[allow(warnings)]
+            #[doc(hidden)]
             async fn #name() {
                 #make
 
@@ -499,6 +505,7 @@ fn check_future_send(item_fn: &ItemFn) -> TokenStream {
     if let Some(receiver) = self_receiver(item_fn) {
         quote! {
             #[allow(warnings)]
+            #[doc(hidden)]
             fn #name() {
                 let future = #receiver #handler_name(#(#args),*);
                 #do_check
@@ -507,6 +514,7 @@ fn check_future_send(item_fn: &ItemFn) -> TokenStream {
     } else {
         quote! {
             #[allow(warnings)]
+            #[doc(hidden)]
             fn #name() {
                 #item_fn
                 let future = #handler_name(#(#args),*);


### PR DESCRIPTION
Added `#[doc(hidden)]` to them to tell rustdoc not to document.
Fixes: #1824
## Motivation
Clean up generated docs when using Axum.
## Solution
Add `#[doc(hidden)]` to generated code