### PR TITLE
Update `rest-grpc-multiplex` example to include reflection

### DIFF
--- a/examples/rest-grpc-multiplex/Cargo.toml
+++ b/examples/rest-grpc-multiplex/Cargo.toml
@@ -10,10 +10,11 @@ futures = "0.3"
 hyper = { version = "0.14", features = ["full"] }
 prost = "0.11"
 tokio = { version = "1", features = ["full"] }
-tonic = { version = "0.8" }
+tonic = { version = "0.9" }
+tonic-reflection = "0.9"
 tower = { version = "0.4", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [build-dependencies]
-tonic-build = { version = "0.8", features = ["prost"] }
+tonic-build = { version = "0.9", features = ["prost"] }

--- a/examples/rest-grpc-multiplex/build.rs
+++ b/examples/rest-grpc-multiplex/build.rs
@@ -1,3 +1,10 @@
+use std::{env, path::PathBuf};
+
 fn main() {
-    tonic_build::compile_protos("proto/helloworld.proto").unwrap();
+    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+
+    tonic_build::configure()
+        .file_descriptor_set_path(out_dir.join("helloworld_descriptor.bin"))
+        .compile(&["proto/helloworld.proto"], &["/proto"])
+        .unwrap();
 }

--- a/examples/rest-grpc-multiplex/src/main.rs
+++ b/examples/rest-grpc-multiplex/src/main.rs
@@ -18,6 +18,9 @@ mod multiplex_service;
 
 mod proto {
     tonic::include_proto!("helloworld");
+
+    pub(crate) const FILE_DESCRIPTOR_SET: &[u8] =
+        tonic::include_file_descriptor_set!("helloworld_descriptor");
 }
 
 #[derive(Default)]
@@ -58,7 +61,14 @@ async fn main() {
     let rest = Router::new().route("/", get(web_root));
 
     // build the grpc service
-    let grpc = GreeterServer::new(GrpcServiceImpl::default());
+    let reflection_service = tonic_reflection::server::Builder::configure()
+        .register_encoded_file_descriptor_set(proto::FILE_DESCRIPTOR_SET)
+        .build()
+        .unwrap();
+    let grpc = tonic::transport::Server::builder()
+        .add_service(reflection_service)
+        .add_service(GreeterServer::new(GrpcServiceImpl::default()))
+        .into_service();
 
     // combine them into one service
     let service = MultiplexService::new(rest, grpc);


### PR DESCRIPTION
This updates the `rest-grpc-multiplex` example to also include setup for
`tonic-reflection`. Unless you're familiar with all the pieces its not very
easy to do so figured it makes sense to include in the example.

Context: https://github.com/tokio-rs/axum/discussions/1840