### PR TITLE
refactor deprecated Cookie::named fn

### DIFF
--- a/axum-extra/Cargo.toml
+++ b/axum-extra/Cargo.toml
@@ -52,7 +52,7 @@ tower-service = "0.3"
 
 # optional dependencies
 axum-macros = { path = "../axum-macros", version = "0.3.7", optional = true }
-cookie = { package = "cookie", version = "0.17", features = ["percent-encode"], optional = true }
+cookie = { package = "cookie", version = "0.18.0", features = ["percent-encode"], optional = true }
 form_urlencoded = { version = "1.1.0", optional = true }
 headers = { version = "0.3.8", optional = true }
 multer = { version = "2.0.0", optional = true }

--- a/axum-extra/src/extract/cookie/mod.rs
+++ b/axum-extra/src/extract/cookie/mod.rs
@@ -168,7 +168,7 @@ impl CookieJar {
     /// use axum::response::IntoResponse;
     ///
     /// async fn handle(jar: CookieJar) -> CookieJar {
-    ///     jar.remove(Cookie::named("foo"))
+    ///     jar.remove(Cookie::from("foo"))
     /// }
     /// ```
     #[must_use]
@@ -250,7 +250,7 @@ mod tests {
                 }
 
                 async fn remove_cookie(jar: $jar) -> impl IntoResponse {
-                    jar.remove(Cookie::named("key"))
+                    jar.remove(Cookie::from("key"))
                 }
 
                 let state = AppState {

--- a/axum-extra/src/extract/cookie/private.rs
+++ b/axum-extra/src/extract/cookie/private.rs
@@ -216,7 +216,7 @@ impl<K> PrivateCookieJar<K> {
     /// use axum::response::IntoResponse;
     ///
     /// async fn handle(jar: PrivateCookieJar) -> PrivateCookieJar {
-    ///     jar.remove(Cookie::named("foo"))
+    ///     jar.remove(Cookie::from("foo"))
     /// }
     /// ```
     #[must_use]

--- a/axum-extra/src/extract/cookie/signed.rs
+++ b/axum-extra/src/extract/cookie/signed.rs
@@ -234,7 +234,7 @@ impl<K> SignedCookieJar<K> {
     /// use axum::response::IntoResponse;
     ///
     /// async fn handle(jar: SignedCookieJar) -> SignedCookieJar {
-    ///     jar.remove(Cookie::named("foo"))
+    ///     jar.remove(Cookie::from("foo"))
     /// }
     /// ```
     #[must_use]


### PR DESCRIPTION
The cookie crate is now at version 0.18

In its changelog i see a deprecated fn and after doing cargo test i saw that Cookie::named could be now substituted by cookie::from or cookie::build
