### PR TITLE
Use `IntoFuture` for test `RequestBuilder`

### DIFF
--- a/axum-extra/src/extract/form.rs
+++ b/axum-extra/src/extract/form.rs
@@ -135,7 +135,6 @@ mod tests {
             .post("/")
             .header(CONTENT_TYPE, "application/x-www-form-urlencoded")
             .body("value=one&value=two")
-            .send()
             .await;
 
         assert_eq!(res.status(), StatusCode::OK);

--- a/axum-extra/src/extract/json_deserializer.rs
+++ b/axum-extra/src/extract/json_deserializer.rs
@@ -245,7 +245,7 @@ mod tests {
         let app = Router::new().route("/", post(handler));
 
         let client = TestClient::new(app);
-        let res = client.post("/").json(&json!({ "foo": "bar" })).send().await;
+        let res = client.post("/").json(&json!({ "foo": "bar" })).await;
         let body = res.text().await;
 
         assert_eq!(body, "bar");
@@ -277,11 +277,7 @@ mod tests {
         let client = TestClient::new(app);
 
         // The escaped characters prevent serde_json from borrowing.
-        let res = client
-            .post("/")
-            .json(&json!({ "foo": "\"bar\"" }))
-            .send()
-            .await;
+        let res = client.post("/").json(&json!({ "foo": "\"bar\"" })).await;
 
         let body = res.text().await;
 
@@ -308,19 +304,11 @@ mod tests {
 
         let client = TestClient::new(app);
 
-        let res = client
-            .post("/")
-            .json(&json!({ "foo": "good" }))
-            .send()
-            .await;
+        let res = client.post("/").json(&json!({ "foo": "good" })).await;
         let body = res.text().await;
         assert_eq!(body, "good");
 
-        let res = client
-            .post("/")
-            .json(&json!({ "foo": "\"bad\"" }))
-            .send()
-            .await;
+        let res = client.post("/").json(&json!({ "foo": "\"bad\"" })).await;
         assert_eq!(res.status(), StatusCode::UNPROCESSABLE_ENTITY);
         let body_text = res.text().await;
         assert_eq!(
@@ -344,7 +332,7 @@ mod tests {
         let app = Router::new().route("/", post(handler));
 
         let client = TestClient::new(app);
-        let res = client.post("/").body(r#"{ "foo": "bar" }"#).send().await;
+        let res = client.post("/").body(r#"{ "foo": "bar" }"#).await;
 
         let status = res.status();
 
@@ -366,7 +354,6 @@ mod tests {
                 .post("/")
                 .header("content-type", content_type)
                 .body("{}")
-                .send()
                 .await;
 
             res.status() == StatusCode::OK
@@ -395,7 +382,6 @@ mod tests {
             .post("/")
             .body("{")
             .header("content-type", "application/json")
-            .send()
             .await;
 
         assert_eq!(res.status(), StatusCode::BAD_REQUEST);
@@ -433,7 +419,6 @@ mod tests {
             .post("/")
             .body("{\"a\": 1, \"b\": [{\"x\": 2}]}")
             .header("content-type", "application/json")
-            .send()
             .await;
 
         assert_eq!(res.status(), StatusCode::UNPROCESSABLE_ENTITY);

--- a/axum-extra/src/extract/multipart.rs
+++ b/axum-extra/src/extract/multipart.rs
@@ -437,7 +437,7 @@ mod tests {
                 .unwrap(),
         );
 
-        client.post("/").multipart(form).send().await;
+        client.post("/").multipart(form).await;
     }
 
     // No need for this to be a #[test], we just want to make sure it compiles
@@ -466,7 +466,7 @@ mod tests {
         let form =
             reqwest::multipart::Form::new().part("file", reqwest::multipart::Part::bytes(BYTES));
 
-        let res = client.post("/").multipart(form).send().await;
+        let res = client.post("/").multipart(form).await;
         assert_eq!(res.status(), StatusCode::PAYLOAD_TOO_LARGE);
     }
 }

--- a/axum-extra/src/extract/optional_path.rs
+++ b/axum-extra/src/extract/optional_path.rs
@@ -81,19 +81,19 @@ mod tests {
 
         let client = TestClient::new(app);
 
-        let res = client.get("/").send().await;
+        let res = client.get("/").await;
         assert_eq!(res.text().await, "Success: 0");
 
-        let res = client.get("/1").send().await;
+        let res = client.get("/1").await;
         assert_eq!(res.text().await, "Success: 1");
 
-        let res = client.get("/0").send().await;
+        let res = client.get("/0").await;
         assert_eq!(
             res.text().await,
             "Invalid URL: invalid value: integer `0`, expected a nonzero u32"
         );
 
-        let res = client.get("/NaN").send().await;
+        let res = client.get("/NaN").await;
         assert_eq!(
             res.text().await,
             "Invalid URL: Cannot parse `\"NaN\"` to a `u32`"

--- a/axum-extra/src/extract/query.rs
+++ b/axum-extra/src/extract/query.rs
@@ -257,7 +257,6 @@ mod tests {
             .post("/?value=one&value=two")
             .header(CONTENT_TYPE, "application/x-www-form-urlencoded")
             .body("")
-            .send()
             .await;
 
         assert_eq!(res.status(), StatusCode::OK);
@@ -286,7 +285,6 @@ mod tests {
             .post("/?value=one&value=two")
             .header(CONTENT_TYPE, "application/x-www-form-urlencoded")
             .body("")
-            .send()
             .await;
 
         assert_eq!(res.status(), StatusCode::OK);
@@ -312,7 +310,7 @@ mod tests {
 
         let client = TestClient::new(app);
 
-        let res = client.post("/").body("").send().await;
+        let res = client.post("/").body("").await;
 
         assert_eq!(res.status(), StatusCode::OK);
         assert_eq!(res.text().await, "None");
@@ -341,7 +339,6 @@ mod tests {
             .post("/?other=something")
             .header(CONTENT_TYPE, "application/x-www-form-urlencoded")
             .body("")
-            .send()
             .await;
 
         assert_eq!(res.status(), StatusCode::BAD_REQUEST);

--- a/axum-extra/src/handler/or.rs
+++ b/axum-extra/src/handler/or.rs
@@ -138,13 +138,13 @@ mod tests {
 
         let client = TestClient::new(app);
 
-        let res = client.get("/123").send().await;
+        let res = client.get("/123").await;
         assert_eq!(res.text().await, "123");
 
-        let res = client.get("/foo?a=bar").send().await;
+        let res = client.get("/foo?a=bar").await;
         assert_eq!(res.text().await, "bar");
 
-        let res = client.get("/foo").send().await;
+        let res = client.get("/foo").await;
         assert_eq!(res.text().await, "fallback");
     }
 }

--- a/axum-extra/src/json_lines.rs
+++ b/axum-extra/src/json_lines.rs
@@ -224,7 +224,6 @@ mod tests {
                 ]
                 .join("\n"),
             )
-            .send()
             .await;
         assert_eq!(res.status(), StatusCode::OK);
     }
@@ -245,7 +244,7 @@ mod tests {
 
         let client = TestClient::new(app);
 
-        let res = client.get("/").send().await;
+        let res = client.get("/").await;
 
         let values = res
             .text()

--- a/axum-extra/src/protobuf.rs
+++ b/axum-extra/src/protobuf.rs
@@ -221,7 +221,7 @@ mod tests {
         };
 
         let client = TestClient::new(app);
-        let res = client.post("/").body(input.encode_to_vec()).send().await;
+        let res = client.post("/").body(input.encode_to_vec()).await;
 
         let body = res.text().await;
 
@@ -249,7 +249,7 @@ mod tests {
         };
 
         let client = TestClient::new(app);
-        let res = client.post("/").body(input.encode_to_vec()).send().await;
+        let res = client.post("/").body(input.encode_to_vec()).await;
 
         assert_eq!(res.status(), StatusCode::UNPROCESSABLE_ENTITY);
     }
@@ -284,7 +284,7 @@ mod tests {
         };
 
         let client = TestClient::new(app);
-        let res = client.post("/").body(input.encode_to_vec()).send().await;
+        let res = client.post("/").body(input.encode_to_vec()).await;
 
         assert_eq!(
             res.headers()["content-type"],

--- a/axum-extra/src/routing/mod.rs
+++ b/axum-extra/src/routing/mod.rs
@@ -352,17 +352,17 @@ mod tests {
 
         let client = TestClient::new(app);
 
-        let res = client.get("/foo").send().await;
+        let res = client.get("/foo").await;
         assert_eq!(res.status(), StatusCode::OK);
 
-        let res = client.get("/foo/").send().await;
+        let res = client.get("/foo/").await;
         assert_eq!(res.status(), StatusCode::PERMANENT_REDIRECT);
         assert_eq!(res.headers()["location"], "/foo");
 
-        let res = client.get("/bar/").send().await;
+        let res = client.get("/bar/").await;
         assert_eq!(res.status(), StatusCode::OK);
 
-        let res = client.get("/bar").send().await;
+        let res = client.get("/bar").await;
         assert_eq!(res.status(), StatusCode::PERMANENT_REDIRECT);
         assert_eq!(res.headers()["location"], "/bar/");
     }
@@ -381,19 +381,19 @@ mod tests {
 
         let client = TestClient::new(app);
 
-        let res = client.get("/a/foo").send().await;
+        let res = client.get("/a/foo").await;
         assert_eq!(res.status(), StatusCode::OK);
         assert_eq!(res.text().await, "foo");
 
-        let res = client.get("/a/foo/").send().await;
+        let res = client.get("/a/foo/").await;
         assert_eq!(res.status(), StatusCode::PERMANENT_REDIRECT);
         assert_eq!(res.headers()["location"], "/a/foo");
 
-        let res = client.get("/b/foo/").send().await;
+        let res = client.get("/b/foo/").await;
         assert_eq!(res.status(), StatusCode::OK);
         assert_eq!(res.text().await, "foo");
 
-        let res = client.get("/b/foo").send().await;
+        let res = client.get("/b/foo").await;
         assert_eq!(res.status(), StatusCode::PERMANENT_REDIRECT);
         assert_eq!(res.headers()["location"], "/b/foo/");
     }
@@ -404,7 +404,7 @@ mod tests {
 
         let client = TestClient::new(app);
 
-        let res = client.get("/foo/?a=a").send().await;
+        let res = client.get("/foo/?a=a").await;
         assert_eq!(res.status(), StatusCode::PERMANENT_REDIRECT);
         assert_eq!(res.headers()["location"], "/foo?a=a");
     }

--- a/axum-extra/src/typed_header.rs
+++ b/axum-extra/src/typed_header.rs
@@ -190,7 +190,6 @@ mod tests {
             .header("user-agent", "foobar")
             .header("cookie", "a=1; b=2")
             .header("cookie", "c=3")
-            .send()
             .await;
         let body = res.text().await;
         assert_eq!(
@@ -198,11 +197,11 @@ mod tests {
             r#"User-Agent="foobar", Cookie=[("a", "1"), ("b", "2"), ("c", "3")]"#
         );
 
-        let res = client.get("/").header("user-agent", "foobar").send().await;
+        let res = client.get("/").header("user-agent", "foobar").await;
         let body = res.text().await;
         assert_eq!(body, r#"User-Agent="foobar", Cookie=[]"#);
 
-        let res = client.get("/").header("cookie", "a=1").send().await;
+        let res = client.get("/").header("cookie", "a=1").await;
         let body = res.text().await;
         assert_eq!(body, "Header of type `user-agent` was missing");
     }

--- a/axum/src/extract/connect_info.rs
+++ b/axum/src/extract/connect_info.rs
@@ -311,7 +311,7 @@ mod tests {
 
         let client = TestClient::new(app);
 
-        let res = client.get("/").send().await;
+        let res = client.get("/").await;
         let body = res.text().await;
         assert!(body.starts_with("0.0.0.0:1337"));
     }

--- a/axum/src/extract/host.rs
+++ b/axum/src/extract/host.rs
@@ -96,7 +96,6 @@ mod tests {
         let host = test_client()
             .get("/")
             .header(http::header::HOST, original_host)
-            .send()
             .await
             .text()
             .await;
@@ -109,7 +108,6 @@ mod tests {
         let host = test_client()
             .get("/")
             .header(X_FORWARDED_HOST_HEADER_KEY, original_host)
-            .send()
             .await
             .text()
             .await;
@@ -124,7 +122,6 @@ mod tests {
             .get("/")
             .header(X_FORWARDED_HOST_HEADER_KEY, x_forwarded_host_header)
             .header(http::header::HOST, host_header)
-            .send()
             .await
             .text()
             .await;
@@ -133,7 +130,7 @@ mod tests {
 
     #[crate::test]
     async fn uri_host() {
-        let host = test_client().get("/").send().await.text().await;
+        let host = test_client().get("/").await.text().await;
         assert!(host.contains("127.0.0.1"));
     }
 

--- a/axum/src/extract/matched_path.rs
+++ b/axum/src/extract/matched_path.rs
@@ -149,7 +149,7 @@ mod tests {
 
         let client = TestClient::new(app);
 
-        let res = client.get("/foo").send().await;
+        let res = client.get("/foo").await;
         assert_eq!(res.text().await, "/:a");
     }
 
@@ -165,7 +165,7 @@ mod tests {
 
         let client = TestClient::new(app);
 
-        let res = client.get("/foo/bar").send().await;
+        let res = client.get("/foo/bar").await;
         assert_eq!(res.text().await, "/:a/:b");
     }
 
@@ -184,7 +184,7 @@ mod tests {
 
         let client = TestClient::new(app);
 
-        let res = client.get("/foo/bar/baz").send().await;
+        let res = client.get("/foo/bar/baz").await;
         assert_eq!(res.text().await, "/:a/:b/:c");
     }
 
@@ -204,7 +204,7 @@ mod tests {
 
         let client = TestClient::new(app);
 
-        let res = client.get("/foo/bar").send().await;
+        let res = client.get("/foo/bar").await;
         assert_eq!(res.status(), StatusCode::OK);
     }
 
@@ -224,7 +224,7 @@ mod tests {
 
         let client = TestClient::new(app);
 
-        let res = client.get("/foo/bar").send().await;
+        let res = client.get("/foo/bar").await;
         assert_eq!(res.status(), StatusCode::OK);
     }
 
@@ -241,7 +241,7 @@ mod tests {
 
         let client = TestClient::new(app);
 
-        let res = client.get("/foo/bar").send().await;
+        let res = client.get("/foo/bar").await;
         assert_eq!(res.status(), StatusCode::OK);
     }
 
@@ -258,7 +258,7 @@ mod tests {
 
         let client = TestClient::new(app);
 
-        let res = client.get("/foo/bar").send().await;
+        let res = client.get("/foo/bar").await;
         assert_eq!(res.status(), StatusCode::OK);
     }
 
@@ -278,7 +278,7 @@ mod tests {
 
         let client = TestClient::new(app);
 
-        let res = client.get("/foo/bar").send().await;
+        let res = client.get("/foo/bar").await;
         assert_eq!(res.status(), StatusCode::OK);
     }
 
@@ -299,7 +299,7 @@ mod tests {
 
         let client = TestClient::new(app);
 
-        let res = client.get("/foo/bar").send().await;
+        let res = client.get("/foo/bar").await;
         assert_eq!(res.status(), StatusCode::OK);
     }
 
@@ -313,7 +313,7 @@ mod tests {
 
         let client = TestClient::new(app);
 
-        let res = client.get("/foo/bar").send().await;
+        let res = client.get("/foo/bar").await;
         assert_eq!(res.status(), StatusCode::OK);
     }
 
@@ -333,7 +333,7 @@ mod tests {
 
         let client = TestClient::new(app);
 
-        let res = client.get("/foo").send().await;
+        let res = client.get("/foo").await;
         assert_eq!(res.status(), StatusCode::OK);
     }
 
@@ -348,7 +348,7 @@ mod tests {
 
         let client = TestClient::new(app);
 
-        let res = client.get("/foo/bar").send().await;
+        let res = client.get("/foo/bar").await;
         assert_eq!(res.status(), StatusCode::OK);
     }
 }

--- a/axum/src/extract/mod.rs
+++ b/axum/src/extract/mod.rs
@@ -104,7 +104,7 @@ mod tests {
         let app = Router::new().route("/", get(|body: String| async { body }));
 
         let client = TestClient::new(app);
-        let res = client.get("/").body("foo").send().await;
+        let res = client.get("/").body("foo").await;
         let body = res.text().await;
 
         assert_eq!(body, "foo");

--- a/axum/src/extract/multipart.rs
+++ b/axum/src/extract/multipart.rs
@@ -345,7 +345,7 @@ mod tests {
                 )])),
         );
 
-        client.post("/").multipart(form).send().await;
+        client.post("/").multipart(form).await;
     }
 
     // No need for this to be a #[test], we just want to make sure it compiles
@@ -376,7 +376,7 @@ mod tests {
         let form =
             reqwest::multipart::Form::new().part("file", reqwest::multipart::Part::bytes(BYTES));
 
-        let res = client.post("/").multipart(form).send().await;
+        let res = client.post("/").multipart(form).await;
         assert_eq!(res.status(), StatusCode::PAYLOAD_TOO_LARGE);
     }
 }

--- a/axum/src/extract/nested_path.rs
+++ b/axum/src/extract/nested_path.rs
@@ -135,7 +135,7 @@ mod tests {
 
         let client = TestClient::new(app);
 
-        let res = client.get("/api/users").send().await;
+        let res = client.get("/api/users").await;
         assert_eq!(res.status(), StatusCode::OK);
     }
 
@@ -153,7 +153,7 @@ mod tests {
 
         let client = TestClient::new(app);
 
-        let res = client.get("/api/users").send().await;
+        let res = client.get("/api/users").await;
         assert_eq!(res.status(), StatusCode::OK);
     }
 
@@ -171,7 +171,7 @@ mod tests {
 
         let client = TestClient::new(app);
 
-        let res = client.get("/api/v2/users").send().await;
+        let res = client.get("/api/v2/users").await;
         assert_eq!(res.status(), StatusCode::OK);
     }
 
@@ -189,7 +189,7 @@ mod tests {
 
         let client = TestClient::new(app);
 
-        let res = client.get("/api/v2/users").send().await;
+        let res = client.get("/api/v2/users").await;
         assert_eq!(res.status(), StatusCode::OK);
     }
 
@@ -207,7 +207,7 @@ mod tests {
 
         let client = TestClient::new(app);
 
-        let res = client.get("/users").send().await;
+        let res = client.get("/users").await;
         assert_eq!(res.status(), StatusCode::OK);
     }
 
@@ -225,7 +225,7 @@ mod tests {
 
         let client = TestClient::new(app);
 
-        let res = client.get("/api/users").send().await;
+        let res = client.get("/api/users").await;
         assert_eq!(res.status(), StatusCode::OK);
     }
 
@@ -240,7 +240,7 @@ mod tests {
 
         let client = TestClient::new(app);
 
-        let res = client.get("/api/doesnt-exist").send().await;
+        let res = client.get("/api/doesnt-exist").await;
         assert_eq!(res.status(), StatusCode::OK);
     }
 
@@ -259,7 +259,7 @@ mod tests {
 
         let client = TestClient::new(app);
 
-        let res = client.get("/api/users").send().await;
+        let res = client.get("/api/users").await;
         assert_eq!(res.status(), StatusCode::OK);
     }
 }

--- a/axum/src/extract/path/mod.rs
+++ b/axum/src/extract/path/mod.rs
@@ -556,10 +556,10 @@ mod tests {
 
         let client = TestClient::new(app);
 
-        let res = client.get("/users/42").send().await;
+        let res = client.get("/users/42").await;
         assert_eq!(res.status(), StatusCode::OK);
 
-        let res = client.post("/users/1337").send().await;
+        let res = client.post("/users/1337").await;
         assert_eq!(res.status(), StatusCode::OK);
     }
 
@@ -569,7 +569,7 @@ mod tests {
 
         let client = TestClient::new(app);
 
-        let res = client.get("/users/42").send().await;
+        let res = client.get("/users/42").await;
         assert_eq!(res.status(), StatusCode::OK);
     }
 
@@ -582,7 +582,7 @@ mod tests {
 
         let client = TestClient::new(app);
 
-        let res = client.get("/one%20two").send().await;
+        let res = client.get("/one%20two").await;
 
         assert_eq!(res.text().await, "one two");
     }
@@ -601,10 +601,10 @@ mod tests {
 
         let client = TestClient::new(app);
 
-        let res = client.get("/i/123").send().await;
+        let res = client.get("/i/123").await;
         assert_eq!(res.text().await, "123");
 
-        let res = client.get("/u/123").send().await;
+        let res = client.get("/u/123").await;
         assert_eq!(res.text().await, "123");
     }
 
@@ -624,10 +624,10 @@ mod tests {
 
         let client = TestClient::new(app);
 
-        let res = client.get("/foo/bar/baz").send().await;
+        let res = client.get("/foo/bar/baz").await;
         assert_eq!(res.text().await, "bar/baz");
 
-        let res = client.get("/bar/baz/qux").send().await;
+        let res = client.get("/bar/baz/qux").await;
         assert_eq!(res.text().await, "baz/qux");
     }
 
@@ -637,10 +637,10 @@ mod tests {
 
         let client = TestClient::new(app);
 
-        let res = client.get("/").send().await;
+        let res = client.get("/").await;
         assert_eq!(res.status(), StatusCode::NOT_FOUND);
 
-        let res = client.get("/foo").send().await;
+        let res = client.get("/foo").await;
         assert_eq!(res.status(), StatusCode::OK);
     }
 
@@ -653,10 +653,10 @@ mod tests {
 
         let client = TestClient::new(app);
 
-        let res = client.get("/abc/method").send().await;
+        let res = client.get("/abc/method").await;
         assert_eq!(res.text().await, "abc");
 
-        let res = client.get("//method").send().await;
+        let res = client.get("//method").await;
         assert_eq!(res.text().await, "");
     }
 
@@ -669,13 +669,13 @@ mod tests {
 
         let client = TestClient::new(app);
 
-        let res = client.get("/method/abc").send().await;
+        let res = client.get("/method/abc").await;
         assert_eq!(res.status(), StatusCode::NOT_FOUND);
 
-        let res = client.get("/method/abc/").send().await;
+        let res = client.get("/method/abc/").await;
         assert_eq!(res.text().await, "abc");
 
-        let res = client.get("/method//").send().await;
+        let res = client.get("/method//").await;
         assert_eq!(res.text().await, "");
     }
 
@@ -688,16 +688,16 @@ mod tests {
 
         let client = TestClient::new(app);
 
-        let res = client.get("/method/abc/").send().await;
+        let res = client.get("/method/abc/").await;
         assert_eq!(res.status(), StatusCode::NOT_FOUND);
 
-        let res = client.get("/method/abc").send().await;
+        let res = client.get("/method/abc").await;
         assert_eq!(res.text().await, "abc");
 
-        let res = client.get("/method/").send().await;
+        let res = client.get("/method/").await;
         assert_eq!(res.text().await, "");
 
-        let res = client.get("/method").send().await;
+        let res = client.get("/method").await;
         assert_eq!(res.status(), StatusCode::NOT_FOUND);
     }
 
@@ -718,11 +718,11 @@ mod tests {
 
         let client = TestClient::new(app);
 
-        let res = client.get("/foo").send().await;
+        let res = client.get("/foo").await;
         assert_eq!(res.text().await, "foo");
 
         // percent decoding should also work
-        let res = client.get("/foo%20bar").send().await;
+        let res = client.get("/foo%20bar").await;
         assert_eq!(res.text().await, "foo bar");
     }
 
@@ -732,7 +732,7 @@ mod tests {
 
         let client = TestClient::new(app);
 
-        let res = client.get("/a/b").send().await;
+        let res = client.get("/a/b").await;
         assert_eq!(res.status(), StatusCode::INTERNAL_SERVER_ERROR);
         assert_eq!(
             res.text().await,
@@ -758,7 +758,7 @@ mod tests {
 
         let client = TestClient::new(app);
 
-        let res = client.get("/foo/bar").send().await;
+        let res = client.get("/foo/bar").await;
         assert_eq!(res.status(), StatusCode::OK);
     }
 
@@ -816,40 +816,27 @@ mod tests {
 
         let client = TestClient::new(app);
 
-        let res = client.get("/single/2023-01-01").send().await;
+        let res = client.get("/single/2023-01-01").await;
         assert_eq!(res.text().await, "single: 2023-01-01");
 
-        let res = client
-            .get("/tuple/2023-01-01/2023-01-02/2023-01-03")
-            .send()
-            .await;
+        let res = client.get("/tuple/2023-01-01/2023-01-02/2023-01-03").await;
         assert_eq!(res.text().await, "tuple: 2023-01-01 2023-01-02 2023-01-03");
 
-        let res = client
-            .get("/vec/2023-01-01/2023-01-02/2023-01-03")
-            .send()
-            .await;
+        let res = client.get("/vec/2023-01-01/2023-01-02/2023-01-03").await;
         assert_eq!(res.text().await, "vec: 2023-01-01 2023-01-02 2023-01-03");
 
         let res = client
             .get("/vec_pairs/2023-01-01/2023-01-02/2023-01-03")
-            .send()
             .await;
         assert_eq!(
             res.text().await,
             "vec_pairs: 2023-01-01 2023-01-02 2023-01-03",
         );
 
-        let res = client
-            .get("/map/2023-01-01/2023-01-02/2023-01-03")
-            .send()
-            .await;
+        let res = client.get("/map/2023-01-01/2023-01-02/2023-01-03").await;
         assert_eq!(res.text().await, "map: 2023-01-01 2023-01-02 2023-01-03");
 
-        let res = client
-            .get("/struct/2023-01-01/2023-01-02/2023-01-03")
-            .send()
-            .await;
+        let res = client.get("/struct/2023-01-01/2023-01-02/2023-01-03").await;
         assert_eq!(res.text().await, "struct: 2023-01-01 2023-01-02 2023-01-03");
     }
 
@@ -863,13 +850,13 @@ mod tests {
 
         let client = TestClient::new(app);
 
-        let res = client.get("/one/1").send().await;
+        let res = client.get("/one/1").await;
         assert!(res
             .text()
             .await
             .starts_with("Wrong number of path arguments for `Path`. Expected 2 but got 1"));
 
-        let res = client.get("/two/1/2").send().await;
+        let res = client.get("/two/1/2").await;
         assert!(res
             .text()
             .await
@@ -890,7 +877,7 @@ mod tests {
         );
 
         let client = TestClient::new(app);
-        let res = client.get("/foo/bar/baz").send().await;
+        let res = client.get("/foo/bar/baz").await;
         let body = res.text().await;
         assert_eq!(body, "a=foo b=bar c=baz");
     }

--- a/axum/src/extract/query.rs
+++ b/axum/src/extract/query.rs
@@ -162,7 +162,7 @@ mod tests {
         let app = Router::new().route("/", get(handler));
         let client = TestClient::new(app);
 
-        let res = client.get("/?n=hi").send().await;
+        let res = client.get("/?n=hi").await;
         assert_eq!(res.status(), StatusCode::BAD_REQUEST);
     }
 

--- a/axum/src/extract/request_parts.rs
+++ b/axum/src/extract/request_parts.rs
@@ -109,7 +109,7 @@ mod tests {
 
         let client = TestClient::new(Router::new().route("/", get(handler)).layer(Extension(Ext)));
 
-        let res = client.get("/").header("x-foo", "123").send().await;
+        let res = client.get("/").header("x-foo", "123").await;
         assert_eq!(res.status(), StatusCode::OK);
     }
 }

--- a/axum/src/form.rs
+++ b/axum/src/form.rs
@@ -252,14 +252,13 @@ mod tests {
 
         let client = TestClient::new(app);
 
-        let res = client.get("/?a=false").send().await;
+        let res = client.get("/?a=false").await;
         assert_eq!(res.status(), StatusCode::BAD_REQUEST);
 
         let res = client
             .post("/")
             .header(CONTENT_TYPE, APPLICATION_WWW_FORM_URLENCODED.as_ref())
             .body("a=false")
-            .send()
             .await;
         assert_eq!(res.status(), StatusCode::UNPROCESSABLE_ENTITY);
     }

--- a/axum/src/handler/mod.rs
+++ b/axum/src/handler/mod.rs
@@ -403,7 +403,7 @@ mod tests {
 
         let client = TestClient::new(handle.into_service());
 
-        let res = client.post("/").body("hi there!").send().await;
+        let res = client.post("/").body("hi there!").await;
         assert_eq!(res.status(), StatusCode::OK);
         assert_eq!(res.text().await, "you said: hi there!");
     }
@@ -424,7 +424,7 @@ mod tests {
             .with_state("foo");
 
         let client = TestClient::new(svc);
-        let res = client.get("/").send().await;
+        let res = client.get("/").await;
         assert_eq!(res.text().await, "foo");
     }
 }

--- a/axum/src/json.rs
+++ b/axum/src/json.rs
@@ -226,7 +226,7 @@ mod tests {
         let app = Router::new().route("/", post(|input: Json<Input>| async { input.0.foo }));
 
         let client = TestClient::new(app);
-        let res = client.post("/").json(&json!({ "foo": "bar" })).send().await;
+        let res = client.post("/").json(&json!({ "foo": "bar" })).await;
         let body = res.text().await;
 
         assert_eq!(body, "bar");
@@ -242,7 +242,7 @@ mod tests {
         let app = Router::new().route("/", post(|input: Json<Input>| async { input.0.foo }));
 
         let client = TestClient::new(app);
-        let res = client.post("/").body(r#"{ "foo": "bar" }"#).send().await;
+        let res = client.post("/").body(r#"{ "foo": "bar" }"#).await;
 
         let status = res.status();
 
@@ -260,7 +260,6 @@ mod tests {
                 .post("/")
                 .header("content-type", content_type)
                 .body("{}")
-                .send()
                 .await;
 
             res.status() == StatusCode::OK
@@ -282,7 +281,6 @@ mod tests {
             .post("/")
             .body("{")
             .header("content-type", "application/json")
-            .send()
             .await;
 
         assert_eq!(res.status(), StatusCode::BAD_REQUEST);
@@ -313,7 +311,6 @@ mod tests {
             .post("/")
             .body("{\"a\": 1, \"b\": [{\"x\": 2}]}")
             .header("content-type", "application/json")
-            .send()
             .await;
 
         assert_eq!(res.status(), StatusCode::UNPROCESSABLE_ENTITY);

--- a/axum/src/middleware/from_extractor.rs
+++ b/axum/src/middleware/from_extractor.rs
@@ -352,13 +352,12 @@ mod tests {
 
         let client = TestClient::new(app);
 
-        let res = client.get("/").send().await;
+        let res = client.get("/").await;
         assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
 
         let res = client
             .get("/")
             .header(http::header::AUTHORIZATION, "secret")
-            .send()
             .await;
         assert_eq!(res.status(), StatusCode::OK);
     }

--- a/axum/src/middleware/map_request.rs
+++ b/axum/src/middleware/map_request.rs
@@ -411,7 +411,7 @@ mod tests {
             .layer(map_request(add_header));
         let client = TestClient::new(app);
 
-        let res = client.get("/").send().await;
+        let res = client.get("/").await;
 
         assert_eq!(res.text().await, "foo");
     }
@@ -431,7 +431,7 @@ mod tests {
             .layer(map_request(add_header));
         let client = TestClient::new(app);
 
-        let res = client.get("/").send().await;
+        let res = client.get("/").await;
 
         assert_eq!(res.status(), StatusCode::INTERNAL_SERVER_ERROR);
         assert_eq!(res.text().await, "something went wrong");

--- a/axum/src/middleware/map_response.rs
+++ b/axum/src/middleware/map_response.rs
@@ -357,7 +357,7 @@ mod tests {
         let app = Router::new().layer(map_response(add_header));
         let client = TestClient::new(app);
 
-        let res = client.get("/").send().await;
+        let res = client.get("/").await;
 
         assert_eq!(res.headers()["x-foo"], "foo");
     }

--- a/axum/src/response/sse.rs
+++ b/axum/src/response/sse.rs
@@ -548,7 +548,7 @@ mod tests {
         );
 
         let client = TestClient::new(app);
-        let mut stream = client.get("/").send().await;
+        let mut stream = client.get("/").await;
 
         assert_eq!(stream.headers()["content-type"], "text/event-stream");
         assert_eq!(stream.headers()["cache-control"], "no-cache");
@@ -590,7 +590,7 @@ mod tests {
         );
 
         let client = TestClient::new(app);
-        let mut stream = client.get("/").send().await;
+        let mut stream = client.get("/").await;
 
         for _ in 0..5 {
             // first message should be an event
@@ -627,7 +627,7 @@ mod tests {
         );
 
         let client = TestClient::new(app);
-        let mut stream = client.get("/").send().await;
+        let mut stream = client.get("/").await;
 
         // first message should be an event
         let event_fields = parse_event(&stream.chunk_text().await.unwrap());

--- a/axum/src/routing/tests/fallback.rs
+++ b/axum/src/routing/tests/fallback.rs
@@ -9,9 +9,9 @@ async fn basic() {
 
     let client = TestClient::new(app);
 
-    assert_eq!(client.get("/foo").send().await.status(), StatusCode::OK);
+    assert_eq!(client.get("/foo").await.status(), StatusCode::OK);
 
-    let res = client.get("/does-not-exist").send().await;
+    let res = client.get("/does-not-exist").await;
     assert_eq!(res.status(), StatusCode::OK);
     assert_eq!(res.text().await, "fallback");
 }
@@ -24,9 +24,9 @@ async fn nest() {
 
     let client = TestClient::new(app);
 
-    assert_eq!(client.get("/foo/bar").send().await.status(), StatusCode::OK);
+    assert_eq!(client.get("/foo/bar").await.status(), StatusCode::OK);
 
-    let res = client.get("/does-not-exist").send().await;
+    let res = client.get("/does-not-exist").await;
     assert_eq!(res.status(), StatusCode::OK);
     assert_eq!(res.text().await, "fallback");
 }
@@ -40,10 +40,10 @@ async fn or() {
 
     let client = TestClient::new(app);
 
-    assert_eq!(client.get("/one").send().await.status(), StatusCode::OK);
-    assert_eq!(client.get("/two").send().await.status(), StatusCode::OK);
+    assert_eq!(client.get("/one").await.status(), StatusCode::OK);
+    assert_eq!(client.get("/two").await.status(), StatusCode::OK);
 
-    let res = client.get("/does-not-exist").send().await;
+    let res = client.get("/does-not-exist").await;
     assert_eq!(res.status(), StatusCode::OK);
     assert_eq!(res.text().await, "fallback");
 }
@@ -56,7 +56,7 @@ async fn fallback_accessing_state() {
 
     let client = TestClient::new(app);
 
-    let res = client.get("/does-not-exist").send().await;
+    let res = client.get("/does-not-exist").await;
     assert_eq!(res.status(), StatusCode::OK);
     assert_eq!(res.text().await, "state");
 }
@@ -76,7 +76,7 @@ async fn nested_router_inherits_fallback() {
 
     let client = TestClient::new(app);
 
-    let res = client.get("/foo/bar").send().await;
+    let res = client.get("/foo/bar").await;
     assert_eq!(res.status(), StatusCode::NOT_FOUND);
     assert_eq!(res.text().await, "outer");
 }
@@ -88,11 +88,11 @@ async fn doesnt_inherit_fallback_if_overridden() {
 
     let client = TestClient::new(app);
 
-    let res = client.get("/foo/bar").send().await;
+    let res = client.get("/foo/bar").await;
     assert_eq!(res.status(), StatusCode::NOT_FOUND);
     assert_eq!(res.text().await, "inner");
 
-    let res = client.get("/").send().await;
+    let res = client.get("/").await;
     assert_eq!(res.status(), StatusCode::NOT_FOUND);
     assert_eq!(res.text().await, "outer");
 }
@@ -105,7 +105,7 @@ async fn deeply_nested_inherit_from_top() {
 
     let client = TestClient::new(app);
 
-    let res = client.get("/foo/bar/baz").send().await;
+    let res = client.get("/foo/bar/baz").await;
     assert_eq!(res.status(), StatusCode::NOT_FOUND);
     assert_eq!(res.text().await, "outer");
 }
@@ -121,7 +121,7 @@ async fn deeply_nested_inherit_from_middle() {
 
     let client = TestClient::new(app);
 
-    let res = client.get("/foo/bar/baz").send().await;
+    let res = client.get("/foo/bar/baz").await;
     assert_eq!(res.status(), StatusCode::NOT_FOUND);
     assert_eq!(res.text().await, "outer");
 }
@@ -137,7 +137,7 @@ async fn with_middleware_on_inner_fallback() {
 
     let client = TestClient::new(app);
 
-    let res = client.get("/foo/bar").send().await;
+    let res = client.get("/foo/bar").await;
     assert_eq!(res.status(), StatusCode::NOT_FOUND);
     assert_eq!(res.text().await, "outer");
 }
@@ -158,7 +158,7 @@ async fn also_inherits_default_layered_fallback() {
 
     let client = TestClient::new(app);
 
-    let res = client.get("/foo/bar").send().await;
+    let res = client.get("/foo/bar").await;
     assert_eq!(res.status(), StatusCode::NOT_FOUND);
     assert_eq!(res.headers()["x-from-fallback"], "1");
     assert_eq!(res.text().await, "outer");
@@ -177,7 +177,7 @@ async fn nest_fallback_on_inner() {
 
     let client = TestClient::new(app);
 
-    let res = client.get("/foo/not-found").send().await;
+    let res = client.get("/foo/not-found").await;
     assert_eq!(res.status(), StatusCode::NOT_FOUND);
     assert_eq!(res.text().await, "inner fallback");
 }
@@ -194,7 +194,7 @@ async fn doesnt_panic_if_used_with_nested_router() {
 
     let client = TestClient::new(routes_all);
 
-    let res = client.get("/foobar").send().await;
+    let res = client.get("/foobar").await;
     assert_eq!(res.status(), StatusCode::OK);
 }
 
@@ -208,11 +208,11 @@ async fn issue_2072() {
 
     let client = TestClient::new(app);
 
-    let res = client.get("/nested/does-not-exist").send().await;
+    let res = client.get("/nested/does-not-exist").await;
     assert_eq!(res.status(), StatusCode::NOT_FOUND);
     assert_eq!(res.text().await, "inner");
 
-    let res = client.get("/does-not-exist").send().await;
+    let res = client.get("/does-not-exist").await;
     assert_eq!(res.status(), StatusCode::NOT_FOUND);
     assert_eq!(res.text().await, "");
 }
@@ -228,11 +228,11 @@ async fn issue_2072_outer_fallback_before_merge() {
 
     let client = TestClient::new(app);
 
-    let res = client.get("/nested/does-not-exist").send().await;
+    let res = client.get("/nested/does-not-exist").await;
     assert_eq!(res.status(), StatusCode::NOT_FOUND);
     assert_eq!(res.text().await, "inner");
 
-    let res = client.get("/does-not-exist").send().await;
+    let res = client.get("/does-not-exist").await;
     assert_eq!(res.status(), StatusCode::NOT_FOUND);
     assert_eq!(res.text().await, "outer");
 }
@@ -248,11 +248,11 @@ async fn issue_2072_outer_fallback_after_merge() {
 
     let client = TestClient::new(app);
 
-    let res = client.get("/nested/does-not-exist").send().await;
+    let res = client.get("/nested/does-not-exist").await;
     assert_eq!(res.status(), StatusCode::NOT_FOUND);
     assert_eq!(res.text().await, "inner");
 
-    let res = client.get("/does-not-exist").send().await;
+    let res = client.get("/does-not-exist").await;
     assert_eq!(res.status(), StatusCode::NOT_FOUND);
     assert_eq!(res.text().await, "outer");
 }
@@ -267,11 +267,11 @@ async fn merge_router_with_fallback_into_nested_router_with_fallback() {
 
     let client = TestClient::new(app);
 
-    let res = client.get("/nested/does-not-exist").send().await;
+    let res = client.get("/nested/does-not-exist").await;
     assert_eq!(res.status(), StatusCode::NOT_FOUND);
     assert_eq!(res.text().await, "inner");
 
-    let res = client.get("/does-not-exist").send().await;
+    let res = client.get("/does-not-exist").await;
     assert_eq!(res.status(), StatusCode::NOT_FOUND);
     assert_eq!(res.text().await, "outer");
 }
@@ -286,11 +286,11 @@ async fn merging_nested_router_with_fallback_into_router_with_fallback() {
 
     let client = TestClient::new(app);
 
-    let res = client.get("/nested/does-not-exist").send().await;
+    let res = client.get("/nested/does-not-exist").await;
     assert_eq!(res.status(), StatusCode::NOT_FOUND);
     assert_eq!(res.text().await, "inner");
 
-    let res = client.get("/does-not-exist").send().await;
+    let res = client.get("/does-not-exist").await;
     assert_eq!(res.status(), StatusCode::NOT_FOUND);
     assert_eq!(res.text().await, "outer");
 }
@@ -301,7 +301,7 @@ async fn merge_empty_into_router_with_fallback() {
 
     let client = TestClient::new(app);
 
-    let res = client.get("/does-not-exist").send().await;
+    let res = client.get("/does-not-exist").await;
     assert_eq!(res.status(), StatusCode::NOT_FOUND);
     assert_eq!(res.text().await, "outer");
 }
@@ -312,7 +312,7 @@ async fn merge_router_with_fallback_into_empty() {
 
     let client = TestClient::new(app);
 
-    let res = client.get("/does-not-exist").send().await;
+    let res = client.get("/does-not-exist").await;
     assert_eq!(res.status(), StatusCode::NOT_FOUND);
     assert_eq!(res.text().await, "outer");
 }

--- a/axum/src/routing/tests/handle_error.rs
+++ b/axum/src/routing/tests/handle_error.rs
@@ -41,7 +41,7 @@ async fn handler() {
 
     let client = TestClient::new(app);
 
-    let res = client.get("/").send().await;
+    let res = client.get("/").await;
     assert_eq!(res.status(), StatusCode::REQUEST_TIMEOUT);
 }
 
@@ -58,7 +58,7 @@ async fn handler_multiple_methods_first() {
 
     let client = TestClient::new(app);
 
-    let res = client.get("/").send().await;
+    let res = client.get("/").await;
     assert_eq!(res.status(), StatusCode::REQUEST_TIMEOUT);
 }
 
@@ -76,7 +76,7 @@ async fn handler_multiple_methods_middle() {
 
     let client = TestClient::new(app);
 
-    let res = client.get("/").send().await;
+    let res = client.get("/").await;
     assert_eq!(res.status(), StatusCode::REQUEST_TIMEOUT);
 }
 
@@ -92,7 +92,7 @@ async fn handler_multiple_methods_last() {
 
     let client = TestClient::new(app);
 
-    let res = client.get("/").send().await;
+    let res = client.get("/").await;
     assert_eq!(res.status(), StatusCode::REQUEST_TIMEOUT);
 }
 
@@ -106,6 +106,6 @@ async fn handler_service_ext() {
 
     let client = TestClient::new(app);
 
-    let res = client.get("/").send().await;
+    let res = client.get("/").await;
     assert_eq!(res.status(), StatusCode::INTERNAL_SERVER_ERROR);
 }

--- a/axum/src/routing/tests/merge.rs
+++ b/axum/src/routing/tests/merge.rs
@@ -14,16 +14,16 @@ async fn basic() {
 
     let client = TestClient::new(app);
 
-    let res = client.get("/foo").send().await;
+    let res = client.get("/foo").await;
     assert_eq!(res.status(), StatusCode::OK);
 
-    let res = client.get("/bar").send().await;
+    let res = client.get("/bar").await;
     assert_eq!(res.status(), StatusCode::OK);
 
-    let res = client.get("/baz").send().await;
+    let res = client.get("/baz").await;
     assert_eq!(res.status(), StatusCode::OK);
 
-    let res = client.get("/qux").send().await;
+    let res = client.get("/qux").await;
     assert_eq!(res.status(), StatusCode::NOT_FOUND);
 }
 
@@ -65,7 +65,7 @@ async fn multiple_ors_balanced_differently() {
 
         for n in ["one", "two", "three", "four"].iter() {
             println!("running: {name} / {n}");
-            let res = client.get(&format!("/{n}")).send().await;
+            let res = client.get(&format!("/{n}")).await;
             assert_eq!(res.status(), StatusCode::OK);
             assert_eq!(res.text().await, *n);
         }
@@ -80,12 +80,12 @@ async fn nested_or() {
     let bar_or_baz = bar.merge(baz);
 
     let client = TestClient::new(bar_or_baz.clone());
-    assert_eq!(client.get("/bar").send().await.text().await, "bar");
-    assert_eq!(client.get("/baz").send().await.text().await, "baz");
+    assert_eq!(client.get("/bar").await.text().await, "bar");
+    assert_eq!(client.get("/baz").await.text().await, "baz");
 
     let client = TestClient::new(Router::new().nest("/foo", bar_or_baz));
-    assert_eq!(client.get("/foo/bar").send().await.text().await, "bar");
-    assert_eq!(client.get("/foo/baz").send().await.text().await, "baz");
+    assert_eq!(client.get("/foo/bar").await.text().await, "bar");
+    assert_eq!(client.get("/foo/baz").await.text().await, "baz");
 }
 
 #[crate::test]
@@ -96,13 +96,13 @@ async fn or_with_route_following() {
 
     let client = TestClient::new(app);
 
-    let res = client.get("/one").send().await;
+    let res = client.get("/one").await;
     assert_eq!(res.status(), StatusCode::OK);
 
-    let res = client.get("/two").send().await;
+    let res = client.get("/two").await;
     assert_eq!(res.status(), StatusCode::OK);
 
-    let res = client.get("/three").send().await;
+    let res = client.get("/three").await;
     assert_eq!(res.status(), StatusCode::OK);
 }
 
@@ -116,10 +116,10 @@ async fn layer() {
 
     let client = TestClient::new(app);
 
-    let res = client.get("/foo").send().await;
+    let res = client.get("/foo").await;
     assert_eq!(res.status(), StatusCode::OK);
 
-    let res = client.get("/bar").send().await;
+    let res = client.get("/bar").await;
     assert_eq!(res.status(), StatusCode::OK);
 }
 
@@ -133,9 +133,9 @@ async fn layer_and_handle_error() {
 
     let client = TestClient::new(app);
 
-    let res = client.get("/timeout").send().await;
+    let res = client.get("/timeout").await;
     assert_eq!(res.status(), StatusCode::REQUEST_TIMEOUT);
-    let res = client.get("/foo").send().await;
+    let res = client.get("/foo").await;
     assert_eq!(res.status(), StatusCode::OK);
 }
 
@@ -147,7 +147,7 @@ async fn nesting() {
 
     let client = TestClient::new(app);
 
-    let res = client.get("/bar/baz").send().await;
+    let res = client.get("/bar/baz").await;
     assert_eq!(res.status(), StatusCode::OK);
 }
 
@@ -159,7 +159,7 @@ async fn boxed() {
 
     let client = TestClient::new(app);
 
-    let res = client.get("/bar").send().await;
+    let res = client.get("/bar").await;
     assert_eq!(res.status(), StatusCode::OK);
 }
 
@@ -177,11 +177,11 @@ async fn many_ors() {
     let client = TestClient::new(app);
 
     for n in 1..=7 {
-        let res = client.get(&format!("/r{n}")).send().await;
+        let res = client.get(&format!("/r{n}")).await;
         assert_eq!(res.status(), StatusCode::OK);
     }
 
-    let res = client.get("/r8").send().await;
+    let res = client.get("/r8").await;
     assert_eq!(res.status(), StatusCode::NOT_FOUND);
 }
 
@@ -205,10 +205,10 @@ async fn services() {
 
     let client = TestClient::new(app);
 
-    let res = client.get("/foo").send().await;
+    let res = client.get("/foo").await;
     assert_eq!(res.status(), StatusCode::OK);
 
-    let res = client.get("/bar").send().await;
+    let res = client.get("/bar").await;
     assert_eq!(res.status(), StatusCode::OK);
 }
 
@@ -231,7 +231,7 @@ async fn nesting_and_seeing_the_right_uri() {
 
     let client = TestClient::new(one.merge(two));
 
-    let res = client.get("/foo/bar").send().await;
+    let res = client.get("/foo/bar").await;
     assert_eq!(res.status(), StatusCode::OK);
     assert_eq!(
         res.json::<Value>().await,
@@ -242,7 +242,7 @@ async fn nesting_and_seeing_the_right_uri() {
         })
     );
 
-    let res = client.get("/foo").send().await;
+    let res = client.get("/foo").await;
     assert_eq!(res.status(), StatusCode::OK);
     assert_eq!(
         res.json::<Value>().await,
@@ -264,7 +264,7 @@ async fn nesting_and_seeing_the_right_uri_at_more_levels_of_nesting() {
 
     let client = TestClient::new(one.merge(two));
 
-    let res = client.get("/foo/bar/baz").send().await;
+    let res = client.get("/foo/bar/baz").await;
     assert_eq!(res.status(), StatusCode::OK);
     assert_eq!(
         res.json::<Value>().await,
@@ -275,7 +275,7 @@ async fn nesting_and_seeing_the_right_uri_at_more_levels_of_nesting() {
         })
     );
 
-    let res = client.get("/foo").send().await;
+    let res = client.get("/foo").await;
     assert_eq!(res.status(), StatusCode::OK);
     assert_eq!(
         res.json::<Value>().await,
@@ -298,7 +298,7 @@ async fn nesting_and_seeing_the_right_uri_ors_with_nesting() {
 
     let client = TestClient::new(one.merge(two).merge(three));
 
-    let res = client.get("/one/bar/baz").send().await;
+    let res = client.get("/one/bar/baz").await;
     assert_eq!(res.status(), StatusCode::OK);
     assert_eq!(
         res.json::<Value>().await,
@@ -309,7 +309,7 @@ async fn nesting_and_seeing_the_right_uri_ors_with_nesting() {
         })
     );
 
-    let res = client.get("/two/qux").send().await;
+    let res = client.get("/two/qux").await;
     assert_eq!(res.status(), StatusCode::OK);
     assert_eq!(
         res.json::<Value>().await,
@@ -320,7 +320,7 @@ async fn nesting_and_seeing_the_right_uri_ors_with_nesting() {
         })
     );
 
-    let res = client.get("/three").send().await;
+    let res = client.get("/three").await;
     assert_eq!(res.status(), StatusCode::OK);
     assert_eq!(
         res.json::<Value>().await,
@@ -342,7 +342,7 @@ async fn nesting_and_seeing_the_right_uri_ors_with_multi_segment_uris() {
 
     let client = TestClient::new(one.merge(two));
 
-    let res = client.get("/one/foo/bar").send().await;
+    let res = client.get("/one/foo/bar").await;
     assert_eq!(res.status(), StatusCode::OK);
     assert_eq!(
         res.json::<Value>().await,
@@ -353,7 +353,7 @@ async fn nesting_and_seeing_the_right_uri_ors_with_multi_segment_uris() {
         })
     );
 
-    let res = client.get("/two/foo").send().await;
+    let res = client.get("/two/foo").await;
     assert_eq!(res.status(), StatusCode::OK);
     assert_eq!(
         res.json::<Value>().await,
@@ -375,22 +375,18 @@ async fn middleware_that_return_early() {
 
     let client = TestClient::new(private.merge(public));
 
-    assert_eq!(
-        client.get("/").send().await.status(),
-        StatusCode::UNAUTHORIZED
-    );
+    assert_eq!(client.get("/").await.status(), StatusCode::UNAUTHORIZED);
     assert_eq!(
         client
             .get("/")
             .header("authorization", "Bearer password")
-            .send()
             .await
             .status(),
         StatusCode::OK
     );
     assert_eq!(
-        client.get("/doesnt-exist").send().await.status(),
+        client.get("/doesnt-exist").await.status(),
         StatusCode::NOT_FOUND
     );
-    assert_eq!(client.get("/public").send().await.status(), StatusCode::OK);
+    assert_eq!(client.get("/public").await.status(), StatusCode::OK);
 }

--- a/axum/src/routing/tests/nest.rs
+++ b/axum/src/routing/tests/nest.rs
@@ -41,19 +41,19 @@ async fn nesting_apps() {
 
     let client = TestClient::new(app);
 
-    let res = client.get("/").send().await;
+    let res = client.get("/").await;
     assert_eq!(res.status(), StatusCode::OK);
     assert_eq!(res.text().await, "hi");
 
-    let res = client.get("/v0/api/users").send().await;
+    let res = client.get("/v0/api/users").await;
     assert_eq!(res.status(), StatusCode::OK);
     assert_eq!(res.text().await, "users#index");
 
-    let res = client.get("/v0/api/users/123").send().await;
+    let res = client.get("/v0/api/users/123").await;
     assert_eq!(res.status(), StatusCode::OK);
     assert_eq!(res.text().await, "v0: users#show (123)");
 
-    let res = client.get("/v0/api/games/123").send().await;
+    let res = client.get("/v0/api/games/123").await;
     assert_eq!(res.status(), StatusCode::OK);
     assert_eq!(res.text().await, "v0: games#show (123)");
 }
@@ -65,14 +65,14 @@ async fn wrong_method_nest() {
 
     let client = TestClient::new(app);
 
-    let res = client.get("/").send().await;
+    let res = client.get("/").await;
     assert_eq!(res.status(), StatusCode::OK);
 
-    let res = client.post("/").send().await;
+    let res = client.post("/").await;
     assert_eq!(res.status(), StatusCode::METHOD_NOT_ALLOWED);
     assert_eq!(res.headers()[ALLOW], "GET,HEAD");
 
-    let res = client.patch("/foo").send().await;
+    let res = client.patch("/foo").await;
     assert_eq!(res.status(), StatusCode::NOT_FOUND);
 }
 
@@ -83,14 +83,14 @@ async fn nesting_router_at_root() {
 
     let client = TestClient::new(app);
 
-    let res = client.get("/").send().await;
+    let res = client.get("/").await;
     assert_eq!(res.status(), StatusCode::NOT_FOUND);
 
-    let res = client.get("/foo").send().await;
+    let res = client.get("/foo").await;
     assert_eq!(res.status(), StatusCode::OK);
     assert_eq!(res.text().await, "/foo");
 
-    let res = client.get("/foo/bar").send().await;
+    let res = client.get("/foo/bar").await;
     assert_eq!(res.status(), StatusCode::NOT_FOUND);
 }
 
@@ -101,14 +101,14 @@ async fn nesting_router_at_empty_path() {
 
     let client = TestClient::new(app);
 
-    let res = client.get("/").send().await;
+    let res = client.get("/").await;
     assert_eq!(res.status(), StatusCode::NOT_FOUND);
 
-    let res = client.get("/foo").send().await;
+    let res = client.get("/foo").await;
     assert_eq!(res.status(), StatusCode::OK);
     assert_eq!(res.text().await, "/foo");
 
-    let res = client.get("/foo/bar").send().await;
+    let res = client.get("/foo/bar").await;
     assert_eq!(res.status(), StatusCode::NOT_FOUND);
 }
 
@@ -118,15 +118,15 @@ async fn nesting_handler_at_root() {
 
     let client = TestClient::new(app);
 
-    let res = client.get("/").send().await;
+    let res = client.get("/").await;
     assert_eq!(res.status(), StatusCode::OK);
     assert_eq!(res.text().await, "/");
 
-    let res = client.get("/foo").send().await;
+    let res = client.get("/foo").await;
     assert_eq!(res.status(), StatusCode::OK);
     assert_eq!(res.text().await, "/foo");
 
-    let res = client.get("/foo/bar").send().await;
+    let res = client.get("/foo/bar").await;
     assert_eq!(res.status(), StatusCode::OK);
     assert_eq!(res.text().await, "/foo/bar");
 }
@@ -148,11 +148,11 @@ async fn nested_url_extractor() {
 
     let client = TestClient::new(app);
 
-    let res = client.get("/foo/bar/baz").send().await;
+    let res = client.get("/foo/bar/baz").await;
     assert_eq!(res.status(), StatusCode::OK);
     assert_eq!(res.text().await, "/baz");
 
-    let res = client.get("/foo/bar/qux").send().await;
+    let res = client.get("/foo/bar/qux").await;
     assert_eq!(res.status(), StatusCode::OK);
     assert_eq!(res.text().await, "/qux");
 }
@@ -172,7 +172,7 @@ async fn nested_url_original_extractor() {
 
     let client = TestClient::new(app);
 
-    let res = client.get("/foo/bar/baz").send().await;
+    let res = client.get("/foo/bar/baz").await;
     assert_eq!(res.status(), StatusCode::OK);
     assert_eq!(res.text().await, "/foo/bar/baz");
 }
@@ -195,7 +195,7 @@ async fn nested_service_sees_stripped_uri() {
 
     let client = TestClient::new(app);
 
-    let res = client.get("/foo/bar/baz").send().await;
+    let res = client.get("/foo/bar/baz").await;
     assert_eq!(res.status(), StatusCode::OK);
     assert_eq!(res.text().await, "/baz");
 }
@@ -206,7 +206,7 @@ async fn nest_static_file_server() {
 
     let client = TestClient::new(app);
 
-    let res = client.get("/static/README.md").send().await;
+    let res = client.get("/static/README.md").await;
     assert_eq!(res.status(), StatusCode::OK);
 }
 
@@ -223,9 +223,9 @@ async fn nested_multiple_routes() {
 
     let client = TestClient::new(app);
 
-    assert_eq!(client.get("/").send().await.text().await, "root");
-    assert_eq!(client.get("/api/users").send().await.text().await, "users");
-    assert_eq!(client.get("/api/teams").send().await.text().await, "teams");
+    assert_eq!(client.get("/").await.text().await, "root");
+    assert_eq!(client.get("/api/users").await.text().await, "users");
+    assert_eq!(client.get("/api/teams").await.text().await, "teams");
 }
 
 #[test]
@@ -257,8 +257,8 @@ async fn multiple_top_level_nests() {
 
     let client = TestClient::new(app);
 
-    assert_eq!(client.get("/one/route").send().await.text().await, "one");
-    assert_eq!(client.get("/two/route").send().await.text().await, "two");
+    assert_eq!(client.get("/one/route").await.text().await, "one");
+    assert_eq!(client.get("/two/route").await.text().await, "two");
 }
 
 #[crate::test]
@@ -308,14 +308,11 @@ async fn outer_middleware_still_see_whole_url() {
 
     let client = TestClient::new(app);
 
-    assert_eq!(client.get("/").send().await.text().await, "/");
-    assert_eq!(client.get("/foo").send().await.text().await, "/foo");
-    assert_eq!(client.get("/foo/bar").send().await.text().await, "/foo/bar");
-    assert_eq!(
-        client.get("/not-found").send().await.text().await,
-        "/not-found"
-    );
-    assert_eq!(client.get("/one/two").send().await.text().await, "/one/two");
+    assert_eq!(client.get("/").await.text().await, "/");
+    assert_eq!(client.get("/foo").await.text().await, "/foo");
+    assert_eq!(client.get("/foo/bar").await.text().await, "/foo/bar");
+    assert_eq!(client.get("/not-found").await.text().await, "/not-found");
+    assert_eq!(client.get("/one/two").await.text().await, "/one/two");
 }
 
 #[crate::test]
@@ -329,7 +326,7 @@ async fn nest_at_capture() {
 
     let client = TestClient::new(app);
 
-    let res = client.get("/foo/bar").send().await;
+    let res = client.get("/foo/bar").await;
     assert_eq!(res.status(), StatusCode::OK);
     assert_eq!(res.text().await, "a=foo b=bar");
 }
@@ -340,13 +337,13 @@ async fn nest_with_and_without_trailing() {
 
     let client = TestClient::new(app);
 
-    let res = client.get("/foo").send().await;
+    let res = client.get("/foo").await;
     assert_eq!(res.status(), StatusCode::OK);
 
-    let res = client.get("/foo/").send().await;
+    let res = client.get("/foo/").await;
     assert_eq!(res.status(), StatusCode::OK);
 
-    let res = client.get("/foo/bar").send().await;
+    let res = client.get("/foo/bar").await;
     assert_eq!(res.status(), StatusCode::OK);
 }
 
@@ -361,28 +358,28 @@ async fn nesting_with_root_inner_router() {
 
     // `/service/` does match the `/service` prefix and the remaining path is technically
     // empty, which is the same as `/` which matches `.route("/", _)`
-    let res = client.get("/service").send().await;
+    let res = client.get("/service").await;
     assert_eq!(res.status(), StatusCode::OK);
 
     // `/service/` does match the `/service` prefix and the remaining path is `/`
     // which matches `.route("/", _)`
     //
     // this is perhaps a little surprising but don't think there is much we can do
-    let res = client.get("/service/").send().await;
+    let res = client.get("/service/").await;
     assert_eq!(res.status(), StatusCode::OK);
 
     // at least it does work like you'd expect when using `nest`
 
-    let res = client.get("/router").send().await;
+    let res = client.get("/router").await;
     assert_eq!(res.status(), StatusCode::OK);
 
-    let res = client.get("/router/").send().await;
+    let res = client.get("/router/").await;
     assert_eq!(res.status(), StatusCode::NOT_FOUND);
 
-    let res = client.get("/router-slash").send().await;
+    let res = client.get("/router-slash").await;
     assert_eq!(res.status(), StatusCode::NOT_FOUND);
 
-    let res = client.get("/router-slash/").send().await;
+    let res = client.get("/router-slash/").await;
     assert_eq!(res.status(), StatusCode::OK);
 }
 
@@ -401,7 +398,7 @@ macro_rules! nested_route_test {
             let inner = Router::new().route($route_path, get(|| async {}));
             let app = Router::new().nest($nested_path, inner);
             let client = TestClient::new(app);
-            let res = client.get($expected_path).send().await;
+            let res = client.get($expected_path).await;
             let status = res.status();
             assert_eq!(status, StatusCode::OK, "Router");
         }


### PR DESCRIPTION
So we can do `client.get("...").await` instead of `client.get("...").send().await`.