### PR TITLE
docs: circumvent oddities with SSE and compression

### DIFF
--- a/axum/src/response/sse.rs
+++ b/axum/src/response/sse.rs
@@ -32,10 +32,11 @@
 //! latest events. If you're using that layer, you can do the following to not
 //! compress SSE:
 //!
-//! ```ignore
-//! CompressionLayer::new()
-//!     .compress_when(DefaultPredicate::new()
-//!     .and(NotForContentType::new("text/event-stream"))
+//! ```
+//! # use tower_http::compression::{predicate::{NotForContentType, DefaultPredicate}, Predicate, CompressionLayer};
+//! let predicate = DefaultPredicate::new().and(NotForContentType::new("text/event-stream"));
+//!
+//! let layer = CompressionLayer::new().compress_when(predicate);
 //! ```
 
 use crate::{

--- a/axum/src/response/sse.rs
+++ b/axum/src/response/sse.rs
@@ -24,6 +24,19 @@
 //! }
 //! # let _: Router = app;
 //! ```
+//!
+//! ## Compression
+//!
+//! By default, using the `tower-http` [compression layer](https://docs.rs/tower-http/latest/tower_http/compression/index.html)
+//! with SSE will break the functionality of SSE where you will miss all or only
+//! latest events. If you're using that layer, you can do the following to not
+//! compress SSE:
+//!
+//! ```ignore
+//! CompressionLayer::new()
+//!     .compress_when(DefaultPredicate::new()
+//!     .and(NotForContentType::new("text/event-stream"))
+//! ```
 
 use crate::{
     body::{Bytes, HttpBody},


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

I was working with SSEs for my personal project and wasn't able to figure out why sometimes I received some events, only if the events were big. Thought it was something with Chrome, Firefox, or Postman. Was able to view the full response with curl but not within the rest.

After trying different things, I saw https://github.com/tokio-rs/axum/discussions/2034#discussioncomment-6120929 and it fixed my issue.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

The solution is to either remove the compression layer itself or to add an exception for SSEs. I've added a note on that in the docs related to SSEs
