### PR TITLE
Fix fallback handlers on nested routers returning 404

### DIFF
--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
-- None.
+- **fixed:** Fallback handlers on nested routers returning 404
 
 # 0.7.4 (13. January, 2024)
 

--- a/axum/src/routing/tests/nest.rs
+++ b/axum/src/routing/tests/nest.rs
@@ -383,6 +383,19 @@ async fn nesting_with_root_inner_router() {
     assert_eq!(res.status(), StatusCode::OK);
 }
 
+#[tokio::test]
+async fn nesting_with_root_inner_fallback() {
+    let app = Router::new().nest("/router", Router::new().fallback(get(|| async {})));
+
+    let client = TestClient::new(app);
+
+    let res = client.get("/router").await;
+    assert_eq!(res.status(), StatusCode::OK);
+
+    let res = client.get("/router/").await;
+    assert_eq!(res.status(), StatusCode::OK);
+}
+
 macro_rules! nested_route_test {
     (
         $name:ident,


### PR DESCRIPTION
## Motivation
The issue #2252 ia about a breaking change  on `fallback` action of a nested `Router`. Previously, if the nested `Router` with a `fallback` is matched,  it should call it's `fallback` when the route is not defined. Example:

https://github.com/dalton-oliveira/axum/blob/1313119b73663ea1f6e461197195ad89248b6e83/axum/src/routing/tests/nest.rs#L387-L397
  
This breaking change was introduced once it started to use [matchit](https://github.com/ibraheemdev/matchit) for routing to the fallback handler. It uses a special [catch-all-parameter](https://github.com/ibraheemdev/matchit?tab=readme-ov-file#catch-all-parameters)  `/*__private__axum_fallback` which does't match _empty_  path which would be the _root_ of the nested router. There's no option for matching `zero-or-more` pattern. There's an open issue [Support optional last param](https://github.com/ibraheemdev/matchit/issues/25) that, once solved, I think would be sufficient for this scenario and thus a better solution too.

## Solution
This changes `Router::nest` to also nest the root  for the `fallback` `PathRouter` 

Fixes #2252 
