### PR TITLE
Don't allow extracting `MatchedPath` in fallbacks

### DIFF
--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -7,7 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
-- None.
+- **fixed:** Don't allow extracting `MatchedPath` in fallbacks ([#1934])
+- **fixed:** Fix panic if `Router` with something nested at `/` was used as a fallback ([#1934])
+
+[#1934]: https://github.com/tokio-rs/axum/pull/1934
 
 # 0.6.15 (12. April, 2023)
 

--- a/axum/src/extract/matched_path.rs
+++ b/axum/src/extract/matched_path.rs
@@ -176,6 +176,7 @@ mod tests {
         Router,
     };
     use http::{Request, StatusCode};
+    use hyper::Body;
 
     #[crate::test]
     async fn extracting_on_handler() {
@@ -347,6 +348,21 @@ mod tests {
         }
 
         let app = Router::new().nest_service("/:a", handler.into_service());
+
+        let client = TestClient::new(app);
+
+        let res = client.get("/foo/bar").send().await;
+        assert_eq!(res.status(), StatusCode::OK);
+    }
+
+    #[crate::test]
+    async fn cant_extract_in_fallback() {
+        async fn handler(path: Option<MatchedPath>, req: Request<Body>) {
+            assert!(path.is_none());
+            assert!(req.extensions().get::<MatchedPath>().is_none());
+        }
+
+        let app = Router::new().fallback(handler);
 
         let client = TestClient::new(app);
 

--- a/axum/src/routing/mod.rs
+++ b/axum/src/routing/mod.rs
@@ -1,10 +1,6 @@
 //! Routing between [`Service`]s and handlers.
 
-use self::{
-    future::RouteFuture,
-    not_found::NotFound,
-    path_router::{IsFallback, IsNotFallback, PathRouter},
-};
+use self::{future::RouteFuture, not_found::NotFound, path_router::PathRouter};
 #[cfg(feature = "tokio")]
 use crate::extract::connect_info::IntoMakeServiceWithConnectInfo;
 use crate::{
@@ -61,8 +57,8 @@ pub(crate) struct RouteId(u32);
 /// The router type for composing handlers and services.
 #[must_use]
 pub struct Router<S = (), B = Body> {
-    path_router: PathRouter<IsNotFallback, S, B>,
-    fallback_router: PathRouter<IsFallback, S, B>,
+    path_router: PathRouter<S, B, false>,
+    fallback_router: PathRouter<S, B, true>,
     default_fallback: bool,
 }
 
@@ -503,7 +499,7 @@ impl<S, B> fmt::Debug for Endpoint<S, B> {
     }
 }
 
-struct SuperFallback<S, B>(SyncWrapper<PathRouter<IsFallback, S, B>>);
+struct SuperFallback<S, B>(SyncWrapper<PathRouter<S, B, true>>);
 
 #[test]
 #[allow(warnings)]

--- a/axum/src/routing/mod.rs
+++ b/axum/src/routing/mod.rs
@@ -1,6 +1,10 @@
 //! Routing between [`Service`]s and handlers.
 
-use self::{future::RouteFuture, not_found::NotFound, path_router::PathRouter};
+use self::{
+    future::RouteFuture,
+    not_found::NotFound,
+    path_router::{IsFallback, IsNotFallback, PathRouter},
+};
 #[cfg(feature = "tokio")]
 use crate::extract::connect_info::IntoMakeServiceWithConnectInfo;
 use crate::{
@@ -57,8 +61,8 @@ pub(crate) struct RouteId(u32);
 /// The router type for composing handlers and services.
 #[must_use]
 pub struct Router<S = (), B = Body> {
-    path_router: PathRouter<S, B>,
-    fallback_router: PathRouter<S, B>,
+    path_router: PathRouter<IsNotFallback, S, B>,
+    fallback_router: PathRouter<IsFallback, S, B>,
     default_fallback: bool,
 }
 
@@ -499,7 +503,7 @@ impl<S, B> fmt::Debug for Endpoint<S, B> {
     }
 }
 
-struct SuperFallback<S, B>(SyncWrapper<PathRouter<S, B>>);
+struct SuperFallback<S, B>(SyncWrapper<PathRouter<IsFallback, S, B>>);
 
 #[test]
 #[allow(warnings)]


### PR DESCRIPTION
With the introduction of `PathRouter` in #1711 I forgot that fallbacks
shouldn't be able to extract `MatchedPath`. The extension for it was
interested regardless if the `PathRouter` was used as a fallback or not.

It doesn't make sense to extract `MatchedPath` in a fallback because
there was no matched route. Turns out it also fixes a panic with a
specifical fallback/nest setup.

Fixes #1931
