### PR TITLE
Fix from_stream doc link to `Stream`

### DIFF
--- a/axum-core/src/body.rs
+++ b/axum-core/src/body.rs
@@ -55,7 +55,7 @@ impl Body {
 
     /// Create a new `Body` from a [`Stream`].
     ///
-    /// [`Stream`]: futures_util::stream::Stream
+    /// [`Stream`]: https://docs.rs/futures-core/latest/futures_core/stream/trait.Stream.html
     pub fn from_stream<S>(stream: S) -> Self
     where
         S: TryStream + Send + 'static,


### PR DESCRIPTION
## Motivation

The link to `Stream` in the doc comment for `from_stream` incorrect.

## Solution

Fix the link 🙂.
