### PR TITLE
Update lib.rs doc : naming

### DIFF
--- a/axum/src/lib.rs
+++ b/axum/src/lib.rs
@@ -64,7 +64,7 @@
 //!
 //! # Routing
 //!
-//! [`Router`] is used to set up which paths goes to which services:
+//! [`Router`] is used to set up which paths goes to which handlers:
 //!
 //! ```rust
 //! use axum::{Router, routing::get};


### PR DESCRIPTION
## Motivation

I'm a Rust newbie, and reading `services` seems wrong, since they're called `handlers` right in the next paragraph. `handlers` makes more sense IMO, but I haven't read the rest of the docs yet.

What do you think?

## Solution

`services` -> `handlers`