### PR TITLE
Implemented support for multiple handlers on the same endpoint.

### DIFF
--- a/axum-core/src/extract/mod.rs
+++ b/axum-core/src/extract/mod.rs
@@ -56,6 +56,12 @@ pub trait FromRequestParts<S>: Sized {
 
     /// Perform the extraction.
     async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection>;
+
+    /// Optimistic estimation of whether this extractor can accept this request.
+    /// Used to allow multiple handlers on a single route.
+    fn can_accept_parts(_req: &Request, _state: &S) -> bool {
+        true
+    }
 }
 
 /// Types that can be created from requests.
@@ -83,6 +89,12 @@ pub trait FromRequest<S, M = private::ViaRequest>: Sized {
 
     /// Perform the extraction.
     async fn from_request(req: Request, state: &S) -> Result<Self, Self::Rejection>;
+
+    /// Optimistic estimation of whether this extractor can accept this request.
+    /// Used to allow multiple handlers on a single route.
+    fn can_accept_request(_req: &Request, _state: &S) -> bool {
+        true
+    }
 }
 
 #[async_trait]
@@ -96,6 +108,10 @@ where
     async fn from_request(req: Request, state: &S) -> Result<Self, Self::Rejection> {
         let (mut parts, _) = req.into_parts();
         Self::from_request_parts(&mut parts, state).await
+    }
+
+    fn can_accept_request(req: &Request, state: &S) -> bool {
+        Self::can_accept_parts(req, state)
     }
 }
 

--- a/axum-core/src/extract/tuple.rs
+++ b/axum-core/src/extract/tuple.rs
@@ -42,6 +42,16 @@ macro_rules! impl_from_request {
 
                 Ok(($($ty,)* $last,))
             }
+
+            fn can_accept_parts(req: &Request, state: &S) -> bool {
+                let mut can_accept = true;
+
+                $(
+                    can_accept = can_accept && $ty::can_accept_parts(req, state);
+                )*
+
+                can_accept && $last::can_accept_parts(req, state)
+            }
         }
 
         // This impl must not be generic over M, otherwise it would conflict with the blanket
@@ -68,6 +78,16 @@ macro_rules! impl_from_request {
                 let $last = $last::from_request(req, state).await.map_err(|err| err.into_response())?;
 
                 Ok(($($ty,)* $last,))
+            }
+
+            fn can_accept_request(req: &Request, state: &S) -> bool {
+                let mut can_accept = true;
+
+                $(
+                    can_accept = can_accept && $ty::can_accept_parts(req, state);
+                )*
+
+                can_accept && $last::can_accept_request(req, state)
             }
         }
     };

--- a/axum/src/extract/multipart.rs
+++ b/axum/src/extract/multipart.rs
@@ -79,6 +79,10 @@ where
         let multipart = multer::Multipart::new(stream, boundary);
         Ok(Self { inner: multipart })
     }
+
+    fn can_accept_request(req: &Request, _state: &S) -> bool {
+        parse_boundary(req.headers()).is_some()
+    }
 }
 
 impl Multipart {

--- a/axum/src/extract/query.rs
+++ b/axum/src/extract/query.rs
@@ -1,4 +1,4 @@
-use super::{rejection::*, FromRequestParts};
+use super::{rejection::*, FromRequestParts, Request};
 use async_trait::async_trait;
 use http::{request::Parts, Uri};
 use serde::de::DeserializeOwned;
@@ -56,6 +56,10 @@ where
 
     async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
         Self::try_from_uri(&parts.uri)
+    }
+
+    fn can_accept_parts(req: &Request, _state: &S) -> bool {
+        Self::try_from_uri(req.uri()).is_ok()
     }
 }
 

--- a/axum/src/extract/raw_form.rs
+++ b/axum/src/extract/raw_form.rs
@@ -54,6 +54,11 @@ where
             Ok(Self(Bytes::from_request(req, state).await?))
         }
     }
+
+    fn can_accept_request(req: &Request, _state: &S) -> bool {
+        req.method() == Method::GET
+            || has_content_type(req.headers(), &mime::APPLICATION_WWW_FORM_URLENCODED)
+    }
 }
 
 #[cfg(test)]

--- a/axum/src/form.rs
+++ b/axum/src/form.rs
@@ -92,6 +92,10 @@ where
             }
         }
     }
+
+    fn can_accept_request(req: &Request, state: &S) -> bool {
+        RawForm::can_accept_request(req, state)
+    }
 }
 
 impl<T> IntoResponse for Form<T>

--- a/axum/src/handler/tuple.rs
+++ b/axum/src/handler/tuple.rs
@@ -1,0 +1,62 @@
+use std::future::Future;
+
+use pin_project_lite::pin_project;
+
+use crate::response::Response;
+
+use super::Handler;
+
+macro_rules! impl_handler {
+    (
+        [$($ty:ident, $tyt:ident, $tyi:tt),*], $last:ident, $lastt:ident, $lasti:tt
+    ) => {
+        #[allow(non_snake_case)]
+        mod $last {
+            use super::*;
+
+            pin_project! {
+                #[project = AnyOfProj]
+                pub enum AnyOf<$($ty,)* $last> {
+                    $( $ty{ #[pin] pinned: $ty }, )*
+                    $last{ #[pin] pinned: $last },
+                }
+            }
+
+            impl<$($ty,)* $last> Future for AnyOf<$($ty,)* $last> where
+                $( $ty: Future<Output = Response>, )*
+                $last: Future<Output = Response>,
+            {
+                type Output = Response;
+
+                fn poll(self: std::pin::Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> std::task::Poll<Self::Output> {
+                    match self.project() {
+                        $( AnyOfProj::$ty { pinned } => pinned.poll(cx), )*
+                        AnyOfProj::$last { pinned } => pinned.poll(cx),
+                    }
+                }
+            }
+
+            impl<S, $($ty, $tyt,)* $last, $lastt> Handler<($($tyt,)* $lastt,), S> for ($($ty,)* $last,) where
+            $($ty: Handler<$tyt, S>, )*
+            $last: Handler<$lastt, S>,
+            S: Send + Sync + 'static,
+            {
+                type Future = AnyOf<$($ty::Future,)* $last::Future>;
+
+                fn call(self, req: axum_core::extract::Request, state: S) -> Self::Future {
+                    $(
+                        if self.$tyi.can_accept(&req, &state) {
+                            return AnyOf::$ty{ pinned: self.$tyi.call(req, state) }
+                        }
+                    )*
+                    AnyOf::$last{ pinned: self.$lasti.call(req, state) }
+                }
+            }
+        }
+    };
+}
+
+impl_handler!([], T1, T1T, 0);
+impl_handler!([T1, T1T, 0], T2, T2T, 1);
+impl_handler!([T1, T1T, 0, T2, T2T, 1], T3, T3T, 2);
+impl_handler!([T1, T1T, 0, T2, T2T, 1, T3, T3T, 2], T4, T4T, 3);

--- a/axum/src/json.rs
+++ b/axum/src/json.rs
@@ -132,6 +132,10 @@ where
             Err(MissingJsonContentType.into())
         }
     }
+
+    fn can_accept_request(req: &Request, _state: &S) -> bool {
+        json_content_type(req.headers())
+    }
 }
 
 fn json_content_type(headers: &HeaderMap) -> bool {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation

There are times where I want to accept both JSON and Form data on the same path/method combination, or when I want to choose between handlers based on available query parameters. This pull request allows an easy syntax for that.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

This PR adds a can_accept(_*) method to `FromRequest`, `FromRequestParts` and `Handler` that is intended to provide an optimistic fast-path check whether the handling is likely to succeed for that `FromRequest` or `Handler`.

This allows us to make tuples of handlers also a handler, which then handles the request with the first handler in the tuple whose `can_accept` returns true for the request, or the last if non can.

Code example:
```
use axum::{
    extract,
    routing::post,
    Router,
};
use serde::Deserialize;

#[derive(Deserialize)]
struct CreateUser {
    email: String,
    password: String,
}

async fn create_user_json(extract::Json(payload): extract::Json<CreateUser>) {
    // payload is a `CreateUser`
}

async fn create_user_form(extract::Form(payload): extract::Form<CreateUser>) {
    // payload is a `CreateUser`
}

let app = Router::new().route("/users", post((create_user_json, create_user_form)));
```

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
