### PR TITLE
Remove unwraps via '?' with anyhow crate for example-oauth

### DIFF
--- a/examples/oauth/Cargo.toml
+++ b/examples/oauth/Cargo.toml
@@ -16,3 +16,4 @@ serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "1.0", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+anyhow = "1"

--- a/examples/oauth/Cargo.toml
+++ b/examples/oauth/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
+anyhow = "1"
 async-session = "3.0.0"
 axum = { path = "../../axum" }
 axum-extra = { path = "../../axum-extra", features = ["typed-header"] }
@@ -16,4 +17,3 @@ serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "1.0", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-anyhow = "1"


### PR DESCRIPTION
Refs: #2039

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation
Substitutes `unwrap` calls with proper error handling via the `anyhow` crate for `example-oauth`.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution
Substitute `unwrap`s with `?` via `anyhow`. Using `if let` or `match` is very verbose and makes the example lose focus. Using `?` keeps the example readable, focused and shows better practices.  

Validated solution by compiling and testing via `CLIENT_ID=REPLACE_ME CLIENT_SECRET=REPLACE_ME cargo run -p example-oauth` 
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
