### PR TITLE
Update axum prometheus-metrics example

### DIFF
--- a/examples/prometheus-metrics/Cargo.toml
+++ b/examples/prometheus-metrics/Cargo.toml
@@ -6,8 +6,8 @@ publish = false
 
 [dependencies]
 axum = { path = "../../axum" }
-metrics = "0.18"
-metrics-exporter-prometheus = "0.8"
+metrics = { version ="0.22", default-features = false }
+metrics-exporter-prometheus = { version ="0.13", default-features = false }
 tokio = { version = "1.0", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/prometheus-metrics/Cargo.toml
+++ b/examples/prometheus-metrics/Cargo.toml
@@ -6,8 +6,8 @@ publish = false
 
 [dependencies]
 axum = { path = "../../axum" }
-metrics = { version ="0.22", default-features = false }
-metrics-exporter-prometheus = { version ="0.13", default-features = false }
+metrics = { version = "0.22", default-features = false }
+metrics-exporter-prometheus = { version = "0.13", default-features = false }
 tokio = { version = "1.0", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/prometheus-metrics/src/main.rs
+++ b/examples/prometheus-metrics/src/main.rs
@@ -101,8 +101,8 @@ async fn track_metrics(req: Request, next: Next) -> impl IntoResponse {
 
     let response = next.run(req).await;
 
-    let latency = start.elapsed().as_secs_f64();
-    let status = response.status().as_u16().to_string();
+    metrics::counter!("http_requests_total", &labels).increment(1);
+    metrics::histogram!("http_requests_duration_seconds", &labels).record(latency);
 
     let labels = [
         ("method", method.to_string()),

--- a/examples/prometheus-metrics/src/main.rs
+++ b/examples/prometheus-metrics/src/main.rs
@@ -110,8 +110,8 @@ async fn track_metrics(req: Request, next: Next) -> impl IntoResponse {
         ("status", status),
     ];
 
-    metrics::increment_counter!("http_requests_total", &labels);
-    metrics::histogram!("http_requests_duration_seconds", latency, &labels);
+    metrics::counter!("http_requests_total", &labels).increment(1);
+    metrics::histogram!("http_requests_duration_seconds", &labels).record(latency);
 
     response
 }

--- a/examples/prometheus-metrics/src/main.rs
+++ b/examples/prometheus-metrics/src/main.rs
@@ -101,8 +101,8 @@ async fn track_metrics(req: Request, next: Next) -> impl IntoResponse {
 
     let response = next.run(req).await;
 
-    metrics::counter!("http_requests_total", &labels).increment(1);
-    metrics::histogram!("http_requests_duration_seconds", &labels).record(latency);
+    let latency = start.elapsed().as_secs_f64();
+    let status = response.status().as_u16().to_string();
 
     let labels = [
         ("method", method.to_string()),


### PR DESCRIPTION
Hello!

## Motivation

Crates **metrics 0.22.x** and **metrics-exporter-prometheus 0.13.x** contains breaking changes. The syntax of some macros in the current repository has been changed.

