### PR TITLE
Add a use of route_service with ServeFile to the static-file-server example

### DIFF
--- a/examples/static-file-server/src/main.rs
+++ b/examples/static-file-server/src/main.rs
@@ -103,8 +103,7 @@ fn calling_serve_dir_from_a_handler() -> Router {
 }
 
 fn using_serve_file_from_a_route() -> Router {
-    Router::new()
-        .route_service("/foo", ServeFile::new("assets/index.html"))
+    Router::new().route_service("/foo", ServeFile::new("assets/index.html"))
 }
 
 async fn serve(app: Router, port: u16) {

--- a/examples/static-file-server/src/main.rs
+++ b/examples/static-file-server/src/main.rs
@@ -32,6 +32,7 @@ async fn main() {
         serve(using_serve_dir_with_handler_as_service(), 3004),
         serve(two_serve_dirs(), 3005),
         serve(calling_serve_dir_from_a_handler(), 3006),
+        serve(using_serve_file_from_a_route(), 3307),
     );
 }
 
@@ -99,6 +100,11 @@ fn calling_serve_dir_from_a_handler() -> Router {
             result
         }),
     )
+}
+
+fn using_serve_file_from_a_route() -> Router {
+    Router::new()
+        .route_service("/foo", ServeFile::new("assets/index.html"))
 }
 
 async fn serve(app: Router, port: u16) {


### PR DESCRIPTION
## Motivation

The docs for `Router::route_service` give an example of using `ServeFile`, but if you come to the static file server example first, you won't necessarily be aware of `route_service`.

## Solution

This PR adds an example using `route_service`, to make it easier to spot for people interested in serving static files.