### PR TITLE
Remove useless #[allow(warnings)]

### DIFF
--- a/axum/src/routing/mod.rs
+++ b/axum/src/routing/mod.rs
@@ -670,7 +670,6 @@ impl<S> fmt::Debug for Endpoint<S> {
 }
 
 #[test]
-#[allow(warnings)]
 fn traits() {
     use crate::test_helpers::*;
     assert_send::<Router<()>>();


### PR DESCRIPTION
[Remove useless #[allow(warnings)]](https://github.com/tokio-rs/axum/commit/ef3b218375313ca0c2ed918bf10392f256f1492a).

We don't get a warning here anymore.

