### PR TITLE
Use "set up" rather than "setup" when used as a verb

### DIFF
--- a/axum/src/extract/ws.rs
+++ b/axum/src/extract/ws.rs
@@ -296,7 +296,7 @@ impl<F> WebSocketUpgrade<F> {
 
     /// Finalize upgrading the connection and call the provided callback with
     /// the stream.
-    #[must_use = "to setup the WebSocket connection, this response must be returned"]
+    #[must_use = "to set up the WebSocket connection, this response must be returned"]
     pub fn on_upgrade<C, Fut>(self, callback: C) -> Response
     where
         C: FnOnce(WebSocket) -> Fut + Send + 'static,

--- a/axum/src/lib.rs
+++ b/axum/src/lib.rs
@@ -64,7 +64,7 @@
 //!
 //! # Routing
 //!
-//! [`Router`] is used to setup which paths goes to which services:
+//! [`Router`] is used to set up which paths goes to which services:
 //!
 //! ```rust
 //! use axum::{Router, routing::get};

--- a/examples/sqlx-postgres/src/main.rs
+++ b/examples/sqlx-postgres/src/main.rs
@@ -39,7 +39,7 @@ async fn main() {
     let db_connection_str = std::env::var("DATABASE_URL")
         .unwrap_or_else(|_| "postgres://postgres:password@localhost".to_string());
 
-    // setup connection pool
+    // set up connection pool
     let pool = PgPoolOptions::new()
         .max_connections(5)
         .acquire_timeout(Duration::from_secs(3))


### PR DESCRIPTION
## Motivation

"setup" was being written as a noun in some cases where it appears it should be
used as a verb "set up"

## Solution

See https://writingexplained.org/setup-vs-set-up-difference
