### PR TITLE
Fix broken links in the documentation

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -48,7 +48,7 @@ jobs:
     - uses: Swatinem/rust-cache@v1
     - name: cargo doc
       env:
-        RUSTDOCFLAGS: "-D rustdoc::all"
+        RUSTDOCFLAGS: "-D rustdoc::all -A rustdoc::private-doc-tests"
       run: cargo doc --all-features --no-deps
 
   cargo-hack:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -48,7 +48,7 @@ jobs:
     - uses: Swatinem/rust-cache@v1
     - name: cargo doc
       env:
-        RUSTDOCFLAGS: "-D broken-intra-doc-links"
+        RUSTDOCFLAGS: "-D rustdoc::all"
       run: cargo doc --all-features --no-deps
 
   cargo-hack:

--- a/axum/src/docs/middleware.md
+++ b/axum/src/docs/middleware.md
@@ -574,14 +574,14 @@ axum::Server::bind(&"0.0.0.0:3000".parse().unwrap())
 [`tower`]: https://crates.io/crates/tower
 [`tower-http`]: https://crates.io/crates/tower-http
 [tower-guides]: https://github.com/tower-rs/tower/tree/master/guides
-[`axum::middleware::from_fn`]: crate::middleware::from_fn
-[`middleware::from_fn`]: crate::middleware::from_fn
+[`axum::middleware::from_fn`]: fn@crate::middleware::from_fn
+[`middleware::from_fn`]: fn@crate::middleware::from_fn
 [tower-from-scratch-guide]: https://github.com/tower-rs/tower/blob/master/guides/building-a-middleware-from-scratch.md
 [`ServiceBuilder::map_request`]: tower::ServiceBuilder::map_request
 [`ServiceBuilder::map_response`]: tower::ServiceBuilder::map_response
 [`ServiceBuilder::then`]: tower::ServiceBuilder::then
 [`ServiceBuilder::and_then`]: tower::ServiceBuilder::and_then
-[`axum::middleware::from_extractor`]: crate::middleware::from_extractor
+[`axum::middleware::from_extractor`]: fn@crate::middleware::from_extractor
 [`Handler::layer`]: crate::handler::Handler::layer
 [`Router::layer`]: crate::routing::Router::layer
 [`MethodRouter::layer`]: crate::routing::MethodRouter::layer


### PR DESCRIPTION
Fixed #1879.

I wasn't able to reproduce the issue initially, but I had an idea that proved to be very useful: Check the [build logs](https://docs.rs/crate/axum/0.6.12/builds/772595) on docs.rs itself!

This is the problem (which I didn't see locally because my nightly toolchain wasn't up to date):

```
warning: `crate::middleware::from_fn` is both a module and a function
 --> axum/src/middleware/mod.rs:1:1
  |
1 | / //! Utilities for writing middleware
2 | | //!
3 | | #![doc = include_str!("../docs/middleware.md")]
  | |_______________________________________________^
  |
  = note: the link appears in this line:
          
          [`axum::middleware::from_fn`]: crate::middleware::from_fn
                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^
  = note: ambiguous link
  = help: to link to the module, prefix with `mod@`: mod@crate::middleware::from_fn
  = help: to link to the function, add parentheses: crate::middleware::from_fn()
  = note: `#[warn(rustdoc::broken_intra_doc_links)]` on by default

warning: `crate::middleware::from_extractor` is both a module and a function
 --> axum/src/middleware/mod.rs:1:1
  |
1 | / //! Utilities for writing middleware
2 | | //!
3 | | #![doc = include_str!("../docs/middleware.md")]
  | |_______________________________________________^
  |
  = note: the link appears in this line:
          
          [`axum::middleware::from_extractor`]: crate::middleware::from_extractor
                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  = note: ambiguous link
  = help: to link to the module, prefix with `mod@`: mod@crate::middleware::from_extractor
  = help: to link to the function, add parentheses: crate::middleware::from_extractor()

warning: `axum` (lib doc) generated 2 warnings
```

I chose to disambiguate using `fn@` rather than parentheses at the end though. This is documented to work [here](https://doc.rust-lang.org/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators).