### PR TITLE
Fix `IntoResponse` for tuples overriding error response codes

### DIFF
--- a/axum-core/src/response/into_response_parts.rs
+++ b/axum-core/src/response/into_response_parts.rs
@@ -237,7 +237,9 @@ macro_rules! impl_into_response_parts {
                     let res = match $ty.into_response_parts(res) {
                         Ok(res) => res,
                         Err(err) => {
-                            return Err(err.into_response());
+                            let mut err_res = err.into_response();
+                            err_res.extensions_mut().insert(super::IntoResponseFailed);
+                            return Err(err_res);
                         }
                     };
                 )*

--- a/axum-core/src/response/mod.rs
+++ b/axum-core/src/response/mod.rs
@@ -4,6 +4,8 @@
 //!
 //! [`axum::response`]: https://docs.rs/axum/0.7/axum/response/index.html
 
+use std::convert::Infallible;
+
 use crate::body::Body;
 
 mod append_headers;
@@ -127,3 +129,30 @@ where
         Self(value.into_response())
     }
 }
+
+/// ```
+/// todo!();
+/// ```
+#[derive(Copy, Clone, Debug)]
+pub struct IntoResponseFailed;
+
+impl IntoResponseParts for IntoResponseFailed {
+    type Error = Infallible;
+
+    fn into_response_parts(self, mut res: ResponseParts) -> Result<ResponseParts, Self::Error> {
+        res.extensions_mut().insert(self);
+        Ok(res)
+    }
+}
+
+/// Not sure it makes sense to return `IntoResponseFailed` as the whole response. You should
+/// probably at least combine it with a status code.
+///
+/// ```compile_fail
+/// fn foo()
+/// where
+///     axum_core::response::IntoResponseFailed: axum_core::response::IntoResponse,
+/// {}
+/// ```
+#[allow(dead_code)]
+fn into_response_failed_doesnt_impl_into_response() {}

--- a/axum/src/json.rs
+++ b/axum/src/json.rs
@@ -1,7 +1,7 @@
 use crate::extract::Request;
 use crate::extract::{rejection::*, FromRequest};
 use async_trait::async_trait;
-use axum_core::response::{IntoResponse, Response};
+use axum_core::response::{IntoResponse, IntoResponseFailed, Response};
 use bytes::{BufMut, Bytes, BytesMut};
 use http::{
     header::{self, HeaderMap, HeaderValue},
@@ -202,6 +202,7 @@ where
                     header::CONTENT_TYPE,
                     HeaderValue::from_static(mime::TEXT_PLAIN_UTF_8.as_ref()),
                 )],
+                IntoResponseFailed,
                 err.to_string(),
             )
                 .into_response(),

--- a/axum/src/response/mod.rs
+++ b/axum/src/response/mod.rs
@@ -63,10 +63,15 @@ impl<T> From<T> for Html<T> {
 #[cfg(test)]
 mod tests {
     use crate::extract::Extension;
+    use crate::test_helpers::*;
+    use crate::Json;
     use crate::{routing::get, Router};
-    use axum_core::response::IntoResponse;
+    use axum_core::response::{
+        IntoResponse, IntoResponseFailed, IntoResponseParts, Response, ResponseParts,
+    };
     use http::HeaderMap;
     use http::{StatusCode, Uri};
+    use std::collections::HashMap;
 
     // just needs to compile
     #[allow(dead_code)]
@@ -223,5 +228,237 @@ mod tests {
             .route("/", get(header_array_impl_into_response))
             .route("/", get(header_array_extension_body))
             .route("/", get(header_array_extension_mixed_body));
+    }
+
+    #[test]
+    fn status_code_tuple_doesnt_override_error() {
+        // sanity check where there is just one status code
+        assert_eq!(
+            StatusCode::INTERNAL_SERVER_ERROR.into_response().status(),
+            StatusCode::INTERNAL_SERVER_ERROR
+        );
+        assert_eq!(
+            (StatusCode::INTERNAL_SERVER_ERROR,)
+                .into_response()
+                .status(),
+            StatusCode::INTERNAL_SERVER_ERROR
+        );
+
+        // non-5xx status should be changed
+        assert_eq!(
+            (StatusCode::SEE_OTHER, StatusCode::NO_CONTENT)
+                .into_response()
+                .status(),
+            StatusCode::SEE_OTHER
+        );
+        let res = (
+            StatusCode::SEE_OTHER,
+            [("location", "foo")],
+            StatusCode::NO_CONTENT,
+        )
+            .into_response();
+        assert_eq!(res.status(), StatusCode::SEE_OTHER);
+        assert_eq!(res.headers()["location"], "foo");
+
+        // 5xx status codes are also changed
+        assert_eq!(
+            (StatusCode::SEE_OTHER, StatusCode::INTERNAL_SERVER_ERROR)
+                .into_response()
+                .status(),
+            StatusCode::SEE_OTHER
+        );
+        let res = (
+            StatusCode::SEE_OTHER,
+            [("location", "foo")],
+            StatusCode::INTERNAL_SERVER_ERROR,
+        )
+            .into_response();
+        assert_eq!(res.status(), StatusCode::SEE_OTHER);
+        assert_eq!(res.headers()["location"], "foo");
+
+        // the status is not changed if `IntoResponseFailed` is used
+        assert_eq!(
+            (
+                StatusCode::SEE_OTHER,
+                (IntoResponseFailed, StatusCode::INTERNAL_SERVER_ERROR)
+            )
+                .into_response()
+                .status(),
+            StatusCode::INTERNAL_SERVER_ERROR
+        );
+        let res = (
+            StatusCode::SEE_OTHER,
+            [("location", "foo")],
+            (IntoResponseFailed, StatusCode::INTERNAL_SERVER_ERROR),
+        )
+            .into_response();
+        assert_eq!(res.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        assert!(res.headers().get("location").is_none());
+
+        // response parts from the inner response do run
+        let res = (
+            // with status override
+            StatusCode::SEE_OTHER,
+            [("location", "foo")],
+            (
+                [("x-bar", "bar")],
+                IntoResponseFailed,
+                [("x-foo", "foo")],
+                StatusCode::INTERNAL_SERVER_ERROR,
+            ),
+        )
+            .into_response();
+        assert_eq!(res.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        assert!(res.headers().get("location").is_none());
+        assert_eq!(res.headers()["x-foo"], "foo");
+        assert_eq!(res.headers()["x-bar"], "bar");
+
+        let res = (
+            // without status override
+            [("location", "foo")],
+            (
+                [("x-bar", "bar")],
+                IntoResponseFailed,
+                [("x-foo", "foo")],
+                StatusCode::INTERNAL_SERVER_ERROR,
+            ),
+        )
+            .into_response();
+        assert_eq!(res.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        assert!(res.headers().get("location").is_none());
+        assert_eq!(res.headers()["x-foo"], "foo");
+        assert_eq!(res.headers()["x-bar"], "bar");
+
+        // (Parts, ...)
+        let res = (
+            Response::new(()).into_parts().0,
+            [("location", "foo")],
+            (
+                [("x-bar", "bar")],
+                IntoResponseFailed,
+                [("x-foo", "foo")],
+                StatusCode::INTERNAL_SERVER_ERROR,
+            ),
+        )
+            .into_response();
+        assert_eq!(res.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        assert!(res.headers().get("location").is_none());
+        assert_eq!(res.headers()["x-foo"], "foo");
+        assert_eq!(res.headers()["x-bar"], "bar");
+
+        // (Response<()>, ...)
+        let res = (
+            Response::new(()),
+            [("location", "foo")],
+            (
+                [("x-bar", "bar")],
+                IntoResponseFailed,
+                [("x-foo", "foo")],
+                StatusCode::INTERNAL_SERVER_ERROR,
+            ),
+        )
+            .into_response();
+        assert_eq!(res.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        assert!(res.headers().get("location").is_none());
+        assert_eq!(res.headers()["x-foo"], "foo");
+        assert_eq!(res.headers()["x-bar"], "bar");
+    }
+
+    #[test]
+    fn into_response_parts_failing_sets_extension() {
+        struct Fail;
+
+        impl IntoResponseParts for Fail {
+            type Error = ();
+
+            fn into_response_parts(
+                self,
+                _res: ResponseParts,
+            ) -> Result<ResponseParts, Self::Error> {
+                Err(())
+            }
+        }
+
+        impl IntoResponse for Fail {
+            fn into_response(self) -> Response {
+                (self, ()).into_response()
+            }
+        }
+
+        assert!(Fail
+            .into_response()
+            .extensions()
+            .get::<IntoResponseFailed>()
+            .is_some());
+
+        assert!((StatusCode::INTERNAL_SERVER_ERROR, Fail, ())
+            .into_response()
+            .extensions()
+            .get::<IntoResponseFailed>()
+            .is_some());
+
+        assert!((Response::new(()).into_parts().0, Fail, ())
+            .into_response()
+            .extensions()
+            .get::<IntoResponseFailed>()
+            .is_some());
+
+        assert!((Response::new(()), Fail, ())
+            .into_response()
+            .extensions()
+            .get::<IntoResponseFailed>()
+            .is_some());
+    }
+
+    #[test]
+    fn doenst_override_status_code_when_using_into_response_failed_at_same_level() {
+        assert_eq!(
+            (StatusCode::INTERNAL_SERVER_ERROR, IntoResponseFailed, ())
+                .into_response()
+                .status(),
+            StatusCode::INTERNAL_SERVER_ERROR,
+        );
+
+        #[derive(Clone)]
+        struct Thing;
+
+        let res = (
+            Response::builder()
+                .status(StatusCode::INTERNAL_SERVER_ERROR)
+                .header("x-foo", "foo")
+                .extension(Thing)
+                .body(())
+                .unwrap()
+                .into_parts()
+                .0,
+            IntoResponseFailed,
+            (),
+        )
+            .into_response();
+        assert_eq!(res.status(), StatusCode::INTERNAL_SERVER_ERROR,);
+        assert_eq!(res.headers()["x-foo"], "foo");
+        assert!(res.extensions().get::<Thing>().is_some());
+
+        // just a sanity check
+        assert_eq!(
+            (IntoResponseFailed, ()).into_response().status(),
+            StatusCode::OK,
+        );
+    }
+
+    #[crate::test]
+    async fn status_code_tuple_doesnt_override_error_json() {
+        let app = Router::new().route(
+            "/",
+            get(|| async {
+                let not_json_compatible = HashMap::from([(Vec::from([1, 2, 3]), 123)]);
+                (StatusCode::IM_A_TEAPOT, Json(not_json_compatible))
+            }),
+        );
+
+        let client = TestClient::new(app);
+
+        let res = client.get("/").send().await;
+        assert_eq!(res.status(), StatusCode::INTERNAL_SERVER_ERROR);
     }
 }


### PR DESCRIPTION
Fixes https://github.com/tokio-rs/axum/issues/2287

I think [3rd option](https://github.com/tokio-rs/axum/issues/2287#issuecomment-1778703040) is the way to go. If we went with [option 2](https://github.com/tokio-rs/axum/issues/2287#issuecomment-1778295170) then things like

```rust
(StatusCode::SEE_OTHER, [("location", "...")], StatusCode::INTERNAL_SERVER_ERROR).into_response()
```

would have to skip the `IntoResponseParts` in the middle as well as `StatusCode::SEE_OTHER`, otherwise we'd get a 500 with a `location` header.

However we probably shouldn't skip the `IntoResponseParts` if the first element isn't a status code

```rust
(Extension(error_that_happened), StatusCode::INTERNAL_SERVER_ERROR).into_response()
```

That feels somewhat inconsistent and combined with the fact that it might break middleware that "catch errors" and use tuples to construct new responses I think adding a specific extension to signal "IntoResponse failed" is nicer.

So this PR does just that. It adds `IntoResponseFailed` which if present in response extensions makes other response transformations not run. Thus the 500 status code of

```
(StatusCode::CREATED, Json::<NotJsonCompatible>(...))
```

is maintained.

## TODO

- [ ] Audit our `IntoResponse` and `IntoResponseParts` impls and add `IntoResponseFailed` where necessary.
- [ ] Make sure you can still write middleware that catch and transforms errors.
- [ ] Provide `OverrideAllStatusCodes(StatusCode)` newtype to opt-out and always set the status code.