### PR TITLE
Upgrade tokio-tungstenite to 0.21

### DIFF
--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # Unreleased
 
 - **change:** Update version of multer used internally for multipart ([#2433])
+- **change:** Update tokio-tungstenite to 0.21 ([#2435])
 
 [#2433]: https://github.com/tokio-rs/axum/pull/2433
 

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **change:** Update tokio-tungstenite to 0.21 ([#2435])
 
 [#2433]: https://github.com/tokio-rs/axum/pull/2433
+[#2435]: https://github.com/tokio-rs/axum/pull/2435
 
 # 0.7.2 (03. December, 2023)
 

--- a/axum/Cargo.toml
+++ b/axum/Cargo.toml
@@ -61,7 +61,7 @@ serde_path_to_error = { version = "0.1.8", optional = true }
 serde_urlencoded = { version = "0.7", optional = true }
 sha1 = { version = "0.10", optional = true }
 tokio = { package = "tokio", version = "1.25.0", features = ["time"], optional = true }
-tokio-tungstenite = { version = "0.20", optional = true }
+tokio-tungstenite = { version = "0.21", optional = true }
 tracing = { version = "0.1", default-features = false, optional = true }
 
 [dependencies.tower-http]

--- a/examples/testing-websockets/Cargo.toml
+++ b/examples/testing-websockets/Cargo.toml
@@ -9,4 +9,4 @@ axum = { path = "../../axum", features = ["ws"] }
 futures = "0.3"
 hyper = { version = "1.0.0", features = ["full"] }
 tokio = { version = "1.0", features = ["full"] }
-tokio-tungstenite = "0.20"
+tokio-tungstenite = "0.21"

--- a/examples/websockets/Cargo.toml
+++ b/examples/websockets/Cargo.toml
@@ -11,7 +11,7 @@ futures = "0.3"
 futures-util = { version = "0.3", default-features = false, features = ["sink", "std"] }
 headers = "0.4"
 tokio = { version = "1.0", features = ["full"] }
-tokio-tungstenite = "0.20"
+tokio-tungstenite = "0.21"
 tower = { version = "0.4", features = ["util"] }
 tower-http = { version = "0.5.0", features = ["fs", "trace"] }
 tracing = "0.1"


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation

Axum dependencies `http` 1.0.0, but the tokio-tungstenite 0.20.1 dependencies `http` 0.2.11. I think axum should keep the dependencies' versions consistent.

## Solution

Upgrade tokio-tungstenite to 0.21. Here is tungstenite 0.21.0 [CHANGELOG](https://github.com/snapview/tungstenite-rs/blob/master/CHANGELOG.md#0210), They had upgrade `http` to 1.0.0.
