### PR TITLE
Add `must_use` attribute to `Serve`

### DIFF
--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -8,8 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # Unreleased
 
 - **fixed:** Improve `debug_handler` on tuple response types ([#2201])
+- **added:** Add `must_use` attribute to `Serve` and `WithGracefulShutdown` ([#2484])
 
 [#2201]: https://github.com/tokio-rs/axum/pull/2201
+[#2484]: https://github.com/tokio-rs/axum/pull/2484
 
 # 0.7.3 (29. December, 2023)
 

--- a/axum/src/serve.rs
+++ b/axum/src/serve.rs
@@ -108,6 +108,7 @@ where
 
 /// Future returned by [`serve`].
 #[cfg(all(feature = "tokio", any(feature = "http1", feature = "http2")))]
+#[must_use = "futures must be awaited or polled"]
 pub struct Serve<M, S> {
     tcp_listener: TcpListener,
     make_service: M,
@@ -234,6 +235,7 @@ where
 
 /// Serve future with graceful shutdown enabled.
 #[cfg(all(feature = "tokio", any(feature = "http1", feature = "http2")))]
+#[must_use = "futures must be awaited or polled"]
 pub struct WithGracefulShutdown<M, S, F> {
     tcp_listener: TcpListener,
     make_service: M,


### PR DESCRIPTION
This commit adds the `must_use` attribute to `Serve` and `WithGracefulShutdown` so that a failure to await these raises a diagnostic message.

## Motivation

Whilst adding `with_graceful_shutdown` to an existing `Serve` I inadvertently removed the await, and then wasted more time than I care to admit barking up the wrong tree and trying to figure out why my signal was firing immediately. This change would have alerted me to my mistake much quicker, and so I thought I would take this opportunity to add it for any future developers who make the same error.

## Solution

This change causes the following message to be emitted when the `Serve` or `WithGracefulShutdown` types are not used in some fashion:-

```
warning: unused `WithGracefulShutdown` that must be used
  --> backend/src/main.rs:44:5
   |
44 |     axum::serve(listener, app).with_graceful_shutdown(shutdown_signal());
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: futures must be awaited or polled
   = note: `#[warn(unused_must_use)]` on by default
help: use `let _ = ...` to ignore the resulting value
   |
44 |     let _ = axum::serve(listener, app).with_graceful_shutdown(shutdown_signal());
   |     +++++++
```
