### PR TITLE
Add support for routing shorthand.

### DIFF
--- a/axum/src/docs/routing/route.md
+++ b/axum/src/docs/routing/route.md
@@ -124,6 +124,23 @@ async fn serve_asset(Path(path): Path<String>) {}
 # let _: Router = app;
 ```
 
+# Shorthand
+
+You can call `get`, `post`, `delete`, and any other `method_router`s directly on a Router instance.
+
+```rust
+use axum::{Router, extract::Path};
+
+// appShorhand == appLonghand
+let appShorhand = Router::new()
+    .get("/", root);
+
+let appLonghand = Router::new()
+    .route("/", get(root));
+
+async fn root() {}
+```
+
 # Panics
 
 Panics if the route overlaps with another route:

--- a/axum/src/routing/mod.rs
+++ b/axum/src/routing/mod.rs
@@ -125,6 +125,86 @@ where
         self
     }
 
+    #[doc = include_str!("../docs/routing/route.md")]
+    #[track_caller]
+    pub fn head<H, T>(self, path: &str, handler: H) -> Self
+    where
+        H: Handler<T, S>,
+        T: 'static,
+    {
+        self.route(path, head(handler))
+    }
+
+    #[doc = include_str!("../docs/routing/route.md")]
+    #[track_caller]
+    pub fn get<H, T>(self, path: &str, handler: H) -> Self
+    where
+        H: Handler<T, S>,
+        T: 'static,
+    {
+        self.route(path, get(handler))
+    }
+
+    #[doc = include_str!("../docs/routing/route.md")]
+    #[track_caller]
+    pub fn post<H, T>(self, path: &str, handler: H) -> Self
+    where
+        H: Handler<T, S>,
+        T: 'static,
+    {
+        self.route(path, post(handler))
+    }
+
+    #[doc = include_str!("../docs/routing/route.md")]
+    #[track_caller]
+    pub fn put<H, T>(self, path: &str, handler: H) -> Self
+    where
+        H: Handler<T, S>,
+        T: 'static,
+    {
+        self.route(path, put(handler))
+    }
+
+    #[doc = include_str!("../docs/routing/route.md")]
+    #[track_caller]
+    pub fn patch<H, T>(self, path: &str, handler: H) -> Self
+    where
+        H: Handler<T, S>,
+        T: 'static,
+    {
+        self.route(path, patch(handler))
+    }
+
+    #[doc = include_str!("../docs/routing/route.md")]
+    #[track_caller]
+    pub fn delete<H, T>(self, path: &str, handler: H) -> Self
+    where
+        H: Handler<T, S>,
+        T: 'static,
+    {
+        self.route(path, delete(handler))
+    }
+
+    #[doc = include_str!("../docs/routing/route.md")]
+    #[track_caller]
+    pub fn options<H, T>(self, path: &str, handler: H) -> Self
+    where
+        H: Handler<T, S>,
+        T: 'static,
+    {
+        self.route(path, options(handler))
+    }
+
+    #[doc = include_str!("../docs/routing/route.md")]
+    #[track_caller]
+    pub fn trace<H, T>(self, path: &str, handler: H) -> Self
+    where
+        H: Handler<T, S>,
+        T: 'static,
+    {
+        self.route(path, trace(handler))
+    }
+
     #[doc = include_str!("../docs/routing/route_service.md")]
     pub fn route_service<T>(mut self, path: &str, service: T) -> Self
     where

--- a/axum/src/routing/tests/mod.rs
+++ b/axum/src/routing/tests/mod.rs
@@ -112,6 +112,36 @@ async fn routing() {
 }
 
 #[crate::test]
+async fn routing_shorthand() {
+    let app = Router::new()
+        .get("/users", |_: Request| async { "users#index" })
+        .post("/users", |_: Request| async { "users#create" })
+        .get("/users/:id", |_: Request| async { "users#show" })
+        .get("/users/:id/action", |_: Request| async { "users#action" });
+
+    let client = TestClient::new(app);
+
+    let res = client.get("/").send().await;
+    assert_eq!(res.status(), StatusCode::NOT_FOUND);
+
+    let res = client.get("/users").send().await;
+    assert_eq!(res.status(), StatusCode::OK);
+    assert_eq!(res.text().await, "users#index");
+
+    let res = client.post("/users").send().await;
+    assert_eq!(res.status(), StatusCode::OK);
+    assert_eq!(res.text().await, "users#create");
+
+    let res = client.get("/users/1").send().await;
+    assert_eq!(res.status(), StatusCode::OK);
+    assert_eq!(res.text().await, "users#show");
+
+    let res = client.get("/users/1/action").send().await;
+    assert_eq!(res.status(), StatusCode::OK);
+    assert_eq!(res.text().await, "users#action");
+}
+
+#[crate::test]
 async fn router_type_doesnt_change() {
     let app: Router = Router::new()
         .route(


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation

The current syntax for defining routes on a Router could be more terse and clear. Calling a "route" method is redundant and the HTTP method type is less obvious (especially if chaining multiple).

```
let appLonghand = Router::new().route("/", get(myHandler));
```

## Solution

We can improve the API by providing "get" etc methods directly on the Router struct

```
let appShorthand = Router::new().get("/", myHandler);
```
