### PR TITLE
GitHub: Add a Q&A discussion template

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/q-a.yml
+++ b/.github/DISCUSSION_TEMPLATE/q-a.yml
@@ -1,0 +1,23 @@
+title: 'Q&A'
+body:
+  - type: textarea
+    attributes:
+      label: Summary
+      description: 'Your question:'
+    validations:
+      required: true
+  - type: input
+    attributes:
+      label: axum version
+      description: 'Please look it up in `Cargo.lock`'
+  - type: markdown
+    attributes:
+      value: |
+        > [!NOTE]
+        > If you have `jq` installed, you can look up the version by running
+        >
+        > ```bash
+        > cargo metadata --format-version=1 | jq -r '.packages[] | select(.name == "axum") | .version'
+        > ```
+      validations:
+        required: true


### PR DESCRIPTION
## Motivation

We're about to release 0.7, it would be nice if new posts in the Q&A discussion sections would contain the version of axum the poster used.

## Solution

Add a template! The [docs](https://docs.github.com/en/discussions/managing-discussions-for-your-community/creating-discussion-category-forms) are quite rudimentary, so I have no clue howe well the one I created will work. Might need further iteration after merge.