### PR TITLE
Make `()` and `None` return a HTTP 204 response instead of 200

### DIFF
--- a/axum-core/src/response/into_response.rs
+++ b/axum-core/src/response/into_response.rs
@@ -134,18 +134,6 @@ impl IntoResponse for Infallible {
     }
 }
 
-impl<T> IntoResponse for Option<T>
-where
-    T: IntoResponse,
-{
-    fn into_response(self) -> Response {
-        match self {
-            Some(v) => v.into_response(),
-            None => StatusCode::NO_CONTENT.into_response(),
-        }
-    }
-}
-
 impl<T, E> IntoResponse for Result<T, E>
 where
     T: IntoResponse,

--- a/axum-core/src/response/into_response.rs
+++ b/axum-core/src/response/into_response.rs
@@ -116,7 +116,7 @@ pub trait IntoResponse {
 
 impl IntoResponse for StatusCode {
     fn into_response(self) -> Response {
-        let mut res = ().into_response();
+        let mut res = Body::empty().into_response();
         *res.status_mut() = self;
         res
     }
@@ -124,13 +124,25 @@ impl IntoResponse for StatusCode {
 
 impl IntoResponse for () {
     fn into_response(self) -> Response {
-        Body::empty().into_response()
+        StatusCode::NO_CONTENT.into_response()
     }
 }
 
 impl IntoResponse for Infallible {
     fn into_response(self) -> Response {
         match self {}
+    }
+}
+
+impl<T> IntoResponse for Option<T>
+where
+    T: IntoResponse,
+{
+    fn into_response(self) -> Response {
+        match self {
+            Some(v) => v.into_response(),
+            None => StatusCode::NO_CONTENT.into_response(),
+        }
     }
 }
 

--- a/axum-extra/src/json_lines.rs
+++ b/axum-extra/src/json_lines.rs
@@ -226,7 +226,7 @@ mod tests {
             )
             .send()
             .await;
-        assert_eq!(res.status(), StatusCode::OK);
+        assert_eq!(res.status(), StatusCode::NO_CONTENT);
     }
 
     #[tokio::test]

--- a/axum-extra/src/routing/mod.rs
+++ b/axum-extra/src/routing/mod.rs
@@ -353,14 +353,14 @@ mod tests {
         let client = TestClient::new(app);
 
         let res = client.get("/foo").send().await;
-        assert_eq!(res.status(), StatusCode::OK);
+        assert_eq!(res.status(), StatusCode::NO_CONTENT);
 
         let res = client.get("/foo/").send().await;
         assert_eq!(res.status(), StatusCode::PERMANENT_REDIRECT);
         assert_eq!(res.headers()["location"], "/foo");
 
         let res = client.get("/bar/").send().await;
-        assert_eq!(res.status(), StatusCode::OK);
+        assert_eq!(res.status(), StatusCode::NO_CONTENT);
 
         let res = client.get("/bar").send().await;
         assert_eq!(res.status(), StatusCode::PERMANENT_REDIRECT);

--- a/axum/src/extract/connect_info.rs
+++ b/axum/src/extract/connect_info.rs
@@ -197,7 +197,7 @@ axum_core::__impl_deref!(ConnectInfo);
 ///
 ///     let request = Request::new(Body::empty());
 ///     let response = app.oneshot(request).await.unwrap();
-///     assert_eq!(response.status(), StatusCode::OK);
+///     assert_eq!(response.status(), StatusCode::NO_CONTENT);
 /// }
 /// #
 /// # #[tokio::main]

--- a/axum/src/extract/matched_path.rs
+++ b/axum/src/extract/matched_path.rs
@@ -205,7 +205,7 @@ mod tests {
         let client = TestClient::new(app);
 
         let res = client.get("/foo/bar").send().await;
-        assert_eq!(res.status(), StatusCode::OK);
+        assert_eq!(res.status(), StatusCode::NO_CONTENT);
     }
 
     #[crate::test]
@@ -225,7 +225,7 @@ mod tests {
         let client = TestClient::new(app);
 
         let res = client.get("/foo/bar").send().await;
-        assert_eq!(res.status(), StatusCode::OK);
+        assert_eq!(res.status(), StatusCode::NO_CONTENT);
     }
 
     #[crate::test]
@@ -242,7 +242,7 @@ mod tests {
         let client = TestClient::new(app);
 
         let res = client.get("/foo/bar").send().await;
-        assert_eq!(res.status(), StatusCode::OK);
+        assert_eq!(res.status(), StatusCode::NO_CONTENT);
     }
 
     #[tokio::test]
@@ -259,7 +259,7 @@ mod tests {
         let client = TestClient::new(app);
 
         let res = client.get("/foo/bar").send().await;
-        assert_eq!(res.status(), StatusCode::OK);
+        assert_eq!(res.status(), StatusCode::NO_CONTENT);
     }
 
     #[crate::test]
@@ -279,7 +279,7 @@ mod tests {
         let client = TestClient::new(app);
 
         let res = client.get("/foo/bar").send().await;
-        assert_eq!(res.status(), StatusCode::OK);
+        assert_eq!(res.status(), StatusCode::NO_CONTENT);
     }
 
     #[crate::test]
@@ -300,7 +300,7 @@ mod tests {
         let client = TestClient::new(app);
 
         let res = client.get("/foo/bar").send().await;
-        assert_eq!(res.status(), StatusCode::OK);
+        assert_eq!(res.status(), StatusCode::NO_CONTENT);
     }
 
     #[crate::test]
@@ -314,7 +314,7 @@ mod tests {
         let client = TestClient::new(app);
 
         let res = client.get("/foo/bar").send().await;
-        assert_eq!(res.status(), StatusCode::OK);
+        assert_eq!(res.status(), StatusCode::NO_CONTENT);
     }
 
     // https://github.com/tokio-rs/axum/issues/1579
@@ -334,7 +334,7 @@ mod tests {
         let client = TestClient::new(app);
 
         let res = client.get("/foo").send().await;
-        assert_eq!(res.status(), StatusCode::OK);
+        assert_eq!(res.status(), StatusCode::NO_CONTENT);
     }
 
     #[crate::test]
@@ -349,6 +349,6 @@ mod tests {
         let client = TestClient::new(app);
 
         let res = client.get("/foo/bar").send().await;
-        assert_eq!(res.status(), StatusCode::OK);
+        assert_eq!(res.status(), StatusCode::NO_CONTENT);
     }
 }

--- a/axum/src/extract/nested_path.rs
+++ b/axum/src/extract/nested_path.rs
@@ -136,7 +136,7 @@ mod tests {
         let client = TestClient::new(app);
 
         let res = client.get("/api/users").send().await;
-        assert_eq!(res.status(), StatusCode::OK);
+        assert_eq!(res.status(), StatusCode::NO_CONTENT);
     }
 
     #[crate::test]
@@ -154,7 +154,7 @@ mod tests {
         let client = TestClient::new(app);
 
         let res = client.get("/api/users").send().await;
-        assert_eq!(res.status(), StatusCode::OK);
+        assert_eq!(res.status(), StatusCode::NO_CONTENT);
     }
 
     #[crate::test]
@@ -172,7 +172,7 @@ mod tests {
         let client = TestClient::new(app);
 
         let res = client.get("/api/v2/users").send().await;
-        assert_eq!(res.status(), StatusCode::OK);
+        assert_eq!(res.status(), StatusCode::NO_CONTENT);
     }
 
     #[crate::test]
@@ -190,7 +190,7 @@ mod tests {
         let client = TestClient::new(app);
 
         let res = client.get("/api/v2/users").send().await;
-        assert_eq!(res.status(), StatusCode::OK);
+        assert_eq!(res.status(), StatusCode::NO_CONTENT);
     }
 
     #[crate::test]
@@ -208,7 +208,7 @@ mod tests {
         let client = TestClient::new(app);
 
         let res = client.get("/users").send().await;
-        assert_eq!(res.status(), StatusCode::OK);
+        assert_eq!(res.status(), StatusCode::NO_CONTENT);
     }
 
     #[crate::test]
@@ -226,7 +226,7 @@ mod tests {
         let client = TestClient::new(app);
 
         let res = client.get("/api/users").send().await;
-        assert_eq!(res.status(), StatusCode::OK);
+        assert_eq!(res.status(), StatusCode::NO_CONTENT);
     }
 
     #[crate::test]
@@ -241,7 +241,7 @@ mod tests {
         let client = TestClient::new(app);
 
         let res = client.get("/api/doesnt-exist").send().await;
-        assert_eq!(res.status(), StatusCode::OK);
+        assert_eq!(res.status(), StatusCode::NO_CONTENT);
     }
 
     #[crate::test]
@@ -260,6 +260,6 @@ mod tests {
         let client = TestClient::new(app);
 
         let res = client.get("/api/users").send().await;
-        assert_eq!(res.status(), StatusCode::OK);
+        assert_eq!(res.status(), StatusCode::NO_CONTENT);
     }
 }

--- a/axum/src/extract/path/mod.rs
+++ b/axum/src/extract/path/mod.rs
@@ -557,10 +557,10 @@ mod tests {
         let client = TestClient::new(app);
 
         let res = client.get("/users/42").send().await;
-        assert_eq!(res.status(), StatusCode::OK);
+        assert_eq!(res.status(), StatusCode::NO_CONTENT);
 
         let res = client.post("/users/1337").send().await;
-        assert_eq!(res.status(), StatusCode::OK);
+        assert_eq!(res.status(), StatusCode::NO_CONTENT);
     }
 
     #[crate::test]
@@ -570,7 +570,7 @@ mod tests {
         let client = TestClient::new(app);
 
         let res = client.get("/users/42").send().await;
-        assert_eq!(res.status(), StatusCode::OK);
+        assert_eq!(res.status(), StatusCode::NO_CONTENT);
     }
 
     #[crate::test]
@@ -641,7 +641,7 @@ mod tests {
         assert_eq!(res.status(), StatusCode::NOT_FOUND);
 
         let res = client.get("/foo").send().await;
-        assert_eq!(res.status(), StatusCode::OK);
+        assert_eq!(res.status(), StatusCode::NO_CONTENT);
     }
 
     #[crate::test]
@@ -759,7 +759,7 @@ mod tests {
         let client = TestClient::new(app);
 
         let res = client.get("/foo/bar").send().await;
-        assert_eq!(res.status(), StatusCode::OK);
+        assert_eq!(res.status(), StatusCode::NO_CONTENT);
     }
 
     #[crate::test]

--- a/axum/src/extract/request_parts.rs
+++ b/axum/src/extract/request_parts.rs
@@ -110,6 +110,6 @@ mod tests {
         let client = TestClient::new(Router::new().route("/", get(handler)).layer(Extension(Ext)));
 
         let res = client.get("/").header("x-foo", "123").send().await;
-        assert_eq!(res.status(), StatusCode::OK);
+        assert_eq!(res.status(), StatusCode::NO_CONTENT);
     }
 }

--- a/axum/src/extract/ws.rs
+++ b/axum/src/extract/ws.rs
@@ -858,7 +858,7 @@ mod tests {
 
         let res = svc.oneshot(req).await.unwrap();
 
-        assert_eq!(res.status(), StatusCode::OK);
+        assert_eq!(res.status(), StatusCode::NO_CONTENT);
     }
 
     #[allow(dead_code)]

--- a/axum/src/json.rs
+++ b/axum/src/json.rs
@@ -263,7 +263,7 @@ mod tests {
                 .send()
                 .await;
 
-            res.status() == StatusCode::OK
+            res.status() == StatusCode::NO_CONTENT
         }
 
         assert!(valid_json_content_type("application/json").await);

--- a/axum/src/middleware/from_extractor.rs
+++ b/axum/src/middleware/from_extractor.rs
@@ -360,7 +360,7 @@ mod tests {
             .header(http::header::AUTHORIZATION, "secret")
             .send()
             .await;
-        assert_eq!(res.status(), StatusCode::OK);
+        assert_eq!(res.status(), StatusCode::NO_CONTENT);
     }
 
     // just needs to compile

--- a/axum/src/response/mod.rs
+++ b/axum/src/response/mod.rs
@@ -62,7 +62,7 @@ impl<T> From<T> for Html<T> {
 
 #[cfg(test)]
 mod tests {
-    use crate::extract::{Extension, Path};
+    use crate::extract::Extension;
     use crate::test_helpers::TestClient;
     use crate::{routing::get, Router};
     use axum_core::response::IntoResponse;
@@ -234,31 +234,5 @@ mod tests {
         let client = TestClient::new(app);
         let res = client.get("/unit").send().await;
         assert_eq!(res.status(), StatusCode::NO_CONTENT)
-    }
-
-    #[tokio::test]
-    async fn test_option_http204_response() {
-        const SOMETHING: &str = "something";
-        async fn optional_value(Path(number): Path<usize>) -> Option<&'static str> {
-            if number % 2 == 0 {
-                None
-            } else {
-                Some(SOMETHING)
-            }
-        }
-
-        let app = Router::new().route("/optional/:number", get(optional_value));
-        let client = TestClient::new(app);
-        for i in 0..4 {
-            let url = format!("/optional/{i}");
-            let res = client.get(&url).send().await;
-            if i % 2 == 0 {
-                assert_eq!(res.status(), StatusCode::NO_CONTENT);
-                assert_eq!(res.text().await.len(), 0);
-            } else {
-                assert_eq!(res.status(), StatusCode::OK);
-                assert_eq!(res.text().await, SOMETHING);
-            }
-        }
     }
 }

--- a/axum/src/routing/tests/fallback.rs
+++ b/axum/src/routing/tests/fallback.rs
@@ -9,7 +9,10 @@ async fn basic() {
 
     let client = TestClient::new(app);
 
-    assert_eq!(client.get("/foo").send().await.status(), StatusCode::OK);
+    assert_eq!(
+        client.get("/foo").send().await.status(),
+        StatusCode::NO_CONTENT
+    );
 
     let res = client.get("/does-not-exist").send().await;
     assert_eq!(res.status(), StatusCode::OK);
@@ -24,7 +27,10 @@ async fn nest() {
 
     let client = TestClient::new(app);
 
-    assert_eq!(client.get("/foo/bar").send().await.status(), StatusCode::OK);
+    assert_eq!(
+        client.get("/foo/bar").send().await.status(),
+        StatusCode::NO_CONTENT
+    );
 
     let res = client.get("/does-not-exist").send().await;
     assert_eq!(res.status(), StatusCode::OK);
@@ -40,8 +46,14 @@ async fn or() {
 
     let client = TestClient::new(app);
 
-    assert_eq!(client.get("/one").send().await.status(), StatusCode::OK);
-    assert_eq!(client.get("/two").send().await.status(), StatusCode::OK);
+    assert_eq!(
+        client.get("/one").send().await.status(),
+        StatusCode::NO_CONTENT
+    );
+    assert_eq!(
+        client.get("/two").send().await.status(),
+        StatusCode::NO_CONTENT
+    );
 
     let res = client.get("/does-not-exist").send().await;
     assert_eq!(res.status(), StatusCode::OK);
@@ -195,7 +207,7 @@ async fn doesnt_panic_if_used_with_nested_router() {
     let client = TestClient::new(routes_all);
 
     let res = client.get("/foobar").send().await;
-    assert_eq!(res.status(), StatusCode::OK);
+    assert_eq!(res.status(), StatusCode::NO_CONTENT);
 }
 
 #[crate::test]

--- a/axum/src/routing/tests/merge.rs
+++ b/axum/src/routing/tests/merge.rs
@@ -15,13 +15,13 @@ async fn basic() {
     let client = TestClient::new(app);
 
     let res = client.get("/foo").send().await;
-    assert_eq!(res.status(), StatusCode::OK);
+    assert_eq!(res.status(), StatusCode::NO_CONTENT);
 
     let res = client.get("/bar").send().await;
-    assert_eq!(res.status(), StatusCode::OK);
+    assert_eq!(res.status(), StatusCode::NO_CONTENT);
 
     let res = client.get("/baz").send().await;
-    assert_eq!(res.status(), StatusCode::OK);
+    assert_eq!(res.status(), StatusCode::NO_CONTENT);
 
     let res = client.get("/qux").send().await;
     assert_eq!(res.status(), StatusCode::NOT_FOUND);
@@ -117,10 +117,10 @@ async fn layer() {
     let client = TestClient::new(app);
 
     let res = client.get("/foo").send().await;
-    assert_eq!(res.status(), StatusCode::OK);
+    assert_eq!(res.status(), StatusCode::NO_CONTENT);
 
     let res = client.get("/bar").send().await;
-    assert_eq!(res.status(), StatusCode::OK);
+    assert_eq!(res.status(), StatusCode::NO_CONTENT);
 }
 
 #[crate::test]
@@ -136,7 +136,7 @@ async fn layer_and_handle_error() {
     let res = client.get("/timeout").send().await;
     assert_eq!(res.status(), StatusCode::REQUEST_TIMEOUT);
     let res = client.get("/foo").send().await;
-    assert_eq!(res.status(), StatusCode::OK);
+    assert_eq!(res.status(), StatusCode::NO_CONTENT);
 }
 
 #[crate::test]
@@ -148,7 +148,7 @@ async fn nesting() {
     let client = TestClient::new(app);
 
     let res = client.get("/bar/baz").send().await;
-    assert_eq!(res.status(), StatusCode::OK);
+    assert_eq!(res.status(), StatusCode::NO_CONTENT);
 }
 
 #[crate::test]
@@ -160,7 +160,7 @@ async fn boxed() {
     let client = TestClient::new(app);
 
     let res = client.get("/bar").send().await;
-    assert_eq!(res.status(), StatusCode::OK);
+    assert_eq!(res.status(), StatusCode::NO_CONTENT);
 }
 
 #[crate::test]
@@ -178,7 +178,7 @@ async fn many_ors() {
 
     for n in 1..=7 {
         let res = client.get(&format!("/r{n}")).send().await;
-        assert_eq!(res.status(), StatusCode::OK);
+        assert_eq!(res.status(), StatusCode::NO_CONTENT);
     }
 
     let res = client.get("/r8").send().await;
@@ -386,11 +386,14 @@ async fn middleware_that_return_early() {
             .send()
             .await
             .status(),
-        StatusCode::OK
+        StatusCode::NO_CONTENT
     );
     assert_eq!(
         client.get("/doesnt-exist").send().await.status(),
         StatusCode::NOT_FOUND
     );
-    assert_eq!(client.get("/public").send().await.status(), StatusCode::OK);
+    assert_eq!(
+        client.get("/public").send().await.status(),
+        StatusCode::NO_CONTENT
+    );
 }

--- a/axum/src/routing/tests/mod.rs
+++ b/axum/src/routing/tests/mod.rs
@@ -220,7 +220,7 @@ async fn wrong_method_handler() {
     assert_eq!(res.headers()[ALLOW], "GET,HEAD,POST");
 
     let res = client.patch("/foo").send().await;
-    assert_eq!(res.status(), StatusCode::OK);
+    assert_eq!(res.status(), StatusCode::NO_CONTENT);
 
     let res = client.post("/foo").send().await;
     assert_eq!(res.status(), StatusCode::METHOD_NOT_ALLOWED);
@@ -260,7 +260,7 @@ async fn wrong_method_service() {
     assert_eq!(res.headers()[ALLOW], "GET,HEAD,POST");
 
     let res = client.patch("/foo").send().await;
-    assert_eq!(res.status(), StatusCode::OK);
+    assert_eq!(res.status(), StatusCode::NO_CONTENT);
 
     let res = client.post("/foo").send().await;
     assert_eq!(res.status(), StatusCode::METHOD_NOT_ALLOWED);
@@ -310,7 +310,7 @@ async fn middleware_applies_to_routes_above() {
     assert_eq!(res.status(), StatusCode::REQUEST_TIMEOUT);
 
     let res = client.get("/two").send().await;
-    assert_eq!(res.status(), StatusCode::OK);
+    assert_eq!(res.status(), StatusCode::NO_CONTENT);
 }
 
 #[crate::test]
@@ -323,7 +323,7 @@ async fn not_found_for_extra_trailing_slash() {
     assert_eq!(res.status(), StatusCode::NOT_FOUND);
 
     let res = client.get("/foo").send().await;
-    assert_eq!(res.status(), StatusCode::OK);
+    assert_eq!(res.status(), StatusCode::NO_CONTENT);
 }
 
 #[crate::test]
@@ -489,7 +489,7 @@ async fn route_layer() {
         .header("authorization", "Bearer password")
         .send()
         .await;
-    assert_eq!(res.status(), StatusCode::OK);
+    assert_eq!(res.status(), StatusCode::NO_CONTENT);
 
     let res = client.get("/foo").send().await;
     assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
@@ -674,7 +674,7 @@ async fn disabling_the_default_limit() {
 
     let res = client.post("/").body(body).send().await;
 
-    assert_eq!(res.status(), StatusCode::OK);
+    assert_eq!(res.status(), StatusCode::NO_CONTENT);
 }
 
 #[crate::test]
@@ -693,7 +693,7 @@ async fn limited_body_with_content_length() {
     let client = TestClient::new(app);
 
     let res = client.post("/").body("a".repeat(LIMIT)).send().await;
-    assert_eq!(res.status(), StatusCode::OK);
+    assert_eq!(res.status(), StatusCode::NO_CONTENT);
 
     let res = client.post("/").body("a".repeat(LIMIT * 2)).send().await;
     assert_eq!(res.status(), StatusCode::PAYLOAD_TOO_LARGE);
@@ -714,7 +714,7 @@ async fn changing_the_default_limit() {
         .body(reqwest::Body::from("a".repeat(new_limit)))
         .send()
         .await;
-    assert_eq!(res.status(), StatusCode::OK);
+    assert_eq!(res.status(), StatusCode::NO_CONTENT);
 
     let res = client
         .post("/")
@@ -747,7 +747,7 @@ async fn changing_the_default_limit_differently_on_different_routes() {
         .body(reqwest::Body::from("a".repeat(limit1)))
         .send()
         .await;
-    assert_eq!(res.status(), StatusCode::OK);
+    assert_eq!(res.status(), StatusCode::NO_CONTENT);
 
     let res = client
         .post("/limit1")
@@ -761,14 +761,14 @@ async fn changing_the_default_limit_differently_on_different_routes() {
         .body(reqwest::Body::from("a".repeat(limit1)))
         .send()
         .await;
-    assert_eq!(res.status(), StatusCode::OK);
+    assert_eq!(res.status(), StatusCode::NO_CONTENT);
 
     let res = client
         .post("/limit2")
         .body(reqwest::Body::from("a".repeat(limit2)))
         .send()
         .await;
-    assert_eq!(res.status(), StatusCode::OK);
+    assert_eq!(res.status(), StatusCode::NO_CONTENT);
 
     let res = client
         .post("/limit2")
@@ -782,7 +782,7 @@ async fn changing_the_default_limit_differently_on_different_routes() {
         .body(reqwest::Body::from("a".repeat(limit1 + limit2)))
         .send()
         .await;
-    assert_eq!(res.status(), StatusCode::OK);
+    assert_eq!(res.status(), StatusCode::NO_CONTENT);
 
     let res = client
         .post("/default")
@@ -814,7 +814,7 @@ async fn limited_body_with_streaming_body() {
         .body(reqwest::Body::wrap_stream(stream))
         .send()
         .await;
-    assert_eq!(res.status(), StatusCode::OK);
+    assert_eq!(res.status(), StatusCode::NO_CONTENT);
 
     let stream = futures_util::stream::iter(vec![Ok::<_, hyper::Error>("a".repeat(LIMIT * 2))]);
     let res = client
@@ -858,7 +858,7 @@ async fn extract_state() {
     let client = TestClient::new(app);
 
     let res = client.get("/").send().await;
-    assert_eq!(res.status(), StatusCode::OK);
+    assert_eq!(res.status(), StatusCode::NO_CONTENT);
 }
 
 #[crate::test]

--- a/axum/src/routing/tests/nest.rs
+++ b/axum/src/routing/tests/nest.rs
@@ -66,7 +66,7 @@ async fn wrong_method_nest() {
     let client = TestClient::new(app);
 
     let res = client.get("/").send().await;
-    assert_eq!(res.status(), StatusCode::OK);
+    assert_eq!(res.status(), StatusCode::NO_CONTENT);
 
     let res = client.post("/").send().await;
     assert_eq!(res.status(), StatusCode::METHOD_NOT_ALLOWED);
@@ -341,13 +341,13 @@ async fn nest_with_and_without_trailing() {
     let client = TestClient::new(app);
 
     let res = client.get("/foo").send().await;
-    assert_eq!(res.status(), StatusCode::OK);
+    assert_eq!(res.status(), StatusCode::NO_CONTENT);
 
     let res = client.get("/foo/").send().await;
-    assert_eq!(res.status(), StatusCode::OK);
+    assert_eq!(res.status(), StatusCode::NO_CONTENT);
 
     let res = client.get("/foo/bar").send().await;
-    assert_eq!(res.status(), StatusCode::OK);
+    assert_eq!(res.status(), StatusCode::NO_CONTENT);
 }
 
 #[tokio::test]
@@ -362,19 +362,19 @@ async fn nesting_with_root_inner_router() {
     // `/service/` does match the `/service` prefix and the remaining path is technically
     // empty, which is the same as `/` which matches `.route("/", _)`
     let res = client.get("/service").send().await;
-    assert_eq!(res.status(), StatusCode::OK);
+    assert_eq!(res.status(), StatusCode::NO_CONTENT);
 
     // `/service/` does match the `/service` prefix and the remaining path is `/`
     // which matches `.route("/", _)`
     //
     // this is perhaps a little surprising but don't think there is much we can do
     let res = client.get("/service/").send().await;
-    assert_eq!(res.status(), StatusCode::OK);
+    assert_eq!(res.status(), StatusCode::NO_CONTENT);
 
     // at least it does work like you'd expect when using `nest`
 
     let res = client.get("/router").send().await;
-    assert_eq!(res.status(), StatusCode::OK);
+    assert_eq!(res.status(), StatusCode::NO_CONTENT);
 
     let res = client.get("/router/").send().await;
     assert_eq!(res.status(), StatusCode::NOT_FOUND);
@@ -383,7 +383,7 @@ async fn nesting_with_root_inner_router() {
     assert_eq!(res.status(), StatusCode::NOT_FOUND);
 
     let res = client.get("/router-slash/").send().await;
-    assert_eq!(res.status(), StatusCode::OK);
+    assert_eq!(res.status(), StatusCode::NO_CONTENT);
 }
 
 macro_rules! nested_route_test {
@@ -403,7 +403,7 @@ macro_rules! nested_route_test {
             let client = TestClient::new(app);
             let res = client.get($expected_path).send().await;
             let status = res.status();
-            assert_eq!(status, StatusCode::OK, "Router");
+            assert_eq!(status, StatusCode::NO_CONTENT, "Router");
         }
     };
 }

--- a/examples/handle-head-request/src/main.rs
+++ b/examples/handle-head-request/src/main.rs
@@ -72,7 +72,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(response.status(), StatusCode::NO_CONTENT);
         assert_eq!(response.headers()["x-some-header"], "header from HEAD");
 
         let body = response.collect().await.unwrap().to_bytes();


### PR DESCRIPTION
## Motivation

I'm proposing an implementation for #2363: The unit type `()` and `None` should generate a HTTP 204 response.

## Solution

This PR does the following things:

* Change the implementation of `IntoResponse` for `()` to always return a HTTP 204 result
* ~~Add an implementation of `IntoResponse` for `Option<T: IntoResponse>` so that HTTP 204 is returned when the `Option` is `None`~~.
* Add unit tests for the above cases in `axum/src/response/mod.rs`. (Please let me know if they should be somewhere else)
* Adjust some of the existing unit tests to expect HTTP 204 responses. Many of the existing unit tests define routes that produce an empty result and the body of the response is not part of those unit tests.