### PR TITLE
Add ReductStore to show cases

### DIFF
--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -69,6 +69,7 @@ If your project isn't listed here and you would like it to be, please feel free 
 - [cobrust](https://github.com/scotow/cobrust): Multiplayer web based snake game.
 - [meta-cross](https://github.com/scotow/meta-cross): Tweaked version of Tic-Tac-Toe.
 - [httq](https://github.com/scotow/httq) HTTP to MQTT trivial proxy.
+- [ReductStore](https://github.com/reductstore/reductstore): A time series database for storing and managing large amounts of blob data 
 
 [Realworld]: https://github.com/gothinkster/realworld
 [SQLx]: https://github.com/launchbadge/sqlx


### PR DESCRIPTION
## Motivation

I've rewritten my [time series database](https://github.com/reductstore/reductstore) in Rust by using Axum for its HTTP fronted. It could be a good showcase for the framework because the database designed for intensive write/read operations over HTTP.

## Solution

No applicable
