### PR TITLE
Fix typo in json_lines.rs

### DIFF
--- a/axum-extra/src/json_lines.rs
+++ b/axum-extra/src/json_lines.rs
@@ -79,12 +79,12 @@ pin_project! {
     }
 }
 
-/// Maker type used to prove that an `JsonLines` was constructed via `FromRequest`.
+/// Marker type used to prove that an `JsonLines` was constructed via `FromRequest`.
 #[derive(Debug)]
 #[non_exhaustive]
 pub struct AsExtractor;
 
-/// Maker type used to prove that an `JsonLines` was constructed via `JsonLines::new`.
+/// Marker type used to prove that an `JsonLines` was constructed via `JsonLines::new`.
 #[derive(Debug)]
 #[non_exhaustive]
 pub struct AsResponse;


### PR DESCRIPTION
I *think* that this meant to say "Marker type", not "Maker type".

## Motivation

It's in the public crate docs, so it's more visible than your average typo.

## Solution

This is my guess as to what it meant to say.  Feel free to close if I'm wrong.
