### PR TITLE
Allow unreachable code in `#[debug_handler]`

### DIFF
--- a/axum-macros/src/debug_handler.rs
+++ b/axum-macros/src/debug_handler.rs
@@ -263,6 +263,7 @@ fn check_inputs_impls_from_request(item_fn: &ItemFn, state_ty: Type) -> TokenStr
 
             quote_spanned! {span=>
                 #[allow(warnings)]
+                #[allow(unreachable_code)]
                 #[doc(hidden)]
                 fn #check_fn #check_fn_generics()
                 where
@@ -272,6 +273,7 @@ fn check_inputs_impls_from_request(item_fn: &ItemFn, state_ty: Type) -> TokenStr
                 // we have to call the function to actually trigger a compile error
                 // since the function is generic, just defining it is not enough
                 #[allow(warnings)]
+                #[allow(unreachable_code)]
                 #[doc(hidden)]
                 fn #call_check_fn()
                 {
@@ -415,6 +417,7 @@ fn check_output_impls_into_response(item_fn: &ItemFn) -> TokenStream {
     let make = if item_fn.sig.asyncness.is_some() {
         quote_spanned! {span=>
             #[allow(warnings)]
+            #[allow(unreachable_code)]
             #[doc(hidden)]
             async fn #make_value_name() -> #ty {
                 #declare_inputs
@@ -424,6 +427,7 @@ fn check_output_impls_into_response(item_fn: &ItemFn) -> TokenStream {
     } else {
         quote_spanned! {span=>
             #[allow(warnings)]
+            #[allow(unreachable_code)]
             #[doc(hidden)]
             fn #make_value_name() -> #ty {
                 #declare_inputs
@@ -439,6 +443,7 @@ fn check_output_impls_into_response(item_fn: &ItemFn) -> TokenStream {
             #make
 
             #[allow(warnings)]
+            #[allow(unreachable_code)]
             #[doc(hidden)]
             async fn #name() {
                 let value = #receiver #make_value_name().await;
@@ -451,6 +456,7 @@ fn check_output_impls_into_response(item_fn: &ItemFn) -> TokenStream {
     } else {
         quote_spanned! {span=>
             #[allow(warnings)]
+            #[allow(unreachable_code)]
             #[doc(hidden)]
             async fn #name() {
                 #make
@@ -501,6 +507,7 @@ fn check_future_send(item_fn: &ItemFn) -> TokenStream {
     if let Some(receiver) = self_receiver(item_fn) {
         quote! {
             #[allow(warnings)]
+            #[allow(unreachable_code)]
             #[doc(hidden)]
             fn #name() {
                 let future = #receiver #handler_name(#(#args),*);
@@ -510,6 +517,7 @@ fn check_future_send(item_fn: &ItemFn) -> TokenStream {
     } else {
         quote! {
             #[allow(warnings)]
+            #[allow(unreachable_code)]
             #[doc(hidden)]
             fn #name() {
                 #item_fn

--- a/axum-macros/tests/debug_handler/pass/deny_unreachable_code.rs
+++ b/axum-macros/tests/debug_handler/pass/deny_unreachable_code.rs
@@ -1,0 +1,8 @@
+#![deny(unreachable_code)]
+
+use axum::extract::Path;
+
+#[axum_macros::debug_handler]
+async fn handler(Path(_): Path<String>) {}
+
+fn main() {}


### PR DESCRIPTION
## Motivation

As reported in #2004, the usage of `#[debug_handler]` conflicts with `#![deny(unreachable_code)]` since the macro itself generates unreachable code by design.

## Solution

This change:
* Adds allow rules to the generated code to prevent this

Closes #2004