### PR TITLE
explain that `Router::merge` only merges paths and fallback

### DIFF
--- a/axum/src/docs/routing/merge.md
+++ b/axum/src/docs/routing/merge.md
@@ -1,4 +1,4 @@
-Merge the paths of two routers into a single [`Router`].
+Merge the paths and fallbacks of two routers into a single [`Router`].
 
 This is useful for breaking apps into smaller pieces and combining them
 into one.

--- a/axum/src/docs/routing/merge.md
+++ b/axum/src/docs/routing/merge.md
@@ -1,4 +1,4 @@
-Merge two routers into one.
+Merge the paths of two routers into a single [`Router`].
 
 This is useful for breaking apps into smaller pieces and combining them
 into one.
@@ -70,6 +70,11 @@ let app = Router::new()
     .with_state(OuterState {});
 # let _: axum::Router = app;
 ```
+
+# Merging routers with fallbacks
+
+When combining [`Router`]s with this method, the [fallback](Router::fallback) is also merged.
+However only one of the routers can have a fallback.
 
 # Panics
 

--- a/axum/src/routing/tests/merge.rs
+++ b/axum/src/routing/tests/merge.rs
@@ -135,6 +135,8 @@ async fn layer_and_handle_error() {
 
     let res = client.get("/timeout").send().await;
     assert_eq!(res.status(), StatusCode::REQUEST_TIMEOUT);
+    let res = client.get("/foo").send().await;
+    assert_eq!(res.status(), StatusCode::OK);
 }
 
 #[crate::test]


### PR DESCRIPTION
## Motivation

The current documentation on `Router::merge` suggests to me in a naive reading that layers applied in a `Router` that is then merged with another `Router` gets applied to the "top-level" `Router`s paths, this is not the case.


## Solution

Explain that only paths and fallbacks are merged, hopefully to dispel any wrongful assumptions. 