### PR TITLE
MSRV of axum-macros is 1.63

### DIFF
--- a/axum-macros/Cargo.toml
+++ b/axum-macros/Cargo.toml
@@ -2,7 +2,7 @@
 categories = ["asynchronous", "network-programming", "web-programming"]
 description = "Macros for axum"
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.63"
 homepage = "https://github.com/tokio-rs/axum"
 keywords = ["axum"]
 license = "MIT"

--- a/axum-macros/src/axum_test.rs
+++ b/axum-macros/src/axum_test.rs
@@ -27,7 +27,7 @@ fn replace_nest_with_nest_service(mut item_fn: ItemFn) -> Option<ItemFn> {
     let mut visitor = NestToNestService::default();
     syn::visit_mut::visit_item_fn_mut(&mut visitor, &mut item_fn);
 
-    (visitor.count > 0).then(|| item_fn)
+    (visitor.count > 0).then_some(item_fn)
 }
 
 #[derive(Default)]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

I found typo in `README.md` in `axum-macros` compared with `Cargo.toml`.

`README.md`:

> axum-macros's MSRV is 1.63.

`Cargo.toml`:

> rust-version = "1.60"

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

I believed tests had been done with the current `Cargo.toml` and therefore thought `README.md` should have been fixed.