### PR TITLE
Don't create a `RouteId` if routes can be merged

### DIFF
--- a/axum/src/routing/path_router.rs
+++ b/axum/src/routing/path_router.rs
@@ -53,8 +53,6 @@ where
 
         validate_path(path)?;
 
-        let id = self.next_route_id();
-
         let endpoint = if let Some((route_id, Endpoint::MethodRouter(prev_method_router))) = self
             .node
             .path_to_route_id
@@ -74,6 +72,7 @@ where
             Endpoint::MethodRouter(method_router)
         };
 
+        let id = self.next_route_id();
         self.set_node(path, id)?;
         self.routes.insert(id, endpoint);
 


### PR DESCRIPTION
While looking through the code, I noticed that the function `PathRouter::route` unnecessarily creates a `RouteId` even if the correct route already exists, thus remaining unused in the code path. To prevent this, move the creation of a new `RouteId` further down to right before it is used.