### PR TITLE
Fix layers being cloned for each request

### DIFF
--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -7,7 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
-- None.
+- **fixed:** Fixed layers being cloned when calling `axum::serve` directly with
+  a `Router` or `MethodRouter` ([#2586])
+
+[#2586]: https://github.com/tokio-rs/axum/pull/2586
 
 # 0.7.4 (13. January, 2024)
 

--- a/axum/src/routing/method_routing.rs
+++ b/axum/src/routing/method_routing.rs
@@ -1239,7 +1239,7 @@ const _: () = {
         }
 
         fn call(&mut self, _req: IncomingStream<'_>) -> Self::Future {
-            std::future::ready(Ok(self.clone()))
+            std::future::ready(Ok(self.clone().with_state(())))
         }
     }
 };

--- a/axum/src/routing/mod.rs
+++ b/axum/src/routing/mod.rs
@@ -492,7 +492,9 @@ const _: () = {
         }
 
         fn call(&mut self, _req: IncomingStream<'_>) -> Self::Future {
-            std::future::ready(Ok(self.clone()))
+            // call `Router::with_state` such that everything is turned into `Route` eagerly
+            // rather than doing that per request
+            std::future::ready(Ok(self.clone().with_state(())))
         }
     }
 };


### PR DESCRIPTION
I would expect https://github.com/tokio-rs/axum/issues/2582 to work since we no longer clone the whole router for each request (https://github.com/tokio-rs/axum/pull/2483).

Turns out we were missing a `.with_state(())` to eagerly apply layers like we used to do for [`.into_ make_service()`](https://github.com/tokio-rs/axum/blob/main/axum/src/routing/mod.rs#L468). This might also have a performance impact.

edit(jplatte): Closes #2582.