### PR TITLE
Prepare `serve` for potentially supporting graceful shutdown

### DIFF
--- a/axum-macros/tests/debug_handler/fail/argument_not_extractor.stderr
+++ b/axum-macros/tests/debug_handler/fail/argument_not_extractor.stderr
@@ -12,8 +12,8 @@ error[E0277]: the trait bound `bool: FromRequestParts<()>` is not satisfied
             <Method as FromRequestParts<S>>
             <axum::http::request::Parts as FromRequestParts<S>>
             <Uri as FromRequestParts<S>>
-            <ConnectInfo<T> as FromRequestParts<S>>
             <Version as FromRequestParts<S>>
+            <ConnectInfo<T> as FromRequestParts<S>>
             <Extensions as FromRequestParts<S>>
           and $N others
   = note: required for `bool` to implement `FromRequest<(), axum_core::extract::private::ViaParts>`

--- a/axum-macros/tests/from_request/fail/parts_extracting_body.stderr
+++ b/axum-macros/tests/from_request/fail/parts_extracting_body.stderr
@@ -13,6 +13,6 @@ error[E0277]: the trait bound `String: FromRequestParts<S>` is not satisfied
             <Method as FromRequestParts<S>>
             <axum::http::request::Parts as FromRequestParts<S>>
             <Uri as FromRequestParts<S>>
-            <ConnectInfo<T> as FromRequestParts<S>>
             <Version as FromRequestParts<S>>
+            <ConnectInfo<T> as FromRequestParts<S>>
           and $N others

--- a/axum/benches/benches.rs
+++ b/axum/benches/benches.rs
@@ -5,6 +5,7 @@ use axum::{
 };
 use serde::{Deserialize, Serialize};
 use std::{
+    future::IntoFuture,
     io::BufRead,
     process::{Command, Stdio},
 };
@@ -161,7 +162,8 @@ impl BenchmarkBuilder {
         let addr = listener.local_addr().unwrap();
 
         std::thread::spawn(move || {
-            rt.block_on(axum::serve(listener, app)).unwrap();
+            rt.block_on(axum::serve(listener, app).into_future())
+                .unwrap();
         });
 
         let mut cmd = Command::new("rewrk");

--- a/examples/testing-websockets/src/main.rs
+++ b/examples/testing-websockets/src/main.rs
@@ -92,7 +92,10 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::net::{Ipv4Addr, SocketAddr};
+    use std::{
+        future::IntoFuture,
+        net::{Ipv4Addr, SocketAddr},
+    };
     use tokio_tungstenite::tungstenite;
 
     // We can integration test one handler by running the server in a background task and
@@ -103,7 +106,7 @@ mod tests {
             .await
             .unwrap();
         let addr = listener.local_addr().unwrap();
-        tokio::spawn(axum::serve(listener, app()));
+        tokio::spawn(axum::serve(listener, app()).into_future());
 
         let (mut socket, _response) =
             tokio_tungstenite::connect_async(format!("ws://{addr}/integration-testable"))


### PR DESCRIPTION
I agree that graceful shutdown is probably the most common thing missing from `axum::serve` and its not exactly easy with the current state of hyper-util (see https://github.com/tokio-rs/axum/pull/2355).

So I could probably convinced to add graceful shutdown support to `serve` 😅 I think a good API for that would be

```rust
axum::serve(listener, service)
    .graceful_shutdown(shutdown_signal_future())
    .await
```

Doing that requires returning some type we control from `serve` but we can use `IntoFuture` so you can still do `serve(...).await`.

This needs to go in before shipping 0.7 since its a breaking change.