### PR TITLE
Backports to 0.6.x

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -2,7 +2,7 @@ name: CI
 
 env:
   CARGO_TERM_COLOR: always
-  MSRV: '1.60'
+  MSRV: '1.63'
 
 on:
   push:

--- a/axum-core/src/macros.rs
+++ b/axum-core/src/macros.rs
@@ -203,12 +203,52 @@ macro_rules! __composite_rejection {
             fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
                 match self {
                     $(
-                        Self::$variant(inner) => Some(inner),
+                        Self::$variant(inner) => inner.source(),
                     )+
                 }
             }
         }
     };
+}
+
+#[cfg(test)]
+mod composite_rejection_tests {
+    use self::defs::*;
+    use crate::Error;
+    use std::error::Error as _;
+
+    #[allow(dead_code, unreachable_pub)]
+    mod defs {
+        use crate::{__composite_rejection, __define_rejection};
+
+        __define_rejection! {
+            #[status = BAD_REQUEST]
+            #[body = "error message 1"]
+            pub struct Inner1;
+        }
+        __define_rejection! {
+            #[status = BAD_REQUEST]
+            #[body = "error message 2"]
+            pub struct Inner2(Error);
+        }
+        __composite_rejection! {
+            pub enum Outer { Inner1, Inner2 }
+        }
+    }
+
+    /// The implementation of `.source()` on `Outer` should defer straight to the implementation
+    /// on its inner type instead of returning the inner type itself, because the `Display`
+    /// implementation on `Outer` already forwards to the inner type and so it would result in two
+    /// errors in the chain `Display`ing the same thing.
+    #[test]
+    fn source_gives_inner_source() {
+        let rejection = Outer::Inner1(Inner1);
+        assert!(rejection.source().is_none());
+
+        let msg = "hello world";
+        let rejection = Outer::Inner2(Inner2(Error::new(msg)));
+        assert_eq!(rejection.source().unwrap().to_string(), msg);
+    }
 }
 
 #[rustfmt::skip]

--- a/axum-core/src/response/into_response.rs
+++ b/axum-core/src/response/into_response.rs
@@ -241,6 +241,12 @@ impl IntoResponse for String {
     }
 }
 
+impl IntoResponse for Box<str> {
+    fn into_response(self) -> Response {
+        String::from(self).into_response()
+    }
+}
+
 impl IntoResponse for Cow<'static, str> {
     fn into_response(self) -> Response {
         let mut res = Full::from(self).into_response();
@@ -363,6 +369,12 @@ impl<const N: usize> IntoResponse for [u8; N] {
 impl IntoResponse for Vec<u8> {
     fn into_response(self) -> Response {
         Cow::<'static, [u8]>::Owned(self).into_response()
+    }
+}
+
+impl IntoResponse for Box<[u8]> {
+    fn into_response(self) -> Response {
+        Vec::from(self).into_response()
     }
 }
 

--- a/axum-extra/Cargo.toml
+++ b/axum-extra/Cargo.toml
@@ -2,7 +2,7 @@
 categories = ["asynchronous", "network-programming", "web-programming"]
 description = "Extra utilities for axum"
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.63"
 homepage = "https://github.com/tokio-rs/axum"
 keywords = ["http", "web", "framework"]
 license = "MIT"

--- a/axum-extra/README.md
+++ b/axum-extra/README.md
@@ -14,7 +14,7 @@ This crate uses `#![forbid(unsafe_code)]` to ensure everything is implemented in
 
 ## Minimum supported Rust version
 
-axum-extra's MSRV is 1.60.
+axum-extra's MSRV is 1.63.
 
 ## Getting Help
 

--- a/axum-extra/src/extract/cookie/private.rs
+++ b/axum-extra/src/extract/cookie/private.rs
@@ -88,7 +88,7 @@ use std::{convert::Infallible, fmt, marker::PhantomData};
 ///     type Target = InnerState;
 ///
 ///     fn deref(&self) -> &Self::Target {
-///         &*self.0
+///         &self.0
 ///     }
 /// }
 ///

--- a/axum-extra/src/extract/multipart.rs
+++ b/axum-extra/src/extract/multipart.rs
@@ -23,7 +23,7 @@ use std::{
 
 /// Extractor that parses `multipart/form-data` requests (commonly used with file uploads).
 ///
-/// Since extracting multipart form data from the request requires consuming the body, the
+/// ⚠️ Since extracting multipart form data from the request requires consuming the body, the
 /// `Multipart` extractor must be *last* if there are multiple extractors in a handler.
 /// See ["the order of extractors"][order-of-extractors]
 ///

--- a/axum-macros/README.md
+++ b/axum-macros/README.md
@@ -14,7 +14,7 @@ This crate uses `#![forbid(unsafe_code)]` to ensure everything is implemented in
 
 ## Minimum supported Rust version
 
-axum-macros's MSRV is 1.60.
+axum-macros's MSRV is 1.63.
 
 ## Getting Help
 

--- a/axum-macros/src/debug_handler.rs
+++ b/axum-macros/src/debug_handler.rs
@@ -276,6 +276,7 @@ fn check_inputs_impls_from_request(
 
             quote_spanned! {span=>
                 #[allow(warnings)]
+                #[allow(unreachable_code)]
                 #[doc(hidden)]
                 fn #check_fn #check_fn_generics()
                 where
@@ -285,6 +286,7 @@ fn check_inputs_impls_from_request(
                 // we have to call the function to actually trigger a compile error
                 // since the function is generic, just defining it is not enough
                 #[allow(warnings)]
+                #[allow(unreachable_code)]
                 #[doc(hidden)]
                 fn #call_check_fn()
                 {
@@ -429,6 +431,7 @@ fn check_output_impls_into_response(item_fn: &ItemFn) -> TokenStream {
     let make = if item_fn.sig.asyncness.is_some() {
         quote_spanned! {span=>
             #[allow(warnings)]
+            #[allow(unreachable_code)]
             #[doc(hidden)]
             async fn #make_value_name() -> #ty {
                 #declare_inputs
@@ -438,6 +441,7 @@ fn check_output_impls_into_response(item_fn: &ItemFn) -> TokenStream {
     } else {
         quote_spanned! {span=>
             #[allow(warnings)]
+            #[allow(unreachable_code)]
             #[doc(hidden)]
             fn #make_value_name() -> #ty {
                 #declare_inputs
@@ -453,6 +457,7 @@ fn check_output_impls_into_response(item_fn: &ItemFn) -> TokenStream {
             #make
 
             #[allow(warnings)]
+            #[allow(unreachable_code)]
             #[doc(hidden)]
             async fn #name() {
                 let value = #receiver #make_value_name().await;
@@ -465,6 +470,7 @@ fn check_output_impls_into_response(item_fn: &ItemFn) -> TokenStream {
     } else {
         quote_spanned! {span=>
             #[allow(warnings)]
+            #[allow(unreachable_code)]
             #[doc(hidden)]
             async fn #name() {
                 #make
@@ -515,6 +521,7 @@ fn check_future_send(item_fn: &ItemFn) -> TokenStream {
     if let Some(receiver) = self_receiver(item_fn) {
         quote! {
             #[allow(warnings)]
+            #[allow(unreachable_code)]
             #[doc(hidden)]
             fn #name() {
                 let future = #receiver #handler_name(#(#args),*);
@@ -524,6 +531,7 @@ fn check_future_send(item_fn: &ItemFn) -> TokenStream {
     } else {
         quote! {
             #[allow(warnings)]
+            #[allow(unreachable_code)]
             #[doc(hidden)]
             fn #name() {
                 #item_fn

--- a/axum-macros/tests/debug_handler/pass/deny_unreachable_code.rs
+++ b/axum-macros/tests/debug_handler/pass/deny_unreachable_code.rs
@@ -1,0 +1,8 @@
+#![deny(unreachable_code)]
+
+use axum::extract::Path;
+
+#[axum_macros::debug_handler]
+async fn handler(Path(_): Path<String>) {}
+
+fn main() {}

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -12,9 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # 0.6.18 (30. April, 2023)
 
 - **fixed:** Don't remove the `Sec-WebSocket-Key` header in `WebSocketUpgrade` ([#1972])
+- **added:** Add `axum::extract::Query::try_from_uri` ([#2058])
 - **added:** Implement `IntoResponse` for `Box<str>` and `Box<[u8]>` ([#2035])
 
 [#1972]: https://github.com/tokio-rs/axum/pull/1972
+[#2058]: https://github.com/tokio-rs/axum/pull/2058
 
 # 0.6.17 (25. April, 2023)
 

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # 0.6.18 (30. April, 2023)
 
 - **fixed:** Don't remove the `Sec-WebSocket-Key` header in `WebSocketUpgrade` ([#1972])
+- **added:** Implement `IntoResponse` for `Box<str>` and `Box<[u8]>` ([#2035])
 
 [#1972]: https://github.com/tokio-rs/axum/pull/1972
 

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
-- None.
+- **fixed:** Fix bugs around merging routers with nested fallbacks ([#2096])
+
+[#2096]: https://github.com/tokio-rs/axum/pull/2096
 
 # 0.6.18 (30. April, 2023)
 

--- a/axum/Cargo.toml
+++ b/axum/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.6.18"
 categories = ["asynchronous", "network-programming", "web-programming::http-server"]
 description = "Web framework that focuses on ergonomics and modularity"
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.63"
 homepage = "https://github.com/tokio-rs/axum"
 keywords = ["http", "web", "framework"]
 license = "MIT"
@@ -61,7 +61,7 @@ serde_path_to_error = { version = "0.1.8", optional = true }
 serde_urlencoded = { version = "0.7", optional = true }
 sha1 = { version = "0.10", optional = true }
 tokio = { package = "tokio", version = "1.25.0", features = ["time"], optional = true }
-tokio-tungstenite = { version = "0.18.0", optional = true }
+tokio-tungstenite = { version = "0.19", optional = true }
 tracing = { version = "0.1", default-features = false, optional = true }
 
 [dependencies.tower-http]

--- a/axum/README.md
+++ b/axum/README.md
@@ -111,7 +111,7 @@ This crate uses `#![forbid(unsafe_code)]` to ensure everything is implemented in
 
 ## Minimum supported Rust version
 
-axum's MSRV is 1.60.
+axum's MSRV is 1.63.
 
 ## Examples
 

--- a/axum/src/docs/error_handling.md
+++ b/axum/src/docs/error_handling.md
@@ -38,6 +38,16 @@ It doesn't matter whether you return `Err(StatusCode::NOT_FOUND)` or
 `Err(StatusCode::INTERNAL_SERVER_ERROR)`. These are not considered errors in
 axum.
 
+Instead of a direct `StatusCode`, it makes sense to use intermediate error type
+that can ultimately be converted to `Reponse`. This allows using `?` operator
+in handlers. See those examples:
+
+* [`anyhow-error-response`][anyhow] for generic boxed errors
+* [`error-handling-and-dependency-injection`][ehdi] for application-specific detailed errors
+
+[anyhow]:https://github.com/tokio-rs/axum/blob/main/examples/anyhow-error-response/src/main.rs
+[ehdi]:https://github.com/tokio-rs/axum/blob/main/examples/error-handling-and-dependency-injection/src/main.rs
+
 This also applies to extractors. If an extractor doesn't match the request the
 request will be rejected and a response will be returned without calling your
 handler. See [`extract`](crate::extract) to learn more about handling extractor

--- a/axum/src/docs/error_handling.md
+++ b/axum/src/docs/error_handling.md
@@ -39,7 +39,7 @@ It doesn't matter whether you return `Err(StatusCode::NOT_FOUND)` or
 axum.
 
 Instead of a direct `StatusCode`, it makes sense to use intermediate error type
-that can ultimately be converted to `Reponse`. This allows using `?` operator
+that can ultimately be converted to `Response`. This allows using `?` operator
 in handlers. See those examples:
 
 * [`anyhow-error-response`][anyhow] for generic boxed errors

--- a/axum/src/docs/middleware.md
+++ b/axum/src/docs/middleware.md
@@ -127,7 +127,7 @@ That is:
 - It then does its thing and passes the request onto `layer_two`
 - Which passes the request onto `layer_one`
 - Which passes the request onto `handler` where a response is produced
-- That response is then passes to `layer_one`
+- That response is then passed to `layer_one`
 - Then to `layer_two`
 - And finally to `layer_three` where it's returned out of your app
 

--- a/axum/src/docs/routing/merge.md
+++ b/axum/src/docs/routing/merge.md
@@ -31,7 +31,7 @@ let app = Router::new()
 // Our app now accepts
 // - GET /users
 // - GET /users/:id
-// - POST /teams
+// - GET /teams
 # async {
 # hyper::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
 # };

--- a/axum/src/docs/routing/route.md
+++ b/axum/src/docs/routing/route.md
@@ -61,7 +61,7 @@ the path `/foo/bar/baz` the value of `rest` will be `bar/baz`.
 
 # Accepting multiple methods
 
-To accept multiple methods for the same route you must add all handlers at the
+To accept multiple methods for the same route you can add all handlers at the
 same time:
 
 ```rust
@@ -80,6 +80,23 @@ async fn delete_root() {}
 # async {
 # axum::Server::bind(&"".parse().unwrap()).serve(app.into_make_service()).await.unwrap();
 # };
+```
+
+Or you can add them one by one:
+
+```rust
+# use axum::Router;
+# use axum::routing::{get, post, delete};
+#
+let app = Router::new()
+    .route("/", get(get_root))
+    .route("/", post(post_root))
+    .route("/", delete(delete_root));
+#
+# let _: Router = app;
+# async fn get_root() {}
+# async fn post_root() {}
+# async fn delete_root() {}
 ```
 
 # More examples

--- a/axum/src/extract/multipart.rs
+++ b/axum/src/extract/multipart.rs
@@ -22,7 +22,7 @@ use std::{
 
 /// Extractor that parses `multipart/form-data` requests (commonly used with file uploads).
 ///
-/// Since extracting multipart form data from the request requires consuming the body, the
+/// ⚠️ Since extracting multipart form data from the request requires consuming the body, the
 /// `Multipart` extractor must be *last* if there are multiple extractors in a handler.
 /// See ["the order of extractors"][order-of-extractors]
 ///

--- a/axum/src/extract/rejection.rs
+++ b/axum/src/extract/rejection.rs
@@ -93,7 +93,7 @@ define_rejection! {
     #[status = BAD_REQUEST]
     #[body = "Failed to deserialize query string"]
     /// Rejection type used if the [`Query`](super::Query) extractor is unable to
-    /// deserialize the form into the target type.
+    /// deserialize the query string into the target type.
     pub struct FailedToDeserializeQueryString(Error);
 }
 

--- a/axum/src/form.rs
+++ b/axum/src/form.rs
@@ -17,7 +17,7 @@ use serde::Serialize;
 /// requests and `application/x-www-form-urlencoded` encoded request bodies for other methods. It
 /// supports any type that implements [`serde::Deserialize`].
 ///
-/// Since parsing form data might require consuming the request body, the `Form` extractor must be
+/// ⚠️ Since parsing form data might require consuming the request body, the `Form` extractor must be
 /// *last* if there are multiple extractors in a handler. See ["the order of
 /// extractors"][order-of-extractors]
 ///

--- a/axum/src/handler/mod.rs
+++ b/axum/src/handler/mod.rs
@@ -32,6 +32,16 @@
 //! }
 //! ```
 //!
+//! Instead of a direct `StatusCode`, it makes sense to use intermediate error type
+//! that can ultimately be converted to `Reponse`. This allows using `?` operator
+//! in handlers. See those examples:
+//!
+//! * [`anyhow-error-response`][anyhow] for generic boxed errors
+//! * [`error-handling-and-dependency-injection`][ehdi] for application-specific detailed errors
+//!
+//! [anyhow]:https://github.com/tokio-rs/axum/blob/main/examples/anyhow-error-response/src/main.rs
+//! [ehdi]:https://github.com/tokio-rs/axum/blob/main/examples/error-handling-and-dependency-injection/src/main.rs
+//!
 #![doc = include_str!("../docs/debugging_handler_type_errors.md")]
 
 #[cfg(feature = "tokio")]

--- a/axum/src/handler/mod.rs
+++ b/axum/src/handler/mod.rs
@@ -33,7 +33,7 @@
 //! ```
 //!
 //! Instead of a direct `StatusCode`, it makes sense to use intermediate error type
-//! that can ultimately be converted to `Reponse`. This allows using `?` operator
+//! that can ultimately be converted to `Response`. This allows using `?` operator
 //! in handlers. See those examples:
 //!
 //! * [`anyhow-error-response`][anyhow] for generic boxed errors

--- a/axum/src/json.rs
+++ b/axum/src/json.rs
@@ -24,7 +24,7 @@ use serde::{de::DeserializeOwned, Serialize};
 /// type.
 /// - Buffering the request body fails.
 ///
-/// Since parsing JSON requires consuming the request body, the `Json` extractor must be
+/// ⚠️ Since parsing JSON requires consuming the request body, the `Json` extractor must be
 /// *last* if there are multiple extractors in a handler.
 /// See ["the order of extractors"][order-of-extractors]
 ///

--- a/examples/testing-websockets/Cargo.toml
+++ b/examples/testing-websockets/Cargo.toml
@@ -9,4 +9,4 @@ axum = { path = "../../axum", features = ["ws"] }
 futures = "0.3"
 hyper = { version = "0.14", features = ["full"] }
 tokio = { version = "1.0", features = ["full"] }
-tokio-tungstenite = "0.17"
+tokio-tungstenite = "0.19"

--- a/examples/websockets/Cargo.toml
+++ b/examples/websockets/Cargo.toml
@@ -10,7 +10,7 @@ futures = "0.3"
 futures-util = { version = "0.3", default-features = false, features = ["sink", "std"] }
 headers = "0.3"
 tokio = { version = "1.0", features = ["full"] }
-tokio-tungstenite = "0.18.0"
+tokio-tungstenite = "0.19"
 tower = { version = "0.4", features = ["util"] }
 tower-http = { version = "0.4.0", features = ["fs", "trace"] }
 tracing = "0.1"


### PR DESCRIPTION
Backports these PRs to the v0.6.x branch

- https://github.com/tokio-rs/axum/pull/2096
- https://github.com/tokio-rs/axum/pull/2095
- https://github.com/tokio-rs/axum/pull/2080
- https://github.com/tokio-rs/axum/pull/2058
- https://github.com/tokio-rs/axum/pull/2080
- https://github.com/tokio-rs/axum/pull/2035
- https://github.com/tokio-rs/axum/pull/2021
- https://github.com/tokio-rs/axum/pull/2025
- https://github.com/tokio-rs/axum/pull/2014
- https://github.com/tokio-rs/axum/pull/2028
- https://github.com/tokio-rs/axum/pull/2030
- https://github.com/tokio-rs/axum/pull/2049
- https://github.com/tokio-rs/axum/pull/2051
- https://github.com/tokio-rs/axum/pull/2056
- https://github.com/tokio-rs/axum/pull/2027
- https://github.com/tokio-rs/axum/pull/2009