### PR TITLE
Re-export `BodyDataStream` from axum

### DIFF
--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **fixed:** Improve `debug_handler` on tuple response types ([#2201])
 - **added:** Add `must_use` attribute to `Serve` and `WithGracefulShutdown` ([#2484])
+- **added:** Re-export `axum_core::body::BodyDataStream` from axum
 
 [#2201]: https://github.com/tokio-rs/axum/pull/2201
 [#2484]: https://github.com/tokio-rs/axum/pull/2484

--- a/axum/src/body/mod.rs
+++ b/axum/src/body/mod.rs
@@ -7,7 +7,7 @@ pub use http_body::Body as HttpBody;
 pub use bytes::Bytes;
 
 #[doc(inline)]
-pub use axum_core::body::Body;
+pub use axum_core::body::{Body, BodyDataStream};
 
 use http_body_util::{BodyExt, Limited};
 


### PR DESCRIPTION
Happened to notice that `BodyDataStream` wasn't re-exported by axum. So you had to depend on axum-core to name that type.