### PR TITLE
Make Router Sync without breaking the API

### DIFF
--- a/axum/src/routing/mod.rs
+++ b/axum/src/routing/mod.rs
@@ -682,4 +682,5 @@ impl<S> fmt::Debug for Endpoint<S> {
 fn traits() {
     use crate::test_helpers::*;
     assert_send::<Router<()>>();
+    assert_sync::<Router<()>>();
 }

--- a/axum/src/routing/route.rs
+++ b/axum/src/routing/route.rs
@@ -14,6 +14,7 @@ use std::{
     fmt,
     future::Future,
     pin::Pin,
+    sync::Mutex,
     task::{Context, Poll},
 };
 use tower::{
@@ -27,7 +28,7 @@ use tower_service::Service;
 ///
 /// You normally shouldn't need to care about this type. It's used in
 /// [`Router::layer`](super::Router::layer).
-pub struct Route<E = Infallible>(BoxCloneService<Request, Response, E>);
+pub struct Route<E = Infallible>(Mutex<BoxCloneService<Request, Response, E>>);
 
 impl<E> Route<E> {
     pub(crate) fn new<T>(svc: T) -> Self
@@ -36,16 +37,16 @@ impl<E> Route<E> {
         T::Response: IntoResponse + 'static,
         T::Future: Send + 'static,
     {
-        Self(BoxCloneService::new(
+        Self(Mutex::new(BoxCloneService::new(
             svc.map_response(IntoResponse::into_response),
-        ))
+        )))
     }
 
     pub(crate) fn oneshot_inner(
         &mut self,
         req: Request,
     ) -> Oneshot<BoxCloneService<Request, Response, E>, Request> {
-        self.0.clone().oneshot(req)
+        self.0.get_mut().unwrap().clone().oneshot(req)
     }
 
     pub(crate) fn layer<L, NewError>(self, layer: L) -> Route<NewError>
@@ -70,7 +71,7 @@ impl<E> Route<E> {
 
 impl<E> Clone for Route<E> {
     fn clone(&self) -> Self {
-        Self(self.0.clone())
+        Self(Mutex::new(self.0.lock().unwrap().clone()))
     }
 }
 


### PR DESCRIPTION
## Motivation

https://github.com/tokio-rs/axum/pull/2476 is currently based on https://github.com/tokio-rs/axum/pull/2473, which is a breaking change. Thus, we can't ship it in a patch release for 0.7 to recover performance of existing apps that have upgraded to axum 0.7.

## Solution

Use `Mutex`es in a few places that only ever actually need to be locked for cloning, to make `Router` `Sync` and enable #2476 to be merged as a non-breaking change. For axum 0.8, we can then revert this PR as part of #2473.