### PR TITLE
axum-extra: Remove unused tower-http dependency

### DIFF
--- a/axum-extra/Cargo.toml
+++ b/axum-extra/Cargo.toml
@@ -45,7 +45,6 @@ pin-project-lite = "0.2"
 serde = "1.0"
 tokio = "1.19"
 tower = { version = "0.4", default_features = false, features = ["util"] }
-tower-http = { version = "0.4", features = ["map-response-body"] }
 tower-layer = "0.3"
 tower-service = "0.3"
 


### PR DESCRIPTION
## Motivation

The dependency is not used.

## Solution

Remove it.

## Notes

This PR is for the 0.6.x branch. I didn't check whether `main` is also affected.