### PR TITLE
feat(typed_header_rejection): add is_missing utility to the reason

### DIFF
--- a/axum-extra/CHANGELOG.md
+++ b/axum-extra/CHANGELOG.md
@@ -9,8 +9,10 @@ and this project adheres to [Semantic Versioning].
 
 - **added:** Implement `TypedPath` for `WithRejection<TypedPath, _>`
 - **fixed:** Documentation link to `serde::Deserialize` in `JsonDeserializer` extractor ([#2498])
+- **added:** Add `is_missing` function for `TypedHeaderRejection` and `TypedHeaderRejectionReason` ([#2503])
 
 [#2498]: https://github.com/tokio-rs/axum/pull/2498
+[#2503]: https://github.com/tokio-rs/axum/pull/2503
 
 # 0.9.1 (29. December, 2023)
 

--- a/axum-extra/src/typed_header.rs
+++ b/axum-extra/src/typed_header.rs
@@ -123,6 +123,14 @@ impl TypedHeaderRejection {
     pub fn reason(&self) -> &TypedHeaderRejectionReason {
         &self.reason
     }
+
+    /// Returns `true` if the typed header rejection reason is [`Missing`].
+    ///
+    /// [`Missing`]: TypedHeaderRejectionReason::Missing
+    #[must_use]
+    pub fn is_missing(&self) -> bool {
+        self.reason.is_missing()
+    }
 }
 
 /// Additional information regarding a [`TypedHeaderRejection`]
@@ -134,6 +142,16 @@ pub enum TypedHeaderRejectionReason {
     Missing,
     /// An error occurred when parsing the header from the HTTP request
     Error(headers::Error),
+}
+
+impl TypedHeaderRejectionReason {
+    /// Returns `true` if the typed header rejection reason is [`Missing`].
+    ///
+    /// [`Missing`]: TypedHeaderRejectionReason::Missing
+    #[must_use]
+    pub fn is_missing(&self) -> bool {
+        matches!(self, Self::Missing)
+    }
 }
 
 impl IntoResponse for TypedHeaderRejection {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

It's hard, when creating your own extractor, to check if a `TypedHeader` is missing or there was an actual error. The `TypedHeaderRejectionReason` doesn't/can't implement `PartialEq` since it include the [headers_core](https://docs.rs/headers-core/0.3.0/headers_core/index.html)::[Error](https://docs.rs/headers-core/0.3.0/headers_core/struct.Error.html#) variant, so you need to add a match to check.

```rust
match typed_header {
   Ok(_) => todo!(),
   Err(err) if matches!(err.reason(), TypedHeaderRejectionReason::Missing)  => todo!(),
   Err(_) => todo!()
}
```

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
Add a utility function to check if the `TypedHeaderRejection` is missing. Example:

```rust
match typed_header {
   Ok(_) => todo!(),
   Err(err) if err.is_missing() => todo!(),
   Err(err) => todo!()
}
```