### PR TITLE
Improve documentation of Path

### DIFF
--- a/axum/src/extract/path/mod.rs
+++ b/axum/src/extract/path/mod.rs
@@ -25,6 +25,10 @@ use std::{fmt, sync::Arc};
 ///
 /// These examples assume the `serde` feature of the [`uuid`] crate is enabled.
 ///
+/// One `Path` argument extracts _all_ captures into a tuple. A function should
+/// not have multiple `Path` arguments---the first will extract all captures
+/// and subsequent ones will do nothing.
+///
 /// [`uuid`]: https://crates.io/crates/uuid
 ///
 /// ```rust,no_run

--- a/axum/src/extract/path/mod.rs
+++ b/axum/src/extract/path/mod.rs
@@ -25,9 +25,8 @@ use std::{fmt, sync::Arc};
 ///
 /// These examples assume the `serde` feature of the [`uuid`] crate is enabled.
 ///
-/// One `Path` argument extracts _all_ captures into a tuple. A function should
-/// not have multiple `Path` arguments---the first will extract all captures
-/// and subsequent ones will do nothing.
+/// One `Path` can extract multiple captures. It is not necessary (and does
+/// not work) to give a handler more than one `Path` argument.
 ///
 /// [`uuid`]: https://crates.io/crates/uuid
 ///


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

This improves the documentation for `Path` by specifically calling out that one `Path` extractor captures all components for a route. New users fall into the trap of thinking that each capture needs its own `Path` argument., which does not work.

See #2313 for more details.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

This PR adds two sentences to the docs to clarify that only one `Path` should be used.

Fixes https://github.com/tokio-rs/axum/issues/2313