### PR TITLE
Remove unnecessary allow(dead_code) from testing example

### DIFF
--- a/examples/testing/src/main.rs
+++ b/examples/testing/src/main.rs
@@ -33,7 +33,6 @@ async fn main() {
 
 /// Having a function that produces our app makes it easy to call it from tests
 /// without having to create an HTTP server.
-#[allow(dead_code)]
 fn app() -> Router {
     Router::new()
         .route("/", get(|| async { "Hello, World!" }))


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation

I saw this while looking through the examples and wanted to fix it

## Solution

Fix it :slightly_smiling_face: 