### PR TITLE
feat(rejection): add rejection as a response extension

### DIFF
--- a/axum-core/src/macros.rs
+++ b/axum-core/src/macros.rs
@@ -26,6 +26,7 @@ macro_rules! __log_rejection {
 #[macro_export]
 macro_rules! __define_rejection {
     (
+        $(#[composite = $composite:ident])?
         #[status = $status:ident]
         #[body = $body:expr]
         $(#[$m:meta])*
@@ -38,12 +39,16 @@ macro_rules! __define_rejection {
 
         impl $crate::response::IntoResponse for $name {
             fn into_response(self) -> $crate::response::Response {
+                let mut resp = (self.status(), $body).into_response();
+
                 $crate::__log_rejection!(
                     rejection_type = $name,
                     body_text = $body,
                     status = http::StatusCode::$status,
                 );
-                (self.status(), $body).into_response()
+
+                resp.extensions_mut().insert($($composite::$name)?(self));
+                resp
             }
         }
 
@@ -75,6 +80,7 @@ macro_rules! __define_rejection {
     };
 
     (
+        $(#[composite = $composite:ident])?
         #[status = $status:ident]
         #[body = $body:expr]
         $(#[$m:meta])*
@@ -95,12 +101,16 @@ macro_rules! __define_rejection {
 
         impl $crate::response::IntoResponse for $name {
             fn into_response(self) -> $crate::response::Response {
+                let mut resp = (self.status(), self.body_text()).into_response();
+
                 $crate::__log_rejection!(
                     rejection_type = $name,
                     body_text = self.body_text(),
                     status = http::StatusCode::$status,
                 );
-                (self.status(), self.body_text()).into_response()
+
+                resp.extensions_mut().insert($($composite::$name)?(self));
+                resp
             }
         }
 

--- a/axum/src/extract/rejection.rs
+++ b/axum/src/extract/rejection.rs
@@ -8,6 +8,7 @@ pub use axum_core::extract::rejection::*;
 
 #[cfg(feature = "json")]
 define_rejection! {
+    #[composite = JsonRejection]
     #[status = UNPROCESSABLE_ENTITY]
     #[body = "Failed to deserialize the JSON body into the target type"]
     #[cfg_attr(docsrs, doc(cfg(feature = "json")))]
@@ -20,6 +21,7 @@ define_rejection! {
 
 #[cfg(feature = "json")]
 define_rejection! {
+    #[composite = JsonRejection]
     #[status = BAD_REQUEST]
     #[body = "Failed to parse the request body as JSON"]
     #[cfg_attr(docsrs, doc(cfg(feature = "json")))]
@@ -31,6 +33,7 @@ define_rejection! {
 
 #[cfg(feature = "json")]
 define_rejection! {
+    #[composite = JsonRejection]
     #[status = UNSUPPORTED_MEDIA_TYPE]
     #[body = "Expected request with `Content-Type: application/json`"]
     #[cfg_attr(docsrs, doc(cfg(feature = "json")))]
@@ -40,6 +43,7 @@ define_rejection! {
 }
 
 define_rejection! {
+    #[composite = ExtensionRejection]
     #[status = INTERNAL_SERVER_ERROR]
     #[body = "Missing request extension"]
     /// Rejection type for [`Extension`](super::Extension) if an expected
@@ -57,6 +61,7 @@ define_rejection! {
 }
 
 define_rejection! {
+    #[composite = FormRejection]
     #[status = UNSUPPORTED_MEDIA_TYPE]
     #[body = "Form requests must have `Content-Type: application/x-www-form-urlencoded`"]
     /// Rejection type for [`Form`](super::Form) or [`RawForm`](super::RawForm)
@@ -66,6 +71,7 @@ define_rejection! {
 }
 
 define_rejection! {
+    #[composite = HostRejection]
     #[status = BAD_REQUEST]
     #[body = "No host found in request"]
     /// Rejection type used if the [`Host`](super::Host) extractor is unable to
@@ -74,6 +80,7 @@ define_rejection! {
 }
 
 define_rejection! {
+    #[composite = FormRejection]
     #[status = BAD_REQUEST]
     #[body = "Failed to deserialize form"]
     /// Rejection type used if the [`Form`](super::Form) extractor is unable to
@@ -82,6 +89,7 @@ define_rejection! {
 }
 
 define_rejection! {
+    #[composite = FormRejection]
     #[status = UNPROCESSABLE_ENTITY]
     #[body = "Failed to deserialize form body"]
     /// Rejection type used if the [`Form`](super::Form) extractor is unable to
@@ -90,6 +98,7 @@ define_rejection! {
 }
 
 define_rejection! {
+    #[composite = QueryRejection]
     #[status = BAD_REQUEST]
     #[body = "Failed to deserialize query string"]
     /// Rejection type used if the [`Query`](super::Query) extractor is unable to

--- a/examples/customize-extractor-error/README.md
+++ b/examples/customize-extractor-error/README.md
@@ -8,6 +8,8 @@ already existing extractors
   rejection
 - [`custom_extractor`](src/custom_extractor.rs): Manual implementation of
   `FromRequest` that wraps another extractor
+- [`response_extension`](src/response_extension.rs): Intercepting responses
+  and checking their extensions for a rejection type.
 
 Run with
 

--- a/examples/customize-extractor-error/src/main.rs
+++ b/examples/customize-extractor-error/src/main.rs
@@ -6,6 +6,7 @@
 
 mod custom_extractor;
 mod derive_from_request;
+mod response_extension;
 mod with_rejection;
 
 use axum::{routing::post, Router};
@@ -25,6 +26,7 @@ async fn main() {
     // Build our application with some routes
     let app = Router::new()
         .route("/with-rejection", post(with_rejection::handler))
+        .nest("/response-extension", response_extension::router())
         .route("/custom-extractor", post(custom_extractor::handler))
         .route("/derive-from-request", post(derive_from_request::handler));
 

--- a/examples/customize-extractor-error/src/response_extension.rs
+++ b/examples/customize-extractor-error/src/response_extension.rs
@@ -1,0 +1,60 @@
+//! Intercepting rejections in a middleware using response extensions.
+//!
+//! + Easy learning curve: Middlewares and extensions are a well-known feature.
+//! + Straightforward: Requires little boilerplate, just the cost of creating a
+//!   middleware and checking the response extensions.
+//! - Performance: Having this check be done in runtime adds overhead when
+//!   compared to solutions like custom extractors.
+use axum::{
+    extract::{
+        rejection::{JsonRejection, QueryRejection},
+        Query,
+    },
+    http::Request,
+    middleware::Next,
+    response::{IntoResponse, Response},
+    Json, Router,
+};
+use serde_json::{json, Value};
+
+pub fn router() -> Router {
+    Router::new()
+        .route("/", axum::routing::post(handler))
+        .layer(axum::middleware::from_fn(handle_rejection))
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct QueryTest {
+    param: Option<i32>,
+}
+
+async fn handler(Query(query): Query<QueryTest>, Json(value): Json<Value>) -> impl IntoResponse {
+    dbg!(query.param);
+    Json(dbg!(value))
+}
+
+async fn handle_rejection<B>(req: Request<B>, next: Next<B>) -> Response {
+    let resp = next.run(req).await;
+
+    if let Some(rejection) = resp.extensions().get::<JsonRejection>() {
+        let payload = json!({
+            "message": rejection.body_text(),
+            "type": "json",
+            "origin": "response_extension"
+        });
+
+        return (resp.status(), axum::Json(payload)).into_response();
+    }
+
+    if let Some(rejection) = resp.extensions().get::<QueryRejection>() {
+        let payload = json!({
+            "message": rejection.body_text(),
+            "type": "query",
+            "origin": "response_extension"
+        });
+
+        return (resp.status(), axum::Json(payload)).into_response();
+    }
+
+    resp
+}


### PR DESCRIPTION
## Motivation

There's no current way to handle rejections in a global manner, which adds a certain layer of
complexity requiring the developer to create its own extractor, or use `WithRejection` every
single time.

It'd be nice to have a way to do this without needing to configure every route separately, to
behave in a way that is expected from all of them.

This is a follow-up to my https://github.com/tokio-rs/axum/issues/1116#issuecomment-1507517724.

## Solution

The idea was to insert the rejection into the Response extensions when calling `IntoResponse`.
This is done via modifying the `define_rejection` macro from `axum-core`. No clones are required
as `self` is never consumed inside this macro.

To simplify the process of checking the rejection type, I've added an optional `composite` meta to
the macro invocation, if present, the rejection is inserted as its composite type, e.g., `JsonSyntaxError`
is inserted as `JsonRejection::JsonSyntaxError`.

This allows a middleware to check whether a Response contains rejection information or not, and
respond accordingly:
```rust
async fn handle_rejection<B>(req: Request<B>, next: Next<B>) -> Response {
    let resp = next.run(req).await;

    if let Some(rejection) = resp.extensions().get::<JsonRejection>() {
        let payload = json!({
            "message": rejection.body_text(),
            "origin": "response_extension"
        });

        return (resp.status(), axum::Json(payload)).into_response();
    }

    resp
}
```
This solution doesn't provide a ready way to change how the rejection behaves but gives the devs
more information, and they are allowed to do whatever they want with it. Extensions seem like the
right place as a rejection is metadata regarding a response.

### Other ideas

We can even go as far as creating a `RejectionHandler<Rejection>` layer which receives a `fn(Rejection) -> Response`, but I don't think it is necessary.
