### PR TITLE
Fix items-after-test-module clippy warning on 1.75.0-beta.1

### DIFF
--- a/axum-core/src/macros.rs
+++ b/axum-core/src/macros.rs
@@ -211,46 +211,6 @@ macro_rules! __composite_rejection {
     };
 }
 
-#[cfg(test)]
-mod composite_rejection_tests {
-    use self::defs::*;
-    use crate::Error;
-    use std::error::Error as _;
-
-    #[allow(dead_code, unreachable_pub)]
-    mod defs {
-        use crate::{__composite_rejection, __define_rejection};
-
-        __define_rejection! {
-            #[status = BAD_REQUEST]
-            #[body = "error message 1"]
-            pub struct Inner1;
-        }
-        __define_rejection! {
-            #[status = BAD_REQUEST]
-            #[body = "error message 2"]
-            pub struct Inner2(Error);
-        }
-        __composite_rejection! {
-            pub enum Outer { Inner1, Inner2 }
-        }
-    }
-
-    /// The implementation of `.source()` on `Outer` should defer straight to the implementation
-    /// on its inner type instead of returning the inner type itself, because the `Display`
-    /// implementation on `Outer` already forwards to the inner type and so it would result in two
-    /// errors in the chain `Display`ing the same thing.
-    #[test]
-    fn source_gives_inner_source() {
-        let rejection = Outer::Inner1(Inner1);
-        assert!(rejection.source().is_none());
-
-        let msg = "hello world";
-        let rejection = Outer::Inner2(Inner2(Error::new(msg)));
-        assert_eq!(rejection.source().unwrap().to_string(), msg);
-    }
-}
-
 #[rustfmt::skip]
 macro_rules! all_the_tuples {
     ($name:ident) => {
@@ -333,4 +293,44 @@ macro_rules! __impl_deref {
             }
         }
     };
+}
+
+#[cfg(test)]
+mod composite_rejection_tests {
+    use self::defs::*;
+    use crate::Error;
+    use std::error::Error as _;
+
+    #[allow(dead_code, unreachable_pub)]
+    mod defs {
+        use crate::{__composite_rejection, __define_rejection};
+
+        __define_rejection! {
+            #[status = BAD_REQUEST]
+            #[body = "error message 1"]
+            pub struct Inner1;
+        }
+        __define_rejection! {
+            #[status = BAD_REQUEST]
+            #[body = "error message 2"]
+            pub struct Inner2(Error);
+        }
+        __composite_rejection! {
+            pub enum Outer { Inner1, Inner2 }
+        }
+    }
+
+    /// The implementation of `.source()` on `Outer` should defer straight to the implementation
+    /// on its inner type instead of returning the inner type itself, because the `Display`
+    /// implementation on `Outer` already forwards to the inner type and so it would result in two
+    /// errors in the chain `Display`ing the same thing.
+    #[test]
+    fn source_gives_inner_source() {
+        let rejection = Outer::Inner1(Inner1);
+        assert!(rejection.source().is_none());
+
+        let msg = "hello world";
+        let rejection = Outer::Inner2(Inner2(Error::new(msg)));
+        assert_eq!(rejection.source().unwrap().to_string(), msg);
+    }
 }

--- a/axum-macros/tests/debug_handler/fail/argument_not_extractor.stderr
+++ b/axum-macros/tests/debug_handler/fail/argument_not_extractor.stderr
@@ -11,8 +11,8 @@ error[E0277]: the trait bound `bool: FromRequestParts<()>` is not satisfied
             <Extension<T> as FromRequestParts<S>>
             <Method as FromRequestParts<S>>
             <Uri as FromRequestParts<S>>
-            <Version as FromRequestParts<S>>
             <ConnectInfo<T> as FromRequestParts<S>>
+            <Version as FromRequestParts<S>>
             <axum::extract::Path<T> as FromRequestParts<S>>
             <RawPathParams as FromRequestParts<S>>
           and $N others

--- a/axum-macros/tests/from_request/fail/parts_extracting_body.stderr
+++ b/axum-macros/tests/from_request/fail/parts_extracting_body.stderr
@@ -12,7 +12,7 @@ error[E0277]: the trait bound `String: FromRequestParts<S>` is not satisfied
             <Extension<T> as FromRequestParts<S>>
             <Method as FromRequestParts<S>>
             <Uri as FromRequestParts<S>>
-            <Version as FromRequestParts<S>>
             <ConnectInfo<T> as FromRequestParts<S>>
+            <Version as FromRequestParts<S>>
             <axum::extract::Path<T> as FromRequestParts<S>>
           and $N others


### PR DESCRIPTION
## Motivation

Fixes CI failure with [items-after-test-module](https://rust-lang.github.io/rust-clippy/master/index.html#/items_after_test_module) clippy warning on 1.75.0-beta.1

## Solution

Move the test module after all other modules
