### PR TITLE
Remove useless use prefix

### DIFF
--- a/axum/src/serve.rs
+++ b/axum/src/serve.rs
@@ -112,7 +112,7 @@ where
             //
             // services like `Router` are always ready, so assume the service
             // we're running here is also always ready...
-            match futures_util::future::poll_fn(|cx| service.poll_ready(cx)).now_or_never() {
+            match poll_fn(|cx| service.poll_ready(cx)).now_or_never() {
                 Some(Ok(())) => {}
                 Some(Err(err)) => match err {},
                 None => {


### PR DESCRIPTION
## Motivation

We already use it at the beginning. So we do not need to use the prefix to import it.

https://github.com/hi-rustin/axum/blob/d8389f9d347024d1e1392ac44545fe248093df5b/axum/src/serve.rs#L88

## Solution

Remove the useless prefix.