### PR TITLE
docs: update router::route multiple methods docs

### DIFF
--- a/axum/src/docs/routing/route.md
+++ b/axum/src/docs/routing/route.md
@@ -61,7 +61,7 @@ the path `/foo/bar/baz` the value of `rest` will be `bar/baz`.
 
 # Accepting multiple methods
 
-To accept multiple methods for the same route you must add all handlers at the
+To accept multiple methods for the same route you can add all handlers at the
 same time:
 
 ```rust
@@ -78,6 +78,15 @@ async fn post_root() {}
 
 async fn delete_root() {}
 # let _: Router = app;
+```
+
+Or you can add them one by one:
+
+```rust
+let app = Router::new()
+    .route("/", get(get_root))
+    .route("/", post(post_root))
+    .route("/", delete(delete_root));
 ```
 
 # More examples

--- a/axum/src/docs/routing/route.md
+++ b/axum/src/docs/routing/route.md
@@ -83,10 +83,18 @@ async fn delete_root() {}
 Or you can add them one by one:
 
 ```rust
+# use axum::Router;
+# use axum::routing::{get, post, delete};
+#
 let app = Router::new()
     .route("/", get(get_root))
     .route("/", post(post_root))
     .route("/", delete(delete_root));
+#
+# let _: Router = app;
+# async fn get_root() {}
+# async fn post_root() {}
+# async fn delete_root() {}
 ```
 
 # More examples


### PR DESCRIPTION
## Motivation
In the early days you had to add handlers at the same time if they are for the same route with different methods,
but that hasn't been the case for a while.
Now you can do both but the docs are outdated.

## Solution
Change `must` to `can`, and add a note that the one-by-one way is also possible.

[Relevant discussion](https://github.com/tokio-rs/axum/discussions/2050) 