### PR TITLE
Make `serve` generic over the listener and IO types

### DIFF
--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -8,9 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # Unreleased
 
 - **fixed:** Improve `debug_handler` on tuple response types ([#2201])
-- **breaking:** Make `serve` generic over the listener and IO types
+- **breaking:** Make `serve` generic over the listener and IO types ([#2479])
 
 [#2201]: https://github.com/tokio-rs/axum/pull/2201
+[#2479]: https://github.com/tokio-rs/axum/pull/2479
 
 # 0.7.3 (29. December, 2023)
 

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # Unreleased
 
 - **fixed:** Improve `debug_handler` on tuple response types ([#2201])
+- **breaking:** Make `serve` generic over the listener and IO types
 
 [#2201]: https://github.com/tokio-rs/axum/pull/2201
 

--- a/axum/Cargo.toml
+++ b/axum/Cargo.toml
@@ -115,6 +115,7 @@ rustversion = "1.0.9"
 [dev-dependencies]
 anyhow = "1.0"
 axum-macros = { path = "../axum-macros", version = "0.4.0", features = ["__private"] }
+hyper = { version = "1.1.0", features = ["client"] }
 quickcheck = "1.0"
 quickcheck_macros = "1.0"
 reqwest = { version = "0.11.14", default-features = false, features = ["json", "stream", "multipart"] }

--- a/axum/src/docs/routing/into_make_service_with_connect_info.md
+++ b/axum/src/docs/routing/into_make_service_with_connect_info.md
@@ -35,6 +35,7 @@ use axum::{
     serve::IncomingStream,
     Router,
 };
+use tokio::net::TcpListener;
 
 let app = Router::new().route("/", get(handler));
 
@@ -49,8 +50,8 @@ struct MyConnectInfo {
     // ...
 }
 
-impl Connected<IncomingStream<'_>> for MyConnectInfo {
-    fn connect_info(target: IncomingStream<'_>) -> Self {
+impl Connected<IncomingStream<'_, TcpListener>> for MyConnectInfo {
+    fn connect_info(target: IncomingStream<'_, TcpListener>) -> Self {
         MyConnectInfo {
             // ...
         }

--- a/axum/src/extract/connect_info.rs
+++ b/axum/src/extract/connect_info.rs
@@ -80,16 +80,17 @@ where
 /// [`Router::into_make_service_with_connect_info`]: crate::routing::Router::into_make_service_with_connect_info
 pub trait Connected<T>: Clone + Send + Sync + 'static {
     /// Create type holding information about the connection.
-    fn connect_info(target: T) -> Self;
+    fn connect_info(stream: T) -> Self;
 }
 
 #[cfg(all(feature = "tokio", any(feature = "http1", feature = "http2")))]
 const _: () = {
-    use crate::serve::IncomingStream;
+    use crate::serve;
+    use tokio::net::TcpListener;
 
-    impl Connected<IncomingStream<'_>> for SocketAddr {
-        fn connect_info(target: IncomingStream<'_>) -> Self {
-            target.remote_addr()
+    impl Connected<serve::IncomingStream<'_, TcpListener>> for SocketAddr {
+        fn connect_info(stream: serve::IncomingStream<'_, TcpListener>) -> Self {
+            *stream.remote_addr()
         }
     }
 };
@@ -264,8 +265,8 @@ mod tests {
             value: &'static str,
         }
 
-        impl Connected<IncomingStream<'_>> for MyConnectInfo {
-            fn connect_info(_target: IncomingStream<'_>) -> Self {
+        impl Connected<IncomingStream<'_, TcpListener>> for MyConnectInfo {
+            fn connect_info(_target: IncomingStream<'_, TcpListener>) -> Self {
                 Self {
                     value: "it worked!",
                 }

--- a/axum/src/handler/service.rs
+++ b/axum/src/handler/service.rs
@@ -180,12 +180,13 @@ where
 // for `axum::serve(listener, handler)`
 #[cfg(all(feature = "tokio", any(feature = "http1", feature = "http2")))]
 const _: () = {
-    use crate::serve::IncomingStream;
+    use crate::serve;
 
-    impl<H, T, S> Service<IncomingStream<'_>> for HandlerService<H, T, S>
+    impl<H, T, S, L> Service<serve::IncomingStream<'_, L>> for HandlerService<H, T, S>
     where
         H: Clone,
         S: Clone,
+        L: serve::Listener,
     {
         type Response = Self;
         type Error = Infallible;
@@ -195,7 +196,7 @@ const _: () = {
             Poll::Ready(Ok(()))
         }
 
-        fn call(&mut self, _req: IncomingStream<'_>) -> Self::Future {
+        fn call(&mut self, _req: serve::IncomingStream<'_, L>) -> Self::Future {
             std::future::ready(Ok(self.clone()))
         }
     }

--- a/axum/src/routing/method_routing.rs
+++ b/axum/src/routing/method_routing.rs
@@ -1227,9 +1227,12 @@ where
 // for `axum::serve(listener, router)`
 #[cfg(all(feature = "tokio", any(feature = "http1", feature = "http2")))]
 const _: () = {
-    use crate::serve::IncomingStream;
+    use crate::serve;
 
-    impl Service<IncomingStream<'_>> for MethodRouter<()> {
+    impl<L> Service<serve::IncomingStream<'_, L>> for MethodRouter<()>
+    where
+        L: serve::Listener,
+    {
         type Response = Self;
         type Error = Infallible;
         type Future = std::future::Ready<Result<Self::Response, Self::Error>>;
@@ -1238,7 +1241,7 @@ const _: () = {
             Poll::Ready(Ok(()))
         }
 
-        fn call(&mut self, _req: IncomingStream<'_>) -> Self::Future {
+        fn call(&mut self, _req: serve::IncomingStream<'_, L>) -> Self::Future {
             std::future::ready(Ok(self.clone()))
         }
     }

--- a/axum/src/routing/mod.rs
+++ b/axum/src/routing/mod.rs
@@ -430,9 +430,12 @@ impl Router {
 // for `axum::serve(listener, router)`
 #[cfg(all(feature = "tokio", any(feature = "http1", feature = "http2")))]
 const _: () = {
-    use crate::serve::IncomingStream;
+    use crate::serve;
 
-    impl Service<IncomingStream<'_>> for Router<()> {
+    impl<L> Service<serve::IncomingStream<'_, L>> for Router<()>
+    where
+        L: serve::Listener,
+    {
         type Response = Self;
         type Error = Infallible;
         type Future = std::future::Ready<Result<Self::Response, Self::Error>>;
@@ -441,7 +444,7 @@ const _: () = {
             Poll::Ready(Ok(()))
         }
 
-        fn call(&mut self, _req: IncomingStream<'_>) -> Self::Future {
+        fn call(&mut self, _req: serve::IncomingStream<'_, L>) -> Self::Future {
             std::future::ready(Ok(self.clone()))
         }
     }

--- a/axum/src/serve.rs
+++ b/axum/src/serve.rs
@@ -25,7 +25,7 @@ use tokio::{
 use tower::util::ServiceExt;
 use tower_service::Service;
 
-/// TODO
+/// Types that can listen for connections.
 pub trait Listener: Send + 'static {
     /// The listener's IO type.
     type Io: AsyncRead + AsyncWrite + Unpin + Send + 'static;

--- a/axum/src/serve.rs
+++ b/axum/src/serve.rs
@@ -6,7 +6,6 @@ use std::{
     future::{poll_fn, Future, IntoFuture},
     io,
     marker::PhantomData,
-    net::SocketAddr,
     sync::Arc,
     time::Duration,
 };
@@ -19,11 +18,58 @@ use hyper_util::{
     server::conn::auto::Builder,
 };
 use tokio::{
+    io::{AsyncRead, AsyncWrite},
     net::{TcpListener, TcpStream},
     sync::watch,
 };
 use tower::util::ServiceExt;
 use tower_service::Service;
+
+/// TODO
+pub trait Listener: Send + 'static {
+    /// The listener's IO type.
+    type Io: AsyncRead + AsyncWrite + Unpin + Send + 'static;
+
+    /// The listener's address type.
+    type Addr: Send;
+
+    /// Accept a new incoming connection to this listener
+    fn accept(&mut self) -> impl Future<Output = io::Result<(Self::Io, Self::Addr)>> + Send;
+
+    /// Returns the local address that this listener is bound to.
+    fn local_addr(&self) -> io::Result<Self::Addr>;
+}
+
+impl Listener for TcpListener {
+    type Io = TcpStream;
+    type Addr = std::net::SocketAddr;
+
+    #[inline]
+    async fn accept(&mut self) -> io::Result<(Self::Io, Self::Addr)> {
+        Self::accept(self).await
+    }
+
+    #[inline]
+    fn local_addr(&self) -> io::Result<Self::Addr> {
+        Self::local_addr(self)
+    }
+}
+
+#[cfg(unix)]
+impl Listener for tokio::net::UnixListener {
+    type Io = tokio::net::UnixStream;
+    type Addr = tokio::net::unix::SocketAddr;
+
+    #[inline]
+    async fn accept(&mut self) -> io::Result<(Self::Io, Self::Addr)> {
+        Self::accept(self).await
+    }
+
+    #[inline]
+    fn local_addr(&self) -> io::Result<Self::Addr> {
+        Self::local_addr(self)
+    }
+}
 
 /// Serve the service with the supplied listener.
 ///
@@ -90,14 +136,15 @@ use tower_service::Service;
 /// [`HandlerWithoutStateExt::into_make_service_with_connect_info`]: crate::handler::HandlerWithoutStateExt::into_make_service_with_connect_info
 /// [`HandlerService::into_make_service_with_connect_info`]: crate::handler::HandlerService::into_make_service_with_connect_info
 #[cfg(all(feature = "tokio", any(feature = "http1", feature = "http2")))]
-pub fn serve<M, S>(tcp_listener: TcpListener, make_service: M) -> Serve<M, S>
+pub fn serve<L, M, S>(listener: L, make_service: M) -> Serve<L, M, S>
 where
-    M: for<'a> Service<IncomingStream<'a>, Error = Infallible, Response = S>,
+    L: Listener,
+    M: for<'a> Service<IncomingStream<'a, L>, Error = Infallible, Response = S>,
     S: Service<Request, Response = Response, Error = Infallible> + Clone + Send + 'static,
     S::Future: Send,
 {
     Serve {
-        tcp_listener,
+        listener,
         make_service,
         _marker: PhantomData,
     }
@@ -105,14 +152,14 @@ where
 
 /// Future returned by [`serve`].
 #[cfg(all(feature = "tokio", any(feature = "http1", feature = "http2")))]
-pub struct Serve<M, S> {
-    tcp_listener: TcpListener,
+pub struct Serve<L, M, S> {
+    listener: L,
     make_service: M,
     _marker: PhantomData<S>,
 }
 
 #[cfg(all(feature = "tokio", any(feature = "http1", feature = "http2")))]
-impl<M, S> Serve<M, S> {
+impl<L, M, S> Serve<L, M, S> {
     /// Prepares a server to handle graceful shutdown when the provided future completes.
     ///
     /// # Example
@@ -134,12 +181,12 @@ impl<M, S> Serve<M, S> {
     ///     // ...
     /// }
     /// ```
-    pub fn with_graceful_shutdown<F>(self, signal: F) -> WithGracefulShutdown<M, S, F>
+    pub fn with_graceful_shutdown<F>(self, signal: F) -> WithGracefulShutdown<L, M, S, F>
     where
         F: Future<Output = ()> + Send + 'static,
     {
         WithGracefulShutdown {
-            tcp_listener: self.tcp_listener,
+            listener: self.listener,
             make_service: self.make_service,
             signal,
             _marker: PhantomData,
@@ -148,29 +195,31 @@ impl<M, S> Serve<M, S> {
 }
 
 #[cfg(all(feature = "tokio", any(feature = "http1", feature = "http2")))]
-impl<M, S> Debug for Serve<M, S>
+impl<L, M, S> Debug for Serve<L, M, S>
 where
+    L: Debug,
     M: Debug,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let Self {
-            tcp_listener,
+            listener,
             make_service,
             _marker: _,
         } = self;
 
         f.debug_struct("Serve")
-            .field("tcp_listener", tcp_listener)
+            .field("listener", listener)
             .field("make_service", make_service)
             .finish()
     }
 }
 
 #[cfg(all(feature = "tokio", any(feature = "http1", feature = "http2")))]
-impl<M, S> IntoFuture for Serve<M, S>
+impl<L, M, S> IntoFuture for Serve<L, M, S>
 where
-    M: for<'a> Service<IncomingStream<'a>, Error = Infallible, Response = S> + Send + 'static,
-    for<'a> <M as Service<IncomingStream<'a>>>::Future: Send,
+    L: Listener,
+    M: for<'a> Service<IncomingStream<'a, L>, Error = Infallible, Response = S> + Send + 'static,
+    for<'a> <M as Service<IncomingStream<'a, L>>>::Future: Send,
     S: Service<Request, Response = Response, Error = Infallible> + Clone + Send + 'static,
     S::Future: Send,
 {
@@ -179,12 +228,12 @@ where
 
     fn into_future(self) -> Self::IntoFuture {
         let Self {
-            tcp_listener,
+            listener,
             make_service,
             _marker: _,
         } = self;
 
-        serve(tcp_listener, make_service)
+        serve(listener, make_service)
             .with_graceful_shutdown(std::future::pending())
             .into_future()
     }
@@ -192,30 +241,31 @@ where
 
 /// Serve future with graceful shutdown enabled.
 #[cfg(all(feature = "tokio", any(feature = "http1", feature = "http2")))]
-pub struct WithGracefulShutdown<M, S, F> {
-    tcp_listener: TcpListener,
+pub struct WithGracefulShutdown<L, M, S, F> {
+    listener: L,
     make_service: M,
     signal: F,
     _marker: PhantomData<S>,
 }
 
 #[cfg(all(feature = "tokio", any(feature = "http1", feature = "http2")))]
-impl<M, S, F> Debug for WithGracefulShutdown<M, S, F>
+impl<L, M, S, F> Debug for WithGracefulShutdown<L, M, S, F>
 where
+    L: Debug,
     M: Debug,
     S: Debug,
     F: Debug,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let Self {
-            tcp_listener,
+            listener,
             make_service,
             signal,
             _marker: _,
         } = self;
 
         f.debug_struct("WithGracefulShutdown")
-            .field("tcp_listener", tcp_listener)
+            .field("listener", listener)
             .field("make_service", make_service)
             .field("signal", signal)
             .finish()
@@ -223,10 +273,11 @@ where
 }
 
 #[cfg(all(feature = "tokio", any(feature = "http1", feature = "http2")))]
-impl<M, S, F> IntoFuture for WithGracefulShutdown<M, S, F>
+impl<L, M, S, F> IntoFuture for WithGracefulShutdown<L, M, S, F>
 where
-    M: for<'a> Service<IncomingStream<'a>, Error = Infallible, Response = S> + Send + 'static,
-    for<'a> <M as Service<IncomingStream<'a>>>::Future: Send,
+    L: Listener,
+    M: for<'a> Service<IncomingStream<'a, L>, Error = Infallible, Response = S> + Send + 'static,
+    for<'a> <M as Service<IncomingStream<'a, L>>>::Future: Send,
     S: Service<Request, Response = Response, Error = Infallible> + Clone + Send + 'static,
     S::Future: Send,
     F: Future<Output = ()> + Send + 'static,
@@ -236,7 +287,7 @@ where
 
     fn into_future(self) -> Self::IntoFuture {
         let Self {
-            tcp_listener,
+            mut listener,
             mut make_service,
             signal,
             _marker: _,
@@ -254,8 +305,8 @@ where
 
         private::ServeFuture(Box::pin(async move {
             loop {
-                let (tcp_stream, remote_addr) = tokio::select! {
-                    conn = tcp_accept(&tcp_listener) => {
+                let (io, remote_addr) = tokio::select! {
+                    conn = accept(&mut listener) => {
                         match conn {
                             Some(conn) => conn,
                             None => continue,
@@ -266,9 +317,7 @@ where
                         break;
                     }
                 };
-                let tcp_stream = TokioIo::new(tcp_stream);
-
-                trace!("connection {remote_addr} accepted");
+                let io = TokioIo::new(io);
 
                 poll_fn(|cx| make_service.poll_ready(cx))
                     .await
@@ -276,7 +325,7 @@ where
 
                 let tower_service = make_service
                     .call(IncomingStream {
-                        tcp_stream: &tcp_stream,
+                        io: &io,
                         remote_addr,
                     })
                     .await
@@ -291,7 +340,7 @@ where
 
                 tokio::spawn(async move {
                     let builder = Builder::new(TokioExecutor::new());
-                    let conn = builder.serve_connection_with_upgrades(tcp_stream, hyper_service);
+                    let conn = builder.serve_connection_with_upgrades(io, hyper_service);
                     pin_mut!(conn);
 
                     let signal_closed = signal_tx.closed().fuse();
@@ -312,14 +361,12 @@ where
                         }
                     }
 
-                    trace!("connection {remote_addr} closed");
-
                     drop(close_rx);
                 });
             }
 
             drop(close_rx);
-            drop(tcp_listener);
+            drop(listener);
 
             trace!(
                 "waiting for {} task(s) to finish",
@@ -341,7 +388,10 @@ fn is_connection_error(e: &io::Error) -> bool {
     )
 }
 
-async fn tcp_accept(listener: &TcpListener) -> Option<(TcpStream, SocketAddr)> {
+async fn accept<L>(listener: &mut L) -> Option<(L::Io, L::Addr)>
+where
+    L: Listener,
+{
     match listener.accept().await {
         Ok(conn) => Some(conn),
         Err(e) => {
@@ -364,6 +414,35 @@ async fn tcp_accept(listener: &TcpListener) -> Option<(TcpStream, SocketAddr)> {
             tokio::time::sleep(Duration::from_secs(1)).await;
             None
         }
+    }
+}
+
+/// An incoming stream.
+///
+/// Used with [`serve`] and [`IntoMakeServiceWithConnectInfo`].
+///
+/// [`IntoMakeServiceWithConnectInfo`]: crate::extract::connect_info::IntoMakeServiceWithConnectInfo
+#[derive(Debug)]
+pub struct IncomingStream<'a, L>
+where
+    L: Listener,
+{
+    io: &'a TokioIo<L::Io>,
+    remote_addr: L::Addr,
+}
+
+impl<L> IncomingStream<'_, L>
+where
+    L: Listener,
+{
+    /// Get a reference to the inner IO type.
+    pub fn io(&self) -> &L::Io {
+        self.io.inner()
+    }
+
+    /// Returns the remote address that this stream is bound to.
+    pub fn remote_addr(&self) -> &L::Addr {
+        &self.remote_addr
     }
 }
 
@@ -393,33 +472,15 @@ mod private {
     }
 }
 
-/// An incoming stream.
-///
-/// Used with [`serve`] and [`IntoMakeServiceWithConnectInfo`].
-///
-/// [`IntoMakeServiceWithConnectInfo`]: crate::extract::connect_info::IntoMakeServiceWithConnectInfo
-#[derive(Debug)]
-pub struct IncomingStream<'a> {
-    tcp_stream: &'a TokioIo<TcpStream>,
-    remote_addr: SocketAddr,
-}
-
-impl IncomingStream<'_> {
-    /// Returns the local address that this stream is bound to.
-    pub fn local_addr(&self) -> std::io::Result<SocketAddr> {
-        self.tcp_stream.inner().local_addr()
-    }
-
-    /// Returns the remote address that this stream is bound to.
-    pub fn remote_addr(&self) -> SocketAddr {
-        self.remote_addr
-    }
-}
-
 #[cfg(test)]
 mod tests {
+    use http::StatusCode;
+    use tokio::net::UnixListener;
+
     use super::*;
     use crate::{
+        body::to_bytes,
+        extract::connect_info::Connected,
         handler::{Handler, HandlerWithoutStateExt},
         routing::get,
         Router,
@@ -427,30 +488,63 @@ mod tests {
 
     #[allow(dead_code, unused_must_use)]
     async fn if_it_compiles_it_works() {
+        #[derive(Clone, Debug)]
+        struct UdsConnectInfo;
+
+        impl Connected<IncomingStream<'_, UnixListener>> for UdsConnectInfo {
+            fn connect_info(_stream: IncomingStream<'_, UnixListener>) -> Self {
+                Self
+            }
+        }
+
         let router: Router = Router::new();
 
         let addr = "0.0.0.0:0";
 
         // router
         serve(TcpListener::bind(addr).await.unwrap(), router.clone());
+        serve(UnixListener::bind("").unwrap(), router.clone());
+
         serve(
             TcpListener::bind(addr).await.unwrap(),
             router.clone().into_make_service(),
         );
         serve(
+            UnixListener::bind("").unwrap(),
+            router.clone().into_make_service(),
+        );
+
+        serve(
             TcpListener::bind(addr).await.unwrap(),
-            router.into_make_service_with_connect_info::<SocketAddr>(),
+            router
+                .clone()
+                .into_make_service_with_connect_info::<std::net::SocketAddr>(),
+        );
+        serve(
+            UnixListener::bind("").unwrap(),
+            router.into_make_service_with_connect_info::<UdsConnectInfo>(),
         );
 
         // method router
         serve(TcpListener::bind(addr).await.unwrap(), get(handler));
+        serve(UnixListener::bind("").unwrap(), get(handler));
+
         serve(
             TcpListener::bind(addr).await.unwrap(),
             get(handler).into_make_service(),
         );
         serve(
+            UnixListener::bind("").unwrap(),
+            get(handler).into_make_service(),
+        );
+
+        serve(
             TcpListener::bind(addr).await.unwrap(),
-            get(handler).into_make_service_with_connect_info::<SocketAddr>(),
+            get(handler).into_make_service_with_connect_info::<std::net::SocketAddr>(),
+        );
+        serve(
+            UnixListener::bind("").unwrap(),
+            get(handler).into_make_service_with_connect_info::<UdsConnectInfo>(),
         );
 
         // handler
@@ -458,19 +552,74 @@ mod tests {
             TcpListener::bind(addr).await.unwrap(),
             handler.into_service(),
         );
+        serve(UnixListener::bind("").unwrap(), handler.into_service());
+
         serve(
             TcpListener::bind(addr).await.unwrap(),
             handler.with_state(()),
         );
+        serve(UnixListener::bind("").unwrap(), handler.with_state(()));
+
         serve(
             TcpListener::bind(addr).await.unwrap(),
             handler.into_make_service(),
         );
+        serve(UnixListener::bind("").unwrap(), handler.into_make_service());
+
         serve(
             TcpListener::bind(addr).await.unwrap(),
-            handler.into_make_service_with_connect_info::<SocketAddr>(),
+            handler.into_make_service_with_connect_info::<std::net::SocketAddr>(),
+        );
+        serve(
+            UnixListener::bind("").unwrap(),
+            handler.into_make_service_with_connect_info::<UdsConnectInfo>(),
         );
     }
 
     async fn handler() {}
+
+    #[crate::test]
+    async fn serving_on_custom_io_type() {
+        struct ReadyListener<T>(Option<T>);
+
+        impl<T> Listener for ReadyListener<T>
+        where
+            T: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+        {
+            type Io = T;
+            type Addr = ();
+
+            async fn accept(&mut self) -> io::Result<(Self::Io, Self::Addr)> {
+                match self.0.take() {
+                    Some(server) => Ok((server, ())),
+                    None => std::future::pending().await,
+                }
+            }
+
+            fn local_addr(&self) -> io::Result<Self::Addr> {
+                Ok(())
+            }
+        }
+
+        let (client, server) = tokio::io::duplex(1024);
+        let listener = ReadyListener(Some(server));
+
+        let app = Router::new().route("/", get(|| async { "Hello, World!" }));
+
+        tokio::spawn(serve(listener, app).into_future());
+
+        let stream = TokioIo::new(client);
+        let (mut sender, conn) = hyper::client::conn::http1::handshake(stream).await.unwrap();
+        tokio::spawn(conn);
+
+        let request = Request::builder().body(Body::empty()).unwrap();
+
+        let response = sender.send_request(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = Body::new(response.into_body());
+        let body = to_bytes(body, usize::MAX).await.unwrap();
+        let body = String::from_utf8(body.to_vec()).unwrap();
+        assert_eq!(body, "Hello, World!");
+    }
 }

--- a/examples/unix-domain-socket/src/main.rs
+++ b/examples/unix-domain-socket/src/main.rs
@@ -22,17 +22,13 @@ mod unix {
         extract::connect_info::{self, ConnectInfo},
         http::{Method, Request, StatusCode},
         routing::get,
+        serve::IncomingStream,
         Router,
     };
     use http_body_util::BodyExt;
-    use hyper::body::Incoming;
-    use hyper_util::{
-        rt::{TokioExecutor, TokioIo},
-        server,
-    };
-    use std::{convert::Infallible, path::PathBuf, sync::Arc};
+    use hyper_util::rt::TokioIo;
+    use std::{path::PathBuf, sync::Arc};
     use tokio::net::{unix::UCred, UnixListener, UnixStream};
-    use tower::Service;
     use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
     pub async fn server() {
@@ -53,33 +49,11 @@ mod unix {
 
         let uds = UnixListener::bind(path.clone()).unwrap();
         tokio::spawn(async move {
-            let app = Router::new().route("/", get(handler));
+            let app = Router::new()
+                .route("/", get(handler))
+                .into_make_service_with_connect_info::<UdsConnectInfo>();
 
-            let mut make_service = app.into_make_service_with_connect_info::<UdsConnectInfo>();
-
-            // See https://github.com/tokio-rs/axum/blob/main/examples/serve-with-hyper/src/main.rs for
-            // more details about this setup
-            loop {
-                let (socket, _remote_addr) = uds.accept().await.unwrap();
-
-                let tower_service = unwrap_infallible(make_service.call(&socket).await);
-
-                tokio::spawn(async move {
-                    let socket = TokioIo::new(socket);
-
-                    let hyper_service =
-                        hyper::service::service_fn(move |request: Request<Incoming>| {
-                            tower_service.clone().call(request)
-                        });
-
-                    if let Err(err) = server::conn::auto::Builder::new(TokioExecutor::new())
-                        .serve_connection_with_upgrades(socket, hyper_service)
-                        .await
-                    {
-                        eprintln!("failed to serve connection: {err:#}");
-                    }
-                });
-            }
+            axum::serve(uds, app).await.unwrap();
         });
 
         let stream = TokioIo::new(UnixStream::connect(path).await.unwrap());
@@ -118,22 +92,14 @@ mod unix {
         peer_cred: UCred,
     }
 
-    impl connect_info::Connected<&UnixStream> for UdsConnectInfo {
-        fn connect_info(target: &UnixStream) -> Self {
-            let peer_addr = target.peer_addr().unwrap();
-            let peer_cred = target.peer_cred().unwrap();
-
+    impl connect_info::Connected<IncomingStream<'_, UnixListener>> for UdsConnectInfo {
+        fn connect_info(stream: IncomingStream<'_, UnixListener>) -> Self {
+            let peer_addr = stream.io().peer_addr().unwrap();
+            let peer_cred = stream.io().peer_cred().unwrap();
             Self {
                 peer_addr: Arc::new(peer_addr),
                 peer_cred,
             }
-        }
-    }
-
-    fn unwrap_infallible<T>(result: Result<T, Infallible>) -> T {
-        match result {
-            Ok(value) => value,
-            Err(err) => match err {},
         }
     }
 }


### PR DESCRIPTION
Based on https://github.com/tokio-rs/axum/pull/2478

Fixes https://github.com/tokio-rs/axum/issues/2474

It's actually not as bad as I had feared so I think we can do this for 0.8.