### PR TITLE
Chore: A few clippy inspired changes

### DIFF
--- a/axum-core/src/ext_traits/request.rs
+++ b/axum-core/src/ext_traits/request.rs
@@ -305,7 +305,7 @@ impl RequestExt for Request {
         *req.uri_mut() = self.uri().clone();
         *req.headers_mut() = std::mem::take(self.headers_mut());
         *req.extensions_mut() = std::mem::take(self.extensions_mut());
-        let (mut parts, _) = req.into_parts();
+        let (mut parts, ()) = req.into_parts();
 
         Box::pin(async move {
             let result = E::from_request_parts(&mut parts, state).await;

--- a/axum-macros/src/from_request.rs
+++ b/axum-macros/src/from_request.rs
@@ -63,8 +63,7 @@ impl State {
     /// ```
     fn trait_generics(&self) -> impl Iterator<Item = Type> {
         match self {
-            State::Default(inner) => iter::once(inner.clone()),
-            State::Custom(inner) => iter::once(inner.clone()),
+            State::Default(inner) | State::Custom(inner) => iter::once(inner.clone()),
             State::CannotInfer => iter::once(parse_quote!(S)),
         }
     }
@@ -85,8 +84,7 @@ impl State {
 impl ToTokens for State {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         match self {
-            State::Custom(inner) => inner.to_tokens(tokens),
-            State::Default(inner) => inner.to_tokens(tokens),
+            State::Custom(inner) | State::Default(inner) => inner.to_tokens(tokens),
             State::CannotInfer => quote! { S }.to_tokens(tokens),
         }
     }

--- a/axum/src/routing/method_filter.rs
+++ b/axum/src/routing/method_filter.rs
@@ -10,21 +10,21 @@ pub struct MethodFilter(u16);
 
 impl MethodFilter {
     /// Match `DELETE` requests.
-    pub const DELETE: Self = Self::from_bits(0b000000010);
+    pub const DELETE: Self = Self::from_bits(0b0_0000_0010);
     /// Match `GET` requests.
-    pub const GET: Self = Self::from_bits(0b000000100);
+    pub const GET: Self = Self::from_bits(0b0_0000_0100);
     /// Match `HEAD` requests.
-    pub const HEAD: Self = Self::from_bits(0b000001000);
+    pub const HEAD: Self = Self::from_bits(0b0_0000_1000);
     /// Match `OPTIONS` requests.
-    pub const OPTIONS: Self = Self::from_bits(0b000010000);
+    pub const OPTIONS: Self = Self::from_bits(0b0_0001_0000);
     /// Match `PATCH` requests.
-    pub const PATCH: Self = Self::from_bits(0b000100000);
+    pub const PATCH: Self = Self::from_bits(0b0_0010_0000);
     /// Match `POST` requests.
-    pub const POST: Self = Self::from_bits(0b001000000);
+    pub const POST: Self = Self::from_bits(0b0_0100_0000);
     /// Match `PUT` requests.
-    pub const PUT: Self = Self::from_bits(0b010000000);
+    pub const PUT: Self = Self::from_bits(0b0_1000_0000);
     /// Match `TRACE` requests.
-    pub const TRACE: Self = Self::from_bits(0b100000000);
+    pub const TRACE: Self = Self::from_bits(0b1_0000_0000);
 
     const fn bits(&self) -> u16 {
         let bits = self;


### PR DESCRIPTION
* Combine identical `match` branches into one statement with a `|` symbol
* Use `_` in a 9-bit binary values (I didn't even realize they were 9-bit instead of the common 8-bit until I did this)
* Replaced a few `.map().unwrap_or_else()` with `.map_or_else()`
* Use specific type with `default()` instead of `Default::default()` to make it easier to read/understand
