### PR TITLE
Add test for not hitting `debug_assert` in `MatchedPath`

### DIFF
--- a/axum/src/extract/matched_path.rs
+++ b/axum/src/extract/matched_path.rs
@@ -172,7 +172,11 @@ fn append_nested_matched_path(matched_path: &Arc<str>, extensions: &http::Extens
 mod tests {
     use super::*;
     use crate::{
-        handler::HandlerWithoutStateExt, middleware::map_request, routing::get, test_helpers::*,
+        body::Body,
+        handler::HandlerWithoutStateExt,
+        middleware::map_request,
+        routing::{any, get},
+        test_helpers::*,
         Router,
     };
     use http::{Request, StatusCode};
@@ -351,6 +355,26 @@ mod tests {
         let client = TestClient::new(app);
 
         let res = client.get("/foo/bar").send().await;
+        assert_eq!(res.status(), StatusCode::OK);
+    }
+
+    // https://github.com/tokio-rs/axum/issues/1579
+    #[crate::test]
+    async fn doesnt_panic_if_router_called_from_wildcard_route() {
+        use tower::ServiceExt;
+
+        let app = Router::new().route(
+            "/*path",
+            any(|req: Request<Body>| {
+                Router::new()
+                    .nest("/", Router::new().route("/foo", get(|| async {})))
+                    .oneshot(req)
+            }),
+        );
+
+        let client = TestClient::new(app);
+
+        let res = client.get("/foo").send().await;
         assert_eq!(res.status(), StatusCode::OK);
     }
 }

--- a/axum/src/extract/matched_path.rs
+++ b/axum/src/extract/matched_path.rs
@@ -375,6 +375,7 @@ mod tests {
         let client = TestClient::new(app);
 
         let res = client.get("/foo").send().await;
+        assert_eq!(res.status(), StatusCode::OK);
     }
 
     #[crate::test]


### PR DESCRIPTION
#1579 was fixed in #1711. This adds a regression test.
