### PR TITLE
add IntoResponse impl on custom Json extractor example

### DIFF
--- a/examples/customize-extractor-error/src/derive_from_request.rs
+++ b/examples/customize-extractor-error/src/derive_from_request.rs
@@ -15,16 +15,25 @@ use axum::{
     extract::rejection::JsonRejection, extract::FromRequest, http::StatusCode,
     response::IntoResponse,
 };
+use serde::Serialize;
 use serde_json::{json, Value};
 
 pub async fn handler(Json(value): Json<Value>) -> impl IntoResponse {
-    Json(dbg!(value));
+    Json(dbg!(value))
 }
 
 // create an extractor that internally uses `axum::Json` but has a custom rejection
 #[derive(FromRequest)]
 #[from_request(via(axum::Json), rejection(ApiError))]
 pub struct Json<T>(T);
+
+// We implement `IntoResponse` for our extractor so it can be used as a response
+impl <T: Serialize> IntoResponse for Json<T> {
+    fn into_response(self) -> axum::response::Response {
+        let Self(value) = self;
+        axum::Json(value).into_response()
+    }
+}
 
 // We create our own rejection type
 #[derive(Debug)]

--- a/examples/customize-extractor-error/src/derive_from_request.rs
+++ b/examples/customize-extractor-error/src/derive_from_request.rs
@@ -28,7 +28,7 @@ pub async fn handler(Json(value): Json<Value>) -> impl IntoResponse {
 pub struct Json<T>(T);
 
 // We implement `IntoResponse` for our extractor so it can be used as a response
-impl <T: Serialize> IntoResponse for Json<T> {
+impl<T: Serialize> IntoResponse for Json<T> {
     fn into_response(self) -> axum::response::Response {
         let Self(value) = self;
         axum::Json(value).into_response()


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation

The current custom-extractor-error/derive_from_requst example does not allow the wrapped `Json` extractor to be used as a response. 
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

Adding an impl for `IntoResponse` for the custom extractor provides the same ergonomics as the original `axum::Json`.

__NOTE__: the example now also echoes back the parsed json request body (which it wasn't before and therefore the code did compile without the `impl`) 

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

edit(jplatte): Closes #2186.