### PR TITLE
Json: add from_bytes method, use that in 'impl FromRequest'

### DIFF
--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -66,6 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **added:** Implement `IntoResponse` for `(R,) where R: IntoResponse` ([#2143])
 - **changed:** For SSE, add space between field and value for compatibility ([#2149])
 - **added:** Add `NestedPath` extractor ([#1924])
+- **added:** Add `axum::Json::from_bytes` ([#2244])
 
 [#1664]: https://github.com/tokio-rs/axum/pull/1664
 [#1751]: https://github.com/tokio-rs/axum/pull/1751
@@ -86,6 +87,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2140]: https://github.com/tokio-rs/axum/pull/2140
 [#2143]: https://github.com/tokio-rs/axum/pull/2143
 [#2149]: https://github.com/tokio-rs/axum/pull/2149
+[#2244]: https://github.com/tokio-rs/axum/pull/2244
 
 # 0.6.17 (25. April, 2023)
 

--- a/axum/src/json.rs
+++ b/axum/src/json.rs
@@ -147,7 +147,7 @@ impl<T> Json<T>
 where
     T: DeserializeOwned,
 {
-    /// Construct a `Json<T>` from `&Bytes`. Most users should prefer to use the `FromRequest` impl
+    /// Construct a `Json<T>` from a byte slice. Most users should prefer to use the `FromRequest` impl
     /// but special cases may require first extracting a `Request` into `Bytes` then optionally
     /// constructing a `Json<T>`.
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, JsonRejection> {

--- a/axum/src/json.rs
+++ b/axum/src/json.rs
@@ -150,11 +150,6 @@ where
     /// Construct a `Json<T>` from `&Bytes`. Most users should prefer to use the `FromRequest` impl
     /// but special cases may require first extracting a `Request` into `Bytes` then optionally
     /// constructing a `Json<T>`.
-    ///
-    /// An example where this would be useful would be one in which a service needs to pass through
-    /// or otherwise preserve the exact byte representation of the request while also interrogating
-    /// it for metadata that may be useful in determining exactly what to do with the preserved
-    /// bytes.
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, JsonRejection> {
         let deserializer = &mut serde_json::Deserializer::from_slice(bytes);
 

--- a/axum/src/json.rs
+++ b/axum/src/json.rs
@@ -155,7 +155,7 @@ where
     /// or otherwise preserve the exact byte representation of the request while also interrogating
     /// it for metadata that may be useful in determining exactly what to do with the preserved
     /// bytes.
-    fn from_bytes(bytes: &Bytes) -> Result<Self, JsonRejection> {
+    pub fn from_bytes(bytes: &Bytes) -> Result<Self, JsonRejection> {
         let deserializer = &mut serde_json::Deserializer::from_slice(&bytes);
 
         let value = match serde_path_to_error::deserialize(deserializer) {

--- a/axum/src/json.rs
+++ b/axum/src/json.rs
@@ -156,7 +156,7 @@ where
     /// it for metadata that may be useful in determining exactly what to do with the preserved
     /// bytes.
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, JsonRejection> {
-        let deserializer = &mut serde_json::Deserializer::from_slice(&bytes);
+        let deserializer = &mut serde_json::Deserializer::from_slice(bytes);
 
         let value = match serde_path_to_error::deserialize(deserializer) {
             Ok(value) => value,

--- a/axum/src/json.rs
+++ b/axum/src/json.rs
@@ -155,7 +155,7 @@ where
     /// or otherwise preserve the exact byte representation of the request while also interrogating
     /// it for metadata that may be useful in determining exactly what to do with the preserved
     /// bytes.
-    pub fn from_bytes(bytes: &Bytes) -> Result<Self, JsonRejection> {
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, JsonRejection> {
         let deserializer = &mut serde_json::Deserializer::from_slice(&bytes);
 
         let value = match serde_path_to_error::deserialize(deserializer) {


### PR DESCRIPTION
I find this necessary in order to both deserialize the body of my service's
request into a `Json<T>` AND preserve the exact byte representation of the
input. The risk of not taking this approach for me is that the spec I am
implementing expects the exact byte representation to be preserved in order to
later serve the exact same content back to the client without a potentially
lossy serialized-deserialized-serialized transformation.

I could almost certainly deserialize these request bodies without the `Json<T>`
but I really would like to take advantage of the error reporting it offers.

Signed-off-by: wayne warren <wayne.warren.s@gmail.com>

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
