### PR TITLE
Remove duplication in serving with and without graceful shutdown

### DIFF
--- a/axum/Cargo.toml
+++ b/axum/Cargo.toml
@@ -64,7 +64,7 @@ tower-service = "0.3"
 axum-macros = { path = "../axum-macros", version = "0.4.0", optional = true }
 base64 = { version = "0.21.0", optional = true }
 hyper = { version = "1.1.0", optional = true }
-hyper-util = { version = "0.1.2", features = ["tokio", "server", "server-auto"], optional = true }
+hyper-util = { version = "0.1.2", features = ["tokio", "server", "server-auto", "service"], optional = true }
 multer = { version = "3.0.0", optional = true }
 serde_json = { version = "1.0", features = ["raw_value"], optional = true }
 serde_path_to_error = { version = "0.1.8", optional = true }

--- a/axum/src/routing/tests/mod.rs
+++ b/axum/src/routing/tests/mod.rs
@@ -965,7 +965,7 @@ async fn logging_rejections() {
         rejection_type: String,
     }
 
-    let events = capture_tracing::<RejectionEvent, _, _>(|| async {
+    let events = capture_tracing::<RejectionEvent, _, _>("axum::rejection=trace", || async {
         let app = Router::new()
             .route("/extension", get(|_: Extension<Infallible>| async {}))
             .route("/string", post(|_: String| async {}));

--- a/axum/src/serve.rs
+++ b/axum/src/serve.rs
@@ -181,54 +181,15 @@ where
     type IntoFuture = private::ServeFuture;
 
     fn into_future(self) -> Self::IntoFuture {
-        private::ServeFuture(Box::pin(async move {
-            let Self {
-                tcp_listener,
-                mut make_service,
-                _marker: _,
-            } = self;
+        let Self {
+            tcp_listener,
+            make_service,
+            _marker: _,
+        } = self;
 
-            loop {
-                let (tcp_stream, remote_addr) = match tcp_accept(&tcp_listener).await {
-                    Some(conn) => conn,
-                    None => continue,
-                };
-                let tcp_stream = TokioIo::new(tcp_stream);
-
-                poll_fn(|cx| make_service.poll_ready(cx))
-                    .await
-                    .unwrap_or_else(|err| match err {});
-
-                let tower_service = make_service
-                    .call(IncomingStream {
-                        tcp_stream: &tcp_stream,
-                        remote_addr,
-                    })
-                    .await
-                    .unwrap_or_else(|err| match err {});
-
-                let hyper_service = TowerToHyperService {
-                    service: tower_service,
-                };
-
-                tokio::spawn(async move {
-                    match Builder::new(TokioExecutor::new())
-                        // upgrades needed for websockets
-                        .serve_connection_with_upgrades(tcp_stream, hyper_service)
-                        .await
-                    {
-                        Ok(()) => {}
-                        Err(_err) => {
-                            // This error only appears when the client doesn't send a request and
-                            // terminate the connection.
-                            //
-                            // If client sends one request then terminate connection whenever, it doesn't
-                            // appear.
-                        }
-                    }
-                });
-            }
-        }))
+        serve(tcp_listener, make_service)
+            .with_graceful_shutdown(std::future::pending())
+            .into_future()
     }
 }
 

--- a/axum/src/test_helpers/tracing_helpers.rs
+++ b/axum/src/test_helpers/tracing_helpers.rs
@@ -17,7 +17,7 @@ pub(crate) struct TracingEvent<T> {
 }
 
 /// Run an async closure and capture the tracing output it produces.
-pub(crate) async fn capture_tracing<T, F, Fut>(f: F) -> Vec<TracingEvent<T>>
+pub(crate) async fn capture_tracing<T, F, Fut>(target: &str, f: F) -> Vec<TracingEvent<T>>
 where
     F: Fn() -> Fut,
     Fut: Future,
@@ -33,7 +33,7 @@ where
             .with_ansi(false)
             .json()
             .flatten_event(false)
-            .with_filter("axum=trace".parse::<Targets>().unwrap()),
+            .with_filter(target.parse::<Targets>().unwrap()),
     );
 
     let guard = tracing::subscriber::set_default(subscriber);


### PR DESCRIPTION
I guess serving without graceful shutdown is the same as serving with shutdown signal that never completes. Does result in the non-graceful case doing a bit more work but since you normally just spawn one server its probably fine.