### PR TITLE
Updated doc link versions from 0.6.x to 0.7.

### DIFF
--- a/axum-core/src/extract/default_body_limit.rs
+++ b/axum-core/src/extract/default_body_limit.rs
@@ -66,8 +66,8 @@ use tower_layer::Layer;
 ///
 /// [`Body::poll_frame`]: http_body::Body::poll_frame
 /// [`Bytes`]: bytes::Bytes
-/// [`Json`]: https://docs.rs/axum/0.6.0/axum/struct.Json.html
-/// [`Form`]: https://docs.rs/axum/0.6.0/axum/struct.Form.html
+/// [`Json`]: https://docs.rs/axum/0.7/axum/struct.Json.html
+/// [`Form`]: https://docs.rs/axum/0.7/axum/struct.Form.html
 /// [`FromRequest`]: crate::extract::FromRequest
 /// [`RequestBodyLimit`]: tower_http::limit::RequestBodyLimit
 /// [`RequestExt::with_limited_body`]: crate::RequestExt::with_limited_body
@@ -114,8 +114,8 @@ impl DefaultBodyLimit {
     /// ```
     ///
     /// [`Bytes`]: bytes::Bytes
-    /// [`Json`]: https://docs.rs/axum/0.6.0/axum/struct.Json.html
-    /// [`Form`]: https://docs.rs/axum/0.6.0/axum/struct.Form.html
+    /// [`Json`]: https://docs.rs/axum/0.7/axum/struct.Json.html
+    /// [`Form`]: https://docs.rs/axum/0.7/axum/struct.Form.html
     pub fn disable() -> Self {
         Self {
             kind: DefaultBodyLimitKind::Disable,
@@ -147,8 +147,8 @@ impl DefaultBodyLimit {
     /// ```
     ///
     /// [`Bytes::from_request`]: bytes::Bytes
-    /// [`Json`]: https://docs.rs/axum/0.6.0/axum/struct.Json.html
-    /// [`Form`]: https://docs.rs/axum/0.6.0/axum/struct.Form.html
+    /// [`Json`]: https://docs.rs/axum/0.7/axum/struct.Json.html
+    /// [`Form`]: https://docs.rs/axum/0.7/axum/struct.Form.html
     pub fn max(limit: usize) -> Self {
         Self {
             kind: DefaultBodyLimitKind::Limit(limit),

--- a/axum-core/src/extract/from_ref.rs
+++ b/axum-core/src/extract/from_ref.rs
@@ -7,7 +7,7 @@
 ///
 /// This trait can be derived using `#[derive(FromRef)]`.
 ///
-/// [`State`]: https://docs.rs/axum/0.6/axum/extract/struct.State.html
+/// [`State`]: https://docs.rs/axum/0.7/axum/extract/struct.State.html
 // NOTE: This trait is defined in axum-core, even though it is mainly used with `State` which is
 // defined in axum. That allows crate authors to use it when implementing extractors.
 pub trait FromRef<T> {

--- a/axum-core/src/extract/mod.rs
+++ b/axum-core/src/extract/mod.rs
@@ -41,7 +41,7 @@ mod private {
 ///
 /// See [`axum::extract`] for more general docs about extractors.
 ///
-/// [`axum::extract`]: https://docs.rs/axum/0.6.0/axum/extract/index.html
+/// [`axum::extract`]: https://docs.rs/axum/0.7/axum/extract/index.html
 #[async_trait]
 #[cfg_attr(
     nightly_error_messages,
@@ -68,7 +68,7 @@ pub trait FromRequestParts<S>: Sized {
 ///
 /// See [`axum::extract`] for more general docs about extractors.
 ///
-/// [`axum::extract`]: https://docs.rs/axum/0.6.0/axum/extract/index.html
+/// [`axum::extract`]: https://docs.rs/axum/0.7/axum/extract/index.html
 #[async_trait]
 #[cfg_attr(
     nightly_error_messages,

--- a/axum-macros/src/lib.rs
+++ b/axum-macros/src/lib.rs
@@ -359,7 +359,7 @@ use from_request::Trait::{FromRequest, FromRequestParts};
 /// ```
 ///
 /// [`FromRequest`]: https://docs.rs/axum/latest/axum/extract/trait.FromRequest.html
-/// [`axum::response::Response`]: https://docs.rs/axum/0.6/axum/response/type.Response.html
+/// [`axum::response::Response`]: https://docs.rs/axum/0.7/axum/response/type.Response.html
 /// [`axum::extract::rejection::ExtensionRejection`]: https://docs.rs/axum/latest/axum/extract/rejection/enum.ExtensionRejection.html
 #[proc_macro_derive(FromRequest, attributes(from_request))]
 pub fn derive_from_request(item: TokenStream) -> TokenStream {
@@ -409,7 +409,7 @@ pub fn derive_from_request(item: TokenStream) -> TokenStream {
 ///
 /// Use `#[derive(FromRequest)]` for that.
 ///
-/// [`FromRequestParts`]: https://docs.rs/axum/0.6/axum/extract/trait.FromRequestParts.html
+/// [`FromRequestParts`]: https://docs.rs/axum/0.7/axum/extract/trait.FromRequestParts.html
 #[proc_macro_derive(FromRequestParts, attributes(from_request))]
 pub fn derive_from_request_parts(item: TokenStream) -> TokenStream {
     expand_with(item, |item| from_request::expand(item, FromRequestParts))
@@ -561,7 +561,7 @@ pub fn derive_from_request_parts(item: TokenStream) -> TokenStream {
 ///
 /// [`axum`]: https://docs.rs/axum/latest
 /// [`Handler`]: https://docs.rs/axum/latest/axum/handler/trait.Handler.html
-/// [`axum::extract::State`]: https://docs.rs/axum/0.6/axum/extract/struct.State.html
+/// [`axum::extract::State`]: https://docs.rs/axum/0.7/axum/extract/struct.State.html
 /// [`debug_handler`]: macro@debug_handler
 #[proc_macro_attribute]
 pub fn debug_handler(_attr: TokenStream, input: TokenStream) -> TokenStream {


### PR DESCRIPTION
Updates documentation with most up to date doc links. More specifically, bumping docs referencing `0.6.0` to `0.7`.

Refs: https://github.com/tokio-rs/axum/issues/2366

edit(jplatte): Closes #2366