### PR TITLE
Add note about missing CSRF validation in oauth example

### DIFF
--- a/examples/oauth/src/main.rs
+++ b/examples/oauth/src/main.rs
@@ -143,6 +143,11 @@ async fn index(user: Option<User>) -> impl IntoResponse {
 }
 
 async fn discord_auth(State(client): State<BasicClient>) -> impl IntoResponse {
+    // TODO: this example currently doesn't validate the CSRF token during login attempts. That
+    // makes it vulnerable to cross-site request forgery. If you copy code from this example make
+    // sure to add a check for the CSRF token.
+    //
+    // Issue for adding check to this example https://github.com/tokio-rs/axum/issues/2511
     let (auth_url, _csrf_token) = client
         .authorize_url(CsrfToken::new_random)
         .add_scope(Scope::new("identify".to_string()))


### PR DESCRIPTION
Was recently made aware that our oauth example doesn't check the CSRF token. This adds a note to the example so people at least are aware of it. Also made an issue to get it fixed https://github.com/tokio-rs/axum/issues/2511