### PR TITLE
Make sure axum-extra also supports being compiled to WASM

### DIFF
--- a/examples/simple-router-wasm/Cargo.toml
+++ b/examples/simple-router-wasm/Cargo.toml
@@ -8,6 +8,9 @@ publish = false
 # `default-features = false` to not depend on tokio features which don't support wasm
 # you can still pull in tokio manually and only add features that tokio supports for wasm
 axum = { path = "../../axum", default-features = false }
+# we don't strictly need axum-extra for this example but wanna make sure that
+# works in wasm as well
+axum-extra = { path = "../../axum-extra", default-features = false }
 futures-executor = "0.3.21"
 http = "0.2.7"
 tower-service = "0.3.1"

--- a/examples/simple-router-wasm/Cargo.toml
+++ b/examples/simple-router-wasm/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 # `default-features = false` to not depend on tokio features which don't support wasm
 # you can still pull in tokio manually and only add features that tokio supports for wasm
 axum = { path = "../../axum", default-features = false }
-# we don't strictly need axum-extra for this example but wanna make sure that
+# we don't strictly use axum-extra in this example but wanna make sure that
 # works in wasm as well
 axum-extra = { path = "../../axum-extra", default-features = false }
 futures-executor = "0.3.21"


### PR DESCRIPTION
Someone on Discord is having issues with compiling axum-extra to WASM so I'm adding that as a dependency to `example-simple-router-wasm`. Just so we don't accidentally break WASM compilation in the future by adding some non-WASM dependency as part of the default feature set.