### PR TITLE
feat: add simple tokio redis example

### DIFF
--- a/examples/tokio-redis/Cargo.toml
+++ b/examples/tokio-redis/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "example-tokio-redis"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+axum = { path = "../../axum" }
+bb8 = "0.7.1"
+tokio = { version = "1.0", features = ["full"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+redis = "0.24.0"
+bb8-redis = "0.14.0"

--- a/examples/tokio-redis/Cargo.toml
+++ b/examples/tokio-redis/Cargo.toml
@@ -7,8 +7,8 @@ publish = false
 [dependencies]
 axum = { path = "../../axum" }
 bb8 = "0.7.1"
+bb8-redis = "0.14.0"
+redis = "0.24.0"
 tokio = { version = "1.0", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-redis = "0.24.0"
-bb8-redis = "0.14.0"

--- a/examples/tokio-redis/src/main.rs
+++ b/examples/tokio-redis/src/main.rs
@@ -50,7 +50,7 @@ async fn main() {
         .with_state(pool);
 
     // run it
-    let listener = tokio::net::TcpListener::bind("127.0.0.1:9889")
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:3000")
         .await
         .unwrap();
     tracing::debug!("listening on {}", listener.local_addr().unwrap());

--- a/examples/tokio-redis/src/main.rs
+++ b/examples/tokio-redis/src/main.rs
@@ -89,15 +89,9 @@ where
 }
 
 async fn using_connection_extractor(
-    State(pool): State<ConnectionPool>,
+    DatabaseConnection(mut conn): DatabaseConnection,
 ) -> Result<String, (StatusCode, String)> {
-    let result: String = pool
-        .get()
-        .await
-        .map_err(internal_error)?
-        .get("foo")
-        .await
-        .map_err(internal_error)?;
+    let result: String = conn.get("foo").await.map_err(internal_error)?;
 
     Ok(result)
 }

--- a/examples/tokio-redis/src/main.rs
+++ b/examples/tokio-redis/src/main.rs
@@ -1,0 +1,112 @@
+//! Run with
+//!
+//! ```not_rust
+//! cargo run -p example-tokio-redis
+//! ```
+
+use axum::{
+    async_trait,
+    extract::{FromRef, FromRequestParts, State},
+    http::{request::Parts, StatusCode},
+    routing::get,
+    Router,
+};
+use bb8::{Pool, PooledConnection};
+use bb8_redis::RedisConnectionManager;
+use redis::AsyncCommands;
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+
+use bb8_redis::bb8;
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::registry()
+        .with(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "example_tokio_redis=debug".into()),
+        )
+        .with(tracing_subscriber::fmt::layer())
+        .init();
+
+    tracing::debug!("connecting to redis");
+    let manager = RedisConnectionManager::new("redis://localhost").unwrap();
+    let pool = bb8::Pool::builder().build(manager).await.unwrap();
+
+    {
+        // ping the database before starting
+        let mut conn = pool.get().await.unwrap();
+        conn.set::<&str, &str, ()>("foo", "bar").await.unwrap();
+        let result: String = conn.get("foo").await.unwrap();
+        assert_eq!(result, "bar");
+    }
+    tracing::debug!("successfully connected to redis and pinged it");
+
+    // build our application with some routes
+    let app = Router::new()
+        .route(
+            "/",
+            get(using_connection_pool_extractor).post(using_connection_extractor),
+        )
+        .with_state(pool);
+
+    // run it
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:9889")
+        .await
+        .unwrap();
+    tracing::debug!("listening on {}", listener.local_addr().unwrap());
+    axum::serve(listener, app).await.unwrap();
+}
+
+type ConnectionPool = Pool<RedisConnectionManager>;
+
+async fn using_connection_pool_extractor(
+    State(pool): State<ConnectionPool>,
+) -> Result<String, (StatusCode, String)> {
+    let mut conn = pool.get().await.map_err(internal_error)?;
+    let result: String = conn.get("foo").await.map_err(internal_error)?;
+    Ok(result)
+}
+
+// we can also write a custom extractor that grabs a connection from the pool
+// which setup is appropriate depends on your application
+struct DatabaseConnection(PooledConnection<'static, RedisConnectionManager>);
+
+#[async_trait]
+impl<S> FromRequestParts<S> for DatabaseConnection
+where
+    ConnectionPool: FromRef<S>,
+    S: Send + Sync,
+{
+    type Rejection = (StatusCode, String);
+
+    async fn from_request_parts(_parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
+        let pool = ConnectionPool::from_ref(state);
+
+        let conn = pool.get_owned().await.map_err(internal_error)?;
+
+        Ok(Self(conn))
+    }
+}
+
+async fn using_connection_extractor(
+    State(pool): State<ConnectionPool>,
+) -> Result<String, (StatusCode, String)> {
+    let result: String = pool
+        .get()
+        .await
+        .map_err(internal_error)?
+        .get("foo")
+        .await
+        .map_err(internal_error)?;
+
+    Ok(result)
+}
+
+/// Utility function for mapping any error into a `500 Internal Server Error`
+/// response.
+fn internal_error<E>(err: E) -> (StatusCode, String)
+where
+    E: std::error::Error,
+{
+    (StatusCode::INTERNAL_SERVER_ERROR, err.to_string())
+}


### PR DESCRIPTION
This PR adds a simple tokio-redis example very similar to the tokio-postgres example

run
```bash
cargo run -p example-tokio-redis
```

test
```bash
curl -X POST http://localhost:3000
# bar
```

resolves: https://github.com/tokio-rs/axum/discussions/702

please let me know if any changes are needed!