### PR TITLE
fix typo in examples README: plural form examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,6 @@
 # Examples
 
-This folder contains numerous example showing how to use axum. Each example is
+This folder contains numerous examples showing how to use axum. Each example is
 setup as its own crate so its dependencies are clear.
 
 For a list of what the community built with axum, please see the list


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

I found typo in `README.md` of `examples`.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

I fixed: 

```diff
< numerous example
> numerous examples
```
