### PR TITLE
Move `TypedHeader` to axum-extra

### DIFF
--- a/axum-core/Cargo.toml
+++ b/axum-core/Cargo.toml
@@ -25,7 +25,8 @@ tower-service = "0.3"
 rustversion = "1.0.9"
 
 [dev-dependencies]
-axum = { path = "../axum", version = "0.6.0", features = ["headers"] }
+axum = { path = "../axum", version = "0.6.0" }
+axum-extra = { path = "../axum-extra", features = ["typed-header"] }
 futures-util = "0.3"
 hyper = "0.14.24"
 tokio = { version = "1.25.0", features = ["macros"] }

--- a/axum-core/src/ext_traits/request.rs
+++ b/axum-core/src/ext_traits/request.rs
@@ -141,16 +141,16 @@ pub trait RequestExt: sealed::Sealed + Sized {
     /// ```
     /// use axum::{
     ///     async_trait,
-    ///     extract::FromRequest,
-    ///     headers::{authorization::Bearer, Authorization},
+    ///     extract::{Path, FromRequest},
     ///     http::Request,
     ///     response::{IntoResponse, Response},
     ///     body::Body,
-    ///     Json, RequestExt, TypedHeader,
+    ///     Json, RequestExt,
     /// };
+    /// use std::collections::HashMap;
     ///
     /// struct MyExtractor<T> {
-    ///     bearer_token: String,
+    ///     path_params: HashMap<String, String>,
     ///     payload: T,
     /// }
     ///
@@ -164,9 +164,10 @@ pub trait RequestExt: sealed::Sealed + Sized {
     ///     type Rejection = Response;
     ///
     ///     async fn from_request(mut req: Request<Body>, _state: &S) -> Result<Self, Self::Rejection> {
-    ///         let TypedHeader(auth_header) = req
-    ///             .extract_parts::<TypedHeader<Authorization<Bearer>>>()
+    ///         let path_params = req
+    ///             .extract_parts::<Path<HashMap<String, String>>>()
     ///             .await
+    ///             .map(|Path(path_params)| path_params)
     ///             .map_err(|err| err.into_response())?;
     ///
     ///         let Json(payload) = req
@@ -174,10 +175,7 @@ pub trait RequestExt: sealed::Sealed + Sized {
     ///             .await
     ///             .map_err(|err| err.into_response())?;
     ///
-    ///         Ok(Self {
-    ///             bearer_token: auth_header.token().to_owned(),
-    ///             payload,
-    ///         })
+    ///         Ok(Self { path_params, payload })
     ///     }
     /// }
     /// ```

--- a/axum-core/src/ext_traits/request_parts.rs
+++ b/axum-core/src/ext_traits/request_parts.rs
@@ -17,9 +17,8 @@ pub trait RequestPartsExt: sealed::Sealed + Sized {
     ///
     /// ```
     /// use axum::{
-    ///     extract::{Query, TypedHeader, FromRequestParts},
+    ///     extract::{Query, Path, FromRequestParts},
     ///     response::{Response, IntoResponse},
-    ///     headers::UserAgent,
     ///     http::request::Parts,
     ///     RequestPartsExt,
     ///     async_trait,
@@ -27,7 +26,7 @@ pub trait RequestPartsExt: sealed::Sealed + Sized {
     /// use std::collections::HashMap;
     ///
     /// struct MyExtractor {
-    ///     user_agent: String,
+    ///     path_params: HashMap<String, String>,
     ///     query_params: HashMap<String, String>,
     /// }
     ///
@@ -39,10 +38,10 @@ pub trait RequestPartsExt: sealed::Sealed + Sized {
     ///     type Rejection = Response;
     ///
     ///     async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
-    ///         let user_agent = parts
-    ///             .extract::<TypedHeader<UserAgent>>()
+    ///         let path_params = parts
+    ///             .extract::<Path<HashMap<String, String>>>()
     ///             .await
-    ///             .map(|user_agent| user_agent.as_str().to_owned())
+    ///             .map(|Path(path_params)| path_params)
     ///             .map_err(|err| err.into_response())?;
     ///
     ///         let query_params = parts
@@ -51,7 +50,7 @@ pub trait RequestPartsExt: sealed::Sealed + Sized {
     ///             .map(|Query(params)| params)
     ///             .map_err(|err| err.into_response())?;
     ///
-    ///         Ok(MyExtractor { user_agent, query_params })
+    ///         Ok(MyExtractor { path_params, query_params })
     ///     }
     /// }
     /// ```

--- a/axum-extra/CHANGELOG.md
+++ b/axum-extra/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning].
 
 # Unreleased
 
-- None.
+- **added:** Added `TypedHeader` which used to be in `axum`
 
 # 0.7.0 (03. March, 2023)
 

--- a/axum-extra/Cargo.toml
+++ b/axum-extra/Cargo.toml
@@ -32,6 +32,7 @@ json-lines = [
 multipart = ["dep:multer"]
 protobuf = ["dep:prost"]
 query = ["dep:serde", "dep:serde_html_form"]
+typed-header = ["dep:headers"]
 typed-routing = ["dep:axum-macros", "dep:serde", "dep:percent-encoding", "dep:serde_html_form", "dep:form_urlencoded"]
 
 [dependencies]
@@ -51,6 +52,7 @@ tower-service = "0.3"
 axum-macros = { path = "../axum-macros", version = "0.3.5", optional = true }
 cookie = { package = "cookie", version = "0.17", features = ["percent-encode"], optional = true }
 form_urlencoded = { version = "1.1.0", optional = true }
+headers = { version = "0.3.8", optional = true }
 multer = { version = "2.0.0", optional = true }
 percent-encoding = { version = "2.1", optional = true }
 prost = { version = "0.11", optional = true }
@@ -61,7 +63,7 @@ tokio-stream = { version = "0.1.9", optional = true }
 tokio-util = { version = "0.7", optional = true }
 
 [dev-dependencies]
-axum = { path = "../axum", version = "0.6.0", features = ["headers"] }
+axum = { path = "../axum", version = "0.6.0" }
 futures = "0.3"
 http-body = "0.4.4"
 hyper = "0.14"

--- a/axum-extra/src/extract/cookie/mod.rs
+++ b/axum-extra/src/extract/cookie/mod.rs
@@ -41,12 +41,16 @@ pub use cookie::Key;
 /// use axum::{
 ///     Router,
 ///     routing::{post, get},
-///     extract::TypedHeader,
 ///     response::{IntoResponse, Redirect},
-///     headers::authorization::{Authorization, Bearer},
 ///     http::StatusCode,
 /// };
-/// use axum_extra::extract::cookie::{CookieJar, Cookie};
+/// use axum_extra::{
+///     typed_header::{
+///         TypedHeader,
+///         headers::authorization::{Authorization, Bearer},
+///     },
+///     extract::cookie::{CookieJar, Cookie},
+/// };
 ///
 /// async fn create_session(
 ///     TypedHeader(auth): TypedHeader<Authorization<Bearer>>,

--- a/axum-extra/src/extract/cookie/private.rs
+++ b/axum-extra/src/extract/cookie/private.rs
@@ -23,12 +23,17 @@ use std::{convert::Infallible, fmt, marker::PhantomData};
 /// use axum::{
 ///     Router,
 ///     routing::{post, get},
-///     extract::{TypedHeader, FromRef},
+///     extract::FromRef,
 ///     response::{IntoResponse, Redirect},
-///     headers::authorization::{Authorization, Bearer},
 ///     http::StatusCode,
 /// };
-/// use axum_extra::extract::cookie::{PrivateCookieJar, Cookie, Key};
+/// use axum_extra::{
+///     typed_header::{
+///         TypedHeader,
+///         headers::authorization::{Authorization, Bearer},
+///     },
+///     extract::cookie::{PrivateCookieJar, Cookie, Key},
+/// };
 ///
 /// async fn set_secret(
 ///     jar: PrivateCookieJar,

--- a/axum-extra/src/extract/cookie/signed.rs
+++ b/axum-extra/src/extract/cookie/signed.rs
@@ -24,12 +24,17 @@ use std::{convert::Infallible, fmt, marker::PhantomData};
 /// use axum::{
 ///     Router,
 ///     routing::{post, get},
-///     extract::{TypedHeader, FromRef},
+///     extract::FromRef,
 ///     response::{IntoResponse, Redirect},
-///     headers::authorization::{Authorization, Bearer},
 ///     http::StatusCode,
 /// };
-/// use axum_extra::extract::cookie::{SignedCookieJar, Cookie, Key};
+/// use axum_extra::{
+///     typed_header::{
+///         TypedHeader,
+///         headers::authorization::{Authorization, Bearer},
+///     },
+///     extract::cookie::{SignedCookieJar, Cookie, Key},
+/// };
 ///
 /// async fn create_session(
 ///     TypedHeader(auth): TypedHeader<Authorization<Bearer>>,

--- a/axum-extra/src/extract/mod.rs
+++ b/axum-extra/src/extract/mod.rs
@@ -40,4 +40,8 @@ pub use self::multipart::Multipart;
 #[doc(no_inline)]
 pub use crate::json_lines::JsonLines;
 
+#[cfg(feature = "typed-header")]
+#[doc(no_inline)]
+pub use crate::typed_header::TypedHeader;
+
 pub use self::with_rejection::WithRejection;

--- a/axum-extra/src/extract/multipart.rs
+++ b/axum-extra/src/extract/multipart.rs
@@ -7,7 +7,7 @@ use axum::{
     body::{Body, Bytes},
     extract::FromRequest,
     response::{IntoResponse, Response},
-    BoxError, RequestExt,
+    RequestExt,
 };
 use futures_util::stream::Stream;
 use http::{
@@ -353,7 +353,7 @@ impl std::error::Error for InvalidBoundary {}
 mod tests {
     use super::*;
     use crate::test_helpers::*;
-    use axum::{body::Body, response::IntoResponse, routing::post, Router};
+    use axum::{response::IntoResponse, routing::post, Router};
 
     #[tokio::test]
     async fn content_type_with_encoding() {

--- a/axum-extra/src/lib.rs
+++ b/axum-extra/src/lib.rs
@@ -21,6 +21,7 @@
 //! `protobuf` | Enables the `Protobuf` extractor and response | No
 //! `query` | Enables the `Query` extractor | No
 //! `typed-routing` | Enables the `TypedPath` routing utilities | No
+//! `typed-header` | Enables the `TypedHeader` extractor and response  | No
 //!
 //! [`axum`]: https://crates.io/crates/axum
 
@@ -78,6 +79,9 @@ pub mod routing;
 
 #[cfg(feature = "json-lines")]
 pub mod json_lines;
+
+#[cfg(feature = "typed-header")]
+pub mod typed_header;
 
 #[cfg(feature = "protobuf")]
 pub mod protobuf;

--- a/axum-extra/src/response/mod.rs
+++ b/axum-extra/src/response/mod.rs
@@ -9,3 +9,7 @@ pub use erased_json::ErasedJson;
 #[cfg(feature = "json-lines")]
 #[doc(no_inline)]
 pub use crate::json_lines::JsonLines;
+
+#[cfg(feature = "typed-header")]
+#[doc(no_inline)]
+pub use crate::typed_header::TypedHeader;

--- a/axum-macros/Cargo.toml
+++ b/axum-macros/Cargo.toml
@@ -29,8 +29,8 @@ syn = { version = "1.0", features = [
 ] }
 
 [dev-dependencies]
-axum = { path = "../axum", version = "0.6.0", features = ["headers", "macros"] }
-axum-extra = { path = "../axum-extra", version = "0.7.0", features = ["typed-routing", "cookie-private"] }
+axum = { path = "../axum", version = "0.6.0", features = ["macros"] }
+axum-extra = { path = "../axum-extra", version = "0.7.0", features = ["typed-routing", "cookie-private", "typed-header"] }
 rustversion = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/axum-macros/src/lib.rs
+++ b/axum-macros/src/lib.rs
@@ -71,9 +71,12 @@ use from_request::Trait::{FromRequest, FromRequestParts};
 /// ```
 /// use axum_macros::FromRequest;
 /// use axum::{
-///     extract::{Extension, TypedHeader},
-///     headers::ContentType,
+///     extract::Extension,
 ///     body::Bytes,
+/// };
+/// use axum_extra::typed_header::{
+///     TypedHeader,
+///     headers::ContentType,
 /// };
 ///
 /// #[derive(FromRequest)]
@@ -116,9 +119,12 @@ use from_request::Trait::{FromRequest, FromRequestParts};
 /// ```
 /// use axum_macros::FromRequest;
 /// use axum::{
-///     extract::{Extension, TypedHeader},
-///     headers::ContentType,
+///     extract::Extension,
 ///     body::Bytes,
+/// };
+/// use axum_extra::typed_header::{
+///     TypedHeader,
+///     headers::ContentType,
 /// };
 ///
 /// #[derive(FromRequest)]
@@ -158,8 +164,9 @@ use from_request::Trait::{FromRequest, FromRequestParts};
 ///
 /// ```
 /// use axum_macros::FromRequest;
-/// use axum::{
-///     extract::{TypedHeader, rejection::TypedHeaderRejection},
+/// use axum_extra::typed_header::{
+///     TypedHeader,
+///     TypedHeaderRejection,
 ///     headers::{ContentType, UserAgent},
 /// };
 ///
@@ -368,7 +375,10 @@ pub fn derive_from_request(item: TokenStream) -> TokenStream {
 /// ```
 /// use axum_macros::FromRequestParts;
 /// use axum::{
-///     extract::{Query, TypedHeader},
+///     extract::Query,
+/// };
+/// use axum_extra::typed_header::{
+///     TypedHeader,
 ///     headers::ContentType,
 /// };
 /// use std::collections::HashMap;

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **breaking:** Change `sse::Event::json_data` to use `axum_core::Error` as its error type ([#1762])
 - **breaking:** Rename `DefaultOnFailedUpdgrade` to `DefaultOnFailedUpgrade` ([#1664])
 - **breaking:** Rename `OnFailedUpdgrade` to `OnFailedUpgrade` ([#1664])
+- **breaking:** `TypedHeader` has been move to `axum-extra`
 - **added:** Add `Router::as_service` and `Router::into_service` to workaround
   type inference issues when calling `ServiceExt` methods on a `Router` ([#1835])
 

--- a/axum/Cargo.toml
+++ b/axum/Cargo.toml
@@ -85,7 +85,6 @@ tower-service = "0.3"
 # optional dependencies
 axum-macros = { path = "../axum-macros", version = "0.3.5", optional = true }
 base64 = { version = "0.21.0", optional = true }
-headers = { version = "0.3.7", optional = true }
 multer = { version = "2.0.0", optional = true }
 serde_json = { version = "1.0", features = ["raw_value"], optional = true }
 serde_path_to_error = { version = "0.1.8", optional = true }
@@ -178,7 +177,6 @@ allowed = [
     "futures_core",
     "futures_sink",
     "futures_util",
-    "headers_core",
     "http",
     "http_body",
     "hyper",

--- a/axum/src/lib.rs
+++ b/axum/src/lib.rs
@@ -348,7 +348,6 @@
 //!
 //! Name | Description | Default?
 //! ---|---|---
-//! `headers` | Enables extracting typed headers via [`TypedHeader`] | No
 //! `http1` | Enables hyper's `http1` feature | Yes
 //! `http2` | Enables hyper's `http2` feature | No
 //! `json` | Enables the [`Json`] type and some similar convenience functionality | Yes
@@ -447,8 +446,6 @@ mod form;
 #[cfg(feature = "json")]
 mod json;
 mod service_ext;
-#[cfg(feature = "headers")]
-mod typed_header;
 mod util;
 
 pub mod body;
@@ -464,9 +461,6 @@ mod test_helpers;
 
 #[doc(no_inline)]
 pub use async_trait::async_trait;
-#[cfg(feature = "headers")]
-#[doc(no_inline)]
-pub use headers;
 #[doc(no_inline)]
 pub use http;
 #[cfg(feature = "tokio")]
@@ -480,10 +474,6 @@ pub use self::extension::Extension;
 pub use self::json::Json;
 #[doc(inline)]
 pub use self::routing::Router;
-
-#[doc(inline)]
-#[cfg(feature = "headers")]
-pub use self::typed_header::TypedHeader;
 
 #[doc(inline)]
 #[cfg(feature = "form")]

--- a/axum/src/middleware/from_fn.rs
+++ b/axum/src/middleware/from_fn.rs
@@ -63,9 +63,7 @@ use tower_service::Service;
 /// ```rust
 /// use axum::{
 ///     Router,
-///     extract::TypedHeader,
-///     http::StatusCode,
-///     headers::authorization::{Authorization, Bearer},
+///     http::{StatusCode, HeaderMap},
 ///     http::Request,
 ///     middleware::{self, Next},
 ///     response::Response,
@@ -73,20 +71,28 @@ use tower_service::Service;
 /// };
 ///
 /// async fn auth<B>(
-///     // run the `TypedHeader` extractor
-///     TypedHeader(auth): TypedHeader<Authorization<Bearer>>,
+///     // run the `HeaderMap` extractor
+///     headers: HeaderMap,
 ///     // you can also add more extractors here but the last
 ///     // extractor must implement `FromRequest` which
 ///     // `Request` does
 ///     request: Request<B>,
 ///     next: Next<B>,
 /// ) -> Result<Response, StatusCode> {
-///     if token_is_valid(auth.token()) {
-///         let response = next.run(request).await;
-///         Ok(response)
-///     } else {
-///         Err(StatusCode::UNAUTHORIZED)
+///     match get_token(&headers) {
+///         Some(token) if token_is_valid(token) => {
+///             let response = next.run(request).await;
+///             Ok(response)
+///         }
+///         _ => {
+///             Err(StatusCode::UNAUTHORIZED)
+///         }
 ///     }
+/// }
+///
+/// fn get_token(headers: &HeaderMap) -> Option<&str> {
+///     // ...
+///     # None
 /// }
 ///
 /// fn token_is_valid(token: &str) -> bool {

--- a/examples/jwt/Cargo.toml
+++ b/examples/jwt/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 publish = false
 
 [dependencies]
-axum = { path = "../../axum", features = ["headers"] }
-headers = "0.3"
+axum = { path = "../../axum" }
+axum-extra = { path = "../../axum-extra", features = ["typed-header"] }
 jsonwebtoken = "8.0"
 once_cell = "1.8"
 serde = { version = "1.0", features = ["derive"] }

--- a/examples/jwt/src/main.rs
+++ b/examples/jwt/src/main.rs
@@ -8,12 +8,15 @@
 
 use axum::{
     async_trait,
-    extract::{FromRequestParts, TypedHeader},
-    headers::{authorization::Bearer, Authorization},
+    extract::FromRequestParts,
     http::{request::Parts, StatusCode},
     response::{IntoResponse, Response},
     routing::{get, post},
     Json, RequestPartsExt, Router,
+};
+use axum_extra::typed_header::{
+    headers::{authorization::Bearer, Authorization},
+    TypedHeader,
 };
 use jsonwebtoken::{decode, encode, DecodingKey, EncodingKey, Header, Validation};
 use once_cell::sync::Lazy;

--- a/examples/oauth/Cargo.toml
+++ b/examples/oauth/Cargo.toml
@@ -6,8 +6,8 @@ publish = false
 
 [dependencies]
 async-session = "3.0.0"
-axum = { path = "../../axum", features = ["headers"] }
-headers = "0.3"
+axum = { path = "../../axum" }
+axum-extra = { path = "../../axum-extra", features = ["typed-header"] }
 http = "0.2"
 oauth2 = "4.1"
 # Use Rustls because it makes it easier to cross-compile on CI

--- a/examples/oauth/src/main.rs
+++ b/examples/oauth/src/main.rs
@@ -11,14 +11,13 @@
 use async_session::{MemoryStore, Session, SessionStore};
 use axum::{
     async_trait,
-    extract::{
-        rejection::TypedHeaderRejectionReason, FromRef, FromRequestParts, Query, State, TypedHeader,
-    },
+    extract::{FromRef, FromRequestParts, Query, State},
     http::{header::SET_COOKIE, HeaderMap},
     response::{IntoResponse, Redirect, Response},
     routing::get,
     RequestPartsExt, Router,
 };
+use axum_extra::typed_header::{headers, TypedHeader, TypedHeaderRejectionReason};
 use http::{header, request::Parts};
 use oauth2::{
     basic::BasicClient, reqwest::async_http_client, AuthUrl, AuthorizationCode, ClientId,

--- a/examples/sessions/Cargo.toml
+++ b/examples/sessions/Cargo.toml
@@ -6,7 +6,8 @@ publish = false
 
 [dependencies]
 async-session = "3.0.0"
-axum = { path = "../../axum", features = ["headers"] }
+axum = { path = "../../axum" }
+axum-extra = { path = "../../axum-extra", features = ["typed-header"] }
 serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "1.0", features = ["full"] }
 tracing = "0.1"

--- a/examples/sessions/src/main.rs
+++ b/examples/sessions/src/main.rs
@@ -7,8 +7,7 @@
 use async_session::{MemoryStore, Session, SessionStore as _};
 use axum::{
     async_trait,
-    extract::{FromRef, FromRequestParts, TypedHeader},
-    headers::Cookie,
+    extract::{FromRef, FromRequestParts},
     http::{
         self,
         header::{HeaderMap, HeaderValue},
@@ -19,6 +18,7 @@ use axum::{
     routing::get,
     RequestPartsExt, Router,
 };
+use axum_extra::typed_header::{headers::Cookie, TypedHeader};
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
 use std::net::SocketAddr;

--- a/examples/sse/Cargo.toml
+++ b/examples/sse/Cargo.toml
@@ -5,7 +5,8 @@ edition = "2021"
 publish = false
 
 [dependencies]
-axum = { path = "../../axum", features = ["headers"] }
+axum = { path = "../../axum" }
+axum-extra = { path = "../../axum-extra", features = ["typed-header"] }
 futures = "0.3"
 headers = "0.3"
 tokio = { version = "1.0", features = ["full"] }

--- a/examples/sse/src/main.rs
+++ b/examples/sse/src/main.rs
@@ -5,11 +5,11 @@
 //! ```
 
 use axum::{
-    extract::TypedHeader,
     response::sse::{Event, Sse},
     routing::get,
     Router,
 };
+use axum_extra::typed_header::{headers, TypedHeader};
 use futures::stream::{self, Stream};
 use std::{convert::Infallible, net::SocketAddr, path::PathBuf, time::Duration};
 use tokio_stream::StreamExt as _;

--- a/examples/websockets/Cargo.toml
+++ b/examples/websockets/Cargo.toml
@@ -5,7 +5,8 @@ edition = "2021"
 publish = false
 
 [dependencies]
-axum = { path = "../../axum", features = ["ws", "headers"] }
+axum = { path = "../../axum", features = ["ws"] }
+axum-extra = { path = "../../axum-extra", features = ["typed-header"] }
 futures = "0.3"
 futures-util = { version = "0.3", default-features = false, features = ["sink", "std"] }
 headers = "0.3"

--- a/examples/websockets/src/main.rs
+++ b/examples/websockets/src/main.rs
@@ -17,14 +17,12 @@
 //! ```
 
 use axum::{
-    extract::{
-        ws::{Message, WebSocket, WebSocketUpgrade},
-        TypedHeader,
-    },
+    extract::ws::{Message, WebSocket, WebSocketUpgrade},
     response::IntoResponse,
     routing::get,
     Router,
 };
+use axum_extra::typed_header::TypedHeader;
 
 use std::borrow::Cow;
 use std::ops::ControlFlow;


### PR DESCRIPTION
This moves `TypedHeader` into axum-extra to protect axum against breaking changes to headers. Turned out to require quite a few changes since it was used in a bunch of docs.

I opted to keep the headers re-export. Probably fine in axum-extra and is nice that users don't have to worry about getting the correct version of headers. That'd otherwise lead to confusing errors.