### PR TITLE
Fix fallback panic on CONNECT requests

### DIFF
--- a/axum/src/routing/method_routing.rs
+++ b/axum/src/routing/method_routing.rs
@@ -1119,15 +1119,7 @@ where
         call!(req, method, DELETE, delete);
         call!(req, method, TRACE, trace);
 
-        let future = match fallback {
-            Fallback::Default(route) | Fallback::Service(route) => {
-                RouteFuture::from_future(route.oneshot_inner(req))
-            }
-            Fallback::BoxedHandler(handler) => {
-                let mut route = handler.clone().into_route(state);
-                RouteFuture::from_future(route.oneshot_inner(req))
-            }
-        };
+        let future = fallback.call_with_state(req, state);
 
         match allow_header {
             AllowHeader::None => future.allow_header(Bytes::new()),

--- a/axum/src/routing/mod.rs
+++ b/axum/src/routing/mod.rs
@@ -60,6 +60,7 @@ pub struct Router<S = (), B = Body> {
     path_router: PathRouter<S, B, false>,
     fallback_router: PathRouter<S, B, true>,
     default_fallback: bool,
+    catch_all_fallback: Fallback<S, B>,
 }
 
 impl<S, B> Clone for Router<S, B> {
@@ -68,6 +69,7 @@ impl<S, B> Clone for Router<S, B> {
             path_router: self.path_router.clone(),
             fallback_router: self.fallback_router.clone(),
             default_fallback: self.default_fallback,
+            catch_all_fallback: self.catch_all_fallback.clone(),
         }
     }
 }
@@ -88,6 +90,7 @@ impl<S, B> fmt::Debug for Router<S, B> {
             .field("path_router", &self.path_router)
             .field("fallback_router", &self.fallback_router)
             .field("default_fallback", &self.default_fallback)
+            .field("catch_all_fallback", &self.catch_all_fallback)
             .finish()
     }
 }
@@ -106,13 +109,16 @@ where
     /// Unless you add additional routes this will respond with `404 Not Found` to
     /// all requests.
     pub fn new() -> Self {
+        // TODO(david): refactor this. Having to set the fallback twice is kinda ugly
         let mut this = Self {
             path_router: Default::default(),
             fallback_router: Default::default(),
             default_fallback: true,
+            catch_all_fallback: Fallback::Default(Route::new(NotFound)),
         };
         this = this.fallback_service(NotFound);
         this.default_fallback = true;
+        this.catch_all_fallback = Fallback::Default(Route::new(NotFound));
         this
     }
 
@@ -151,6 +157,10 @@ where
             path_router,
             fallback_router,
             default_fallback,
+            // we don't need to inherit the catch-all fallback. It is only used for CONNECT
+            // requests with an empty path. If we were to inherit the catch-all fallback
+            // it would end up matching `/{path}/*` which doesn't match empty paths.
+            catch_all_fallback: _,
         } = router;
 
         panic_on_err!(self.path_router.nest(path, path_router));
@@ -184,6 +194,7 @@ where
             path_router,
             fallback_router: other_fallback,
             default_fallback,
+            catch_all_fallback,
         } = other.into();
 
         panic_on_err!(self.path_router.merge(path_router));
@@ -208,6 +219,11 @@ where
             }
         };
 
+        self.catch_all_fallback = self
+            .catch_all_fallback
+            .merge(catch_all_fallback)
+            .unwrap_or_else(|| panic!("Cannot merge two `Router`s that both have a fallback"));
+
         self
     }
 
@@ -223,8 +239,9 @@ where
     {
         Router {
             path_router: self.path_router.layer(layer.clone()),
-            fallback_router: self.fallback_router.layer(layer),
+            fallback_router: self.fallback_router.layer(layer.clone()),
             default_fallback: self.default_fallback,
+            catch_all_fallback: self.catch_all_fallback.map(|route| route.layer(layer)),
         }
     }
 
@@ -242,30 +259,34 @@ where
             path_router: self.path_router.route_layer(layer),
             fallback_router: self.fallback_router,
             default_fallback: self.default_fallback,
+            catch_all_fallback: self.catch_all_fallback,
         }
     }
 
     #[track_caller]
     #[doc = include_str!("../docs/routing/fallback.md")]
-    pub fn fallback<H, T>(self, handler: H) -> Self
+    pub fn fallback<H, T>(mut self, handler: H) -> Self
     where
         H: Handler<T, S, B>,
         T: 'static,
     {
-        let endpoint = Endpoint::MethodRouter(any(handler));
-        self.fallback_endpoint(endpoint)
+        self.catch_all_fallback =
+            Fallback::BoxedHandler(BoxedIntoRoute::from_handler(handler.clone()));
+        self.fallback_endpoint(Endpoint::MethodRouter(any(handler)))
     }
 
     /// Add a fallback [`Service`] to the router.
     ///
     /// See [`Router::fallback`] for more details.
-    pub fn fallback_service<T>(self, service: T) -> Self
+    pub fn fallback_service<T>(mut self, service: T) -> Self
     where
         T: Service<Request<B>, Error = Infallible> + Clone + Send + 'static,
         T::Response: IntoResponse,
         T::Future: Send + 'static,
     {
-        self.fallback_endpoint(Endpoint::Route(Route::new(service)))
+        let route = Route::new(service);
+        self.catch_all_fallback = Fallback::Service(route.clone());
+        self.fallback_endpoint(Endpoint::Route(route))
     }
 
     fn fallback_endpoint(mut self, endpoint: Endpoint<S, B>) -> Self {
@@ -280,8 +301,9 @@ where
     pub fn with_state<S2>(self, state: S) -> Router<S2, B> {
         Router {
             path_router: self.path_router.with_state(state.clone()),
-            fallback_router: self.fallback_router.with_state(state),
+            fallback_router: self.fallback_router.with_state(state.clone()),
             default_fallback: self.default_fallback,
+            catch_all_fallback: self.catch_all_fallback.with_state(state),
         }
     }
 
@@ -307,19 +329,17 @@ where
                     .map(|SuperFallback(path_router)| path_router.into_inner());
 
                 if let Some(mut super_fallback) = super_fallback {
-                    return super_fallback
-                        .call_with_state(req, state)
-                        .unwrap_or_else(|_| unreachable!());
+                    match super_fallback.call_with_state(req, state) {
+                        Ok(future) => return future,
+                        Err((req, state)) => {
+                            return self.catch_all_fallback.call_with_state(req, state);
+                        }
+                    }
                 }
 
                 match self.fallback_router.call_with_state(req, state) {
                     Ok(future) => future,
-                    Err((_req, _state)) => {
-                        unreachable!(
-                            "the default fallback added in `Router::new` \
-                             matches everything"
-                        )
-                    }
+                    Err((req, state)) => self.catch_all_fallback.call_with_state(req, state),
                 }
             }
         }
@@ -426,6 +446,18 @@ where
             Fallback::Default(route) => Fallback::Default(route),
             Fallback::Service(route) => Fallback::Service(route),
             Fallback::BoxedHandler(handler) => Fallback::Service(handler.into_route(state)),
+        }
+    }
+
+    fn call_with_state(&mut self, req: Request<B>, state: S) -> RouteFuture<B, E> {
+        match self {
+            Fallback::Default(route) | Fallback::Service(route) => {
+                RouteFuture::from_future(route.oneshot_inner(req))
+            }
+            Fallback::BoxedHandler(handler) => {
+                let mut route = handler.clone().into_route(state);
+                RouteFuture::from_future(route.oneshot_inner(req))
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/tokio-rs/axum/issues/1955

Turns out that CONNECT requests have an empty path, so the default fallback didn't match it. It had routes for `/` and `/*` which don't match an empty path.

This fixes it for 0.6.x. Will fix for 0.7 when this is merged.