### PR TITLE
Use exactly 1.0.0-rc.3 hyper and update UI test

### DIFF
--- a/axum-extra/src/json_lines.rs
+++ b/axum-extra/src/json_lines.rs
@@ -215,13 +215,11 @@ mod tests {
         let res = client
             .post("/")
             .body(
-                vec![
-                    "{\"id\":1}",
+                ["{\"id\":1}",
                     "{\"id\":2}",
                     "{\"id\":3}",
                     // to trigger an error for source downcasting
-                    "{\"id\":false}",
-                ]
+                    "{\"id\":false}"]
                 .join("\n"),
             )
             .send()

--- a/axum-extra/src/json_lines.rs
+++ b/axum-extra/src/json_lines.rs
@@ -215,7 +215,7 @@ mod tests {
         let res = client
             .post("/")
             .body(
-                [
+                vec![
                     "{\"id\":1}",
                     "{\"id\":2}",
                     "{\"id\":3}",

--- a/axum-extra/src/json_lines.rs
+++ b/axum-extra/src/json_lines.rs
@@ -215,11 +215,13 @@ mod tests {
         let res = client
             .post("/")
             .body(
-                ["{\"id\":1}",
+                [
+                    "{\"id\":1}",
                     "{\"id\":2}",
                     "{\"id\":3}",
                     // to trigger an error for source downcasting
-                    "{\"id\":false}"]
+                    "{\"id\":false}",
+                ]
                 .join("\n"),
             )
             .send()

--- a/axum-macros/tests/typed_path/fail/not_deserialize.stderr
+++ b/axum-macros/tests/typed_path/fail/not_deserialize.stderr
@@ -5,15 +5,15 @@ error[E0277]: the trait bound `for<'de> MyPath: serde::de::Deserialize<'de>` is 
   |          ^^^^^^^^^ the trait `for<'de> serde::de::Deserialize<'de>` is not implemented for `MyPath`
   |
   = help: the following other types implement trait `serde::de::Deserialize<'de>`:
-            &'a [u8]
-            &'a serde_json::raw::RawValue
-            &'a std::path::Path
-            &'a str
-            ()
-            (T0, T1)
-            (T0, T1, T2)
-            (T0, T1, T2, T3)
-          and 129 others
+            bool
+            char
+            isize
+            i8
+            i16
+            i32
+            i64
+            i128
+          and $N others
   = note: required for `MyPath` to implement `serde::de::DeserializeOwned`
   = note: required for `axum::extract::Path<MyPath>` to implement `FromRequestParts<S>`
   = note: this error originates in the derive macro `TypedPath` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/axum-macros/tests/typed_path/fail/not_deserialize.stderr
+++ b/axum-macros/tests/typed_path/fail/not_deserialize.stderr
@@ -5,14 +5,14 @@ error[E0277]: the trait bound `for<'de> MyPath: serde::de::Deserialize<'de>` is 
   |          ^^^^^^^^^ the trait `for<'de> serde::de::Deserialize<'de>` is not implemented for `MyPath`
   |
   = help: the following other types implement trait `serde::de::Deserialize<'de>`:
-            bool
-            char
-            isize
-            i8
-            i16
-            i32
-            i64
-            i128
+            &'a [u8]
+            &'a serde_json::raw::RawValue
+            &'a std::path::Path
+            &'a str
+            ()
+            (T0, T1)
+            (T0, T1, T2)
+            (T0, T1, T2, T3)
           and $N others
   = note: required for `MyPath` to implement `serde::de::DeserializeOwned`
   = note: required for `axum::extract::Path<MyPath>` to implement `FromRequestParts<S>`

--- a/axum/Cargo.toml
+++ b/axum/Cargo.toml
@@ -51,7 +51,7 @@ tower-layer = "0.3.2"
 tower-service = "0.3"
 
 # wont need this when axum uses http-body 1.0
-hyper1 = { package = "hyper", version = "^1.0.0-rc.3", features = ["server", "http1"] }
+hyper1 = { package = "hyper", version = "=1.0.0-rc.3", features = ["server", "http1"] }
 tower-hyper-http-body-compat = { version = "0.1.4", features = ["server", "http1"] }
 
 # optional dependencies

--- a/axum/Cargo.toml
+++ b/axum/Cargo.toml
@@ -51,7 +51,7 @@ tower-layer = "0.3.2"
 tower-service = "0.3"
 
 # wont need this when axum uses http-body 1.0
-hyper1 = { package = "hyper", version = "1.0.0-rc.3", features = ["server", "http1"] }
+hyper1 = { package = "hyper", version = "^1.0.0-rc.3", features = ["server", "http1"] }
 tower-hyper-http-body-compat = { version = "0.1.4", features = ["server", "http1"] }
 
 # optional dependencies

--- a/axum/src/extract/matched_path.rs
+++ b/axum/src/extract/matched_path.rs
@@ -139,7 +139,7 @@ pub(crate) fn set_matched_path_for_request(
 
     if matched_path.ends_with(NEST_TAIL_PARAM_CAPTURE) {
         extensions.insert(MatchedNestedPath(matched_path));
-        debug_assert!(matches!(extensions.remove::<MatchedPath>(), None));
+        debug_assert!(extensions.remove::<MatchedPath>().is_none());
     } else {
         extensions.insert(MatchedPath(matched_path));
         extensions.remove::<MatchedNestedPath>();


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation
close https://github.com/tokio-rs/axum/pull/2085

Because we don't have the Cargo.lock file so you try to build with Cargo, it will help you pick the `1.0.0-rc.4` to build the code. 

Then you will get an error:
```console
   Compiling axum v0.6.16 (/Volumes/t7/code/axum/axum)
error[E0277]: the trait bound `tokio::net::TcpStream: hyper::rt::Read` is not satisfied
   --> axum/src/serve.rs:136:35
    |
136 |                 .serve_connection(tcp_stream, service)
    |                  ---------------- ^^^^^^^^^^ the trait `hyper::rt::Read` is not implemented for `tokio::net::TcpStream`
    |                  |
    |                  required by a bound introduced by this call
    |
    = help: the following other types implement trait `hyper::rt::Read`:
              &mut T
              Box<T>
              Upgraded
note: required by a bound in `hyper::server::conn::http1::Builder::serve_connection`
   --> /Users/hi-rustin/.cargo/registry/src/index.crates.io-6f17d22bba15001f/hyper-1.0.0-rc.4/src/server/conn/http1.rs:359:12
    |
359 |         I: Read + Write + Unpin,
    |            ^^^^ required by this bound in `Builder::serve_connection`

error[E0277]: the trait bound `tokio::net::TcpStream: hyper::rt::Write` is not satisfied
   --> axum/src/serve.rs:136:35
    |
136 |                 .serve_connection(tcp_stream, service)
    |                  ---------------- ^^^^^^^^^^ the trait `hyper::rt::Write` is not implemented for `tokio::net::TcpStream`
    |                  |
    |                  required by a bound introduced by this call
    |
    = help: the following other types implement trait `hyper::rt::Write`:
              &mut T
              Box<T>
              Upgraded
note: required by a bound in `hyper::server::conn::http1::Builder::serve_connection`
   --> /Users/hi-rustin/.cargo/registry/src/index.crates.io-6f17d22bba15001f/hyper-1.0.0-rc.4/src/server/conn/http1.rs:359:19
    |
359 |         I: Read + Write + Unpin,
    |                   ^^^^^ required by this bound in `Builder::serve_connection`

error[E0599]: the method `with_upgrades` exists for struct `Connection<TcpStream, ServiceFn<[closure@serve.rs:98:51], Incoming>>`, but its trait bounds were not satisfied
   --> axum/src/serve.rs:138:18
    |
135 |               match http1::Builder::new()
    |  ___________________-
136 | |                 .serve_connection(tcp_stream, service)
137 | |                 // for websockets
138 | |                 .with_upgrades()
    | |                 -^^^^^^^^^^^^^ method cannot be called due to unsatisfied trait bounds
    | |_________________|
    | 
    |
   ::: /Users/hi-rustin/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.29.1/src/net/tcp/stream.rs:69:5
    |
69  |       pub struct TcpStream {
    |       --------------------
    |       |
    |       doesn't satisfy `tokio::net::TcpStream: hyper::rt::Read`
    |       doesn't satisfy `tokio::net::TcpStream: hyper::rt::Write`
    |
    = note: the full type name has been written to '/Volumes/t7/code/axum/target/debug/deps/axum-aaccf8d8ae7886df.long-type-16884531195687648243.txt'
    = note: the following trait bounds were not satisfied:
            `tokio::net::TcpStream: hyper::rt::Read`
            `tokio::net::TcpStream: hyper::rt::Write`

Some errors have detailed explanations: E0277, E0599.
For more information about an error, try `rustc --explain E0277`.
error: could not compile `axum` (lib) due to 3 previous errors
```

## Solution

Use a fixed version hyper. But if bump it is OK. I can also bump it to 1.0.0-rc.4.
