### PR TITLE
Fix example on README.md

### DIFF
--- a/axum/README.md
+++ b/axum/README.md
@@ -51,6 +51,7 @@ async fn main() {
         // `POST /users` goes to `create_user`
         .route("/users", post(create_user));
 
+    // run our app with hyper, listening globally on port 3000
     axum::Server::bind(&"0.0.0.0:3000".parse().unwrap())
         .serve(app.into_make_service())
         .await

--- a/axum/README.md
+++ b/axum/README.md
@@ -35,11 +35,9 @@ applications written using [`hyper`] or [`tonic`].
 use axum::{
     routing::{get, post},
     http::StatusCode,
-    response::IntoResponse,
     Json, Router,
 };
 use serde::{Deserialize, Serialize};
-use std::net::SocketAddr;
 
 #[tokio::main]
 async fn main() {
@@ -53,9 +51,11 @@ async fn main() {
         // `POST /users` goes to `create_user`
         .route("/users", post(create_user));
 
-    // run our app with hyper, listening globally on port 3000
-    let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await.unwrap();
-    axum::serve(listener, app).await.unwrap();
+    axum::Server::bind(&"0.0.0.0:3000".parse().unwrap())
+        .serve(app.into_make_service())
+        .await
+        .unwrap();
+
 }
 
 // basic handler that responds with a static string


### PR DESCRIPTION
`serve` method no longer exists. Changed to make it match the `cargo doc` examples


## Motivation

When trying to follow the basic README.md documentation I got compilation errors.

## Solution

Adapted the README.md to the documentanion available on [hello world example](https://docs.rs/axum/latest/axum/)
