### PR TITLE
Implement axum_extra query rejection tracing

### DIFF
--- a/axum-extra/Cargo.toml
+++ b/axum-extra/Cargo.toml
@@ -35,6 +35,7 @@ protobuf = ["dep:prost"]
 query = ["dep:serde_html_form"]
 typed-header = ["dep:headers"]
 typed-routing = ["dep:axum-macros", "dep:percent-encoding", "dep:serde_html_form", "dep:form_urlencoded"]
+tracing = ["dep:tracing"]
 
 [dependencies]
 axum = { path = "../axum", version = "0.7.2", default-features = false }
@@ -65,6 +66,7 @@ serde_path_to_error = { version = "0.1.8", optional = true }
 tokio = { version = "1.19", optional = true }
 tokio-stream = { version = "0.1.9", optional = true }
 tokio-util = { version = "0.7", optional = true }
+tracing = { version = "0.1.40", optional = true }
 
 [dev-dependencies]
 axum = { path = "../axum", version = "0.7.2" }

--- a/axum-extra/src/extract/mod.rs
+++ b/axum-extra/src/extract/mod.rs
@@ -16,6 +16,9 @@ mod json_deserializer;
 #[cfg(feature = "query")]
 mod query;
 
+pub mod rejection;
+pub use rejection::QueryRejection;
+
 #[cfg(feature = "multipart")]
 pub mod multipart;
 
@@ -34,7 +37,7 @@ pub use self::cookie::SignedCookieJar;
 pub use self::form::{Form, FormRejection};
 
 #[cfg(feature = "query")]
-pub use self::query::{OptionalQuery, OptionalQueryRejection, Query, QueryRejection};
+pub use self::query::{OptionalQuery, OptionalQueryRejection, Query};
 
 #[cfg(feature = "multipart")]
 pub use self::multipart::Multipart;

--- a/axum-extra/src/extract/rejection.rs
+++ b/axum-extra/src/extract/rejection.rs
@@ -1,0 +1,22 @@
+use axum_core::__composite_rejection as composite_rejection;
+use axum_core::__define_rejection as define_rejection;
+
+use axum_core::extract::rejection::*;
+
+define_rejection! {
+    #[status = BAD_REQUEST]
+    #[body = "Failed to deserialize query string"]
+    /// Rejection type used if the [`Query`](super::Query) extractor is unable to
+    /// deserialize the query string into the target type.
+    pub struct FailedToDeserializeQueryString(Error);
+}
+
+composite_rejection! {
+    /// Rejection used for [`Query`](super::Query).
+    ///
+    /// Contains one variant for each way the [`Query`](super::Query) extractor
+    /// can fail.
+    pub enum QueryRejection {
+        FailedToDeserializeQueryString,
+    }
+}


### PR DESCRIPTION
This pull request aims to implement rejection tracing for `axum_extra::extract::Query`. Currently, the rejection tracing feature works well for other axum extractor types when using the env_filter feature, but it is not implemented for `axum_extra::extract::Query`.

The **expected behavior** is that rejections from axum_extra::extract::Query should be traced to the terminal when using the rejection tracing feature in Axum.

To address this issue, I have thoroughly investigated how rejection tracing is implemented for the `axum::extract::Query` type. I discovered that a macro from `axum_core` is used for this purpose. However, due to the presence of private fields in some of the generated types, it is not possible to simply import them. As a solution, I have created a new `axum_extra::extract::rejection` submodule and carefully copied the relevant macro calls from `axum::extract::rejection`.

Additionally, I have observed that proper tracing will only occur if the rejection tracing feature is enabled as an optional feature, as indicated by the `#[cfg(feature = "tracing")]` in `axum_core` crate (conditional compilation used):
```rust
/// Private API.
#[doc(hidden)]
#[macro_export]
macro_rules! __log_rejection {
    (
        rejection_type = $ty:ident,
        body_text = $body_text:expr,
        status = $status:expr,
    ) => {
        #[cfg(feature = "tracing")]
        {
            tracing::event!(
                target: "axum::rejection",
                tracing::Level::TRACE,
                status = $status.as_u16(),
                body = $body_text,
                rejection_type = std::any::type_name::<$ty>(),
                "rejecting request",
            );
        }
    };
}
```
With the changes that have been made, the tracing of rejections from `axum_extra::extract::Query` works now ("query" and "tracing" features should be enabled in `axum_extra`).
I have conducted thorough testing by running `cargo test`, and I am pleased to report that all tests have passed successfully.

Furthermore, I have noticed that rejection tracing is not implemented for some types within the `axum_extra` library. If you believe that my approach is on the right track, I would be more than happy to extend this implementation to cover all relevant types.

Thank you for your consideration.