### PR TITLE
Add an example integration test for SSE

### DIFF
--- a/examples/sse/Cargo.toml
+++ b/examples/sse/Cargo.toml
@@ -9,7 +9,6 @@ axum = { path = "../../axum" }
 axum-extra = { path = "../../axum-extra", features = ["typed-header"] }
 futures = "0.3"
 headers = "0.4"
-serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "1.0", features = ["full"] }
 tokio-stream = "0.1"
 tower-http = { version = "0.5.0", features = ["fs", "trace"] }

--- a/examples/sse/Cargo.toml
+++ b/examples/sse/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 [dependencies]
 axum = { path = "../../axum" }
 axum-extra = { path = "../../axum-extra", features = ["typed-header"] }
+serde = { version = "1.0", features = ["derive"] }
 futures = "0.3"
 headers = "0.4"
 tokio = { version = "1.0", features = ["full"] }
@@ -14,3 +15,8 @@ tokio-stream = "0.1"
 tower-http = { version = "0.5.0", features = ["fs", "trace"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
+[dev-dependencies]
+reqwest = { version = "0.11", features = ["stream"] }
+reqwest-eventsource = "0.5"
+eventsource-stream = "0.2"

--- a/examples/sse/Cargo.toml
+++ b/examples/sse/Cargo.toml
@@ -7,9 +7,9 @@ publish = false
 [dependencies]
 axum = { path = "../../axum" }
 axum-extra = { path = "../../axum-extra", features = ["typed-header"] }
-serde = { version = "1.0", features = ["derive"] }
 futures = "0.3"
 headers = "0.4"
+serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "1.0", features = ["full"] }
 tokio-stream = "0.1"
 tower-http = { version = "0.5.0", features = ["fs", "trace"] }
@@ -17,6 +17,6 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]
+eventsource-stream = "0.2"
 reqwest = { version = "0.11", features = ["stream"] }
 reqwest-eventsource = "0.5"
-eventsource-stream = "0.2"

--- a/examples/sse/src/main.rs
+++ b/examples/sse/src/main.rs
@@ -84,7 +84,7 @@ mod tests {
         async fn spawn_app(host: impl Into<String>) -> String {
             let host = host.into();
             // Bind to localhost at the port 0, which will let the OS assign an available port to us
-            let listener = TcpListener::bind(format!("{}:0", _host)).await.unwrap();
+            let listener = TcpListener::bind(format!("{}:0", host)).await.unwrap();
             // Retrieve the port assigned to us by the OS
             let port = listener.local_addr().unwrap().port();
             tokio::spawn(async {
@@ -92,7 +92,7 @@ mod tests {
                 axum::serve(listener, app).await.unwrap();
             });
             // Returns address (e.g. http://127.0.0.1{random_port})
-            format!("http://{}:{}", _host, port)
+            format!("http://{}:{}", host, port)
         }
         let listening_url = spawn_app("127.0.0.1").await;
 

--- a/examples/sse/src/main.rs
+++ b/examples/sse/src/main.rs
@@ -98,7 +98,7 @@ mod tests {
             let listener = TcpListener::bind(format!("{}:0", _host)).await.unwrap();
             // Retrieve the port assigned to us by the OS
             let port = listener.local_addr().unwrap().port();
-            let _ = tokio::spawn(async move {
+            tokio::spawn(async move {
                 let app = app();
                 axum::serve(listener, app).await.unwrap();
             });

--- a/examples/sse/src/main.rs
+++ b/examples/sse/src/main.rs
@@ -67,7 +67,7 @@ async fn sse_handler(
     Sse::new(stream).keep_alive(
         axum::response::sse::KeepAlive::new()
             .interval(Duration::from_secs(1))
-            .text("keep-alive-text")
+            .text("keep-alive-text"),
     )
 }
 

--- a/examples/sse/src/main.rs
+++ b/examples/sse/src/main.rs
@@ -3,14 +3,20 @@
 //! ```not_rust
 //! cargo run -p example-sse
 //! ```
+//! Test with
+//! ```not_rust
+//! cargo test -p example-sse
+//! ```
 
 use axum::{
+    extract::Query,
     response::sse::{Event, Sse},
     routing::get,
     Router,
 };
 use axum_extra::{headers, TypedHeader};
 use futures::stream::{self, Stream};
+use serde::Deserialize;
 use std::{convert::Infallible, path::PathBuf, time::Duration};
 use tokio_stream::StreamExt as _;
 use tower_http::{services::ServeDir, trace::TraceLayer};
@@ -26,15 +32,8 @@ async fn main() {
         .with(tracing_subscriber::fmt::layer())
         .init();
 
-    let assets_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("assets");
-
-    let static_files_service = ServeDir::new(assets_dir).append_index_html_on_directories(true);
-
-    // build our application with a route
-    let app = Router::new()
-        .fallback_service(static_files_service)
-        .route("/sse", get(sse_handler))
-        .layer(TraceLayer::new_for_http());
+    // build our application
+    let app = app();
 
     // run it
     let listener = tokio::net::TcpListener::bind("127.0.0.1:3000")
@@ -44,16 +43,35 @@ async fn main() {
     axum::serve(listener, app).await.unwrap();
 }
 
+fn app() -> Router {
+    let assets_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("assets");
+    let static_files_service = ServeDir::new(assets_dir).append_index_html_on_directories(true);
+    // build our application with a route
+    Router::new()
+        .fallback_service(static_files_service)
+        .route("/sse", get(sse_handler))
+        .layer(TraceLayer::new_for_http())
+}
+
+#[derive(Deserialize)]
+struct Repeat {
+    take_n: Option<usize>,
+}
+
 async fn sse_handler(
     TypedHeader(user_agent): TypedHeader<headers::UserAgent>,
+    repeat: Query<Repeat>,
 ) -> Sse<impl Stream<Item = Result<Event, Infallible>>> {
     println!("`{}` connected", user_agent.as_str());
+    // default to repeating 100 times
+    let n = repeat.take_n.unwrap_or(100);
 
     // A `Stream` that repeats an event every second
     //
     // You can also create streams from tokio channels using the wrappers in
     // https://docs.rs/tokio-stream
     let stream = stream::repeat_with(|| Event::default().data("hi!"))
+        .take(n)
         .map(Ok)
         .throttle(Duration::from_secs(1));
 
@@ -62,4 +80,61 @@ async fn sse_handler(
             .interval(Duration::from_secs(1))
             .text("keep-alive-text"),
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use eventsource_stream::Eventsource;
+    use tokio::net::TcpListener;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn integration_test() {
+        // A helper function that spawns our application in the background
+        async fn spawn_app(host: impl Into<String>) -> String {
+            let _host = host.into();
+            // Bind to localhost at the port 0, which will let the OS assign an available port to us
+            let listener = TcpListener::bind(format!("{}:0", _host)).await.unwrap();
+            // Retrieve the port assigned to us by the OS
+            let port = listener.local_addr().unwrap().port();
+            let _ = tokio::spawn(async move {
+                let app = app();
+                axum::serve(listener, app).await.unwrap();
+            });
+            // Returns address (e.g. http://127.0.0.1{random_port})
+            format!("http://{}:{}", _host, port)
+        }
+        let listening_url = spawn_app("127.0.0.1").await;
+
+        let take_n = 1;
+        let mut event_stream = reqwest::Client::new()
+            .get(&format!("{}/sse?take_n={}", listening_url, take_n))
+            .header("User-Agent", "integration_test")
+            .send()
+            .await
+            .unwrap()
+            .bytes_stream()
+            .eventsource();
+
+        let mut event_data: Vec<String> = vec![];
+        while let Some(event) = event_stream.next().await {
+            match event {
+                Ok(event) => {
+                    // break the loop at the end of SSE stream
+                    if event.data == "[DONE]" {
+                        break;
+                    }
+
+                    event_data.push(event.data);
+                }
+                Err(_) => {
+                    panic!("Error in event stream");
+                }
+            }
+        }
+
+        assert!(event_data.len() == take_n);
+        assert!(event_data[0] == "hi!");
+    }
 }

--- a/examples/sse/src/main.rs
+++ b/examples/sse/src/main.rs
@@ -82,7 +82,7 @@ mod tests {
     async fn integration_test() {
         // A helper function that spawns our application in the background
         async fn spawn_app(host: impl Into<String>) -> String {
-            let _host = host.into();
+            let host = host.into();
             // Bind to localhost at the port 0, which will let the OS assign an available port to us
             let listener = TcpListener::bind(format!("{}:0", _host)).await.unwrap();
             // Retrieve the port assigned to us by the OS

--- a/examples/sse/src/main.rs
+++ b/examples/sse/src/main.rs
@@ -88,8 +88,7 @@ mod tests {
             // Retrieve the port assigned to us by the OS
             let port = listener.local_addr().unwrap().port();
             tokio::spawn(async {
-                let app = app();
-                axum::serve(listener, app).await.unwrap();
+                axum::serve(listener, app()).await.unwrap();
             });
             // Returns address (e.g. http://127.0.0.1{random_port})
             format!("http://{}:{}", host, port)


### PR DESCRIPTION
## Motivation

The SSE example was missing a test, would be nice to have one.

## Solution

This PR adds an example for integration test.

- Adding the integration test requiring some minor refactoring of the example, this PR moves the create of app into a separate `app()`.
-  Add dev-dependencies: `reqwest`/`reqwest-eventsource`/`eventsource-stream` that were used in tests.