### PR TITLE
Fix error in Q&A discussion template

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/q-a.yml
+++ b/.github/DISCUSSION_TEMPLATE/q-a.yml
@@ -10,6 +10,8 @@ body:
     attributes:
       label: axum version
       description: 'Please look it up in `Cargo.lock`'
+    validations:
+      required: true
   - type: markdown
     attributes:
       value: |
@@ -19,5 +21,3 @@ body:
         > ```bash
         > cargo metadata --format-version=1 | jq -r '.packages[] | select(.name == "axum") | .version'
         > ```
-      validations:
-        required: true


### PR DESCRIPTION
## Motivation

#2340 didn't work. Luckily after opening the file in GitHub's web UI, I got a somewhat usable error message.

## Solution

Fix the error x)
It was about indentation of the validations.required thing, but also that was on the wrong item in the first place.