### PR TITLE
Add `Html`, `Css`, `JavaScript`, and `Wasm` response types

### DIFF
--- a/axum-extra/CHANGELOG.md
+++ b/axum-extra/CHANGELOG.md
@@ -7,7 +7,10 @@ and this project adheres to [Semantic Versioning].
 
 # Unreleased
 
-- None.
+- **added:** Add `Html` response type.
+- **added:** Add `Css` response type.
+- **added:** Add `JavaScript` response type.
+- **added:** Add `Wasm` response type.
 
 # 0.7.2 (22. March, 2023)
 

--- a/axum-extra/src/response/mod.rs
+++ b/axum-extra/src/response/mod.rs
@@ -9,3 +9,82 @@ pub use erased_json::ErasedJson;
 #[cfg(feature = "json-lines")]
 #[doc(no_inline)]
 pub use crate::json_lines::JsonLines;
+
+macro_rules! mime_response {
+    (
+        $(#[$m:meta])*
+        $ident:ident,
+        $mime:ident,
+    ) => {
+        mime_response! {
+            $(#[$m])*
+            $ident,
+            mime::$mime.as_ref(),
+        }
+    };
+
+    (
+        $(#[$m:meta])*
+        $ident:ident,
+        $mime:expr,
+    ) => {
+        $(#[$m])*
+        #[derive(Clone, Copy, Debug)]
+        #[must_use]
+        pub struct $ident<T>(pub T);
+
+        impl<T> axum::response::IntoResponse for $ident<T>
+        where
+            T: axum::response::IntoResponse,
+        {
+            fn into_response(self) -> axum::response::Response {
+                (
+                    [(
+                        http::header::CONTENT_TYPE,
+                        http::HeaderValue::from_static($mime),
+                    )],
+                    self.0,
+                )
+                    .into_response()
+            }
+        }
+
+        impl<T> From<T> for $ident<T> {
+            fn from(inner: T) -> Self {
+                Self(inner)
+            }
+        }
+    };
+}
+
+mime_response! {
+    /// A HTML response.
+    ///
+    /// Will automatically get `Content-Type: text/html; charset=utf-8`.
+    Html,
+    TEXT_HTML_UTF_8,
+}
+
+mime_response! {
+    /// A JavaScript response.
+    ///
+    /// Will automatically get `Content-Type: application/javascript; charset=utf-8`.
+    JavaScript,
+    APPLICATION_JAVASCRIPT_UTF_8,
+}
+
+mime_response! {
+    /// A CSS response.
+    ///
+    /// Will automatically get `Content-Type: text/css; charset=utf-8`.
+    Css,
+    TEXT_CSS_UTF_8,
+}
+
+mime_response! {
+    /// A WASM response.
+    ///
+    /// Will automatically get `Content-Type: application/wasm`.
+    Wasm,
+    "application/wasm",
+}


### PR DESCRIPTION
I think using `T: IntoResponse` is more flexible than [the previous bound](https://github.com/tokio-rs/axum/blob/main/axum/src/response/mod.rs#L47). For example you can response with the contents of a file with

```rust
Router::new().route(
    "/",
    get(|| async {
        let Ok(file) = tokio::fs::File::open("index.html").await else {
            return Err(StatusCode::INTERNAL_SERVER_ERROR);
        };
        Ok(Html(AsyncReadBody::new(file)))
    }),
);
```

Also added css, javascript, and wasm, because why not.

We can move `Html` into axum in 0.7.

Supersedes https://github.com/tokio-rs/axum/pull/1920