### PR TITLE
Updated docs regarding constraints of Handler arguments

### DIFF
--- a/axum/src/docs/debugging_handler_type_errors.md
+++ b/axum/src/docs/debugging_handler_type_errors.md
@@ -4,7 +4,9 @@ For a function to be used as a handler it must implement the [`Handler`] trait.
 axum provides blanket implementations for functions that:
 
 - Are `async fn`s.
-- Take no more than 16 arguments that all implement [`FromRequest`].
+- Take no more than 16 arguments that all implement `Send`.
+  - All except the last argument implement [`FromRequestParts`].
+  - The last argument implements [`FromRequest`].
 - Returns something that implements [`IntoResponse`].
 - If a closure is used it must implement `Clone + Send` and be
 `'static`.


### PR DESCRIPTION
Fixes: #2450

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

Fixed documentation regarding the trait bounds of arguments in functions that implement `Handler`. The existing docs don't mention `Send` or `FromRequestParts`. Both of these have been added. 

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

This fixes #2450 as the documentation no longer accurately described the trait bounds of arguments in functions that implement `Handler`. Now it does again.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
Modified docs.

Feedback regarding the wording would be appreciated.