### PR TITLE
docs: delete MatchedPath nesting section

### DIFF
--- a/axum/src/extract/matched_path.rs
+++ b/axum/src/extract/matched_path.rs
@@ -52,43 +52,6 @@ use std::{collections::HashMap, sync::Arc};
 ///     );
 /// # let _: Router = app;
 /// ```
-///
-/// # Matched path in nested routers
-///
-/// Because of how [nesting] works `MatchedPath` isn't accessible in middleware on nested routes:
-///
-/// ```
-/// use axum::{
-///     Router,
-///     RequestExt,
-///     routing::get,
-///     extract::{Request, MatchedPath, rejection::MatchedPathRejection},
-///     middleware::map_request,
-///     body::Body,
-/// };
-///
-/// async fn access_matched_path(mut request: Request) -> Request {
-///     // if `/foo/bar` is called this will be `Err(_)` since that matches
-///     // a nested route
-///     let matched_path: Result<MatchedPath, MatchedPathRejection> =
-///         request.extract_parts::<MatchedPath>().await;
-///
-///     request
-/// }
-///
-/// // `MatchedPath` is always accessible on handlers added via `Router::route`
-/// async fn handler(matched_path: MatchedPath) {}
-///
-/// let app = Router::new()
-///     .nest(
-///         "/foo",
-///         Router::new().route("/bar", get(handler)),
-///     )
-///     .layer(map_request(access_matched_path));
-/// # let _: Router = app;
-/// ```
-///
-/// [nesting]: crate::Router::nest
 #[cfg_attr(docsrs, doc(cfg(feature = "matched-path")))]
 #[derive(Clone, Debug)]
 pub struct MatchedPath(pub(crate) Arc<str>);


### PR DESCRIPTION
## Motivation

`MatchedPath` used to have limitations when used together with [`Router::nest`](https://docs.rs/axum/latest/axum/routing/struct.Router.html#method.nest). This is no longer the case.

Relevant changelog for April 2023: https://github.com/tokio-rs/axum/blob/main/axum/CHANGELOG.md#0613-11-april-2023

Test that covers the new use case: https://github.com/tokio-rs/axum/blob/5567d665d7c5f0ed09e1d5c588c18c28751f23e1/axum/src/extract/matched_path.rs#L248-L266

Discord discussion: https://discord.com/channels/500028886025895936/870760546109116496/1133784088336154624

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

This PR removes the outdated section of the docs on `MatchedPath`, [Matched path in nested routers](https://docs.rs/axum/latest/axum/extract/struct.MatchedPath.html#matched-path-in-nested-routers).
