### PR TITLE
Remove `impl Connected<&AddrStream> for SocketAddr`

### DIFF
--- a/axum/Cargo.toml
+++ b/axum/Cargo.toml
@@ -191,7 +191,6 @@ allowed = [
     "futures_util",
     "http",
     "http_body",
-    "hyper",
     "serde",
     "tokio",
     "tower_layer",

--- a/axum/src/extract/connect_info.rs
+++ b/axum/src/extract/connect_info.rs
@@ -8,7 +8,6 @@ use super::{Extension, FromRequestParts};
 use crate::{middleware::AddExtension, serve::IncomingStream};
 use async_trait::async_trait;
 use http::request::Parts;
-use hyper::server::conn::AddrStream;
 use std::{
     convert::Infallible,
     fmt,
@@ -81,12 +80,6 @@ where
 pub trait Connected<T>: Clone + Send + Sync + 'static {
     /// Create type holding information about the connection.
     fn connect_info(target: T) -> Self;
-}
-
-impl Connected<&AddrStream> for SocketAddr {
-    fn connect_info(target: &AddrStream) -> Self {
-        target.remote_addr()
-    }
 }
 
 impl Connected<IncomingStream<'_>> for SocketAddr {

--- a/examples/low-level-openssl/src/main.rs
+++ b/examples/low-level-openssl/src/main.rs
@@ -1,13 +1,13 @@
 use openssl::ssl::{Ssl, SslAcceptor, SslFiletype, SslMethod};
 use tokio_openssl::SslStream;
 
-use axum::{body::Body, extract::ConnectInfo, http::Request, routing::get, Router};
+use axum::{body::Body, http::Request, routing::get, Router};
 use futures_util::future::poll_fn;
 use hyper::server::{
     accept::Accept,
     conn::{AddrIncoming, Http},
 };
-use std::{net::SocketAddr, path::PathBuf, pin::Pin, sync::Arc};
+use std::{path::PathBuf, pin::Pin, sync::Arc};
 use tokio::net::TcpListener;
 use tower::MakeService;
 
@@ -52,9 +52,7 @@ async fn main() {
 
     let protocol = Arc::new(Http::new());
 
-    let mut app = Router::new()
-        .route("/", get(handler))
-        .into_make_service_with_connect_info::<SocketAddr>();
+    let mut app = Router::new().route("/", get(handler)).into_make_service();
 
     tracing::info!("listening on https://localhost:3000");
 
@@ -83,6 +81,6 @@ async fn main() {
     }
 }
 
-async fn handler(ConnectInfo(addr): ConnectInfo<SocketAddr>) -> String {
-    addr.to_string()
+async fn handler() -> &'static str {
+    "Hello, World!"
 }

--- a/examples/low-level-rustls/src/main.rs
+++ b/examples/low-level-rustls/src/main.rs
@@ -4,7 +4,7 @@
 //! cargo run -p example-low-level-rustls
 //! ```
 
-use axum::{extract::ConnectInfo, extract::Request, routing::get, Router};
+use axum::{extract::Request, routing::get, Router};
 use futures_util::future::poll_fn;
 use hyper::server::{
     accept::Accept,
@@ -14,7 +14,6 @@ use rustls_pemfile::{certs, pkcs8_private_keys};
 use std::{
     fs::File,
     io::BufReader,
-    net::SocketAddr,
     path::{Path, PathBuf},
     pin::Pin,
     sync::Arc,
@@ -55,7 +54,7 @@ async fn main() {
 
     let mut app = Router::<()>::new()
         .route("/", get(handler))
-        .into_make_service_with_connect_info::<SocketAddr>();
+        .into_make_service();
 
     loop {
         let stream = poll_fn(|cx| Pin::new(&mut listener).poll_accept(cx))
@@ -77,8 +76,8 @@ async fn main() {
     }
 }
 
-async fn handler(ConnectInfo(addr): ConnectInfo<SocketAddr>) -> String {
-    addr.to_string()
+async fn handler() -> &'static str {
+    "Hello, World!"
 }
 
 fn rustls_server_config(key: impl AsRef<Path>, cert: impl AsRef<Path>) -> Arc<ServerConfig> {


### PR DESCRIPTION
This removes hyper from axum's public API. `AddrStream` is going away
for hyper 1.0 anyway so have to remove this eventually no matter what.
