### PR TITLE
Add workaround for inference errors after removing `B` type param

### DIFF
--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **breaking:** Change `sse::Event::json_data` to use `axum_core::Error` as its error type ([#1762])
 - **breaking:** Rename `DefaultOnFailedUpdgrade` to `DefaultOnFailedUpgrade` ([#1664])
 - **breaking:** Rename `OnFailedUpdgrade` to `OnFailedUpgrade` ([#1664])
+- **added:** Add `Router::as_service` to workaround type inference issues when
+  calling `ServiceExt` methods on a `Router`
 
 [#1762]: https://github.com/tokio-rs/axum/pull/1762
 [#1664]: https://github.com/tokio-rs/axum/pull/1664

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -12,10 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **breaking:** Rename `DefaultOnFailedUpdgrade` to `DefaultOnFailedUpgrade` ([#1664])
 - **breaking:** Rename `OnFailedUpdgrade` to `OnFailedUpgrade` ([#1664])
 - **added:** Add `Router::as_service` to workaround type inference issues when
-  calling `ServiceExt` methods on a `Router`
+  calling `ServiceExt` methods on a `Router` ([#1835])
 
 [#1762]: https://github.com/tokio-rs/axum/pull/1762
 [#1664]: https://github.com/tokio-rs/axum/pull/1664
+[#1835]: https://github.com/tokio-rs/axum/pull/1835
 
 # 0.6.9 (24. February, 2023)
 

--- a/examples/hyper-1-0/src/main.rs
+++ b/examples/hyper-1-0/src/main.rs
@@ -8,13 +8,11 @@ use axum::{routing::get, Router};
 use std::net::SocketAddr;
 use tokio::net::TcpListener;
 use tower_http::trace::TraceLayer;
-use tower_hyper_http_body_compat::{
-    HttpBody1ToHttpBody04, TowerService03HttpServiceAsHyper1HttpService,
-};
+use tower_hyper_http_body_compat::TowerService03HttpServiceAsHyper1HttpService;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 // this is hyper 1.0
-use hyper::{body::Incoming, server::conn::http1};
+use hyper::server::conn::http1;
 
 #[tokio::main]
 async fn main() {
@@ -26,8 +24,7 @@ async fn main() {
         .with(tracing_subscriber::fmt::layer())
         .init();
 
-    // you have to use `HttpBody1ToHttpBody04<Incoming>` as the second type parameter to `Router`
-    let app: Router<_, HttpBody1ToHttpBody04<Incoming>> = Router::new()
+    let app = Router::new()
         .route("/", get(|| async { "Hello, World!" }))
         // we can still add regular tower middleware
         .layer(TraceLayer::new_for_http());

--- a/examples/static-file-server/src/main.rs
+++ b/examples/static-file-server/src/main.rs
@@ -72,10 +72,7 @@ fn using_serve_dir_with_handler_as_service() -> Router {
     }
 
     // you can convert handler function to service
-    let service = tower::ServiceExt::<Request<Body>>::map_err(
-        handle_404.into_service(),
-        |err| -> std::io::Error { match err {} },
-    );
+    let service = handle_404.into_service();
 
     let serve_dir = ServeDir::new("assets").not_found_service(service);
 

--- a/examples/testing/src/main.rs
+++ b/examples/testing/src/main.rs
@@ -196,7 +196,7 @@ mod tests {
             .uri("/requires-connect-into")
             .body(Body::empty())
             .unwrap();
-        let response = app.ready().await.unwrap().call(request).await.unwrap();
+       let response = app.as_service().ready().await.unwrap().call(request).await.unwrap();
         assert_eq!(response.status(), StatusCode::OK);
     }
 }

--- a/examples/testing/src/main.rs
+++ b/examples/testing/src/main.rs
@@ -196,7 +196,14 @@ mod tests {
             .uri("/requires-connect-into")
             .body(Body::empty())
             .unwrap();
-       let response = app.as_service().ready().await.unwrap().call(request).await.unwrap();
+        let response = app
+            .as_service()
+            .ready()
+            .await
+            .unwrap()
+            .call(request)
+            .await
+            .unwrap();
         assert_eq!(response.status(), StatusCode::OK);
     }
 }


### PR DESCRIPTION
This adds `Router::as_service` which fixes the request body type and helps with type inference. Its a workaround for the issues like

```
    Checking example-testing v0.1.0 (/Users/david.pedersen/code/axum/examples/testing)
error[E0698]: type inside `async` block must be known in this context
   --> testing/src/main.rs:199:28
    |
199 |         let response = app.ready().await.unwrap().call(request).await.unwrap();
    |                            ^^^^^ cannot infer type for type parameter `B`
    |
```

that we encountered [here](https://github.com/tokio-rs/axum/pull/1751#issuecomment-1450182222).

I'm not really fond of having to do this but I don't see any other solutions 😞