### PR TITLE
Add WASM response type

### DIFF
--- a/axum-extra/src/response/mod.rs
+++ b/axum-extra/src/response/mod.rs
@@ -9,3 +9,6 @@ pub use erased_json::ErasedJson;
 #[cfg(feature = "json-lines")]
 #[doc(no_inline)]
 pub use crate::json_lines::JsonLines;
+
+mod wasm;
+pub use wasm::Wasm;

--- a/axum-extra/src/response/wasm.rs
+++ b/axum-extra/src/response/wasm.rs
@@ -1,0 +1,26 @@
+use axum::response::{IntoResponse, Response};
+use bytes::Bytes;
+use http::header;
+use http_body::Full;
+
+/// A WASM response.
+///
+/// Will automatically get `Content-Type: application/wasm`.
+#[derive(Clone, Copy, Debug)]
+#[must_use]
+pub struct Wasm<T>(pub T);
+
+impl<T> IntoResponse for Wasm<T>
+where
+    T: Into<Full<Bytes>>,
+{
+    fn into_response(self) -> Response {
+        ([(header::CONTENT_TYPE, "application/wasm")], self.0.into()).into_response()
+    }
+}
+
+impl<T> From<T> for Wasm<T> {
+    fn from(inner: T) -> Self {
+        Self(inner)
+    }
+}

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
-- None.
+- **added:** Wasm response type for `application/wasm` ([#1920])
+
+[#1920]: https://github.com/tokio-rs/axum/pull/1920
 
 # 0.6.12 (22. March, 2023)
 

--- a/axum/src/response/mod.rs
+++ b/axum/src/response/mod.rs
@@ -64,35 +64,6 @@ impl<T> From<T> for Html<T> {
     }
 }
 
-/// A WASM response.
-///
-/// Will automatically get `Content-Type: application/wasm`.
-#[derive(Clone, Copy, Debug)]
-#[must_use]
-pub struct Wasm<T>(pub T);
-
-impl<T> IntoResponse for Wasm<T>
-where
-    T: Into<Full<Bytes>>,
-{
-    fn into_response(self) -> Response {
-        (
-            [(
-                header::CONTENT_TYPE,
-                "application/wasm",
-            )],
-            self.0.into(),
-        )
-            .into_response()
-    }
-}
-
-impl<T> From<T> for Wasm<T> {
-    fn from(inner: T) -> Self {
-        Self(inner)
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use crate::extract::Extension;

--- a/axum/src/response/mod.rs
+++ b/axum/src/response/mod.rs
@@ -64,6 +64,35 @@ impl<T> From<T> for Html<T> {
     }
 }
 
+/// A WASM response.
+///
+/// Will automatically get `Content-Type: application/wasm`.
+#[derive(Clone, Copy, Debug)]
+#[must_use]
+pub struct Wasm<T>(pub T);
+
+impl<T> IntoResponse for Wasm<T>
+where
+    T: Into<Full<Bytes>>,
+{
+    fn into_response(self) -> Response {
+        (
+            [(
+                header::CONTENT_TYPE,
+                "application/wasm",
+            )],
+            self.0.into(),
+        )
+            .into_response()
+    }
+}
+
+impl<T> From<T> for Wasm<T> {
+    fn from(inner: T) -> Self {
+        Self(inner)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::extract::Extension;


### PR DESCRIPTION
## Description

Added a `Wasm` response type to `axum-extra` that automatically gets the `Content-Type: application/wasm` header.

## Motivation

I was returning WASM from an API and had to implment this myself.

## Solution

Pretty much the same as the `Html` response type but with the `Content-Type: application/wasm` header.

## Additional Info

As there is no `application/wasm` in the mime crate and as the crate is no longer maintained I decided to just go with a string literal.
