### PR TITLE
Fix blocking-mode tcp listener in auto-reload example

### DIFF
--- a/examples/auto-reload/src/main.rs
+++ b/examples/auto-reload/src/main.rs
@@ -16,7 +16,10 @@ async fn main() {
     let mut listenfd = ListenFd::from_env();
     let listener = match listenfd.take_tcp_listener(0).unwrap() {
         // if we are given a tcp listener on listen fd 0, we use that one
-        Some(listener) => TcpListener::from_std(listener).unwrap(),
+        Some(listener) => {
+            listener.set_nonblocking(true).unwrap();
+            TcpListener::from_std(listener).unwrap()
+        }
         // otherwise fall back to local listening
         None => TcpListener::bind("127.0.0.1:3000").await.unwrap(),
     };


### PR DESCRIPTION
## Motivation

TCP listeners should be in non-blocking mode for use with hyper.

## Solution

Call `.set_nonblocking(true)` before converting the std listener to a tokio one.