### PR TITLE
chore: remove h2 from dependencies when http2 feature is off

### DIFF
--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -10,9 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **fixed:** Fixed layers being cloned when calling `axum::serve` directly with
   a `Router` or `MethodRouter` ([#2586])
 - **fixed:** `h2` is no longer pulled as a dependency unless the `http2` feature
-  is enabled feature is enabled ([#2605])
+  is enabled ([#2605])
 
 [#2586]: https://github.com/tokio-rs/axum/pull/2586
+[#2605]: https://github.com/tokio-rs/axum/pull/2605
 
 # 0.7.4 (13. January, 2024)
 

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **fixed:** Fixed layers being cloned when calling `axum::serve` directly with
   a `Router` or `MethodRouter` ([#2586])
+- **fixed:** `h2` is no longer pulled as a dependency unless the `http2` feature
+  is enabled feature is enabled ([#2605])
 
 [#2586]: https://github.com/tokio-rs/axum/pull/2586
 

--- a/axum/Cargo.toml
+++ b/axum/Cargo.toml
@@ -24,8 +24,8 @@ default = [
     "tracing",
 ]
 form = ["dep:serde_urlencoded"]
-http1 = ["dep:hyper", "hyper?/http1"]
-http2 = ["dep:hyper", "hyper?/http2"]
+http1 = ["dep:hyper", "hyper?/http1", "hyper-util?/http1"]
+http2 = ["dep:hyper", "hyper?/http2", "hyper-util?/http2"]
 json = ["dep:serde_json", "dep:serde_path_to_error"]
 macros = ["dep:axum-macros"]
 matched-path = []
@@ -64,7 +64,7 @@ tower-service = "0.3"
 axum-macros = { path = "../axum-macros", version = "0.4.1", optional = true }
 base64 = { version = "0.21.0", optional = true }
 hyper = { version = "1.1.0", optional = true }
-hyper-util = { version = "0.1.2", features = ["tokio", "server", "server-auto"], optional = true }
+hyper-util = { version = "0.1.2", features = ["tokio", "server"], optional = true }
 multer = { version = "3.0.0", optional = true }
 serde_json = { version = "1.0", features = ["raw_value"], optional = true }
 serde_path_to_error = { version = "0.1.8", optional = true }

--- a/axum/Cargo.toml
+++ b/axum/Cargo.toml
@@ -64,7 +64,7 @@ tower-service = "0.3"
 axum-macros = { path = "../axum-macros", version = "0.4.1", optional = true }
 base64 = { version = "0.21.0", optional = true }
 hyper = { version = "1.1.0", optional = true }
-hyper-util = { version = "0.1.2", features = ["tokio", "server"], optional = true }
+hyper-util = { version = "0.1.3", features = ["tokio", "server"], optional = true }
 multer = { version = "3.0.0", optional = true }
 serde_json = { version = "1.0", features = ["raw_value"], optional = true }
 serde_path_to_error = { version = "0.1.8", optional = true }

--- a/axum/src/serve.rs
+++ b/axum/src/serve.rs
@@ -16,10 +16,9 @@ use std::{
 use axum_core::{body::Body, extract::Request, response::Response};
 use futures_util::{pin_mut, FutureExt};
 use hyper::body::Incoming;
-use hyper_util::{
-    rt::{TokioExecutor, TokioIo},
-    server::conn::auto::Builder,
-};
+use hyper_util::rt::{TokioExecutor, TokioIo};
+#[cfg(any(feature = "http1", feature = "http2"))]
+use hyper_util::server::conn::auto::Builder;
 use pin_project_lite::pin_project;
 use tokio::{
     net::{TcpListener, TcpStream},


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation

Closes #2386 

`h2` does not need to be a dependency when the feature `http2` is not enabled.

## Solution

I've changed the features of `hyper-util` we depend on conditionally.

`cargo tree -i h2 --features default,macros,multipart,ws --edges no-dev` prints nothing so the dependency is not there anymore.
