### PR TITLE
Make tokio an optional dependency of axum-extra

### DIFF
--- a/axum-extra/CHANGELOG.md
+++ b/axum-extra/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning].
 - **added:** `TypedHeader` which used to be in `axum` ([#1850])
 - **added:** `Clone` implementation for `ErasedJson` ([#2142])
 - **breaking:** Update to prost 0.12. Used for the `Protobuf` extractor
+- **breaking:** Make `tokio` an optional dependency
 
 [#1850]: https://github.com/tokio-rs/axum/pull/1850
 [#2142]: https://github.com/tokio-rs/axum/pull/2142

--- a/axum-extra/Cargo.toml
+++ b/axum-extra/Cargo.toml
@@ -14,7 +14,7 @@ version = "0.7.4"
 [features]
 default = []
 
-async-read-body = ["dep:tokio-util", "tokio-util?/io"]
+async-read-body = ["dep:tokio-util", "tokio-util?/io", "dep:tokio"]
 cookie = ["dep:cookie"]
 cookie-private = ["cookie", "cookie?/private"]
 cookie-signed = ["cookie", "cookie?/signed"]
@@ -26,7 +26,8 @@ json-lines = [
     "dep:tokio-util",
     "dep:tokio-stream",
     "tokio-util?/io",
-    "tokio-stream?/io-util"
+    "tokio-stream?/io-util",
+    "dep:tokio",
 ]
 multipart = ["dep:multer"]
 protobuf = ["dep:prost"]
@@ -44,7 +45,6 @@ http-body = "0.4.4"
 mime = "0.3"
 pin-project-lite = "0.2"
 serde = "1.0"
-tokio = "1.19"
 tower = { version = "0.4", default_features = false, features = ["util"] }
 tower-layer = "0.3"
 tower-service = "0.3"
@@ -59,6 +59,7 @@ percent-encoding = { version = "2.1", optional = true }
 prost = { version = "0.12", optional = true }
 serde_html_form = { version = "0.2.0", optional = true }
 serde_json = { version = "1.0.71", optional = true }
+tokio = { version = "1.19", optional = true }
 tokio-stream = { version = "0.1.9", optional = true }
 tokio-util = { version = "0.7", optional = true }
 


### PR DESCRIPTION
Requested by someone in Discord. That way you can use axum-extra in wasm, as long as you don't enable the features that require tokio. We already do this for axum but think we just forgot axum-extra.

@jplatte I'm right in this being a breaking change right? 🤔