### PR TITLE
Run cargo clippy --fix to fix CI

### DIFF
--- a/axum/src/extension.rs
+++ b/axum/src/extension.rs
@@ -87,8 +87,7 @@ where
                     "Extension of type `{}` was not found. Perhaps you forgot to add it? See `axum::Extension`.",
                     std::any::type_name::<T>()
                 ))
-            })
-            .map(|x| x.clone())?;
+            }).cloned()?;
 
         Ok(Extension(value))
     }

--- a/axum/src/test_helpers/mod.rs
+++ b/axum/src/test_helpers/mod.rs
@@ -10,4 +10,5 @@ pub(crate) mod tracing_helpers;
 pub(crate) fn assert_send<T: Send>() {}
 pub(crate) fn assert_sync<T: Sync>() {}
 
+#[allow(dead_code)]
 pub(crate) struct NotSendSync(*const ());


### PR DESCRIPTION
I ran this command:

    cargo +beta clippy --fix --workspace --all-targets --all-features -- -D warnings

which fixes a clippy problem that CI currently complains about: https://github.com/tokio-rs/axum/pull/2567

In the case of `NotSendSync` its unused field is important so that it stays not Send and not Sync. So allow it to be unused.