### PR TITLE
Include non-default ports, if extracting Host

### DIFF
--- a/axum/src/extract/host.rs
+++ b/axum/src/extract/host.rs
@@ -51,8 +51,8 @@ where
             return Ok(Host(host.to_owned()));
         }
 
-        if let Some(host) = parts.uri.host() {
-            return Ok(Host(host.to_owned()));
+        if let Some(host) = parts.uri.authority() {
+            return Ok(Host(host.to_string()));
         }
 
         Err(HostRejection::FailedToResolveHost(FailedToResolveHost))


### PR DESCRIPTION
This fixes the Host extractor to include the port, if the request is made via http2. Host should always include the port, if it is not the default. See also
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Host, which is referred to by the different forwarded headers.

## Motivation

This fixes the different behavior between http and http2, if  `axum::extract::Host`. This might also fix other code paths, that hit the last if in this extractor. (see also #1916)

## Solution

The Host extractor now uses `parts.uri.authority()` to extract the host. (and to_string(), because to_owned is not defined on Authority)

:warning: I just did some more digging and the authority part of an uri (according to [rfc 3986](https://www.rfc-editor.org/rfc/rfc3986.html#section-3.2) ) can contain userinfo (mostly "username:password@"), while the authority header in http2 must not include this. Even in http1 the userinfo is transmitted in the "Authorization" header. 

In http1 the Host-header is  mandatory and the last if (with the parts.uri.authority()) should not be hit and I tested it with http2 and the userinfo part was not there, so I think this fix should work as intended.

And I could not get retrieve the userinfo via the parts.uri even with http1 (and the use of username:password@ in the uri is deprecated according to the http crate)
