### PR TITLE
Don't depend on axum-macros in examples

### DIFF
--- a/examples/customize-extractor-error/Cargo.toml
+++ b/examples/customize-extractor-error/Cargo.toml
@@ -5,9 +5,8 @@ edition = "2021"
 publish = false
 
 [dependencies]
-axum = { path = "../../axum" }
+axum = { path = "../../axum", features = ["macros"] }
 axum-extra = { path = "../../axum-extra" }
-axum-macros = { path = "../../axum-macros" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0"

--- a/examples/customize-extractor-error/README.md
+++ b/examples/customize-extractor-error/README.md
@@ -3,9 +3,9 @@ already existing extractors
 
 - [`with_rejection`](src/with_rejection.rs): Uses
   `axum_extra::extract::WithRejection` to transform one rejection into another
-- [`derive_from_request`](src/derive_from_request.rs): Uses
-  `axum_macros::FromRequest` to wrap another extractor and customize the
-  rejection
+- [`derive_from_request`](src/derive_from_request.rs): Uses the
+  `axum::extractr::FromRequest` derive macro to wrap another extractor and
+  customize the rejection
 - [`custom_extractor`](src/custom_extractor.rs): Manual implementation of
   `FromRequest` that wraps another extractor
 

--- a/examples/customize-extractor-error/src/derive_from_request.rs
+++ b/examples/customize-extractor-error/src/derive_from_request.rs
@@ -1,4 +1,4 @@
-//! Uses `axum_macros::FromRequest` to wrap another extractor and customize the
+//! Uses `axum::extract::FromRequest` to wrap another extractor and customize the
 //! rejection
 //!
 //! + Easy learning curve: Deriving `FromRequest` generates a `FromRequest`
@@ -11,8 +11,10 @@
 //!
 //! [`thiserror`]: https://crates.io/crates/thiserror
 //! [FromRequest#known-limitations]: https://docs.rs/axum-macros/*/axum_macros/derive.FromRequest.html#known-limitations
-use axum::{extract::rejection::JsonRejection, http::StatusCode, response::IntoResponse};
-use axum_macros::FromRequest;
+use axum::{
+    extract::rejection::JsonRejection, extract::FromRequest, http::StatusCode,
+    response::IntoResponse,
+};
 use serde_json::{json, Value};
 
 pub async fn handler(Json(value): Json<Value>) -> impl IntoResponse {

--- a/examples/diesel-async-postgres/Cargo.toml
+++ b/examples/diesel-async-postgres/Cargo.toml
@@ -5,8 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-axum = { path = "../../axum" }
-axum-macros = { path = "../../axum-macros" }
+axum = { path = "../../axum", features = ["macros"] }
 bb8 = "0.8"
 diesel = "2"
 diesel-async = { version = "0.3", features = ["postgres", "bb8"] }

--- a/examples/diesel-postgres/Cargo.toml
+++ b/examples/diesel-postgres/Cargo.toml
@@ -5,8 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-axum = { path = "../../axum" }
-axum-macros = { path = "../../axum-macros" }
+axum = { path = "../../axum", features = ["macros"] }
 deadpool-diesel = { version = "0.4.1", features = ["postgres"] }
 diesel = { version = "2", features = ["postgres"] }
 diesel_migrations = "2"


### PR DESCRIPTION
All macros are re-exported by axum so that's the recommended way to get the macros.