### PR TITLE
Remove `bitflags` crate dependency

### DIFF
--- a/axum-extra/src/routing/resource.rs
+++ b/axum-extra/src/routing/resource.rs
@@ -109,7 +109,10 @@ where
         T: 'static,
     {
         let path = self.show_update_destroy_path();
-        self.route(&path, on(MethodFilter::PUT | MethodFilter::PATCH, handler))
+        self.route(
+            &path,
+            on(MethodFilter::PUT.or(MethodFilter::PATCH), handler),
+        )
     }
 
     /// Add a handler at `DELETE /{resource_name}/:{resource_name}_id`.

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -55,6 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **fixed:** Don't remove the `Sec-WebSocket-Key` header in `WebSocketUpgrade` ([#1972])
 - **added:** Add `axum::extract::Query::try_from_uri` ([#2058])
 - **added:** Implement `IntoResponse` for `Box<str>` and `Box<[u8]>` ([#2035])
+- **breaking:** Simplify `MethodFilter`. It no longer uses bitflags ([#2073])
 
 [#1664]: https://github.com/tokio-rs/axum/pull/1664
 [#1751]: https://github.com/tokio-rs/axum/pull/1751
@@ -66,6 +67,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#1956]: https://github.com/tokio-rs/axum/pull/1956
 [#1972]: https://github.com/tokio-rs/axum/pull/1972
 [#2058]: https://github.com/tokio-rs/axum/pull/2058
+[#2073]: https://github.com/tokio-rs/axum/pull/2073
 
 # 0.6.17 (25. April, 2023)
 

--- a/axum/Cargo.toml
+++ b/axum/Cargo.toml
@@ -33,7 +33,6 @@ __private_docs = ["tower/full", "dep:tower-http"]
 [dependencies]
 async-trait = "0.1.67"
 axum-core = { path = "../axum-core", version = "0.3.4" }
-bitflags = "1.0"
 bytes = "1.0"
 futures-util = { version = "0.3", default-features = false, features = ["alloc"] }
 http = "0.2.9"

--- a/axum/src/form.rs
+++ b/axum/src/form.rs
@@ -235,7 +235,7 @@ mod tests {
         let app = Router::new().route(
             "/",
             on(
-                MethodFilter::GET | MethodFilter::POST,
+                MethodFilter::GET.or(MethodFilter::POST),
                 |_: Form<Payload>| async {},
             ),
         );

--- a/axum/src/response/sse.rs
+++ b/axum/src/response/sse.rs
@@ -403,13 +403,6 @@ impl EventFlags {
         *same = Self::from_bits(same.bits() | other.bits());
     }
 }
-impl std::ops::BitOr for EventFlags {
-    type Output = Self;
-
-    fn bitor(self, rhs: Self) -> Self::Output {
-        Self(self.0 | rhs.0)
-    }
-}
 
 /// Configure the interval between keep-alive messages, the content
 /// of each message, and the associated stream.

--- a/axum/src/response/sse.rs
+++ b/axum/src/response/sse.rs
@@ -383,32 +383,24 @@ impl EventFlags {
 
     const fn bits(&self) -> u8 {
         let bits = self;
-        {
-            bits.0
-        }
+        bits.0
     }
 
     const fn from_bits(bits: u8) -> Self {
         let bits = bits;
-        {
-            Self(bits)
-        }
+        Self(bits)
     }
 
     const fn contains(&self, other: Self) -> bool {
         let same = self;
         let other = other;
-        {
-            same.bits() & other.bits() == other.bits()
-        }
+        same.bits() & other.bits() == other.bits()
     }
 
     fn insert(&mut self, other: Self) {
         let same = self;
         let other = other;
-        {
-            *same = Self::from_bits(same.bits() | other.bits());
-        }
+        *same = Self::from_bits(same.bits() | other.bits());
     }
 }
 impl std::ops::BitOr for EventFlags {

--- a/axum/src/response/sse.rs
+++ b/axum/src/response/sse.rs
@@ -372,13 +372,50 @@ impl Event {
     }
 }
 
-bitflags::bitflags! {
-    #[derive(Default)]
-    struct EventFlags: u8 {
-        const HAS_DATA  = 0b0001;
-        const HAS_EVENT = 0b0010;
-        const HAS_RETRY = 0b0100;
-        const HAS_ID    = 0b1000;
+#[derive(Default, Debug, Copy, Clone, PartialEq)]
+struct EventFlags(u8);
+
+impl EventFlags {
+    const HAS_DATA: Self = Self::from_bits(0b0001);
+    const HAS_EVENT: Self = Self::from_bits(0b0010);
+    const HAS_RETRY: Self = Self::from_bits(0b0100);
+    const HAS_ID: Self = Self::from_bits(0b1000);
+
+    const fn bits(&self) -> u8 {
+        let bits = self;
+        {
+            bits.0
+        }
+    }
+
+    const fn from_bits(bits: u8) -> Self {
+        let bits = bits;
+        {
+            Self(bits)
+        }
+    }
+
+    const fn contains(&self, other: Self) -> bool {
+        let same = self;
+        let other = other;
+        {
+            same.bits() & other.bits() == other.bits()
+        }
+    }
+
+    fn insert(&mut self, other: Self) {
+        let same = self;
+        let other = other;
+        {
+            *same = Self::from_bits(same.bits() | other.bits());
+        }
+    }
+}
+impl std::ops::BitOr for EventFlags {
+    type Output = Self;
+
+    fn bitor(self, rhs: Self) -> Self::Output {
+        Self(self.0 | rhs.0)
     }
 }
 

--- a/axum/src/routing/method_filter.rs
+++ b/axum/src/routing/method_filter.rs
@@ -1,4 +1,3 @@
-// use bitflags::bitflags;
 use http::Method;
 use std::{
     fmt,

--- a/axum/src/routing/method_filter.rs
+++ b/axum/src/routing/method_filter.rs
@@ -28,24 +28,18 @@ impl MethodFilter {
 
     const fn bits(&self) -> u16 {
         let bits = self;
-        {
-            bits.0
-        }
+        bits.0
     }
 
     const fn from_bits(bits: u16) -> Self {
         let bits = bits;
-        {
-            Self(bits)
-        }
+        Self(bits)
     }
 
     pub(crate) const fn contains(&self, other: Self) -> bool {
         let same = self;
         let other = other;
-        {
-            same.bits() & other.bits() == other.bits()
-        }
+        same.bits() & other.bits() == other.bits()
     }
 }
 impl std::ops::BitOr for MethodFilter {

--- a/axum/src/routing/method_filter.rs
+++ b/axum/src/routing/method_filter.rs
@@ -41,12 +41,10 @@ impl MethodFilter {
         let other = other;
         same.bits() & other.bits() == other.bits()
     }
-}
-impl std::ops::BitOr for MethodFilter {
-    type Output = Self;
 
-    fn bitor(self, rhs: Self) -> Self::Output {
-        Self(self.0 | rhs.0)
+    /// Performs the OR operation between the [`MethodFilter`] in `self` with `other`.
+    pub const fn or(self, other: Self) -> Self {
+        Self(self.0 | other.0)
     }
 }
 

--- a/axum/src/routing/method_filter.rs
+++ b/axum/src/routing/method_filter.rs
@@ -1,29 +1,59 @@
-use bitflags::bitflags;
+// use bitflags::bitflags;
 use http::Method;
 use std::{
     fmt,
     fmt::{Debug, Formatter},
 };
 
-bitflags! {
-    /// A filter that matches one or more HTTP methods.
-    pub struct MethodFilter: u16 {
-        /// Match `DELETE` requests.
-        const DELETE =  0b000000010;
-        /// Match `GET` requests.
-        const GET =     0b000000100;
-        /// Match `HEAD` requests.
-        const HEAD =    0b000001000;
-        /// Match `OPTIONS` requests.
-        const OPTIONS = 0b000010000;
-        /// Match `PATCH` requests.
-        const PATCH =   0b000100000;
-        /// Match `POST` requests.
-        const POST =    0b001000000;
-        /// Match `PUT` requests.
-        const PUT =     0b010000000;
-        /// Match `TRACE` requests.
-        const TRACE =   0b100000000;
+/// A filter that matches one or more HTTP methods.
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub struct MethodFilter(u16);
+
+impl MethodFilter {
+    /// Match `DELETE` requests.
+    pub const DELETE: Self = Self::from_bits(0b000000010);
+    /// Match `GET` requests.
+    pub const GET: Self = Self::from_bits(0b000000100);
+    /// Match `HEAD` requests.
+    pub const HEAD: Self = Self::from_bits(0b000001000);
+    /// Match `OPTIONS` requests.
+    pub const OPTIONS: Self = Self::from_bits(0b000010000);
+    /// Match `PATCH` requests.
+    pub const PATCH: Self = Self::from_bits(0b000100000);
+    /// Match `POST` requests.
+    pub const POST: Self = Self::from_bits(0b001000000);
+    /// Match `PUT` requests.
+    pub const PUT: Self = Self::from_bits(0b010000000);
+    /// Match `TRACE` requests.
+    pub const TRACE: Self = Self::from_bits(0b100000000);
+
+    const fn bits(&self) -> u16 {
+        let bits = self;
+        {
+            bits.0
+        }
+    }
+
+    const fn from_bits(bits: u16) -> Self {
+        let bits = bits;
+        {
+            Self(bits)
+        }
+    }
+
+    pub(crate) const fn contains(&self, other: Self) -> bool {
+        let same = self;
+        let other = other;
+        {
+            same.bits() & other.bits() == other.bits()
+        }
+    }
+}
+impl std::ops::BitOr for MethodFilter {
+    type Output = Self;
+
+    fn bitor(self, rhs: Self) -> Self::Output {
+        Self(self.0 | rhs.0)
     }
 }
 

--- a/axum/src/routing/tests/mod.rs
+++ b/axum/src/routing/tests/mod.rs
@@ -284,7 +284,7 @@ async fn multiple_methods_for_one_handler() {
         "Hello, World!"
     }
 
-    let app = Router::new().route("/", on(MethodFilter::GET | MethodFilter::POST, root));
+    let app = Router::new().route("/", on(MethodFilter::GET.or(MethodFilter::POST), root));
 
     let client = TestClient::new(app);
 

--- a/deny.toml
+++ b/deny.toml
@@ -28,7 +28,9 @@ skip-tree = [
     # until 1.0 is out we're pulling in both 0.14 and 1.0-rc.x
     { name = "hyper" },
     # pulled in by tracing-subscriber
-    { name = "regex-syntax" }
+    { name = "regex-syntax" },
+    # pulled in by tracing-subscriber
+    { name = "regex-automata" },
 ]
 
 [sources]


### PR DESCRIPTION
Implement our own `MethodFilter` and `EventFlags` types and remove `bitflags` dependency.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation
Remove dependency from `bitflags` crate by creating our own types as discussed [here](https://github.com/tokio-rs/axum/pull/2067#issuecomment-1616483907)

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

- Remove `bitflags` crate from `axum/Cargo.toml`
- Create `method_filter/MethodFilter` and `response/EventFlag` types following a similar structure as that of the `bitflags` macro expansion
- No other code modifications
- Implement only required methods to compile and pass tests 

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
Fixes https://github.com/tokio-rs/axum/issues/2066