### PR TITLE
Don't require `S: Debug` for `impl Debug for Router<S>`

### DIFF
--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
-- **fixed:** Don't require `S: Debug` for `impl Debug for Router<S>`
+- **fixed:** Don't require `S: Debug` for `impl Debug for Router<S>` ([#1836])
+
+[#1836]: https://github.com/tokio-rs/axum/pull/1836
 
 # 0.6.10 (03. March, 2023)
 

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
-- None.
+- **fixed:** Don't require `S: Debug` for `impl Debug for Router<S>`
 
 # 0.6.10 (03. March, 2023)
 

--- a/axum/src/routing/mod.rs
+++ b/axum/src/routing/mod.rs
@@ -77,10 +77,7 @@ where
     }
 }
 
-impl<S, B> fmt::Debug for Router<S, B>
-where
-    S: fmt::Debug,
-{
+impl<S, B> fmt::Debug for Router<S, B> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Router")
             .field("routes", &self.routes)
@@ -721,10 +718,7 @@ impl<S, B> Clone for Endpoint<S, B> {
     }
 }
 
-impl<S, B> fmt::Debug for Endpoint<S, B>
-where
-    S: fmt::Debug,
-{
+impl<S, B> fmt::Debug for Endpoint<S, B> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::MethodRouter(method_router) => {


### PR DESCRIPTION
This bound wasn't necessary since the routes are boxed and don't
actually print the state.
