### PR TITLE
Added utility function to convert body into bytes

### DIFF
--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **added:** Add `axum::body::to_bytes` ([#2373])
 
+[#2373]: https://github.com/tokio-rs/axum/pull/2373
+
 # 0.7.1 (27. November, 2023)
 
 - **fix**: Fix readme.

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
-- None.
+- **added:** Add `axum::body::to_bytes` ([#2373])
 
 # 0.7.1 (27. November, 2023)
 

--- a/axum/src/body/mod.rs
+++ b/axum/src/body/mod.rs
@@ -26,6 +26,25 @@ use http_body_util::{BodyExt, Limited};
 /// # Ok(())
 /// # }
 /// ```
+///
+/// You can detect if the limit was hit by checking the source of the error:
+///
+/// ```rust
+/// use axum::body::{to_bytes, Body};
+/// use http_body_util::LengthLimitError;
+///
+/// # #[tokio::main]
+/// # async fn main() {
+/// let body = Body::from(vec![1, 2, 3]);
+/// match to_bytes(body, 1).await {
+///     Ok(_bytes) => panic!("should have hit the limit"),
+///     Err(err) => {
+///         let source = std::error::Error::source(&err).unwrap();
+///         assert!(source.is::<LengthLimitError>());
+///     }
+/// }
+/// # }
+/// ```
 pub async fn to_bytes(body: Body, limit: usize) -> Result<Bytes, axum_core::Error> {
     Limited::new(body, limit)
         .collect()

--- a/axum/src/body/mod.rs
+++ b/axum/src/body/mod.rs
@@ -9,16 +9,27 @@ pub use bytes::Bytes;
 #[doc(inline)]
 pub use axum_core::body::Body;
 
-use http_body_util::BodyExt;
+use http_body_util::{BodyExt, Limited};
 
-/// Converts [`Body`] into [`Bytes`].
+/// Converts [`Body`] into [`Bytes`] and limits the maximum size of the body.
+///
+/// # Example
+///
 /// ```rust
-/// # use axum::body::{to_bytes, Body};
-/// async fn foo() {
-///     let body = Body::from(vec![1, 2, 3]);
-///     assert_eq!(&to_bytes(body).await.unwrap()[..], &[1, 2, 3]);
-/// }
+/// use axum::body::{to_bytes, Body};
+///
+/// # async fn foo() -> Result<(), axum_core::Error> {
+/// let body = Body::from(vec![1, 2, 3]);
+/// // Use `usize::MAX` if you don't care about the maximum size.
+/// let bytes = to_bytes(body, usize::MAX).await?;
+/// assert_eq!(&bytes[..], &[1, 2, 3]);
+/// # Ok(())
+/// # }
 /// ```
-pub async fn to_bytes(body: Body) -> Result<Bytes, axum_core::Error> {
-    body.collect().await.map(|col| col.to_bytes())
+pub async fn to_bytes(body: Body, limit: usize) -> Result<Bytes, axum_core::Error> {
+    Limited::new(body, limit)
+        .collect()
+        .await
+        .map(|col| col.to_bytes())
+        .map_err(axum_core::Error::new)
 }

--- a/axum/src/body/mod.rs
+++ b/axum/src/body/mod.rs
@@ -13,7 +13,7 @@ use http_body_util::BodyExt;
 
 /// Converts [`Body`] into [`Bytes`].
 /// ```rust
-/// # use axum::body::to_bytes;
+/// # use axum::body::{to_bytes, Body};
 /// async fn foo() {
 ///     let body = Body::from(vec![1, 2, 3]);
 ///     assert_eq!(&to_bytes(body).await.unwrap()[..], &[1, 2, 3]);

--- a/axum/src/body/mod.rs
+++ b/axum/src/body/mod.rs
@@ -8,3 +8,17 @@ pub use bytes::Bytes;
 
 #[doc(inline)]
 pub use axum_core::body::Body;
+
+use http_body_util::BodyExt;
+
+/// Converts [`Body`] into [`Bytes`].
+/// ```rust
+/// # use axum::body::to_bytes;
+/// async fn foo() {
+///     let body = Body::from(vec![1, 2, 3]);
+///     assert_eq!(&to_bytes(body).await.unwrap()[..], &[1, 2, 3]);
+/// }
+/// ```
+pub async fn to_bytes(body: Body) -> Result<Bytes, axum_core::Error> {
+    body.collect().await.map(|col| col.to_bytes())
+}


### PR DESCRIPTION
## Motivation
Sometimes it is useful to convert axum body into bytes, for that one needs to use [collect](https://docs.rs/http-body-util/0.1.0/http_body_util/trait.BodyExt.html#method.collect), so to avoid pulling in `http-body-util` I want to provide this function. 