### PR TITLE
Body: Implement `From<()>`

### DIFF
--- a/axum-core/src/body.rs
+++ b/axum-core/src/body.rs
@@ -84,6 +84,12 @@ impl Default for Body {
     }
 }
 
+impl From<()> for Body {
+    fn from(_: ()) -> Self {
+        Self::empty()
+    }
+}
+
 macro_rules! body_from_impl {
     ($ty:ty) => {
         impl From<$ty> for Body {

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -7,9 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
+- **added:** `Body` implements `From<()>` now ([#2411])
 - **change:** Update version of multer used internally for multipart ([#2433])
 - **change:** Update tokio-tungstenite to 0.21 ([#2435])
 
+[#2411]: https://github.com/tokio-rs/axum/pull/2411
 [#2433]: https://github.com/tokio-rs/axum/pull/2433
 [#2435]: https://github.com/tokio-rs/axum/pull/2435
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation

In crates.io I was implementing a function with `request: Request<impl Into<Body>>` and my plan was to use it with `Request::get(...).body(()).unwrap()`. Unfortunately there was no built-in conversion from `()` to `Body` implemented though, so I had to use `Request::get(...).body("").unwrap()` instead. While it is the same amount of characters, the former is using `http_body_util::Empty` and the latter `http_body_util::Full`, which is assume is slightly less efficient?

## Solution

The solution is a simple `impl From<()> for Body` block :)
