### PR TITLE
Release axum 0.6.14

### DIFF
--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - None.
 
+# 0.6.14 (11. April, 2023)
+
+- **fixed:** Removed leftover "path_router hit" debug message ([#1925])
+
+[#1925]: https://github.com/tokio-rs/axum/pull/1925
+
 # 0.6.13 (11. April, 2023)
 
 - **added:** Log rejections from built-in extractors with the

--- a/axum/Cargo.toml
+++ b/axum/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axum"
-version = "0.6.13"
+version = "0.6.14"
 categories = ["asynchronous", "network-programming", "web-programming::http-server"]
 description = "Web framework that focuses on ergonomics and modularity"
 edition = "2021"


### PR DESCRIPTION
Includes https://github.com/tokio-rs/axum/pull/1925.

I'll just publish this quickly when CI is happy.