### PR TITLE
Implement `IntoResponse` for boxed slices

### DIFF
--- a/axum-core/src/response/into_response.rs
+++ b/axum-core/src/response/into_response.rs
@@ -190,6 +190,12 @@ impl IntoResponse for String {
     }
 }
 
+impl IntoResponse for Box<str> {
+    fn into_response(self) -> Response {
+        String::from(self).into_response()
+    }
+}
+
 impl IntoResponse for Cow<'static, str> {
     fn into_response(self) -> Response {
         let mut res = Body::from(self).into_response();
@@ -312,6 +318,12 @@ impl<const N: usize> IntoResponse for [u8; N] {
 impl IntoResponse for Vec<u8> {
     fn into_response(self) -> Response {
         Cow::<'static, [u8]>::Owned(self).into_response()
+    }
+}
+
+impl IntoResponse for Box<[u8]> {
+    fn into_response(self) -> Response {
+        Vec::from(self).into_response()
     }
 }
 

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -53,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **breaking:** Only inherit fallbacks for routers nested with `Router::nest`.
   Routers nested with `Router::nest_service` will no longer inherit fallbacks ([#1956])
 - **fixed:** Don't remove the `Sec-WebSocket-Key` header in `WebSocketUpgrade` ([#1972])
+- **added:** Implement `IntoResponse` for `Box<str>` and `Box<[u8]>` ([#2035])
 
 [#1664]: https://github.com/tokio-rs/axum/pull/1664
 [#1751]: https://github.com/tokio-rs/axum/pull/1751


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

This change makes it possible to create responses from boxed slices: `Box<[u8]>` and `Box<str>`.
