### PR TITLE
Improve documentation of `axum_extra::extract::Query`

### DIFF
--- a/axum-extra/src/extract/query.rs
+++ b/axum-extra/src/extract/query.rs
@@ -55,7 +55,7 @@ use std::fmt;
 /// While `Option<T>` will handle empty parameters (e.g. `param=`), beware when using this with a
 /// `Vec<T>`. If your list is optional, use `Vec<T>` in combination with `#[serde(default)]`
 /// instead of `Option<Vec<T>>`. `Option<Vec<T>>` will handle 0, 2, or more arguments, but not one
-/// argument. For details, see [the documentation of `serde_html_form`].
+/// argument.
 ///
 /// # Example
 ///
@@ -78,8 +78,6 @@ use std::fmt;
 /// let app = Router::new().route("/process_items", get(process_items));
 /// # let _: Router = app;
 /// ```
-///
-/// [the documentation of `serde_html_form`]: https://docs.rs/serde_html_form/0.2.3/serde_html_form/index.html
 #[cfg_attr(docsrs, doc(cfg(feature = "query")))]
 #[derive(Debug, Clone, Copy, Default)]
 pub struct Query<T>(pub T);

--- a/axum-extra/src/extract/query.rs
+++ b/axum-extra/src/extract/query.rs
@@ -51,6 +51,35 @@ use std::fmt;
 /// example.
 ///
 /// [example]: https://github.com/tokio-rs/axum/blob/main/examples/query-params-with-empty-strings/src/main.rs
+///
+/// While `Option<T>` will handle empty parameters (e.g. `param=`), beware when using this with a
+/// `Vec<T>`. If your list is optional, use `Vec<T>` in combination with `#[serde(default)]`
+/// instead of `Option<Vec<T>>`. `Option<Vec<T>>` will handle 0, 2, or more arguments, but not one
+/// argument. For details, see [the documentation of `serde_html_form`].
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use axum::{routing::get, Router};
+/// use axum_extra::extract::Query;
+/// use serde::Deserialize;
+///
+/// #[derive(Deserialize)]
+/// struct Params {
+///     #[serde(default)]
+///     items: Vec<usize>,
+/// }
+///
+/// // This will parse 0 occurrences of `items` as an empty `Vec`.
+/// async fn process_items(Query(params): Query<Params>) {
+///     // ...
+/// }
+///
+/// let app = Router::new().route("/process_items", get(process_items));
+/// # let _: Router = app;
+/// ```
+///
+/// [the documentation of `serde_html_form`]: https://docs.rs/serde_html_form/0.2.3/serde_html_form/index.html
 #[cfg_attr(docsrs, doc(cfg(feature = "query")))]
 #[derive(Debug, Clone, Copy, Default)]
 pub struct Query<T>(pub T);

--- a/axum/src/extract/query.rs
+++ b/axum/src/extract/query.rs
@@ -42,6 +42,11 @@ use serde::de::DeserializeOwned;
 /// example.
 ///
 /// [example]: https://github.com/tokio-rs/axum/blob/main/examples/query-params-with-empty-strings/src/main.rs
+///
+/// For handling multiple values for the same query parameter, in a `?foo=1&foo=2&foo=3`
+/// fashion, use [`axum_extra::extract::Query`] instead.
+///
+/// [`axum_extra::extract::Query`]: https://docs.rs/axum-extra/latest/axum_extra/extract/struct.Query.html
 #[cfg_attr(docsrs, doc(cfg(feature = "query")))]
 #[derive(Debug, Clone, Copy, Default)]
 pub struct Query<T>(pub T);


### PR DESCRIPTION
This commit documents a potential footgun with using `Option<Vec<T>>` in query
parameters. It also refers to `axum_extra` in the `axum::extract::Query` docs
for handling multiple values in query parameters.

## Motivation

Some people might be inclined to use `Option<Vec<T>>` for an optional list of
query parameters, because they are used to using `Option<T>` for other, non-list
types. This however has a weird quirk to it, that it handles 0, 2, or more
values correctly, but not 1. `Option<Vec<T>>` is also kind of redundant, and an
empty `Vec<T>` with `#[serde(default)]` should be preferred, as mentioned in the
documentation of `serde_html_form`.

## Solution

Add extra notes and examples about parsing multiple values for query parameters
to `axum_extra::extract::Query` and `axum::extract::Query`.
