### PR TITLE
Fix static-file-server example instructions

### DIFF
--- a/examples/static-file-server/src/main.rs
+++ b/examples/static-file-server/src/main.rs
@@ -1,7 +1,7 @@
 //! Run with
 //!
 //! ```not_rust
-//! cd examples && cargo run -p example-static-file-server
+//! cd examples/static-file-server && cargo run -p example-static-file-server
 //! ```
 
 use axum::{


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation

Running `cd examples && cargo run -p example-static-file-server` won't actually work, because the assets directory is inside the `static-file-server` folder. This had me stumped for way too long.

## Solution

I changed the comment. Another possible solution would be to move the assets folder to `examples` but I think the subfolders of examples are meant to be one example each.
