### PR TITLE
Removed leftover "path_router hit" debug message

### DIFF
--- a/axum/src/routing/mod.rs
+++ b/axum/src/routing/mod.rs
@@ -299,10 +299,7 @@ where
         }
 
         match self.path_router.call_with_state(req, state) {
-            Ok(future) => {
-                println!("path_router hit");
-                future
-            }
+            Ok(future) => future,
             Err((mut req, state)) => {
                 let super_fallback = req
                     .extensions_mut()


### PR DESCRIPTION
## Motivation

A leftover debug message should have been removed in the latest release.

## Solution

Delete the `println!()`