### PR TITLE
Implement `IntoResponse` for `(R,) where R: IntoResponse`

### DIFF
--- a/axum-core/src/response/into_response.rs
+++ b/axum-core/src/response/into_response.rs
@@ -398,6 +398,16 @@ where
     }
 }
 
+impl<R> IntoResponse for (R,)
+where
+    R: IntoResponse,
+{
+    fn into_response(self) -> Response {
+        let (res,) = self;
+        res.into_response()
+    }
+}
+
 macro_rules! impl_into_response {
     ( $($ty:ident),* $(,)? ) => {
         #[allow(non_snake_case)]

--- a/axum-macros/tests/debug_handler/fail/wrong_return_type.stderr
+++ b/axum-macros/tests/debug_handler/fail/wrong_return_type.stderr
@@ -9,10 +9,10 @@ error[E0277]: the trait bound `bool: IntoResponse` is not satisfied
             &'static [u8]
             &'static str
             ()
+            (R,)
             (Response<()>, R)
             (Response<()>, T1, R)
             (Response<()>, T1, T2, R)
-            (Response<()>, T1, T2, T3, R)
           and $N others
 note: required by a bound in `__axum_macros_check_handler_into_response::{closure#0}::check`
  --> tests/debug_handler/fail/wrong_return_type.rs:4:23

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -63,6 +63,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **change:** Update tokio-tungstenite to 0.19 ([#2021])
 - **change:** axum's MSRV is now 1.63 ([#2021])
 - **added:** Implement `Handler` for `T: IntoResponse` ([#2140])
+- **added:** Implement `IntoResponse` for `(R,) where R: IntoResponse` ([#2143])
 
 [#2021]: https://github.com/tokio-rs/axum/pull/2021
 [#2014]: https://github.com/tokio-rs/axum/pull/2014
@@ -80,6 +81,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2073]: https://github.com/tokio-rs/axum/pull/2073
 [#2096]: https://github.com/tokio-rs/axum/pull/2096
 [#2140]: https://github.com/tokio-rs/axum/pull/2140
+[#2143]: https://github.com/tokio-rs/axum/pull/2143
 
 # 0.6.17 (25. April, 2023)
 


### PR DESCRIPTION
I just happened to notice we were missing this impl. Probably isn't the most useful thing but still nice to have for consistency and maybe some cursed macro stuff.