### PR TITLE
docs: Remove explicit auto deref from PrivateCookieJar example

### DIFF
--- a/axum-extra/src/extract/cookie/private.rs
+++ b/axum-extra/src/extract/cookie/private.rs
@@ -91,7 +91,7 @@ use std::{convert::Infallible, fmt, marker::PhantomData};
 ///     type Target = InnerState;
 ///
 ///     fn deref(&self) -> &Self::Target {
-///         &*self.0
+///         &self.0
 ///     }
 /// }
 ///


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

Without it clippy produces the following lint:
```
warning: deref which would be done by auto-deref
   --> src/main.rs:101:9
    |
101 |         &*self.0
    |         ^^^^^^^^ help: try this: `&self.0`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#explicit_auto_deref
    = note: `#[warn(clippy::explicit_auto_deref)]` on by default
```

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Trivial.
