### PR TITLE
Internally `Arc` `Router`

### DIFF
--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -11,8 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **breaking:** Require `Sync` for all handlers and services added to `Router`
   and `MethodRouter` ([#2473])
 
-[#2473]: https://github.com/tokio-rs/axum/pull/2473
 [#2201]: https://github.com/tokio-rs/axum/pull/2201
+[#2473]: https://github.com/tokio-rs/axum/pull/2473
 
 # 0.7.3 (29. December, 2023)
 

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -11,8 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **breaking:** Require `Sync` for all handlers and services added to `Router`
   and `MethodRouter` ([#2473])
 
-[#2201]: https://github.com/tokio-rs/axum/pull/2201
 [#2473]: https://github.com/tokio-rs/axum/pull/2473
+[#2201]: https://github.com/tokio-rs/axum/pull/2201
 
 # 0.7.3 (29. December, 2023)
 

--- a/axum/src/boxed.rs
+++ b/axum/src/boxed.rs
@@ -118,7 +118,7 @@ where
         (self.into_route)(self.router, state)
     }
 
-    fn call_with_state(mut self: Box<Self>, request: Request, state: S) -> RouteFuture<Infallible> {
+    fn call_with_state(self: Box<Self>, request: Request, state: S) -> RouteFuture<Infallible> {
         self.router.call_with_state(request, state)
     }
 }

--- a/axum/src/routing/method_routing.rs
+++ b/axum/src/routing/method_routing.rs
@@ -1023,7 +1023,7 @@ where
         self
     }
 
-    pub(crate) fn call_with_state(&mut self, req: Request, state: S) -> RouteFuture<E> {
+    pub(crate) fn call_with_state(&self, req: Request, state: S) -> RouteFuture<E> {
         macro_rules! call {
             (
                 $req:expr,
@@ -1039,7 +1039,7 @@ where
                                 .strip_body($method == Method::HEAD);
                         }
                         MethodEndpoint::BoxedHandler(handler) => {
-                            let mut route = handler.clone().into_route(state);
+                            let route = handler.clone().into_route(state);
                             return RouteFuture::from_future(route.oneshot_inner($req))
                                 .strip_body($method == Method::HEAD);
                         }
@@ -1220,7 +1220,7 @@ where
 {
     type Future = InfallibleRouteFuture;
 
-    fn call(mut self, req: Request, state: S) -> Self::Future {
+    fn call(self, req: Request, state: S) -> Self::Future {
         InfallibleRouteFuture::new(self.call_with_state(req, state))
     }
 }

--- a/axum/src/routing/path_router.rs
+++ b/axum/src/routing/path_router.rs
@@ -316,7 +316,7 @@ where
     }
 
     pub(super) fn call_with_state(
-        &mut self,
+        &self,
         mut req: Request,
         state: S,
     ) -> Result<RouteFuture<Infallible>, (Request, S)> {
@@ -349,7 +349,7 @@ where
 
                 let endpoint = self
                     .routes
-                    .get_mut(&id)
+                    .get(&id)
                     .expect("no route for id. This is a bug in axum. Please file an issue");
 
                 match endpoint {

--- a/axum/src/routing/route.rs
+++ b/axum/src/routing/route.rs
@@ -43,7 +43,7 @@ impl<E> Route<E> {
     }
 
     pub(crate) fn oneshot_inner(
-        &mut self,
+        &self,
         req: Request,
     ) -> Oneshot<BoxCloneService<Request, Response, E>, Request> {
         self.0.clone().oneshot(req)

--- a/axum/src/routing/tests/mod.rs
+++ b/axum/src/routing/tests/mod.rs
@@ -951,7 +951,7 @@ async fn state_isnt_cloned_too_much() {
 
     client.get("/").await;
 
-    assert_eq!(COUNT.load(Ordering::SeqCst), 5);
+    assert_eq!(COUNT.load(Ordering::SeqCst), 3);
 }
 
 #[crate::test]


### PR DESCRIPTION
Based on https://github.com/tokio-rs/axum/pull/2473.

With `Router` being `Sync` we can now store it as an `Arc` internally which should help a lot with cloning it.

This might impact https://github.com/tokio-rs/axum/issues/2449.

## TODO

- [ ] Changelog
- [ ] Benchmark it and see if there is a difference