### PR TITLE
Add test cases to cover colon and percent encoding issues

### DIFF
--- a/axum/src/extract/path/mod.rs
+++ b/axum/src/extract/path/mod.rs
@@ -585,6 +585,40 @@ mod tests {
     }
 
     #[crate::test]
+    #[should_panic] // TODO: #2128
+    async fn percent_decoding_at_sign() {
+        let app = Router::new().route(
+            "/look@this",
+            get(|Path(param): Path<String>| async move { param }),
+        );
+
+        let client = TestClient::new(app);
+
+        let res = client.get("/look@this").send().await;
+        assert_eq!(res.status(), StatusCode::OK); // PANIC: actual code 500
+
+        let res = client.get("/look%40this").send().await;
+        assert_eq!(res.status(), StatusCode::OK);
+    }
+
+    #[crate::test]
+    #[should_panic] // TODO: #2128
+    async fn percent_decoding_sub_delims() {
+        let app = Router::new().route(
+            "/look!this",
+            get(|Path(param): Path<String>| async move { param }),
+        );
+
+        let client = TestClient::new(app);
+
+        let res = client.get("/look!this").send().await;
+        assert_eq!(res.status(), StatusCode::OK); // PANIC: actual code 500
+
+        let res = client.get("/look%21this").send().await;
+        assert_eq!(res.status(), StatusCode::OK);
+    }
+
+    #[crate::test]
     async fn supports_128_bit_numbers() {
         let app = Router::new()
             .route(

--- a/axum/src/extract/path/mod.rs
+++ b/axum/src/extract/path/mod.rs
@@ -642,7 +642,7 @@ mod tests {
     }
 
     #[crate::test]
-    #[should_panic]
+    #[should_panic] // TODO: #2128
     async fn captures_dont_include_path_with_inner_colon() {
         let app = Router::new().route(
             "/:instance/namespace_a:method_b",
@@ -656,7 +656,7 @@ mod tests {
     }
 
     #[crate::test]
-    #[should_panic]
+    #[should_panic] // TODO: #2128
     async fn captures_dont_include_path_with_inner_colon_encoded() {
         let app = Router::new().route(
             "/:instance/namespace_a:method_b",
@@ -670,7 +670,7 @@ mod tests {
     }
 
     #[crate::test]
-    #[should_panic]
+    #[should_panic] // TODO: #2128
     async fn captures_dont_include_path_with_inner_colon_percent_encoded() {
         let app = Router::new().route(
             "/:instance/namespace_a%3Amethod_b",


### PR DESCRIPTION
They currently do not pass, but should be addressed when #2128 is fixed.

## Motivation

Currently cannot figure out how to use path segments with embedded `:` characters.

## Solution

Add test cases that will need to be fixed to show that the use case works.