### PR TITLE
Add a diesel and diesel-async example

### DIFF
--- a/examples/diesel-async-postgres/Cargo.toml
+++ b/examples/diesel-async-postgres/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "example-diesel-async-postgres"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+axum = { path = "../../axum" }
+axum-macros = { path = "../../axum-macros" }
+bb8 = "0.8"
+diesel = "2"
+diesel-async = { version = "0.2", features = ["postgres", "bb8"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1"
+tokio = { version = "1.0", features = ["full"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/diesel-async-postgres/migrations/2023-03-14-180127_add_users/down.sql
+++ b/examples/diesel-async-postgres/migrations/2023-03-14-180127_add_users/down.sql
@@ -1,0 +1,2 @@
+-- This file should undo anything in "up.sql"
+DROP TABLE "users";

--- a/examples/diesel-async-postgres/migrations/2023-03-14-180127_add_users/up.sql
+++ b/examples/diesel-async-postgres/migrations/2023-03-14-180127_add_users/up.sql
@@ -1,0 +1,6 @@
+-- Your SQL goes here
+CREATE TABLE "users"(
+    "id" SERIAL PRIMARY KEY,
+    "name" TEXT NOT NULL,
+    "hair_color" TEXT
+);

--- a/examples/diesel-async-postgres/src/main.rs
+++ b/examples/diesel-async-postgres/src/main.rs
@@ -1,0 +1,143 @@
+//! Run with
+//!
+//! ```sh
+//! export DATABASE_URL=postgres://localhost/your_db
+//! diesel migration run
+//! cargo0 run -p example-diesel-postgres//!
+//! ```
+//!
+//! Checkout the [diesel webpage](https://diesel.rs) for
+//! longer guides about diesel
+//!
+//! Checkout the [crates.io source code](https://github.com/rust-lang/crates.io/)
+//! for a real world application using axum and diesel
+
+use axum::{
+    async_trait,
+    extract::{FromRef, FromRequestParts, State},
+    http::{request::Parts, StatusCode},
+    response::Json,
+    routing::{get, post},
+    Router,
+};
+use diesel::prelude::*;
+use diesel_async::{
+    pooled_connection::AsyncDieselConnectionManager, AsyncPgConnection, RunQueryDsl,
+};
+use std::net::SocketAddr;
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+
+// normally part of your generated schema.rs file
+table! {
+    users (id) {
+        id -> Integer,
+        name -> Text,
+        hair_color -> Nullable<Text>,
+    }
+}
+
+#[derive(serde::Serialize, Selectable, Queryable)]
+struct User {
+    id: i32,
+    name: String,
+    hair_color: Option<String>,
+}
+
+#[derive(serde::Deserialize, Insertable)]
+#[diesel(table_name = users)]
+struct NewUser {
+    name: String,
+    hair_color: Option<String>,
+}
+
+type Pool = bb8::Pool<AsyncDieselConnectionManager<AsyncPgConnection>>;
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::registry()
+        .with(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "example_tokio_postgres=debug".into()),
+        )
+        .with(tracing_subscriber::fmt::layer())
+        .init();
+
+    let db_url = std::env::var("DATABASE_URL").unwrap();
+
+    // set up connection pool
+    let config = AsyncDieselConnectionManager::<diesel_async::AsyncPgConnection>::new(db_url);
+    let pool = bb8::Pool::builder().build(config).await.unwrap();
+
+    // build our application with some routes
+    let app = Router::new()
+        .route("/user/list", get(list_users))
+        .route("/user/create", post(create_user))
+        .with_state(pool);
+
+    // run it with hyper
+    let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
+    tracing::debug!("listening on {}", addr);
+    axum::Server::bind(&addr)
+        .serve(app.into_make_service())
+        .await
+        .unwrap();
+}
+
+#[axum_macros::debug_handler]
+async fn create_user(
+    State(pool): State<Pool>,
+    Json(new_user): Json<NewUser>,
+) -> Result<Json<User>, (StatusCode, String)> {
+    let mut conn = pool.get().await.map_err(internal_error)?;
+
+    let res = diesel::insert_into(users::table)
+        .values(new_user)
+        .returning(User::as_returning())
+        .get_result(&mut conn)
+        .await
+        .map_err(internal_error)?;
+    Ok(Json(res))
+}
+
+// we can also write a custom extractor that grabs a connection from the pool
+// which setup is appropriate depends on your application
+struct DatabaseConnection(
+    bb8::PooledConnection<'static, AsyncDieselConnectionManager<AsyncPgConnection>>,
+);
+
+#[async_trait]
+impl<S> FromRequestParts<S> for DatabaseConnection
+where
+    S: Send + Sync,
+    Pool: FromRef<S>,
+{
+    type Rejection = (StatusCode, String);
+
+    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
+        let pool = Pool::from_ref(state);
+
+        let conn = pool.get_owned().await.map_err(internal_error)?;
+
+        Ok(Self(conn))
+    }
+}
+
+async fn list_users(
+    DatabaseConnection(mut conn): DatabaseConnection,
+) -> Result<Json<Vec<User>>, (StatusCode, String)> {
+    let res = users::table
+        .select(User::as_select())
+        .load(&mut conn)
+        .await
+        .map_err(internal_error)?;
+    Ok(Json(res))
+}
+
+/// Utility function for mapping any error into a `500 Internal Server Error`
+/// response.
+fn internal_error<E>(err: E) -> (StatusCode, String)
+where
+    E: std::error::Error,
+{
+    (StatusCode::INTERNAL_SERVER_ERROR, err.to_string())
+}

--- a/examples/diesel-async-postgres/src/main.rs
+++ b/examples/diesel-async-postgres/src/main.rs
@@ -3,7 +3,7 @@
 //! ```sh
 //! export DATABASE_URL=postgres://localhost/your_db
 //! diesel migration run
-//! cargo0 run -p example-diesel-postgres//!
+//! cargo run -p example-diesel-async-postgres
 //! ```
 //!
 //! Checkout the [diesel webpage](https://diesel.rs) for
@@ -57,7 +57,7 @@ async fn main() {
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "example_tokio_postgres=debug".into()),
+                .unwrap_or_else(|_| "example_diesel_async_postgres=debug".into()),
         )
         .with(tracing_subscriber::fmt::layer())
         .init();
@@ -83,7 +83,6 @@ async fn main() {
         .unwrap();
 }
 
-#[axum_macros::debug_handler]
 async fn create_user(
     State(pool): State<Pool>,
     Json(new_user): Json<NewUser>,
@@ -113,7 +112,7 @@ where
 {
     type Rejection = (StatusCode, String);
 
-    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
+    async fn from_request_parts(_parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
         let pool = Pool::from_ref(state);
 
         let conn = pool.get_owned().await.map_err(internal_error)?;

--- a/examples/diesel-postgres/Cargo.toml
+++ b/examples/diesel-postgres/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "example-diesel-postgres"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+axum = { path = "../../axum" }
+axum-macros = { path = "../../axum-macros" }
+deadpool-diesel = { version = "0.4.1", features = ["postgres"] }
+diesel = { version = "2", features = ["postgres"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1"
+tokio = { version = "1.0", features = ["full"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/diesel-postgres/Cargo.toml
+++ b/examples/diesel-postgres/Cargo.toml
@@ -9,6 +9,7 @@ axum = { path = "../../axum" }
 axum-macros = { path = "../../axum-macros" }
 deadpool-diesel = { version = "0.4.1", features = ["postgres"] }
 diesel = { version = "2", features = ["postgres"] }
+diesel_migrations = "2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1.0", features = ["full"] }

--- a/examples/diesel-postgres/migrations/2023-03-14-180127_add_users/down.sql
+++ b/examples/diesel-postgres/migrations/2023-03-14-180127_add_users/down.sql
@@ -1,0 +1,2 @@
+-- This file should undo anything in "up.sql"
+DROP TABLE "users";

--- a/examples/diesel-postgres/migrations/2023-03-14-180127_add_users/up.sql
+++ b/examples/diesel-postgres/migrations/2023-03-14-180127_add_users/up.sql
@@ -1,0 +1,6 @@
+-- Your SQL goes here
+CREATE TABLE "users"(
+    "id" SERIAL PRIMARY KEY,
+    "name" TEXT NOT NULL,
+    "hair_color" TEXT
+);

--- a/examples/diesel-postgres/src/main.rs
+++ b/examples/diesel-postgres/src/main.rs
@@ -1,0 +1,119 @@
+//! Run with
+//!
+//! ```not_rust
+//! cargo run -p example-diesel-postgres
+//! ```
+//!
+//! Checkout the [diesel webpage](https://diesel.rs) for
+//! longer guides about diesel
+//!
+//! Checkout the [crates.io source code](https://github.com/rust-lang/crates.io/)
+//! for a real world application using axum and diesel
+
+use axum::{
+    extract::State,
+    http::StatusCode,
+    response::Json,
+    routing::{get, post},
+    Router,
+};
+use diesel::prelude::*;
+use std::net::SocketAddr;
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+
+// normally part of your generated schema.rs file
+table! {
+    users (id) {
+        id -> Integer,
+        name -> Text,
+        hair_color -> Nullable<Text>,
+    }
+}
+
+#[derive(serde::Serialize, Selectable, Queryable)]
+struct User {
+    id: i32,
+    name: String,
+    hair_color: Option<String>,
+}
+
+#[derive(serde::Deserialize, Insertable)]
+#[diesel(table_name = users)]
+struct NewUser {
+    name: String,
+    hair_color: Option<String>,
+}
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::registry()
+        .with(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "example_tokio_postgres=debug".into()),
+        )
+        .with(tracing_subscriber::fmt::layer())
+        .init();
+
+    let db_url = std::env::var("DATABASE_URL").unwrap();
+
+    // set up connection pool
+    let manager = deadpool_diesel::postgres::Manager::new(db_url, deadpool_diesel::Runtime::Tokio1);
+    let pool = deadpool_diesel::postgres::Pool::builder(manager)
+        .build()
+        .unwrap();
+
+    // build our application with some routes
+    let app = Router::new()
+        .route("/user/list", get(list_users))
+        .route("/user/create", post(create_user))
+        .with_state(pool);
+
+    // run it with hyper
+    let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
+    tracing::debug!("listening on {}", addr);
+    axum::Server::bind(&addr)
+        .serve(app.into_make_service())
+        .await
+        .unwrap();
+}
+
+#[axum_macros::debug_handler]
+async fn create_user(
+    State(pool): State<deadpool_diesel::postgres::Pool>,
+    Json(new_user): Json<NewUser>,
+) -> Result<Json<User>, (StatusCode, String)> {
+    let conn = pool.get().await.map_err(internal_error)?;
+    let res = conn
+        .interact(|conn| {
+            diesel::insert_into(users::table)
+                .values(new_user)
+                .returning(User::as_returning())
+                .get_result(conn)
+        })
+        .await
+        .map_err(internal_error)?
+        .map_err(internal_error)?;
+    Ok(Json(res))
+}
+
+#[axum_macros::debug_handler]
+async fn list_users(
+    State(pool): State<deadpool_diesel::postgres::Pool>,
+) -> Result<Json<Vec<User>>, (StatusCode, String)> {
+    let conn = pool.get().await.map_err(internal_error)?;
+    let res = conn
+        .interact(|conn| users::table.select(User::as_select()).load(conn))
+        .await
+        .map_err(internal_error)?
+        .map_err(internal_error)?;
+    Ok(Json(res))
+}
+
+/// Utility function for mapping any error into a `500 Internal Server Error`
+/// response.
+fn internal_error<E>(err: E) -> (StatusCode, String)
+where
+    E: std::error::Error,
+{
+    (StatusCode::INTERNAL_SERVER_ERROR, err.to_string())
+}

--- a/examples/diesel-postgres/src/main.rs
+++ b/examples/diesel-postgres/src/main.rs
@@ -77,7 +77,6 @@ async fn main() {
         .unwrap();
 }
 
-#[axum_macros::debug_handler]
 async fn create_user(
     State(pool): State<deadpool_diesel::postgres::Pool>,
     Json(new_user): Json<NewUser>,
@@ -96,7 +95,6 @@ async fn create_user(
     Ok(Json(res))
 }
 
-#[axum_macros::debug_handler]
 async fn list_users(
     State(pool): State<deadpool_diesel::postgres::Pool>,
 ) -> Result<Json<Vec<User>>, (StatusCode, String)> {


### PR DESCRIPTION
## Motivation

Diesel is a popular ORM that is often used in combination with web frameworks like axum. I've noticed that there are no examples for this in the example directory yet. 

## Solution

Add two examples, one based on the main (sync) diesel crate and one based on the slightly experimental diesel-async version.