### PR TITLE
Clean up Q&A discussion template

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/q-a.yml
+++ b/.github/DISCUSSION_TEMPLATE/q-a.yml
@@ -1,4 +1,3 @@
-title: 'Q&A'
 body:
   - type: textarea
     attributes:
@@ -9,13 +8,12 @@ body:
   - type: input
     attributes:
       label: axum version
-      description: 'Please look it up in `Cargo.lock`'
+      description: 'Please look it up in `Cargo.lock`, or as described below'
     validations:
       required: true
   - type: markdown
     attributes:
       value: |
-        > [!NOTE]
         > If you have `jq` installed, you can look up the version by running
         >
         > ```bash


### PR DESCRIPTION
## Motivation

First working version is a bit ugly, the [note highlight](https://github.com/orgs/community/discussions/16925) didn't work at all and the title was actually a placeholder:

![Screenshot_2023-11-24_122449](https://github.com/tokio-rs/axum/assets/951129/1fbc645c-a745-4b87-be25-5fa5222871b9)

## Solution

Remove both.