### PR TITLE
route.md: Add wildcard example code

### DIFF
--- a/axum/src/docs/routing/route.md
+++ b/axum/src/docs/routing/route.md
@@ -56,7 +56,22 @@ Note that `/*key` doesn't match empty segments. Thus:
 - `/*key` doesn't match `/` but does match `/a`, `/a/`, etc.
 - `/x/*key` doesn't match `/x` or `/x/` but does match `/x/a`, `/x/a/`, etc.
 
-Wildcard captures can also be extracted using [`Path`](crate::extract::Path).
+Wildcard captures can also be extracted using [`Path`](crate::extract::Path):
+
+```rust
+use axum::{
+    Router,
+    routing::get,
+    extract::Path,
+};
+
+let app = Router::new().route("/*key", get(handler));
+
+async fn handler(Path(path): Path<String>) -> String {
+    path
+}
+```
+
 Note that the leading slash is not included, i.e. for the route `/foo/*rest` and
 the path `/foo/bar/baz` the value of `rest` will be `bar/baz`.
 

--- a/axum/src/docs/routing/route.md
+++ b/axum/src/docs/routing/route.md
@@ -65,7 +65,7 @@ use axum::{
     extract::Path,
 };
 
-let app = Router::new().route("/*key", get(handler));
+let app: Router = Router::new().route("/*key", get(handler));
 
 async fn handler(Path(path): Path<String>) -> String {
     path


### PR DESCRIPTION
To developers completely new to axum, it helps a lot to give example code on to get access to the variable path in a handler.

Rendered:

![image](https://github.com/tokio-rs/axum/assets/115040/b0779a06-c8a9-4557-bb3b-ae1542220748)

Even if the example is not perfect, my hope is that it will be better than nothing. It certainly would have helped me at least.

But feel free to close this PR if the example is too sloppy.