### PR TITLE
Update tokio-tungstenite 0.20

### DIFF
--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
+- **breaking:** Remove deprecated `WebSocketUpgrade::max_send_queue`
 - **breaking:** The following types/traits are no longer generic over the request body
   (i.e. the `B` type param has been removed) ([#1751] and [#1789]):
   - `FromRequestParts`

--- a/axum/Cargo.toml
+++ b/axum/Cargo.toml
@@ -63,7 +63,7 @@ serde_path_to_error = { version = "0.1.8", optional = true }
 serde_urlencoded = { version = "0.7", optional = true }
 sha1 = { version = "0.10", optional = true }
 tokio = { package = "tokio", version = "1.25.0", features = ["time"], optional = true }
-tokio-tungstenite = { version = "0.19", optional = true }
+tokio-tungstenite = { version = "0.20", optional = true }
 tracing = { version = "0.1", default-features = false, optional = true }
 
 [dependencies.tower-http]

--- a/axum/src/extract/ws.rs
+++ b/axum/src/extract/ws.rs
@@ -151,6 +151,7 @@ impl<F> std::fmt::Debug for WebSocketUpgrade<F> {
 impl<F> WebSocketUpgrade<F> {
     /// The target minimum size of the write buffer to reach before writing the data
     /// to the underlying stream.
+    ///
     /// The default value is 128 KiB.
     ///
     /// If set to `0` each message will be eagerly written to the underlying stream.
@@ -164,6 +165,7 @@ impl<F> WebSocketUpgrade<F> {
 
     /// The max size of the write buffer in bytes. Setting this can provide backpressure
     /// in the case the write buffer is filling up due to write errors.
+    ///
     /// The default value is unlimited.
     ///
     /// Note: The write buffer only builds up past [`write_buffer_size`](Self::write_buffer_size)

--- a/axum/src/extract/ws.rs
+++ b/axum/src/extract/ws.rs
@@ -149,12 +149,6 @@ impl<F> std::fmt::Debug for WebSocketUpgrade<F> {
 }
 
 impl<F> WebSocketUpgrade<F> {
-    /// Does nothing, instead use `max_write_buffer_size`.
-    #[deprecated]
-    pub fn max_send_queue(self, _: usize) -> Self {
-        self
-    }
-
     /// The target minimum size of the write buffer to reach before writing the data
     /// to the underlying stream.
     /// The default value is 128 KiB.

--- a/axum/src/extract/ws.rs
+++ b/axum/src/extract/ws.rs
@@ -149,9 +149,37 @@ impl<F> std::fmt::Debug for WebSocketUpgrade<F> {
 }
 
 impl<F> WebSocketUpgrade<F> {
-    /// Set the size of the internal message send queue.
-    pub fn max_send_queue(mut self, max: usize) -> Self {
-        self.config.max_send_queue = Some(max);
+    /// Does nothing, instead use `max_write_buffer_size`.
+    #[deprecated]
+    pub fn max_send_queue(self, _: usize) -> Self {
+        self
+    }
+
+    /// The target minimum size of the write buffer to reach before writing the data
+    /// to the underlying stream.
+    /// The default value is 128 KiB.
+    ///
+    /// If set to `0` each message will be eagerly written to the underlying stream.
+    /// It is often more optimal to allow them to buffer a little, hence the default value.
+    ///
+    /// Note: [`flush`](SinkExt::flush) will always fully write the buffer regardless.
+    pub fn write_buffer_size(mut self, size: usize) -> Self {
+        self.config.write_buffer_size = size;
+        self
+    }
+
+    /// The max size of the write buffer in bytes. Setting this can provide backpressure
+    /// in the case the write buffer is filling up due to write errors.
+    /// The default value is unlimited.
+    ///
+    /// Note: The write buffer only builds up past [`write_buffer_size`](Self::write_buffer_size)
+    /// when writes to the underlying stream are failing. So the **write buffer can not
+    /// fill up if you are not observing write errors even if not flushing**.
+    ///
+    /// Note: Should always be at least [`write_buffer_size + 1 message`](Self::write_buffer_size)
+    /// and probably a little more depending on error handling strategy.
+    pub fn max_write_buffer_size(mut self, max: usize) -> Self {
+        self.config.max_write_buffer_size = max;
         self
     }
 

--- a/examples/testing-websockets/Cargo.toml
+++ b/examples/testing-websockets/Cargo.toml
@@ -9,4 +9,4 @@ axum = { path = "../../axum", features = ["ws"] }
 futures = "0.3"
 hyper = { version = "0.14", features = ["full"] }
 tokio = { version = "1.0", features = ["full"] }
-tokio-tungstenite = "0.19"
+tokio-tungstenite = "0.20"

--- a/examples/websockets/Cargo.toml
+++ b/examples/websockets/Cargo.toml
@@ -11,7 +11,7 @@ futures = "0.3"
 futures-util = { version = "0.3", default-features = false, features = ["sink", "std"] }
 headers = "0.3"
 tokio = { version = "1.0", features = ["full"] }
-tokio-tungstenite = "0.19"
+tokio-tungstenite = "0.20"
 tower = { version = "0.4", features = ["util"] }
 tower-http = { version = "0.4.0", features = ["fs", "trace"] }
 tracing = "0.1"


### PR DESCRIPTION
## Motivation
More optimal websocket `SinkExt::feed` performance by using recent upstream versions with better flushing behaviour.

## Solution
* Update _tokio-tungstenite_ to `0.20`. See [changelog](https://github.com/snapview/tokio-tungstenite/blob/master/CHANGELOG.md#0200), [tungstenite changelog](https://github.com/snapview/tungstenite-rs/blob/master/CHANGELOG.md#0200).
* **breaking:** Remove `WebSocketUpgrade::max_send_queue`.
* Add `WebSocketUpgrade::write_buffer_size`, `max_write_buffer_size` (new upstream).
  _Note: I added all upstream docs, feel free to trim them down if you prefer._

