### PR TITLE
examples: Add wildcard-route

### DIFF
--- a/examples/wildcard-route/Cargo.toml
+++ b/examples/wildcard-route/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "example-wildcard-route"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+axum = { path = "../../axum" }
+tokio = { version = "1.0", features = ["full"] }

--- a/examples/wildcard-route/src/main.rs
+++ b/examples/wildcard-route/src/main.rs
@@ -1,0 +1,24 @@
+//! Run with
+//!
+//! ```not_rust
+//! cargo run -p example-wildcard-route
+//! ```
+
+use axum::{http::Uri, response::Html, routing::get, Router};
+
+#[tokio::main]
+async fn main() {
+    let app = Router::new()
+        .route("/", get(handler))
+        .route("/*rest", get(handler));
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:3000")
+        .await
+        .unwrap();
+    println!("listening on http://{}", listener.local_addr().unwrap());
+    axum::serve(listener, app).await.unwrap();
+}
+
+async fn handler(uri: Uri) -> Html<String> {
+    Html(format!("<h1>uri={uri}</h1>"))
+}


### PR DESCRIPTION
I tried to find examples of wildcard routes but didn't find any with

    cd examples ; git grep 'route(".*\*'

so add such an example.
