### PR TITLE
Add rejection tracing to all extractors (#2526)

### DIFF
--- a/axum-extra/CHANGELOG.md
+++ b/axum-extra/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning].
 
 # Unreleased
 
-- None.
+- **added:** New `tracing` feature which enables logging rejections from
+  built-in extractor with the `axum::rejection=trace` target ([#2596])
 
 # 0.9.2 (13. January, 2024)
 

--- a/axum-extra/Cargo.toml
+++ b/axum-extra/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/tokio-rs/axum"
 version = "0.9.2"
 
 [features]
-default = []
+default = ["tracing"]
 
 async-read-body = ["dep:tokio-util", "tokio-util?/io", "dep:tokio"]
 cookie = ["dep:cookie"]
@@ -33,6 +33,7 @@ json-lines = [
 multipart = ["dep:multer"]
 protobuf = ["dep:prost"]
 query = ["dep:serde_html_form"]
+tracing = ["dep:tracing", "axum-core/tracing"]
 typed-header = ["dep:headers"]
 typed-routing = ["dep:axum-macros", "dep:percent-encoding", "dep:serde_html_form", "dep:form_urlencoded"]
 
@@ -65,6 +66,7 @@ serde_path_to_error = { version = "0.1.8", optional = true }
 tokio = { version = "1.19", optional = true }
 tokio-stream = { version = "0.1.9", optional = true }
 tokio-util = { version = "0.7", optional = true }
+tracing = { version = "0.1.37", default-features = false, optional = true }
 
 [dev-dependencies]
 axum = { path = "../axum", version = "0.7.2" }

--- a/axum-extra/src/extract/form.rs
+++ b/axum-extra/src/extract/form.rs
@@ -81,11 +81,16 @@ impl IntoResponse for FormRejection {
     fn into_response(self) -> Response {
         match self {
             Self::RawFormRejection(inner) => inner.into_response(),
-            Self::FailedToDeserializeForm(inner) => (
-                StatusCode::BAD_REQUEST,
-                format!("Failed to deserialize form: {inner}"),
-            )
-                .into_response(),
+            Self::FailedToDeserializeForm(inner) => {
+                let body = format!("Failed to deserialize form: {inner}");
+                let status = StatusCode::BAD_REQUEST;
+                axum_core::__log_rejection!(
+                    rejection_type = Self,
+                    body_text = body,
+                    status = status,
+                );
+                (status, body).into_response()
+            }
         }
     }
 }

--- a/axum-extra/src/extract/multipart.rs
+++ b/axum-extra/src/extract/multipart.rs
@@ -379,7 +379,13 @@ pub struct InvalidBoundary;
 
 impl IntoResponse for InvalidBoundary {
     fn into_response(self) -> Response {
-        (self.status(), self.body_text()).into_response()
+        let body = self.body_text();
+        axum_core::__log_rejection!(
+            rejection_type = Self,
+            body_text = body,
+            status = self.status(),
+        );
+        (self.status(), body).into_response()
     }
 }
 

--- a/axum-extra/src/extract/query.rs
+++ b/axum-extra/src/extract/query.rs
@@ -114,11 +114,16 @@ pub enum QueryRejection {
 impl IntoResponse for QueryRejection {
     fn into_response(self) -> Response {
         match self {
-            Self::FailedToDeserializeQueryString(inner) => (
-                StatusCode::BAD_REQUEST,
-                format!("Failed to deserialize query string: {inner}"),
-            )
-                .into_response(),
+            Self::FailedToDeserializeQueryString(inner) => {
+                let body = format!("Failed to deserialize query string: {inner}");
+                let status = StatusCode::BAD_REQUEST;
+                axum_core::__log_rejection!(
+                    rejection_type = Self,
+                    body_text = body,
+                    status = status,
+                );
+                (status, body).into_response()
+            }
         }
     }
 }

--- a/axum-extra/src/lib.rs
+++ b/axum-extra/src/lib.rs
@@ -21,6 +21,7 @@
 //! `multipart` | Enables the `Multipart` extractor | No
 //! `protobuf` | Enables the `Protobuf` extractor and response | No
 //! `query` | Enables the `Query` extractor | No
+//! `tracing` | Log rejections from built-in extractors | Yes
 //! `typed-routing` | Enables the `TypedPath` routing utilities | No
 //! `typed-header` | Enables the `TypedHeader` extractor and response  | No
 //!

--- a/axum/src/extract/multipart.rs
+++ b/axum/src/extract/multipart.rs
@@ -274,12 +274,13 @@ impl std::error::Error for MultipartError {
 
 impl IntoResponse for MultipartError {
     fn into_response(self) -> Response {
+        let body = self.body_text();
         axum_core::__log_rejection!(
             rejection_type = Self,
-            body_text = self.body_text(),
+            body_text = body,
             status = self.status(),
         );
-        (self.status(), self.body_text()).into_response()
+        (self.status(), body).into_response()
     }
 }
 

--- a/axum/src/extract/path/mod.rs
+++ b/axum/src/extract/path/mod.rs
@@ -398,12 +398,13 @@ impl FailedToDeserializePathParams {
 
 impl IntoResponse for FailedToDeserializePathParams {
     fn into_response(self) -> Response {
+        let body = self.body_text();
         axum_core::__log_rejection!(
             rejection_type = Self,
-            body_text = self.body_text(),
+            body_text = body,
             status = self.status(),
         );
-        (self.status(), self.body_text()).into_response()
+        (self.status(), body).into_response()
     }
 }
 
@@ -530,7 +531,13 @@ impl std::error::Error for InvalidUtf8InPathParam {}
 
 impl IntoResponse for InvalidUtf8InPathParam {
     fn into_response(self) -> Response {
-        (self.status(), self.body_text()).into_response()
+        let body = self.body_text();
+        axum_core::__log_rejection!(
+            rejection_type = Self,
+            body_text = body,
+            status = self.status(),
+        );
+        (self.status(), body).into_response()
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation

Rejection tracing was missing at some points.
Closes #2526


## Solution

This should add the tracing eveyrwhere, I searched by `into_response` implementations.

I've also changed the places where it already was to call `body_text` only once as it makes an unnecessary copy of the string.
