### PR TITLE
Re-export Duration for Cookie set_max_age

### DIFF
--- a/axum-extra/src/extract/cookie/mod.rs
+++ b/axum-extra/src/extract/cookie/mod.rs
@@ -24,7 +24,7 @@ pub use self::private::PrivateCookieJar;
 #[cfg(feature = "cookie-signed")]
 pub use self::signed::SignedCookieJar;
 
-pub use cookie::{Cookie, Expiration, SameSite};
+pub use cookie::{Cookie, Duration, Expiration, SameSite};
 
 #[cfg(any(feature = "cookie-signed", feature = "cookie-private"))]
 pub use cookie::Key;

--- a/axum-extra/src/extract/cookie/mod.rs
+++ b/axum-extra/src/extract/cookie/mod.rs
@@ -24,7 +24,7 @@ pub use self::private::PrivateCookieJar;
 #[cfg(feature = "cookie-signed")]
 pub use self::signed::SignedCookieJar;
 
-pub use cookie::{Cookie, Duration, Expiration, SameSite};
+pub use cookie::{time::Duration, Cookie, Expiration, SameSite};
 
 #[cfg(any(feature = "cookie-signed", feature = "cookie-private"))]
 pub use cookie::Key;


### PR DESCRIPTION
## Motivation

The `set_max_age` method of `Cookie` takes a `time::Duration` as argument. The `cookie` crate re-exports this struct, but axum-extra does not.

## Solution

Re-export the `Duration` struct to make the API accessible without the need to include `time` as a direct dependency.