### PR TITLE
Document usage of concrete state in `FromRequest` macro (#2550)

### DIFF
--- a/axum-macros/src/lib.rs
+++ b/axum-macros/src/lib.rs
@@ -233,6 +233,55 @@ use from_request::Trait::{FromRequest, FromRequestParts};
 /// }
 /// ```
 ///
+/// ## Concrete state
+///
+/// If the extraction can be done only for a concrete state, that type can be specified with
+/// `#[from_request(state(YourState))]`:
+///
+/// ```
+/// use axum::extract::{FromRequest, FromRequestParts};
+///
+/// #[derive(Clone)]
+/// struct CustomState;
+///
+/// struct MyInnerType;
+///
+/// #[axum::async_trait]
+/// impl FromRequestParts<CustomState> for MyInnerType {
+///     // ...
+///     # type Rejection = ();
+///
+///     # async fn from_request_parts(
+///         # _parts: &mut axum::http::request::Parts,
+///         # _state: &CustomState
+///     # ) -> Result<Self, Self::Rejection> {
+///     #    todo!()
+///     # }
+/// }
+///
+/// #[derive(FromRequest)]
+/// #[from_request(state(CustomState))]
+/// struct MyExtractor {
+///     custom: MyInnerType,
+///     body: String,
+/// }
+/// ```
+///
+/// This is not needed for a `State<T>` as the type is inferred in that case.
+///
+/// ```
+/// use axum::extract::{FromRequest, FromRequestParts, State};
+///
+/// #[derive(Clone)]
+/// struct CustomState;
+///
+/// #[derive(FromRequest)]
+/// struct MyExtractor {
+///     custom: State<CustomState>,
+///     body: String,
+/// }
+/// ```
+///
 /// # The whole type at once
 ///
 /// By using `#[from_request(via(...))]` on the container you can extract the whole type at once,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation

The feature was not documented, #2550 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

Added a documentation with example to the macro. `FromRequestParts` links back to `FromRequest` for information about its options so nothing is needed there.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
