### PR TITLE
Add sqlx-postgresql-stream example

### DIFF
--- a/examples/sqlx-postgres-stream/Cargo.toml
+++ b/examples/sqlx-postgres-stream/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "example-sqlx-postgres-stream"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+axum = { path = "../../axum" }
+futures = "0.3"
+ouroboros = "0.15"
+sqlx = { version = "0.7", features = ["postgres", "runtime-tokio"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/sqlx-postgres-stream/src/main.rs
+++ b/examples/sqlx-postgres-stream/src/main.rs
@@ -1,0 +1,80 @@
+//! Example of application streaming large csv from postgres using <https://github.com/launchbadge/sqlx>
+//!
+//! Run with
+//!
+//! ```not_rust
+//! cargo run -p example-sqlx-postgres-stream
+//! ```
+//!
+//! Test with curl:
+//!
+//! ```not_rust
+//! curl 127.0.0.1:3000
+//! ```
+
+use std::{net::SocketAddr, time::Duration};
+
+use axum::{
+    body::StreamBody, extract::State, http::header, http::StatusCode, response::IntoResponse,
+    routing::get, Router,
+};
+use futures::TryStreamExt;
+use sqlx::postgres::{PgPool, PgPoolOptions};
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+
+use crate::self_ref_stream::SelfRefStream;
+
+mod self_ref_stream;
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::registry()
+        .with(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "example_tokio_postgres=debug".into()),
+        )
+        .with(tracing_subscriber::fmt::layer())
+        .init();
+
+    let db_connection_str = std::env::var("DATABASE_URL")
+        .unwrap_or_else(|_| "postgres://postgres:password@localhost".to_string());
+
+    // setup connection pool
+    let pool = PgPoolOptions::new()
+        .max_connections(5)
+        .acquire_timeout(Duration::from_secs(3))
+        .connect(&db_connection_str)
+        .await
+        .expect("can't connect to database");
+
+    // build our application with some routes
+    let app = Router::new()
+        .route("/", get(using_self_ref_stream))
+        .with_state(pool);
+
+    // run it with hyper
+    let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
+    tracing::debug!("listening on {}", addr);
+    axum::Server::bind(&addr)
+        .serve(app.into_make_service())
+        .await
+        .unwrap();
+}
+
+// we can extract the connection pool with `State`
+async fn using_self_ref_stream(State(pool): State<PgPool>) -> impl IntoResponse {
+    // sqlx requires borrowed pool, so we need to wrap original stream with SelfRefStream
+    let body = SelfRefStream::build(pool, |pool_ref| {
+        sqlx::query_scalar::<_, String>(
+            r#"SELECT col1 FROM (VALUES ('hello'), ('from'), ('postgres')) AS q (col1)"#,
+        )
+        .fetch(pool_ref)
+    })
+    .map_ok(|s| s + "\n");
+
+    (
+        StatusCode::OK,
+        [(header::CONTENT_TYPE, "text/plain")],
+        StreamBody::new(body),
+    )
+}

--- a/examples/sqlx-postgres-stream/src/self_ref_stream.rs
+++ b/examples/sqlx-postgres-stream/src/self_ref_stream.rs
@@ -1,0 +1,38 @@
+use std::pin::Pin;
+
+use futures::{
+    stream::BoxStream,
+    task::{Context, Poll},
+    Stream,
+};
+
+#[ouroboros::self_referencing]
+pub struct SelfRefStream<Params: 'static, Item> {
+    params: Params,
+    #[borrows(params)]
+    #[covariant]
+    inner: BoxStream<'this, Item>,
+}
+
+impl<Params: 'static, Item> SelfRefStream<Params, Item> {
+    #[inline]
+    pub fn build(
+        params: Params,
+        inner_builder: impl for<'this> FnOnce(&'this Params) -> BoxStream<'this, Item>,
+    ) -> Self {
+        SelfRefStreamBuilder {
+            params,
+            inner_builder,
+        }
+        .build()
+    }
+}
+
+impl<Params: 'static, Item> Stream for SelfRefStream<Params, Item> {
+    type Item = Item;
+
+    #[inline]
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.with_inner_mut(|s| s.as_mut().poll_next(cx))
+    }
+}


### PR DESCRIPTION
## Motivation
It is not straightforward  how to stream large data sets with sqlx.
Sqlx requires a borrowed pool or connection which is not compatible with axum `StreamBody`.
You can do this with `SelfRefStream` trick.

I found the relevant discussion https://github.com/tokio-rs/axum/discussions/400, but it doesn't contain good example.

May be you decide to include code from this PR to axum core to simplify such use cases.

## Solution
Working example with postgres streaming.
