### PR TITLE
Update allowed crates in public API

### DIFF
--- a/axum-extra/Cargo.toml
+++ b/axum-extra/Cargo.toml
@@ -80,6 +80,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 allowed = [
     "axum",
     "axum_core",
+    "axum_macros",
     "bytes",
     "cookie",
     "futures_core",
@@ -87,7 +88,6 @@ allowed = [
     "http",
     "http_body",
     "hyper",
-    "percent_encoding",
     "prost",
     "serde",
     "tokio",

--- a/axum/Cargo.toml
+++ b/axum/Cargo.toml
@@ -176,11 +176,14 @@ features = [
 
 [package.metadata.cargo-public-api-crates]
 allowed = [
+    "async_trait",
     "axum_core",
+    "axum_macros",
     "bytes",
     "futures_core",
     "futures_sink",
     "futures_util",
+    "headers",
     "headers_core",
     "http",
     "http_body",


### PR DESCRIPTION
`cargo-public-api-crates` now [detects re-exports](https://github.com/davidpdrsn/cargo-public-api-crates/pull/2) meaning we had to tweak some things here.