### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -122,7 +122,6 @@ jobs:
         -p axum-extra
         -p axum-core
         --all-features
-        --all-targets
         --locked
     # the compiler errors are different on our MSRV which makes
     # the trybuild tests in axum-macros fail, so just run the doc


### PR DESCRIPTION
By not running benchmarks as part of the MSRV tests.