### PR TITLE
Update example reverse-proxy to axum 0.7

### DIFF
--- a/examples/reverse-proxy/Cargo.toml
+++ b/examples/reverse-proxy/Cargo.toml
@@ -6,4 +6,5 @@ edition = "2021"
 [dependencies]
 axum = { path = "../../axum" }
 hyper = { version = "1.0.0", features = ["full"] }
+hyper-util = { version = "0.1.1", features = ["client-legacy"] }
 tokio = { version = "1", features = ["full"] }

--- a/examples/reverse-proxy/src/main.rs
+++ b/examples/reverse-proxy/src/main.rs
@@ -7,63 +7,61 @@
 //! cargo run -p example-reverse-proxy
 //! ```
 
-// TODO
-fn main() {
-    eprint!("this example has not yet been updated to hyper 1.0");
+use axum::{
+    body::Body,
+    extract::{Request, State},
+    http::uri::Uri,
+    response::{IntoResponse, Response},
+    routing::get,
+    Router,
+};
+use hyper::StatusCode;
+use hyper_util::{client::legacy::connect::HttpConnector, rt::TokioExecutor};
+
+type Client = hyper_util::client::legacy::Client<HttpConnector, Body>;
+
+#[tokio::main]
+async fn main() {
+    tokio::spawn(server());
+
+    let client: Client =
+        hyper_util::client::legacy::Client::<(), ()>::builder(TokioExecutor::new())
+            .build(HttpConnector::new());
+
+    let app = Router::new().route("/", get(handler)).with_state(client);
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:4000")
+        .await
+        .unwrap();
+    println!("listening on {}", listener.local_addr().unwrap());
+    axum::serve(listener, app).await.unwrap();
 }
 
-// use axum::{
-//     body::Body,
-//     extract::{Request, State},
-//     http::uri::Uri,
-//     response::{IntoResponse, Response},
-//     routing::get,
-//     Router,
-// };
-// use hyper::{client::HttpConnector, StatusCode};
+async fn handler(State(client): State<Client>, mut req: Request) -> Result<Response, StatusCode> {
+    let path = req.uri().path();
+    let path_query = req
+        .uri()
+        .path_and_query()
+        .map(|v| v.as_str())
+        .unwrap_or(path);
 
-// type Client = hyper::client::Client<HttpConnector, Body>;
+    let uri = format!("http://127.0.0.1:3000{}", path_query);
 
-// #[tokio::main]
-// async fn main() {
-//     tokio::spawn(server());
+    *req.uri_mut() = Uri::try_from(uri).unwrap();
 
-//     let client: Client = hyper::Client::builder().build(HttpConnector::new());
+    Ok(client
+        .request(req)
+        .await
+        .map_err(|_| StatusCode::BAD_REQUEST)?
+        .into_response())
+}
 
-//     let app = Router::new().route("/", get(handler)).with_state(client);
+async fn server() {
+    let app = Router::new().route("/", get(|| async { "Hello, world!" }));
 
-//     let listener = tokio::net::TcpListener::bind("127.0.0.1:4000")
-//         .await
-//         .unwrap();
-//     println!("listening on {}", listener.local_addr().unwrap());
-//     axum::serve(listener, app).await.unwrap();
-// }
-
-// async fn handler(State(client): State<Client>, mut req: Request) -> Result<Response, StatusCode> {
-//     let path = req.uri().path();
-//     let path_query = req
-//         .uri()
-//         .path_and_query()
-//         .map(|v| v.as_str())
-//         .unwrap_or(path);
-
-//     let uri = format!("http://127.0.0.1:3000{}", path_query);
-
-//     *req.uri_mut() = Uri::try_from(uri).unwrap();
-
-//     Ok(client
-//         .request(req)
-//         .await
-//         .map_err(|_| StatusCode::BAD_REQUEST)?
-//         .into_response())
-// }
-
-// async fn server() {
-//     let app = Router::new().route("/", get(|| async { "Hello, world!" }));
-
-//     let listener = tokio::net::TcpListener::bind("127.0.0.1:3000")
-//         .await
-//         .unwrap();
-//     println!("listening on {}", listener.local_addr().unwrap());
-//     axum::serve(listener, app).await.unwrap();
-// }
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:3000")
+        .await
+        .unwrap();
+    println!("listening on {}", listener.local_addr().unwrap());
+    axum::serve(listener, app).await.unwrap();
+}


### PR DESCRIPTION
## Motivation

Following [#2356](https://github.com/tokio-rs/axum/issues/2356), the PR updates the example reverse-proxy to support axum 0.7.

## Solution

Use legacy _Client_ from hyper::util.