### PR TITLE
Give better error if generics are used with #[derive(FromRef)]

### DIFF
--- a/axum-macros/src/from_ref.rs
+++ b/axum-macros/src/from_ref.rs
@@ -8,12 +8,22 @@ use syn::{
 
 use crate::attr_parsing::{combine_unary_attribute, parse_attrs, Combine};
 
-pub(crate) fn expand(item: ItemStruct) -> TokenStream {
-    item.fields
+pub(crate) fn expand(item: ItemStruct) -> syn::Result<TokenStream> {
+    if !item.generics.params.is_empty() {
+        return Err(syn::Error::new_spanned(
+            item.generics,
+            "`#[derive(FromRef)]` doesn't support generics",
+        ));
+    }
+
+    let tokens = item
+        .fields
         .iter()
         .enumerate()
         .map(|(idx, field)| expand_field(&item.ident, idx, field))
-        .collect()
+        .collect();
+
+    Ok(tokens)
 }
 
 fn expand_field(state: &Ident, idx: usize, field: &Field) -> TokenStream {

--- a/axum-macros/src/lib.rs
+++ b/axum-macros/src/lib.rs
@@ -655,7 +655,7 @@ pub fn derive_typed_path(input: TokenStream) -> TokenStream {
 /// [`FromRef`]: https://docs.rs/axum/latest/axum/extract/trait.FromRef.html
 #[proc_macro_derive(FromRef, attributes(from_ref))]
 pub fn derive_from_ref(item: TokenStream) -> TokenStream {
-    expand_with(item, |item| Ok(from_ref::expand(item)))
+    expand_with(item, from_ref::expand)
 }
 
 fn expand_with<F, I, K>(input: TokenStream, f: F) -> TokenStream

--- a/axum-macros/tests/from_ref/fail/generics.rs
+++ b/axum-macros/tests/from_ref/fail/generics.rs
@@ -1,0 +1,8 @@
+use axum::extract::FromRef;
+
+#[derive(Clone, FromRef)]
+struct AppState<T> {
+    foo: T,
+}
+
+fn main() {}

--- a/axum-macros/tests/from_ref/fail/generics.stderr
+++ b/axum-macros/tests/from_ref/fail/generics.stderr
@@ -1,0 +1,5 @@
+error: `#[derive(FromRef)]` doesn't support generics
+ --> tests/from_ref/fail/generics.rs:4:16
+  |
+4 | struct AppState<T> {
+  |                ^^^


### PR DESCRIPTION
Generics gives overlapping impls.
