### PR TITLE
axum-extra: Remove unused tower-http dependency

### DIFF
--- a/axum-extra/Cargo.toml
+++ b/axum-extra/Cargo.toml
@@ -46,7 +46,6 @@ pin-project-lite = "0.2"
 serde = "1.0"
 tokio = "1.19"
 tower = { version = "0.4", default_features = false, features = ["util"] }
-tower-http = { version = "0.4", features = ["map-response-body"] }
 tower-layer = "0.3"
 tower-service = "0.3"
 


### PR DESCRIPTION
Turns out it wasn't used on main either.