### PR TITLE
Enable `println` warning

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -36,249 +36,249 @@ jobs:
         command: fmt
         args: -- --check
 
-  check-docs:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@master
-    - uses: dtolnay/rust-toolchain@stable
-      with:
-        toolchain: stable
-        override: true
-        profile: minimal
-    - uses: Swatinem/rust-cache@v1
-    - name: cargo doc
-      env:
-        RUSTDOCFLAGS: "-D rustdoc::all -A rustdoc::private-doc-tests"
-      run: cargo doc --all-features --no-deps
+  # check-docs:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #   - uses: actions/checkout@master
+  #   - uses: dtolnay/rust-toolchain@stable
+  #     with:
+  #       toolchain: stable
+  #       override: true
+  #       profile: minimal
+  #   - uses: Swatinem/rust-cache@v1
+  #   - name: cargo doc
+  #     env:
+  #       RUSTDOCFLAGS: "-D rustdoc::all -A rustdoc::private-doc-tests"
+  #     run: cargo doc --all-features --no-deps
 
-  cargo-hack:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@master
-    - uses: arduino/setup-protoc@v1
-    - uses: dtolnay/rust-toolchain@stable
-      with:
-        toolchain: stable
-        override: true
-        profile: minimal
-    - uses: Swatinem/rust-cache@v1
-    - name: Install cargo-hack
-      run: |
-        curl -LsSf https://github.com/taiki-e/cargo-hack/releases/latest/download/cargo-hack-x86_64-unknown-linux-gnu.tar.gz | tar xzf - -C ~/.cargo/bin
-    - name: cargo hack check
-      run: cargo hack check --each-feature --no-dev-deps --all
+  # cargo-hack:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #   - uses: actions/checkout@master
+  #   - uses: arduino/setup-protoc@v1
+  #   - uses: dtolnay/rust-toolchain@stable
+  #     with:
+  #       toolchain: stable
+  #       override: true
+  #       profile: minimal
+  #   - uses: Swatinem/rust-cache@v1
+  #   - name: Install cargo-hack
+  #     run: |
+  #       curl -LsSf https://github.com/taiki-e/cargo-hack/releases/latest/download/cargo-hack-x86_64-unknown-linux-gnu.tar.gz | tar xzf - -C ~/.cargo/bin
+  #   - name: cargo hack check
+  #     run: cargo hack check --each-feature --no-dev-deps --all
 
-  cargo-public-api-crates:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        crate: [axum, axum-core, axum-extra, axum-macros]
-    steps:
-    - uses: actions/checkout@master
-    - uses: dtolnay/rust-toolchain@stable
-      with:
-        toolchain: nightly
-        override: true
-        profile: minimal
-    - uses: Swatinem/rust-cache@v1
-    - name: Install cargo-public-api-crates
-      run: |
-        cargo install --git https://github.com/davidpdrsn/cargo-public-api-crates
-    - name: cargo public-api-crates check
-      run: cargo public-api-crates --manifest-path ${{ matrix.crate }}/Cargo.toml check
+  # cargo-public-api-crates:
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     matrix:
+  #       crate: [axum, axum-core, axum-extra, axum-macros]
+  #   steps:
+  #   - uses: actions/checkout@master
+  #   - uses: dtolnay/rust-toolchain@stable
+  #     with:
+  #       toolchain: nightly
+  #       override: true
+  #       profile: minimal
+  #   - uses: Swatinem/rust-cache@v1
+  #   - name: Install cargo-public-api-crates
+  #     run: |
+  #       cargo install --git https://github.com/davidpdrsn/cargo-public-api-crates
+  #   - name: cargo public-api-crates check
+  #     run: cargo public-api-crates --manifest-path ${{ matrix.crate }}/Cargo.toml check
 
-  test-versions:
-    needs: check
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        rust: [stable, beta]
-    steps:
-    - uses: actions/checkout@master
-    - uses: arduino/setup-protoc@v1
-    - uses: dtolnay/rust-toolchain@stable
-      with:
-        toolchain: ${{ matrix.rust }}
-        override: true
-        profile: minimal
-    - uses: Swatinem/rust-cache@v1
-    - name: Run tests
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --all --all-features --all-targets
+  # test-versions:
+  #   needs: check
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     matrix:
+  #       rust: [stable, beta]
+  #   steps:
+  #   - uses: actions/checkout@master
+  #   - uses: arduino/setup-protoc@v1
+  #   - uses: dtolnay/rust-toolchain@stable
+  #     with:
+  #       toolchain: ${{ matrix.rust }}
+  #       override: true
+  #       profile: minimal
+  #   - uses: Swatinem/rust-cache@v1
+  #   - name: Run tests
+  #     uses: actions-rs/cargo@v1
+  #     with:
+  #       command: test
+  #       args: --all --all-features --all-targets
 
-  # some examples doesn't support our MSRV so we only test axum itself on our MSRV
-  test-nightly:
-    needs: check
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@master
-    - uses: dtolnay/rust-toolchain@stable
-      with:
-        # same as `axum-macros/rust-toolchain`
-        toolchain: nightly-2022-11-18
-        override: true
-        profile: minimal
-    - uses: Swatinem/rust-cache@v1
-    - name: Run nightly tests
-      working-directory: axum-macros
-      run: |
-        cargo test
+  # # some examples doesn't support our MSRV so we only test axum itself on our MSRV
+  # test-nightly:
+  #   needs: check
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #   - uses: actions/checkout@master
+  #   - uses: dtolnay/rust-toolchain@stable
+  #     with:
+  #       # same as `axum-macros/rust-toolchain`
+  #       toolchain: nightly-2022-11-18
+  #       override: true
+  #       profile: minimal
+  #   - uses: Swatinem/rust-cache@v1
+  #   - name: Run nightly tests
+  #     working-directory: axum-macros
+  #     run: |
+  #       cargo test
 
-  # some examples doesn't support our MSRV (such as async-graphql)
-  # so we only test axum itself on our MSRV
-  test-msrv:
-    needs: check
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@master
-    - uses: dtolnay/rust-toolchain@stable
-      with:
-        toolchain: ${{ env.MSRV }}
-        override: true
-        profile: minimal
-    - name: "install Rust nightly"
-      uses: dtolnay/rust-toolchain@stable
-      with:
-        toolchain: nightly
-        profile: minimal
-    - uses: Swatinem/rust-cache@v1
-    - name: Select minimal versions
-      uses: actions-rs/cargo@v1
-      with:
-        command: update
-        args: -Z minimal-versions
-        toolchain: nightly
-    - name: Fix up Cargo.lock
-      uses: actions-rs/cargo@v1
-      with:
-        command: update
-        args: -p crc32fast --precise 1.1.1
-        toolchain: nightly
-    - name: Run tests
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: >
-          -p axum
-          -p axum-extra
-          -p axum-core
-          --all-features
-          --all-targets
-          --locked
-        toolchain: ${{ env.MSRV }}
-    # the compiler errors are different on our MSRV which makes
-    # the trybuild tests in axum-macros fail, so just run the doc
-    # tests
-    - name: Run axum-macros doc tests
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: >
-          -p axum-macros
-          --doc
-          --all-features
-          --locked
-        toolchain: ${{ env.MSRV }}
+  # # some examples doesn't support our MSRV (such as async-graphql)
+  # # so we only test axum itself on our MSRV
+  # test-msrv:
+  #   needs: check
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #   - uses: actions/checkout@master
+  #   - uses: dtolnay/rust-toolchain@stable
+  #     with:
+  #       toolchain: ${{ env.MSRV }}
+  #       override: true
+  #       profile: minimal
+  #   - name: "install Rust nightly"
+  #     uses: dtolnay/rust-toolchain@stable
+  #     with:
+  #       toolchain: nightly
+  #       profile: minimal
+  #   - uses: Swatinem/rust-cache@v1
+  #   - name: Select minimal versions
+  #     uses: actions-rs/cargo@v1
+  #     with:
+  #       command: update
+  #       args: -Z minimal-versions
+  #       toolchain: nightly
+  #   - name: Fix up Cargo.lock
+  #     uses: actions-rs/cargo@v1
+  #     with:
+  #       command: update
+  #       args: -p crc32fast --precise 1.1.1
+  #       toolchain: nightly
+  #   - name: Run tests
+  #     uses: actions-rs/cargo@v1
+  #     with:
+  #       command: test
+  #       args: >
+  #         -p axum
+  #         -p axum-extra
+  #         -p axum-core
+  #         --all-features
+  #         --all-targets
+  #         --locked
+  #       toolchain: ${{ env.MSRV }}
+  #   # the compiler errors are different on our MSRV which makes
+  #   # the trybuild tests in axum-macros fail, so just run the doc
+  #   # tests
+  #   - name: Run axum-macros doc tests
+  #     uses: actions-rs/cargo@v1
+  #     with:
+  #       command: test
+  #       args: >
+  #         -p axum-macros
+  #         --doc
+  #         --all-features
+  #         --locked
+  #       toolchain: ${{ env.MSRV }}
 
-  test-docs:
-    needs: check
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@master
-    - uses: dtolnay/rust-toolchain@stable
-      with:
-        toolchain: stable
-        override: true
-        profile: minimal
-    - uses: Swatinem/rust-cache@v1
-    - name: Run doc tests
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --all-features --doc
+  # test-docs:
+  #   needs: check
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #   - uses: actions/checkout@master
+  #   - uses: dtolnay/rust-toolchain@stable
+  #     with:
+  #       toolchain: stable
+  #       override: true
+  #       profile: minimal
+  #   - uses: Swatinem/rust-cache@v1
+  #   - name: Run doc tests
+  #     uses: actions-rs/cargo@v1
+  #     with:
+  #       command: test
+  #       args: --all-features --doc
 
-  deny-check:
-    name: cargo-deny check
-    runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.checks == 'advisories' }}
-    strategy:
-      matrix:
-        checks:
-          - advisories
-          - bans licenses sources
-    steps:
-      - uses: actions/checkout@v2
-      - uses: EmbarkStudios/cargo-deny-action@v1
-        with:
-          command: check ${{ matrix.checks }}
-          arguments: --all-features --manifest-path axum/Cargo.toml
+  # deny-check:
+  #   name: cargo-deny check
+  #   runs-on: ubuntu-latest
+  #   continue-on-error: ${{ matrix.checks == 'advisories' }}
+  #   strategy:
+  #     matrix:
+  #       checks:
+  #         - advisories
+  #         - bans licenses sources
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - uses: EmbarkStudios/cargo-deny-action@v1
+  #       with:
+  #         command: check ${{ matrix.checks }}
+  #         arguments: --all-features --manifest-path axum/Cargo.toml
 
-  armv5te-unknown-linux-musleabi:
-    needs: check
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@master
-    - uses: dtolnay/rust-toolchain@stable
-      with:
-        toolchain: stable
-        target: armv5te-unknown-linux-musleabi
-        override: true
-        profile: minimal
-    - uses: Swatinem/rust-cache@v1
-    - name: Check
-      uses: actions-rs/cargo@v1
-      env:
-        # Clang has native cross-compilation support
-        CC: clang
-      with:
-        command: check
-        args: >
-          --all-targets
-          --all-features
-          -p axum
-          -p axum-core
-          -p axum-extra
-          -p axum-macros
-          --target armv5te-unknown-linux-musleabi
+  # armv5te-unknown-linux-musleabi:
+  #   needs: check
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #   - uses: actions/checkout@master
+  #   - uses: dtolnay/rust-toolchain@stable
+  #     with:
+  #       toolchain: stable
+  #       target: armv5te-unknown-linux-musleabi
+  #       override: true
+  #       profile: minimal
+  #   - uses: Swatinem/rust-cache@v1
+  #   - name: Check
+  #     uses: actions-rs/cargo@v1
+  #     env:
+  #       # Clang has native cross-compilation support
+  #       CC: clang
+  #     with:
+  #       command: check
+  #       args: >
+  #         --all-targets
+  #         --all-features
+  #         -p axum
+  #         -p axum-core
+  #         -p axum-extra
+  #         -p axum-macros
+  #         --target armv5te-unknown-linux-musleabi
 
-  wasm32-unknown-unknown:
-    needs: check
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@master
-    - uses: dtolnay/rust-toolchain@stable
-      with:
-        toolchain: stable
-        target: wasm32-unknown-unknown
-        override: true
-        profile: minimal
-    - uses: Swatinem/rust-cache@v1
-    - name: Check
-      uses: actions-rs/cargo@v1
-      with:
-        command: check
-        args: >
-          --manifest-path ./examples/simple-router-wasm/Cargo.toml
-          --target wasm32-unknown-unknown
+  # wasm32-unknown-unknown:
+  #   needs: check
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #   - uses: actions/checkout@master
+  #   - uses: dtolnay/rust-toolchain@stable
+  #     with:
+  #       toolchain: stable
+  #       target: wasm32-unknown-unknown
+  #       override: true
+  #       profile: minimal
+  #   - uses: Swatinem/rust-cache@v1
+  #   - name: Check
+  #     uses: actions-rs/cargo@v1
+  #     with:
+  #       command: check
+  #       args: >
+  #         --manifest-path ./examples/simple-router-wasm/Cargo.toml
+  #         --target wasm32-unknown-unknown
 
-  dependencies-are-sorted:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@master
-    - uses: dtolnay/rust-toolchain@stable
-      with:
-        toolchain: beta
-        override: true
-        profile: minimal
-    - uses: Swatinem/rust-cache@v2
-    - name: Install cargo-sort
-      run: |
-        cargo install cargo-sort
-    # Work around cargo-sort not honoring workspace.exclude
-    - name: Remove non-crate folder
-      run: rm -rf examples/async-graphql
-    - name: Check dependency tables
-      run: |
-        cargo sort --workspace --grouped --check
+  # dependencies-are-sorted:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #   - uses: actions/checkout@master
+  #   - uses: dtolnay/rust-toolchain@stable
+  #     with:
+  #       toolchain: beta
+  #       override: true
+  #       profile: minimal
+  #   - uses: Swatinem/rust-cache@v2
+  #   - name: Install cargo-sort
+  #     run: |
+  #       cargo install cargo-sort
+  #   # Work around cargo-sort not honoring workspace.exclude
+  #   - name: Remove non-crate folder
+  #     run: rm -rf examples/async-graphql
+  #   - name: Check dependency tables
+  #     run: |
+  #       cargo sort --workspace --grouped --check

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -29,7 +29,7 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: clippy
-        args: --workspace --all-targets --all-features
+        args: --workspace --all-targets --all-features -- -D warnings
     - name: rustfmt
       uses: actions-rs/cargo@v1
       with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -36,249 +36,249 @@ jobs:
         command: fmt
         args: -- --check
 
-  # check-docs:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #   - uses: actions/checkout@master
-  #   - uses: dtolnay/rust-toolchain@stable
-  #     with:
-  #       toolchain: stable
-  #       override: true
-  #       profile: minimal
-  #   - uses: Swatinem/rust-cache@v1
-  #   - name: cargo doc
-  #     env:
-  #       RUSTDOCFLAGS: "-D rustdoc::all -A rustdoc::private-doc-tests"
-  #     run: cargo doc --all-features --no-deps
+  check-docs:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: dtolnay/rust-toolchain@stable
+      with:
+        toolchain: stable
+        override: true
+        profile: minimal
+    - uses: Swatinem/rust-cache@v1
+    - name: cargo doc
+      env:
+        RUSTDOCFLAGS: "-D rustdoc::all -A rustdoc::private-doc-tests"
+      run: cargo doc --all-features --no-deps
 
-  # cargo-hack:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #   - uses: actions/checkout@master
-  #   - uses: arduino/setup-protoc@v1
-  #   - uses: dtolnay/rust-toolchain@stable
-  #     with:
-  #       toolchain: stable
-  #       override: true
-  #       profile: minimal
-  #   - uses: Swatinem/rust-cache@v1
-  #   - name: Install cargo-hack
-  #     run: |
-  #       curl -LsSf https://github.com/taiki-e/cargo-hack/releases/latest/download/cargo-hack-x86_64-unknown-linux-gnu.tar.gz | tar xzf - -C ~/.cargo/bin
-  #   - name: cargo hack check
-  #     run: cargo hack check --each-feature --no-dev-deps --all
+  cargo-hack:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: arduino/setup-protoc@v1
+    - uses: dtolnay/rust-toolchain@stable
+      with:
+        toolchain: stable
+        override: true
+        profile: minimal
+    - uses: Swatinem/rust-cache@v1
+    - name: Install cargo-hack
+      run: |
+        curl -LsSf https://github.com/taiki-e/cargo-hack/releases/latest/download/cargo-hack-x86_64-unknown-linux-gnu.tar.gz | tar xzf - -C ~/.cargo/bin
+    - name: cargo hack check
+      run: cargo hack check --each-feature --no-dev-deps --all
 
-  # cargo-public-api-crates:
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     matrix:
-  #       crate: [axum, axum-core, axum-extra, axum-macros]
-  #   steps:
-  #   - uses: actions/checkout@master
-  #   - uses: dtolnay/rust-toolchain@stable
-  #     with:
-  #       toolchain: nightly
-  #       override: true
-  #       profile: minimal
-  #   - uses: Swatinem/rust-cache@v1
-  #   - name: Install cargo-public-api-crates
-  #     run: |
-  #       cargo install --git https://github.com/davidpdrsn/cargo-public-api-crates
-  #   - name: cargo public-api-crates check
-  #     run: cargo public-api-crates --manifest-path ${{ matrix.crate }}/Cargo.toml check
+  cargo-public-api-crates:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        crate: [axum, axum-core, axum-extra, axum-macros]
+    steps:
+    - uses: actions/checkout@master
+    - uses: dtolnay/rust-toolchain@stable
+      with:
+        toolchain: nightly
+        override: true
+        profile: minimal
+    - uses: Swatinem/rust-cache@v1
+    - name: Install cargo-public-api-crates
+      run: |
+        cargo install --git https://github.com/davidpdrsn/cargo-public-api-crates
+    - name: cargo public-api-crates check
+      run: cargo public-api-crates --manifest-path ${{ matrix.crate }}/Cargo.toml check
 
-  # test-versions:
-  #   needs: check
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     matrix:
-  #       rust: [stable, beta]
-  #   steps:
-  #   - uses: actions/checkout@master
-  #   - uses: arduino/setup-protoc@v1
-  #   - uses: dtolnay/rust-toolchain@stable
-  #     with:
-  #       toolchain: ${{ matrix.rust }}
-  #       override: true
-  #       profile: minimal
-  #   - uses: Swatinem/rust-cache@v1
-  #   - name: Run tests
-  #     uses: actions-rs/cargo@v1
-  #     with:
-  #       command: test
-  #       args: --all --all-features --all-targets
+  test-versions:
+    needs: check
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust: [stable, beta]
+    steps:
+    - uses: actions/checkout@master
+    - uses: arduino/setup-protoc@v1
+    - uses: dtolnay/rust-toolchain@stable
+      with:
+        toolchain: ${{ matrix.rust }}
+        override: true
+        profile: minimal
+    - uses: Swatinem/rust-cache@v1
+    - name: Run tests
+      uses: actions-rs/cargo@v1
+      with:
+        command: test
+        args: --all --all-features --all-targets
 
-  # # some examples doesn't support our MSRV so we only test axum itself on our MSRV
-  # test-nightly:
-  #   needs: check
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #   - uses: actions/checkout@master
-  #   - uses: dtolnay/rust-toolchain@stable
-  #     with:
-  #       # same as `axum-macros/rust-toolchain`
-  #       toolchain: nightly-2022-11-18
-  #       override: true
-  #       profile: minimal
-  #   - uses: Swatinem/rust-cache@v1
-  #   - name: Run nightly tests
-  #     working-directory: axum-macros
-  #     run: |
-  #       cargo test
+  # some examples doesn't support our MSRV so we only test axum itself on our MSRV
+  test-nightly:
+    needs: check
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: dtolnay/rust-toolchain@stable
+      with:
+        # same as `axum-macros/rust-toolchain`
+        toolchain: nightly-2022-11-18
+        override: true
+        profile: minimal
+    - uses: Swatinem/rust-cache@v1
+    - name: Run nightly tests
+      working-directory: axum-macros
+      run: |
+        cargo test
 
-  # # some examples doesn't support our MSRV (such as async-graphql)
-  # # so we only test axum itself on our MSRV
-  # test-msrv:
-  #   needs: check
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #   - uses: actions/checkout@master
-  #   - uses: dtolnay/rust-toolchain@stable
-  #     with:
-  #       toolchain: ${{ env.MSRV }}
-  #       override: true
-  #       profile: minimal
-  #   - name: "install Rust nightly"
-  #     uses: dtolnay/rust-toolchain@stable
-  #     with:
-  #       toolchain: nightly
-  #       profile: minimal
-  #   - uses: Swatinem/rust-cache@v1
-  #   - name: Select minimal versions
-  #     uses: actions-rs/cargo@v1
-  #     with:
-  #       command: update
-  #       args: -Z minimal-versions
-  #       toolchain: nightly
-  #   - name: Fix up Cargo.lock
-  #     uses: actions-rs/cargo@v1
-  #     with:
-  #       command: update
-  #       args: -p crc32fast --precise 1.1.1
-  #       toolchain: nightly
-  #   - name: Run tests
-  #     uses: actions-rs/cargo@v1
-  #     with:
-  #       command: test
-  #       args: >
-  #         -p axum
-  #         -p axum-extra
-  #         -p axum-core
-  #         --all-features
-  #         --all-targets
-  #         --locked
-  #       toolchain: ${{ env.MSRV }}
-  #   # the compiler errors are different on our MSRV which makes
-  #   # the trybuild tests in axum-macros fail, so just run the doc
-  #   # tests
-  #   - name: Run axum-macros doc tests
-  #     uses: actions-rs/cargo@v1
-  #     with:
-  #       command: test
-  #       args: >
-  #         -p axum-macros
-  #         --doc
-  #         --all-features
-  #         --locked
-  #       toolchain: ${{ env.MSRV }}
+  # some examples doesn't support our MSRV (such as async-graphql)
+  # so we only test axum itself on our MSRV
+  test-msrv:
+    needs: check
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: dtolnay/rust-toolchain@stable
+      with:
+        toolchain: ${{ env.MSRV }}
+        override: true
+        profile: minimal
+    - name: "install Rust nightly"
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        toolchain: nightly
+        profile: minimal
+    - uses: Swatinem/rust-cache@v1
+    - name: Select minimal versions
+      uses: actions-rs/cargo@v1
+      with:
+        command: update
+        args: -Z minimal-versions
+        toolchain: nightly
+    - name: Fix up Cargo.lock
+      uses: actions-rs/cargo@v1
+      with:
+        command: update
+        args: -p crc32fast --precise 1.1.1
+        toolchain: nightly
+    - name: Run tests
+      uses: actions-rs/cargo@v1
+      with:
+        command: test
+        args: >
+          -p axum
+          -p axum-extra
+          -p axum-core
+          --all-features
+          --all-targets
+          --locked
+        toolchain: ${{ env.MSRV }}
+    # the compiler errors are different on our MSRV which makes
+    # the trybuild tests in axum-macros fail, so just run the doc
+    # tests
+    - name: Run axum-macros doc tests
+      uses: actions-rs/cargo@v1
+      with:
+        command: test
+        args: >
+          -p axum-macros
+          --doc
+          --all-features
+          --locked
+        toolchain: ${{ env.MSRV }}
 
-  # test-docs:
-  #   needs: check
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #   - uses: actions/checkout@master
-  #   - uses: dtolnay/rust-toolchain@stable
-  #     with:
-  #       toolchain: stable
-  #       override: true
-  #       profile: minimal
-  #   - uses: Swatinem/rust-cache@v1
-  #   - name: Run doc tests
-  #     uses: actions-rs/cargo@v1
-  #     with:
-  #       command: test
-  #       args: --all-features --doc
+  test-docs:
+    needs: check
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: dtolnay/rust-toolchain@stable
+      with:
+        toolchain: stable
+        override: true
+        profile: minimal
+    - uses: Swatinem/rust-cache@v1
+    - name: Run doc tests
+      uses: actions-rs/cargo@v1
+      with:
+        command: test
+        args: --all-features --doc
 
-  # deny-check:
-  #   name: cargo-deny check
-  #   runs-on: ubuntu-latest
-  #   continue-on-error: ${{ matrix.checks == 'advisories' }}
-  #   strategy:
-  #     matrix:
-  #       checks:
-  #         - advisories
-  #         - bans licenses sources
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - uses: EmbarkStudios/cargo-deny-action@v1
-  #       with:
-  #         command: check ${{ matrix.checks }}
-  #         arguments: --all-features --manifest-path axum/Cargo.toml
+  deny-check:
+    name: cargo-deny check
+    runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.checks == 'advisories' }}
+    strategy:
+      matrix:
+        checks:
+          - advisories
+          - bans licenses sources
+    steps:
+      - uses: actions/checkout@v2
+      - uses: EmbarkStudios/cargo-deny-action@v1
+        with:
+          command: check ${{ matrix.checks }}
+          arguments: --all-features --manifest-path axum/Cargo.toml
 
-  # armv5te-unknown-linux-musleabi:
-  #   needs: check
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #   - uses: actions/checkout@master
-  #   - uses: dtolnay/rust-toolchain@stable
-  #     with:
-  #       toolchain: stable
-  #       target: armv5te-unknown-linux-musleabi
-  #       override: true
-  #       profile: minimal
-  #   - uses: Swatinem/rust-cache@v1
-  #   - name: Check
-  #     uses: actions-rs/cargo@v1
-  #     env:
-  #       # Clang has native cross-compilation support
-  #       CC: clang
-  #     with:
-  #       command: check
-  #       args: >
-  #         --all-targets
-  #         --all-features
-  #         -p axum
-  #         -p axum-core
-  #         -p axum-extra
-  #         -p axum-macros
-  #         --target armv5te-unknown-linux-musleabi
+  armv5te-unknown-linux-musleabi:
+    needs: check
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: dtolnay/rust-toolchain@stable
+      with:
+        toolchain: stable
+        target: armv5te-unknown-linux-musleabi
+        override: true
+        profile: minimal
+    - uses: Swatinem/rust-cache@v1
+    - name: Check
+      uses: actions-rs/cargo@v1
+      env:
+        # Clang has native cross-compilation support
+        CC: clang
+      with:
+        command: check
+        args: >
+          --all-targets
+          --all-features
+          -p axum
+          -p axum-core
+          -p axum-extra
+          -p axum-macros
+          --target armv5te-unknown-linux-musleabi
 
-  # wasm32-unknown-unknown:
-  #   needs: check
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #   - uses: actions/checkout@master
-  #   - uses: dtolnay/rust-toolchain@stable
-  #     with:
-  #       toolchain: stable
-  #       target: wasm32-unknown-unknown
-  #       override: true
-  #       profile: minimal
-  #   - uses: Swatinem/rust-cache@v1
-  #   - name: Check
-  #     uses: actions-rs/cargo@v1
-  #     with:
-  #       command: check
-  #       args: >
-  #         --manifest-path ./examples/simple-router-wasm/Cargo.toml
-  #         --target wasm32-unknown-unknown
+  wasm32-unknown-unknown:
+    needs: check
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: dtolnay/rust-toolchain@stable
+      with:
+        toolchain: stable
+        target: wasm32-unknown-unknown
+        override: true
+        profile: minimal
+    - uses: Swatinem/rust-cache@v1
+    - name: Check
+      uses: actions-rs/cargo@v1
+      with:
+        command: check
+        args: >
+          --manifest-path ./examples/simple-router-wasm/Cargo.toml
+          --target wasm32-unknown-unknown
 
-  # dependencies-are-sorted:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #   - uses: actions/checkout@master
-  #   - uses: dtolnay/rust-toolchain@stable
-  #     with:
-  #       toolchain: beta
-  #       override: true
-  #       profile: minimal
-  #   - uses: Swatinem/rust-cache@v2
-  #   - name: Install cargo-sort
-  #     run: |
-  #       cargo install cargo-sort
-  #   # Work around cargo-sort not honoring workspace.exclude
-  #   - name: Remove non-crate folder
-  #     run: rm -rf examples/async-graphql
-  #   - name: Check dependency tables
-  #     run: |
-  #       cargo sort --workspace --grouped --check
+  dependencies-are-sorted:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: dtolnay/rust-toolchain@stable
+      with:
+        toolchain: beta
+        override: true
+        profile: minimal
+    - uses: Swatinem/rust-cache@v2
+    - name: Install cargo-sort
+      run: |
+        cargo install cargo-sort
+    # Work around cargo-sort not honoring workspace.exclude
+    - name: Remove non-crate folder
+      run: rm -rf examples/async-graphql
+    - name: Check dependency tables
+      run: |
+        cargo sort --workspace --grouped --check

--- a/axum-core/src/lib.rs
+++ b/axum-core/src/lib.rs
@@ -48,7 +48,7 @@
 #![allow(elided_lifetimes_in_paths, clippy::type_complexity)]
 #![forbid(unsafe_code)]
 #![cfg_attr(test, allow(clippy::float_cmp))]
-#![cfg_attr(not(test), warn(clippy::print_stdout))]
+#![cfg_attr(not(test), warn(clippy::print_stdout, clippy::dbg_macro))]
 
 #[macro_use]
 pub(crate) mod macros;

--- a/axum-core/src/lib.rs
+++ b/axum-core/src/lib.rs
@@ -48,6 +48,7 @@
 #![allow(elided_lifetimes_in_paths, clippy::type_complexity)]
 #![forbid(unsafe_code)]
 #![cfg_attr(test, allow(clippy::float_cmp))]
+#![cfg_attr(not(test), warn(clippy::print_stdout))]
 
 #[macro_use]
 pub(crate) mod macros;

--- a/axum-extra/src/lib.rs
+++ b/axum-extra/src/lib.rs
@@ -64,6 +64,7 @@
 #![forbid(unsafe_code)]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(test, allow(clippy::float_cmp))]
+#![cfg_attr(not(test), warn(clippy::print_stdout))]
 
 #[allow(unused_extern_crates)]
 extern crate self as axum_extra;

--- a/axum-extra/src/lib.rs
+++ b/axum-extra/src/lib.rs
@@ -64,7 +64,7 @@
 #![forbid(unsafe_code)]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(test, allow(clippy::float_cmp))]
-#![cfg_attr(not(test), warn(clippy::print_stdout))]
+#![cfg_attr(not(test), warn(clippy::print_stdout, clippy::dbg_macro))]
 
 #[allow(unused_extern_crates)]
 extern crate self as axum_extra;

--- a/axum-macros/src/lib.rs
+++ b/axum-macros/src/lib.rs
@@ -42,7 +42,7 @@
 #![forbid(unsafe_code)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(test, allow(clippy::float_cmp))]
-#![cfg_attr(not(test), warn(clippy::print_stdout))]
+#![cfg_attr(not(test), warn(clippy::print_stdout, clippy::dbg_macro))]
 
 use proc_macro::TokenStream;
 use quote::{quote, ToTokens};

--- a/axum-macros/src/lib.rs
+++ b/axum-macros/src/lib.rs
@@ -42,6 +42,7 @@
 #![forbid(unsafe_code)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(test, allow(clippy::float_cmp))]
+#![cfg_attr(not(test), warn(clippy::print_stdout))]
 
 use proc_macro::TokenStream;
 use quote::{quote, ToTokens};

--- a/axum/src/lib.rs
+++ b/axum/src/lib.rs
@@ -399,7 +399,6 @@
 
 #![warn(
     clippy::all,
-    clippy::dbg_macro,
     clippy::todo,
     clippy::empty_enum,
     clippy::enum_glob_use,
@@ -437,7 +436,7 @@
 #![forbid(unsafe_code)]
 #![cfg_attr(docsrs, feature(doc_auto_cfg, doc_cfg))]
 #![cfg_attr(test, allow(clippy::float_cmp))]
-#![cfg_attr(not(test), warn(clippy::print_stdout))]
+#![cfg_attr(not(test), warn(clippy::print_stdout, clippy::dbg_macro))]
 
 #[macro_use]
 pub(crate) mod macros;

--- a/axum/src/lib.rs
+++ b/axum/src/lib.rs
@@ -437,6 +437,7 @@
 #![forbid(unsafe_code)]
 #![cfg_attr(docsrs, feature(doc_auto_cfg, doc_cfg))]
 #![cfg_attr(test, allow(clippy::float_cmp))]
+#![cfg_attr(not(test), warn(clippy::print_stdout))]
 
 #[macro_use]
 pub(crate) mod macros;

--- a/axum/src/routing/mod.rs
+++ b/axum/src/routing/mod.rs
@@ -106,6 +106,8 @@ where
     /// Unless you add additional routes this will respond with `404 Not Found` to
     /// all requests.
     pub fn new() -> Self {
+        println!("prints not allowed. Build should fail");
+
         let mut this = Self {
             path_router: Default::default(),
             fallback_router: Default::default(),

--- a/axum/src/routing/mod.rs
+++ b/axum/src/routing/mod.rs
@@ -106,9 +106,6 @@ where
     /// Unless you add additional routes this will respond with `404 Not Found` to
     /// all requests.
     pub fn new() -> Self {
-        println!("prints not allowed. Build should fail");
-        dbg!("dbg not allowed either");
-
         let mut this = Self {
             path_router: Default::default(),
             fallback_router: Default::default(),

--- a/axum/src/routing/mod.rs
+++ b/axum/src/routing/mod.rs
@@ -107,6 +107,7 @@ where
     /// all requests.
     pub fn new() -> Self {
         println!("prints not allowed. Build should fail");
+        dbg!("dbg not allowed either");
 
         let mut this = Self {
             path_router: Default::default(),

--- a/examples/websockets/src/client.rs
+++ b/examples/websockets/src/client.rs
@@ -30,7 +30,6 @@ async fn main() {
     let start_time = Instant::now();
     //spawn several clients that will concurrently talk to the server
     let mut clients = (0..N_CLIENTS)
-        .into_iter()
         .map(|cli| tokio::spawn(spawn_client(cli)))
         .collect::<FuturesUnordered<_>>();
 


### PR DESCRIPTION
Turns out there is a clippy lint for usage of `println!`. We should probably enable that.
