### PR TITLE
Add empty path capture docs and tests

### DIFF
--- a/axum/src/docs/routing/route.md
+++ b/axum/src/docs/routing/route.md
@@ -22,7 +22,8 @@ be called.
 # Captures
 
 Paths can contain segments like `/:key` which matches any single segment and
-will store the value captured at `key`.
+will store the value captured at `key`. The value captured can be zero-length
+except for in the invalid path `//`.
 
 Examples:
 

--- a/axum/src/extract/path/mod.rs
+++ b/axum/src/extract/path/mod.rs
@@ -629,7 +629,7 @@ mod tests {
     }
 
     #[crate::test]
-    async fn captures_dont_match_empty_segments() {
+    async fn captures_dont_match_empty_path() {
         let app = Router::new().route("/:key", get(|| async {}));
 
         let client = TestClient::new(app);
@@ -639,6 +639,41 @@ mod tests {
 
         let res = client.get("/foo").send().await;
         assert_eq!(res.status(), StatusCode::OK);
+    }
+
+    #[crate::test]
+    async fn captures_match_empty_inner_segments() {
+        let app = Router::new().route(
+            "/:key/method",
+            get(|Path(param): Path<String>| async move { param.to_string() }),
+        );
+
+        let client = TestClient::new(app);
+
+        let res = client.get("/abc/method").send().await;
+        assert_eq!(res.text().await, "abc");
+
+        let res = client.get("//method").send().await;
+        assert_eq!(res.text().await, "");
+    }
+
+    #[crate::test]
+    async fn captures_match_empty_trailing_segment() {
+        let app = Router::new().route(
+            "/method/:key",
+            get(|Path(param): Path<String>| async move { param.to_string() }),
+        );
+
+        let client = TestClient::new(app);
+
+        let res = client.get("/method/abc").send().await;
+        assert_eq!(res.text().await, "abc");
+
+        let res = client.get("/method/").send().await;
+        assert_eq!(res.text().await, "");
+
+        let res = client.get("/method").send().await;
+        assert_eq!(res.status(), StatusCode::NOT_FOUND);
     }
 
     #[crate::test]


### PR DESCRIPTION
Fixes: #2126

## Motivation

Inform users that empty path segment capture is possible.

## Solution

Update path segment capture docs and add unit tests to demo and confirm it works.
