### PR TITLE
Clone state a bit less

### DIFF
--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -8,8 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # Unreleased
 
 - **fixed:** Don't require `S: Debug` for `impl Debug for Router<S>` ([#1836])
+- **fixed:** Clone state a bit less when handling requests ([#1837])
 
 [#1836]: https://github.com/tokio-rs/axum/pull/1836
+[#1837]: https://github.com/tokio-rs/axum/pull/1837
 
 # 0.6.10 (03. March, 2023)
 

--- a/axum/Cargo.toml
+++ b/axum/Cargo.toml
@@ -104,6 +104,7 @@ futures = "0.3"
 quickcheck = "1.0"
 quickcheck_macros = "1.0"
 reqwest = { version = "0.11.14", default-features = false, features = ["json", "stream", "multipart"] }
+rustversion = "1.0.9"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 time = { version = "0.3", features = ["serde-human-readable"] }

--- a/axum/src/routing/mod.rs
+++ b/axum/src/routing/mod.rs
@@ -447,7 +447,29 @@ where
                     }
                 }
 
-                self.call_route(match_, req, state)
+                let id = *match_.value;
+
+                #[cfg(feature = "matched-path")]
+                crate::extract::matched_path::set_matched_path_for_request(
+                    id,
+                    &self.node.route_id_to_path,
+                    req.extensions_mut(),
+                );
+
+                url_params::insert_url_params(req.extensions_mut(), match_.params);
+
+                let endpont = self
+                    .routes
+                    .get_mut(&id)
+                    .expect("no route for id. This is a bug in axum. Please file an issue");
+
+                match endpont {
+                    Endpoint::MethodRouter(method_router) => {
+                        method_router.call_with_state(req, state)
+                    }
+                    Endpoint::Route(route) => route.call(req),
+                    Endpoint::NestedRouter(router) => router.clone().call_with_state(req, state),
+                }
             }
             Err(
                 MatchError::NotFound
@@ -466,37 +488,6 @@ where
                 Fallback::Service(fallback) => fallback.call(req),
                 Fallback::BoxedHandler(handler) => handler.clone().into_route(state).call(req),
             },
-        }
-    }
-
-    #[inline]
-    fn call_route(
-        &self,
-        match_: matchit::Match<&RouteId>,
-        mut req: Request<B>,
-        state: S,
-    ) -> RouteFuture<B, Infallible> {
-        let id = *match_.value;
-
-        #[cfg(feature = "matched-path")]
-        crate::extract::matched_path::set_matched_path_for_request(
-            id,
-            &self.node.route_id_to_path,
-            req.extensions_mut(),
-        );
-
-        url_params::insert_url_params(req.extensions_mut(), match_.params);
-
-        let endpont = self
-            .routes
-            .get(&id)
-            .expect("no route for id. This is a bug in axum. Please file an issue")
-            .clone();
-
-        match endpont {
-            Endpoint::MethodRouter(mut method_router) => method_router.call_with_state(req, state),
-            Endpoint::Route(mut route) => route.call(req),
-            Endpoint::NestedRouter(router) => router.call_with_state(req, state),
         }
     }
 

--- a/axum/src/routing/tests/mod.rs
+++ b/axum/src/routing/tests/mod.rs
@@ -822,7 +822,7 @@ async fn state_isnt_cloned_too_much() {
 
     impl Clone for AppState {
         fn clone(&self) -> Self {
-            #[rustversion::stable]
+            #[rustversion::since(1.65)]
             #[track_caller]
             fn count() {
                 if SETUP_DONE.load(Ordering::SeqCst) {
@@ -838,7 +838,7 @@ async fn state_isnt_cloned_too_much() {
                 }
             }
 
-            #[rustversion::not(stable)]
+            #[rustversion::not(since(1.65))]
             fn count() {
                 if SETUP_DONE.load(Ordering::SeqCst) {
                     COUNT.fetch_add(1, Ordering::SeqCst);

--- a/axum/src/routing/tests/mod.rs
+++ b/axum/src/routing/tests/mod.rs
@@ -15,7 +15,7 @@ use serde_json::json;
 use std::{
     convert::Infallible,
     future::{ready, Ready},
-    sync::atomic::{AtomicUsize, Ordering},
+    sync::atomic::{AtomicBool, AtomicUsize, Ordering},
     task::{Context, Poll},
     time::Duration,
 };
@@ -811,4 +811,44 @@ fn method_router_fallback_with_state() {
     let _: Router = Router::new()
         .fallback(get(fallback).fallback(not_found))
         .with_state(state);
+}
+
+#[crate::test]
+async fn state_isnt_cloned_too_much() {
+    static SETUP_DONE: AtomicBool = AtomicBool::new(false);
+    static COUNT: AtomicUsize = AtomicUsize::new(0);
+
+    struct AppState;
+
+    impl Clone for AppState {
+        fn clone(&self) -> Self {
+            if SETUP_DONE.load(Ordering::SeqCst) {
+                let bt = std::backtrace::Backtrace::force_capture();
+                let bt = bt
+                    .to_string()
+                    .lines()
+                    .filter(|line| line.contains("axum") || line.contains("./src"))
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                println!("AppState::Clone:\n===============\n{}\n", bt);
+
+                COUNT.fetch_add(1, Ordering::SeqCst);
+            }
+
+            Self
+        }
+    }
+
+    let app = Router::new()
+        .route("/", get(|_: State<AppState>| async {}))
+        .with_state(AppState);
+
+    let client = TestClient::new(app);
+
+    // ignore clones made during setup
+    SETUP_DONE.store(true, Ordering::SeqCst);
+
+    client.get("/").send().await;
+
+    assert_eq!(COUNT.load(Ordering::SeqCst), 4);
 }

--- a/axum/src/routing/tests/mod.rs
+++ b/axum/src/routing/tests/mod.rs
@@ -821,6 +821,7 @@ async fn state_isnt_cloned_too_much() {
     struct AppState;
 
     impl Clone for AppState {
+        #[rustversion::stable]
         fn clone(&self) -> Self {
             if SETUP_DONE.load(Ordering::SeqCst) {
                 let bt = std::backtrace::Backtrace::force_capture();
@@ -835,6 +836,12 @@ async fn state_isnt_cloned_too_much() {
                 COUNT.fetch_add(1, Ordering::SeqCst);
             }
 
+            Self
+        }
+
+        // our MSRV doesn't support backtrace
+        #[rustversion::not(stable)]
+        fn clone(&self) -> Self {
             Self
         }
     }


### PR DESCRIPTION
This reduces the state clones by 1 for each request. Not much but better than nothing. Had to inline the `call_route` to get around some borrowing issues.

The remaining clones are
1. https://github.com/tokio-rs/axum/blob/main/axum/src/handler/service.rs#L171
    - I'm gonna invest making `Handler::call` take `S` by reference rather than value. Not sure what the implications are. Think the response future should still be `'static` so might not be possible.
3. https://github.com/tokio-rs/axum/blob/main/axum-core/src/extract/from_ref.rs#L23
    - This one we can't do much about. Its the `State` extractor via `FromRef`. That needs to produce an owned state.
4. https://github.com/tokio-rs/axum/blob/main/axum/src/routing/route.rs#L48
    - Because of backpressure `Route::call` uses `oneshot` which requires `clone`. Not sure its possible to fix but worth investigating.
5. https://github.com/tokio-rs/axum/blob/main/axum/src/test_helpers/test_client.rs#L32 (when hyper calls `call` on `Shared` that clones the service)
    - Nothing we can do about this. Hyper needs an owned service to serve the connection.

Part of https://github.com/tokio-rs/axum/issues/1827