### PR TITLE
fix: back to forbid `unsafe`

### DIFF
--- a/axum/src/lib.rs
+++ b/axum/src/lib.rs
@@ -413,9 +413,7 @@
 )]
 #![deny(unreachable_pub)]
 #![allow(elided_lifetimes_in_paths, clippy::type_complexity)]
-// can't be `forbid` since we've vendored code from hyper-util that contains `unsafe`
-// when hyper-util is on crates.io we can stop vendoring it and go back to `forbid`
-#![deny(unsafe_code)]
+#![forbid(unsafe_code)]
 #![cfg_attr(docsrs, feature(doc_auto_cfg, doc_cfg))]
 #![cfg_attr(test, allow(clippy::float_cmp))]
 #![cfg_attr(not(test), warn(clippy::print_stdout, clippy::dbg_macro))]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation
Thanks to the great work from #1882 by @davidpdrsn, Axum stopped vendoring `hyper-utils`. We can now switch from `#![deny(unsafe_code)]`  to `#![forbid(unsafe_code)]`.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

one of axum philosophies is [100% safe code](https://github.com/tokio-rs/axum?tab=readme-ov-file#safety), so just enabled back to `#![forbid(unsafe_code)]` 
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
