### PR TITLE
 the trait `std::convert::From<axum::http::HeaderValue>` is not imple…

### DIFF
--- a/examples/cors/src/main.rs
+++ b/examples/cors/src/main.rs
@@ -5,13 +5,13 @@
 //! ```
 
 use axum::{
-    http::{HeaderValue, Method},
+    http::Method,
     response::{Html, IntoResponse},
     routing::get,
     Json, Router,
 };
 use std::net::SocketAddr;
-use tower_http::cors::CorsLayer;
+use tower_http::cors::{CorsLayer, Origin};
 
 #[tokio::main]
 async fn main() {
@@ -29,7 +29,7 @@ async fn main() {
             // it is required to add ".allow_headers([http::header::CONTENT_TYPE])"
             // or see this issue https://github.com/tokio-rs/axum/issues/849
             CorsLayer::new()
-                .allow_origin("http://localhost:3000".parse::<HeaderValue>().unwrap())
+                .allow_origin(Origin::exact("http://localhost:3000".parse().unwrap()));
                 .allow_methods([Method::GET]),
         );
         serve(app, 4000).await;


### PR DESCRIPTION
…mented for `AnyOr<Origin>`

`.allow_origin("http://localhost:3000".parse::<HeaderValue>().unwrap());` gives error. Instead of parse::<HeaderValue>, Origin::exact() works just fine.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation

I countered a problem and fixed it. 

## Solution

I changed parse::<HeaderValue> as Origin::exact()
