### PR TITLE
Updating `tls-rustls` example

### DIFF
--- a/examples/tls-rustls/Cargo.toml
+++ b/examples/tls-rustls/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [dependencies]
 axum = { path = "../../axum" }
-axum-server = { version = "0.3", features = ["tls-rustls"] }
+axum-server = { version = "0.6", features = ["tls-rustls"] }
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }


### PR DESCRIPTION
Following #2356, updated the [tls-rustls](https://github.com/tokio-rs/axum/blob/main/examples/tls-rustls/src/main.rs) for the latest [axum-server](https://github.com/programatik29/axum-server) version, which supports [hyper](https://github.com/hyperium/hyper) 1.0