### PR TITLE
Don't inherit fallbacks when using `Router::nest_service`

### DIFF
--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -50,6 +50,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   type inference issues when calling `ServiceExt` methods on a `Router` ([#1835])
 - **breaking:** Removed `axum::Server` as it was removed in hyper 1.0. Instead
   use `axum::serve(listener, service)` or hyper/hyper-util for more configuration options ([#1868])
+- **breaking:** Only inherit fallbacks for routers nested with `Router::nest`.
+  Routers nested with `Router::nest_service` will no longer inherit fallbacks ([#1956])
 
 [#1664]: https://github.com/tokio-rs/axum/pull/1664
 [#1751]: https://github.com/tokio-rs/axum/pull/1751
@@ -58,6 +60,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#1835]: https://github.com/tokio-rs/axum/pull/1835
 [#1850]: https://github.com/tokio-rs/axum/pull/1850
 [#1868]: https://github.com/tokio-rs/axum/pull/1868
+[#1956]: https://github.com/tokio-rs/axum/pull/1956
 
 # 0.6.16 (18. April, 2023)
 

--- a/axum/src/routing/tests/fallback.rs
+++ b/axum/src/routing/tests/fallback.rs
@@ -1,5 +1,3 @@
-use tower::ServiceExt;
-
 use super::*;
 use crate::middleware::{map_request, map_response};
 
@@ -163,48 +161,6 @@ async fn also_inherits_default_layered_fallback() {
     let res = client.get("/foo/bar").send().await;
     assert_eq!(res.status(), StatusCode::NOT_FOUND);
     assert_eq!(res.headers()["x-from-fallback"], "1");
-    assert_eq!(res.text().await, "outer");
-}
-
-#[crate::test]
-async fn fallback_inherited_into_nested_router_service() {
-    let inner = Router::new()
-        .route(
-            "/bar",
-            get(|State(state): State<&'static str>| async move { state }),
-        )
-        .with_state("inner");
-
-    // with a different state
-    let app = Router::new()
-        .nest_service("/foo", inner)
-        .fallback(outer_fallback);
-
-    let client = TestClient::new(app);
-    let res = client.get("/foo/not-found").send().await;
-    assert_eq!(res.status(), StatusCode::NOT_FOUND);
-    assert_eq!(res.text().await, "outer");
-}
-
-#[crate::test]
-async fn fallback_inherited_into_nested_opaque_service() {
-    let inner = Router::new()
-        .route(
-            "/bar",
-            get(|State(state): State<&'static str>| async move { state }),
-        )
-        .with_state("inner")
-        // even if the service is made more opaque it should still inherit the fallback
-        .boxed_clone();
-
-    // with a different state
-    let app = Router::new()
-        .nest_service("/foo", inner)
-        .fallback(outer_fallback);
-
-    let client = TestClient::new(app);
-    let res = client.get("/foo/not-found").send().await;
-    assert_eq!(res.status(), StatusCode::NOT_FOUND);
     assert_eq!(res.text().await, "outer");
 }
 


### PR DESCRIPTION
I think it makes sense to only inherit fallbacks for routers nested with
`Router::nest` and not `Router::nest_service`. It also simplifies the
code and avoids some unfortunate extension work arounds.
