### PR TITLE
Add `socketioxide` lib to ECOSYSTEM.md

### DIFF
--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -42,6 +42,7 @@ If your project isn't listed here and you would like it to be, please feel free 
 - [axum-valid](https://github.com/gengteng/axum-valid): Extractors for data validation using validator, garde, and validify.
 - [tower-sessions](https://github.com/maxcountryman/tower-sessions): Sessions as a `tower` and `axum` middleware.
 - [shuttle](https://github.com/shuttle-hq/shuttle): Build & ship backends without writing any infrastructure files. Now with Axum support.
+- [socketioxide](https://github.com/totodore/socketioxide): An easy to use socket.io server implementation working as a `tower` layer/service. 
 
 ## Project showcase
 


### PR DESCRIPTION
## Motivation
I am making a socket.io server framework working as a [`tower`] layer so it integrates well with any http framework based on the tower/tokio/hyper ecosystem. I took a lot of inspiration from the axum handlers (with dynamic parameters) :).

It would be really nice to add it to the ECOSYSTEM.md file !

Edit : The github repo : https://github.com/totodore/socketioxide