### PR TITLE
Add a Redirect factory function for 302 Found

### DIFF
--- a/axum/src/response/redirect.rs
+++ b/axum/src/response/redirect.rs
@@ -69,6 +69,17 @@ impl Redirect {
         Self::with_status_code(StatusCode::PERMANENT_REDIRECT, uri)
     }
 
+    /// Create a new [`Redirect`] that uses a [`302 Found`][mdn] status code.
+    ///
+    /// # Panics
+    ///
+    /// If `uri` isn't a valid [`HeaderValue`].
+    ///
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/302
+    pub fn found(uri: &str) -> Self {
+        Self::with_status_code(StatusCode::FOUND, uri)
+    }
+
     // This is intentionally not public since other kinds of redirects might not
     // use the `Location` header, namely `304 Not Modified`.
     //


### PR DESCRIPTION
Hello 👋 
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

I use the `302 Found` redirect in a project of mine, and today building something custom with
```rust
(StatusCode::FOUND, [(LOCATION, HeaderValue::from_static(uri))]).into_response()
```

It is a little cumbersome, considering that the `Redirect` struct seems to supply shorthands for other redirection codes (303, 308, etc.)

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Add a factory function for `302 Found` in the `Redirect` struct implementation.

Let me know if I missed something 😉