### PR TITLE
fix typo in prometheus_metrics_example

### DIFF
--- a/examples/prometheus-metrics/src/main.rs
+++ b/examples/prometheus-metrics/src/main.rs
@@ -64,7 +64,7 @@ async fn main() {
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "example_todos=debug,tower_http=debug".into()),
+                .unwrap_or_else(|_| "example_prometheus_metrics=debug,tower_http=debug".into()),
         )
         .with(tracing_subscriber::fmt::layer())
         .init();


### PR DESCRIPTION
the target name was wrong in prometheus_metrics_example.