### PR TITLE
Updated doc link versions to use more explicit 0.7 version.

### DIFF
--- a/axum-core/src/extract/mod.rs
+++ b/axum-core/src/extract/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! See [`axum::extract`] for more details.
 //!
-//! [`axum::extract`]: https://docs.rs/axum/latest/axum/extract/index.html
+//! [`axum::extract`]: https://docs.rs/axum/0.7/axum/extract/index.html
 
 use crate::{body::Body, response::IntoResponse};
 use async_trait::async_trait;
@@ -46,7 +46,7 @@ mod private {
 #[cfg_attr(
     nightly_error_messages,
     diagnostic::on_unimplemented(
-        note = "Function argument is not a valid axum extractor. \nSee `https://docs.rs/axum/latest/axum/extract/index.html` for details",
+        note = "Function argument is not a valid axum extractor. \nSee `https://docs.rs/axum/0.7/axum/extract/index.html` for details",
     )
 )]
 pub trait FromRequestParts<S>: Sized {
@@ -73,7 +73,7 @@ pub trait FromRequestParts<S>: Sized {
 #[cfg_attr(
     nightly_error_messages,
     diagnostic::on_unimplemented(
-        note = "Function argument is not a valid axum extractor. \nSee `https://docs.rs/axum/latest/axum/extract/index.html` for details",
+        note = "Function argument is not a valid axum extractor. \nSee `https://docs.rs/axum/0.7/axum/extract/index.html` for details",
     )
 )]
 pub trait FromRequest<S, M = private::ViaRequest>: Sized {

--- a/axum-core/src/extract/request_parts.rs
+++ b/axum-core/src/extract/request_parts.rs
@@ -58,7 +58,7 @@ where
 ///
 /// Prefer using [`TypedHeader`] to extract only the headers you need.
 ///
-/// [`TypedHeader`]: https://docs.rs/axum/latest/axum/extract/struct.TypedHeader.html
+/// [`TypedHeader`]: https://docs.rs/axum/0.7/axum/extract/struct.TypedHeader.html
 #[async_trait]
 impl<S> FromRequestParts<S> for HeaderMap
 where

--- a/axum-core/src/response/mod.rs
+++ b/axum-core/src/response/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! See [`axum::response`] for more details.
 //!
-//! [`axum::response`]: https://docs.rs/axum/latest/axum/response/index.html
+//! [`axum::response`]: https://docs.rs/axum/0.7/axum/response/index.html
 
 use crate::body::Body;
 

--- a/axum-macros/src/lib.rs
+++ b/axum-macros/src/lib.rs
@@ -358,9 +358,9 @@ use from_request::Trait::{FromRequest, FromRequestParts};
 /// }
 /// ```
 ///
-/// [`FromRequest`]: https://docs.rs/axum/latest/axum/extract/trait.FromRequest.html
+/// [`FromRequest`]: https://docs.rs/axum/0.7/axum/extract/trait.FromRequest.html
 /// [`axum::response::Response`]: https://docs.rs/axum/0.7/axum/response/type.Response.html
-/// [`axum::extract::rejection::ExtensionRejection`]: https://docs.rs/axum/latest/axum/extract/rejection/enum.ExtensionRejection.html
+/// [`axum::extract::rejection::ExtensionRejection`]: https://docs.rs/axum/0.7/axum/extract/rejection/enum.ExtensionRejection.html
 #[proc_macro_derive(FromRequest, attributes(from_request))]
 pub fn derive_from_request(item: TokenStream) -> TokenStream {
     expand_with(item, |item| from_request::expand(item, FromRequest))
@@ -559,8 +559,8 @@ pub fn derive_from_request_parts(item: TokenStream) -> TokenStream {
 ///
 /// This macro has no effect when compiled with the release profile. (eg. `cargo build --release`)
 ///
-/// [`axum`]: https://docs.rs/axum/latest
-/// [`Handler`]: https://docs.rs/axum/latest/axum/handler/trait.Handler.html
+/// [`axum`]: https://docs.rs/axum/0.7
+/// [`Handler`]: https://docs.rs/axum/0.7/axum/handler/trait.Handler.html
 /// [`axum::extract::State`]: https://docs.rs/axum/0.7/axum/extract/struct.State.html
 /// [`debug_handler`]: macro@debug_handler
 #[proc_macro_attribute]
@@ -642,7 +642,7 @@ pub fn derive_typed_path(input: TokenStream) -> TokenStream {
 /// # let _: axum::Router = app;
 /// ```
 ///
-/// [`FromRef`]: https://docs.rs/axum/latest/axum/extract/trait.FromRef.html
+/// [`FromRef`]: https://docs.rs/axum/0.7/axum/extract/trait.FromRef.html
 #[proc_macro_derive(FromRef, attributes(from_ref))]
 pub fn derive_from_ref(item: TokenStream) -> TokenStream {
     expand_with(item, from_ref::expand)

--- a/axum-macros/tests/debug_handler/fail/argument_not_extractor.stderr
+++ b/axum-macros/tests/debug_handler/fail/argument_not_extractor.stderr
@@ -5,7 +5,7 @@ error[E0277]: the trait bound `bool: FromRequestParts<()>` is not satisfied
   |                        ^^^^ the trait `FromRequestParts<()>` is not implemented for `bool`
   |
   = note: Function argument is not a valid axum extractor.
-          See `https://docs.rs/axum/latest/axum/extract/index.html` for details
+          See `https://docs.rs/axum/0.7/axum/extract/index.html` for details
   = help: the following other types implement trait `FromRequestParts<S>`:
             <HeaderMap as FromRequestParts<S>>
             <Extension<T> as FromRequestParts<S>>

--- a/axum-macros/tests/from_request/fail/parts_extracting_body.stderr
+++ b/axum-macros/tests/from_request/fail/parts_extracting_body.stderr
@@ -5,7 +5,7 @@ error[E0277]: the trait bound `String: FromRequestParts<S>` is not satisfied
   |           ^^^^^^ the trait `FromRequestParts<S>` is not implemented for `String`
   |
   = note: Function argument is not a valid axum extractor.
-          See `https://docs.rs/axum/latest/axum/extract/index.html` for details
+          See `https://docs.rs/axum/0.7/axum/extract/index.html` for details
   = help: the following other types implement trait `FromRequestParts<S>`:
             <Extractor as FromRequestParts<S>>
             <HeaderMap as FromRequestParts<S>>


### PR DESCRIPTION
As per conversation on https://github.com/tokio-rs/axum/issues/2366, updated doc links to use more explicit `0.7` version instead of `latest`