### PR TITLE
Implement Clone for ErasedJson

### DIFF
--- a/axum-extra/CHANGELOG.md
+++ b/axum-extra/CHANGELOG.md
@@ -7,9 +7,11 @@ and this project adheres to [Semantic Versioning].
 
 # Unreleased
 
-- **added:** Added `TypedHeader` which used to be in `axum` ([#1850])
+- **added:** `TypedHeader` which used to be in `axum` ([#1850])
+- **added:** `Clone` implementation for `ErasedJson` ([#2142])
 
 [#1850]: https://github.com/tokio-rs/axum/pull/1850
+[#2142]: https://github.com/tokio-rs/axum/pull/2142
 
 # 0.7.4 (18. April, 2023)
 


### PR DESCRIPTION
## Motivation

Makes `ErasedJson` a `Handler`. Also kinda expected, maybe? All of `Json`, `Html` and so on implement `Clone`.

## Solution

Implement `Clone`. Requires the serde_json error to be wrapped in `Arc` because it's not `Clone`, but failing to serialize should be an extremely rare edge-case.