### PR TITLE
Use tuples instead of `ServiceBuilder` internally

### DIFF
--- a/axum/src/routing/method_routing.rs
+++ b/axum/src/routing/method_routing.rs
@@ -1254,7 +1254,7 @@ mod tests {
     use axum_core::response::IntoResponse;
     use http::{header::ALLOW, HeaderMap};
     use std::time::Duration;
-    use tower::{timeout::TimeoutLayer, Service, ServiceBuilder, ServiceExt};
+    use tower::{timeout::TimeoutLayer, Service, ServiceExt};
     use tower_http::{services::fs::ServeDir, validate_request::ValidateRequestHeaderLayer};
 
     #[crate::test]
@@ -1354,13 +1354,10 @@ mod tests {
                 .merge(delete_service(ServeDir::new(".")))
                 .fallback(|| async { StatusCode::NOT_FOUND })
                 .put(ok)
-                .layer(
-                    ServiceBuilder::new()
-                        .layer(HandleErrorLayer::new(|_| async {
-                            StatusCode::REQUEST_TIMEOUT
-                        }))
-                        .layer(TimeoutLayer::new(Duration::from_secs(10))),
-                ),
+                .layer((
+                    HandleErrorLayer::new(|_| async { StatusCode::REQUEST_TIMEOUT }),
+                    TimeoutLayer::new(Duration::from_secs(10)),
+                )),
         );
 
         let listener = tokio::net::TcpListener::bind("0.0.0.0:0").await.unwrap();

--- a/axum/src/routing/tests/handle_error.rs
+++ b/axum/src/routing/tests/handle_error.rs
@@ -1,6 +1,6 @@
 use super::*;
 use std::future::{pending, ready};
-use tower::{timeout::TimeoutLayer, ServiceBuilder};
+use tower::timeout::TimeoutLayer;
 
 async fn unit() {}
 
@@ -33,13 +33,10 @@ impl<R> Service<R> for Svc {
 async fn handler() {
     let app = Router::new().route(
         "/",
-        get(forever.layer(
-            ServiceBuilder::new()
-                .layer(HandleErrorLayer::new(|_: BoxError| async {
-                    StatusCode::REQUEST_TIMEOUT
-                }))
-                .layer(timeout()),
-        )),
+        get(forever.layer((
+            HandleErrorLayer::new(|_: BoxError| async { StatusCode::REQUEST_TIMEOUT }),
+            timeout(),
+        ))),
     );
 
     let client = TestClient::new(app);
@@ -52,13 +49,10 @@ async fn handler() {
 async fn handler_multiple_methods_first() {
     let app = Router::new().route(
         "/",
-        get(forever.layer(
-            ServiceBuilder::new()
-                .layer(HandleErrorLayer::new(|_: BoxError| async {
-                    StatusCode::REQUEST_TIMEOUT
-                }))
-                .layer(timeout()),
-        ))
+        get(forever.layer((
+            HandleErrorLayer::new(|_: BoxError| async { StatusCode::REQUEST_TIMEOUT }),
+            timeout(),
+        )))
         .post(unit),
     );
 
@@ -73,15 +67,10 @@ async fn handler_multiple_methods_middle() {
     let app = Router::new().route(
         "/",
         delete(unit)
-            .get(
-                forever.layer(
-                    ServiceBuilder::new()
-                        .layer(HandleErrorLayer::new(|_: BoxError| async {
-                            StatusCode::REQUEST_TIMEOUT
-                        }))
-                        .layer(timeout()),
-                ),
-            )
+            .get(forever.layer((
+                HandleErrorLayer::new(|_: BoxError| async { StatusCode::REQUEST_TIMEOUT }),
+                timeout(),
+            )))
             .post(unit),
     );
 
@@ -95,15 +84,10 @@ async fn handler_multiple_methods_middle() {
 async fn handler_multiple_methods_last() {
     let app = Router::new().route(
         "/",
-        delete(unit).get(
-            forever.layer(
-                ServiceBuilder::new()
-                    .layer(HandleErrorLayer::new(|_: BoxError| async {
-                        StatusCode::REQUEST_TIMEOUT
-                    }))
-                    .layer(timeout()),
-            ),
-        ),
+        delete(unit).get(forever.layer((
+            HandleErrorLayer::new(|_: BoxError| async { StatusCode::REQUEST_TIMEOUT }),
+            timeout(),
+        ))),
     );
 
     let client = TestClient::new(app);

--- a/axum/src/routing/tests/merge.rs
+++ b/axum/src/routing/tests/merge.rs
@@ -127,13 +127,10 @@ async fn layer_and_handle_error() {
     let one = Router::new().route("/foo", get(|| async {}));
     let two = Router::new()
         .route("/timeout", get(std::future::pending::<()>))
-        .layer(
-            ServiceBuilder::new()
-                .layer(HandleErrorLayer::new(|_| async {
-                    StatusCode::REQUEST_TIMEOUT
-                }))
-                .layer(TimeoutLayer::new(Duration::from_millis(10))),
-        );
+        .layer((
+            HandleErrorLayer::new(|_| async { StatusCode::REQUEST_TIMEOUT }),
+            TimeoutLayer::new(Duration::from_millis(10)),
+        ));
     let app = one.merge(two);
 
     let client = TestClient::new(app);

--- a/examples/consume-body-in-extractor-or-middleware/src/main.rs
+++ b/examples/consume-body-in-extractor-or-middleware/src/main.rs
@@ -14,7 +14,6 @@ use axum::{
     routing::post,
     Router,
 };
-use tower::ServiceBuilder;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 #[tokio::main]
@@ -29,7 +28,7 @@ async fn main() {
 
     let app = Router::new()
         .route("/", post(handler))
-        .layer(ServiceBuilder::new().layer(middleware::from_fn(print_request_body)));
+        .layer(middleware::from_fn(print_request_body));
 
     let listener = tokio::net::TcpListener::bind("127.0.0.1:3000")
         .await


### PR DESCRIPTION
Replace most uses of `ServiceBuilder` internally with tuples. A bit cleaner I think.

I still kept uses of `ServiceBuilder` in the docs because its more discoverable.