### PR TITLE
Remove PATCH versions from all dependencies

### DIFF
--- a/axum-core/Cargo.toml
+++ b/axum-core/Cargo.toml
@@ -18,32 +18,32 @@ tracing = ["dep:tracing"]
 __private_docs = ["dep:tower-http"]
 
 [dependencies]
-async-trait = "0.1.67"
+async-trait = "0.1"
 bytes = "1.0"
 futures-util = { version = "0.3", default-features = false, features = ["alloc"] }
-http = "1.0.0"
-http-body = "1.0.0"
-http-body-util = "0.1.0"
-mime = "0.3.16"
-pin-project-lite = "0.2.7"
-sync_wrapper = "0.1.1"
+http = "1.0"
+http-body = "1.0"
+http-body-util = "0.1"
+mime = "0.3"
+pin-project-lite = "0.2"
+sync_wrapper = "0.1"
 tower-layer = "0.3"
 tower-service = "0.3"
 
 # optional dependencies
-tower-http = { version = "0.5.0", optional = true, features = ["limit"] }
-tracing = { version = "0.1.37", default-features = false, optional = true }
+tower-http = { version = "0.5", optional = true, features = ["limit"] }
+tracing = { version = "0.1", default-features = false, optional = true }
 
 [build-dependencies]
-rustversion = "1.0.9"
+rustversion = "1.0"
 
 [dev-dependencies]
-axum = { path = "../axum", version = "0.6.0" }
+axum = { path = "../axum", version = "0.6" }
 axum-extra = { path = "../axum-extra", features = ["typed-header"] }
 futures-util = { version = "0.3", default-features = false, features = ["alloc"] }
-hyper = "1.0.0"
-tokio = { version = "1.25.0", features = ["macros"] }
-tower-http = { version = "0.5.0", features = ["limit"] }
+hyper = "1.0"
+tokio = { version = "1.25", features = ["macros"] }
+tower-http = { version = "0.5", features = ["limit"] }
 
 [package.metadata.cargo-public-api-crates]
 allowed = [

--- a/axum-extra/Cargo.toml
+++ b/axum-extra/Cargo.toml
@@ -36,13 +36,13 @@ typed-header = ["dep:headers"]
 typed-routing = ["dep:axum-macros", "dep:percent-encoding", "dep:serde_html_form", "dep:form_urlencoded"]
 
 [dependencies]
-axum = { path = "../axum", version = "0.6.13", default-features = false }
-axum-core = { path = "../axum-core", version = "0.3.4" }
-bytes = "1.1.0"
+axum = { path = "../axum", version = "0.6", default-features = false }
+axum-core = { path = "../axum-core", version = "0.3" }
+bytes = "1.1"
 futures-util = { version = "0.3", default-features = false, features = ["alloc"] }
-http = "1.0.0"
-http-body = "1.0.0"
-http-body-util = "0.1.0"
+http = "1.0"
+http-body = "1.0"
+http-body-util = "0.1"
 mime = "0.3"
 pin-project-lite = "0.2"
 serde = "1.0"
@@ -51,28 +51,28 @@ tower-layer = "0.3"
 tower-service = "0.3"
 
 # optional dependencies
-axum-macros = { path = "../axum-macros", version = "0.3.7", optional = true }
-cookie = { package = "cookie", version = "0.18.0", features = ["percent-encode"], optional = true }
-form_urlencoded = { version = "1.1.0", optional = true }
-headers = { version = "0.3.8", optional = true }
-multer = { version = "2.0.0", optional = true }
+axum-macros = { path = "../axum-macros", version = "0.3", optional = true }
+cookie = { package = "cookie", version = "0.18", features = ["percent-encode"], optional = true }
+form_urlencoded = { version = "1.1", optional = true }
+headers = { version = "0.3", optional = true }
+multer = { version = "2.0", optional = true }
 percent-encoding = { version = "2.1", optional = true }
 prost = { version = "0.12", optional = true }
-serde_html_form = { version = "0.2.0", optional = true }
-serde_json = { version = "1.0.71", optional = true }
+serde_html_form = { version = "0.2", optional = true }
+serde_json = { version = "1.0", optional = true }
 tokio = { version = "1.19", optional = true }
-tokio-stream = { version = "0.1.9", optional = true }
+tokio-stream = { version = "0.1", optional = true }
 tokio-util = { version = "0.7", optional = true }
 
 [dev-dependencies]
-axum = { path = "../axum", version = "0.6.0" }
-hyper = "1.0.0"
+axum = { path = "../axum", version = "0.6" }
+hyper = "1.0"
 reqwest = { version = "0.11", default-features = false, features = ["json", "stream", "multipart"] }
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0.71"
+serde_json = "1.0"
 tokio = { version = "1.14", features = ["full"] }
 tower = { version = "0.4", features = ["util"] }
-tower-http = { version = "0.5.0", features = ["map-response-body", "timeout"] }
+tower-http = { version = "0.5", features = ["map-response-body", "timeout"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/axum-macros/Cargo.toml
+++ b/axum-macros/Cargo.toml
@@ -30,14 +30,14 @@ syn = { version = "2.0", features = [
 ] }
 
 [dev-dependencies]
-axum = { path = "../axum", version = "0.6.0", features = ["macros"] }
-axum-extra = { path = "../axum-extra", version = "0.7.0", features = ["typed-routing", "cookie-private", "typed-header"] }
+axum = { path = "../axum", version = "0.6", features = ["macros"] }
+axum-extra = { path = "../axum-extra", version = "0.7", features = ["typed-routing", "cookie-private", "typed-header"] }
 rustversion = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 syn = { version = "2.0", features = ["full", "extra-traits"] }
-tokio = { version = "1.25.0", features = ["full"] }
-trybuild = "1.0.63"
+tokio = { version = "1.25", features = ["full"] }
+trybuild = "1.0"
 
 [package.metadata.cargo-public-api-crates]
 allowed = []

--- a/axum/Cargo.toml
+++ b/axum/Cargo.toml
@@ -31,41 +31,41 @@ ws = ["tokio", "dep:tokio-tungstenite", "dep:sha1", "dep:base64"]
 __private_docs = ["tower/full", "dep:tower-http"]
 
 [dependencies]
-async-trait = "0.1.67"
-axum-core = { path = "../axum-core", version = "0.3.4" }
+async-trait = "0.1"
+axum-core = { path = "../axum-core", version = "0.3" }
 bytes = "1.0"
 futures-util = { version = "0.3", default-features = false, features = ["alloc"] }
-http = "1.0.0"
-http-body = "1.0.0"
-http-body-util = "0.1.0"
-hyper = { package = "hyper", version = "1.0.0", features = ["server", "http1"] }
-itoa = "1.0.5"
+http = "1.0"
+http-body = "1.0"
+http-body-util = "0.1"
+hyper = { package = "hyper", version = "1.0", features = ["server", "http1"] }
+itoa = "1.0"
 matchit = "0.7"
-memchr = "2.4.1"
-mime = "0.3.16"
+memchr = "2.4"
+mime = "0.3"
 percent-encoding = "2.1"
-pin-project-lite = "0.2.7"
+pin-project-lite = "0.2"
 serde = "1.0"
-sync_wrapper = "0.1.1"
-tower = { version = "0.4.13", default-features = false, features = ["util"] }
-tower-layer = "0.3.2"
+sync_wrapper = "0.1"
+tower = { version = "0.4", default-features = false, features = ["util"] }
+tower-layer = "0.3"
 tower-service = "0.3"
 
 # optional dependencies
-axum-macros = { path = "../axum-macros", version = "0.3.7", optional = true }
-base64 = { version = "0.21.0", optional = true }
-hyper-util = { version = "0.1.1", features = ["tokio", "server", "server-auto"], optional = true }
-multer = { version = "2.0.0", optional = true }
+axum-macros = { path = "../axum-macros", version = "0.3", optional = true }
+base64 = { version = "0.21", optional = true }
+hyper-util = { version = "0.1", features = ["tokio", "server", "server-auto"], optional = true }
+multer = { version = "2.0", optional = true }
 serde_json = { version = "1.0", features = ["raw_value"], optional = true }
-serde_path_to_error = { version = "0.1.8", optional = true }
+serde_path_to_error = { version = "0.1", optional = true }
 serde_urlencoded = { version = "0.7", optional = true }
 sha1 = { version = "0.10", optional = true }
-tokio = { package = "tokio", version = "1.25.0", features = ["time"], optional = true }
+tokio = { package = "tokio", version = "1.25", features = ["time"], optional = true }
 tokio-tungstenite = { version = "0.20", optional = true }
 tracing = { version = "0.1", default-features = false, optional = true }
 
 [dependencies.tower-http]
-version = "0.5.0"
+version = "0.5"
 optional = true
 features = [
     # all tower-http features except (de)?compression-zstd which doesn't
@@ -100,19 +100,19 @@ features = [
 ]
 
 [build-dependencies]
-rustversion = "1.0.9"
+rustversion = "1.0"
 
 [dev-dependencies]
 anyhow = "1.0"
-axum-macros = { path = "../axum-macros", version = "0.3.7", features = ["__private"] }
+axum-macros = { path = "../axum-macros", version = "0.3", features = ["__private"] }
 quickcheck = "1.0"
 quickcheck_macros = "1.0"
-reqwest = { version = "0.11.14", default-features = false, features = ["json", "stream", "multipart"] }
-rustversion = "1.0.9"
+reqwest = { version = "0.11", default-features = false, features = ["json", "stream", "multipart"] }
+rustversion = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 time = { version = "0.3", features = ["serde-human-readable"] }
-tokio = { package = "tokio", version = "1.25.0", features = ["macros", "rt", "rt-multi-thread", "net", "test-util"] }
+tokio = { package = "tokio", version = "1.25", features = ["macros", "rt", "rt-multi-thread", "net", "test-util"] }
 tokio-stream = "0.1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["json"] }
@@ -124,7 +124,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dev-dependencies.tower]
 package = "tower"
-version = "0.4.10"
+version = "0.4"
 features = [
     "util",
     "timeout",
@@ -135,7 +135,7 @@ features = [
 ]
 
 [dev-dependencies.tower-http]
-version = "0.5.0"
+version = "0.5"
 features = [
     # all tower-http features except (de)?compression-zstd which doesn't
     # build on `--target armv5te-unknown-linux-musleabi`


### PR DESCRIPTION
## Motivation

The [SemVer](https://semver.org/) specification states that PATCH versions should only contain backward-compatible bug fixes. 

## Solution

Removing explicit PATCH version dependencies from cargo.toml files allows dependency maintainers to push bug fixes without the need for axum to update them manually.
