### PR TITLE
Make axum generic over it's Listener type

### DIFF
--- a/axum-core/src/lib.rs
+++ b/axum-core/src/lib.rs
@@ -1,4 +1,3 @@
-#![cfg_attr(nightly_error_messages, feature(diagnostic_namespace))]
 //! Core types and traits for [`axum`].
 //!
 //! Libraries authors that want to provide [`FromRequest`] or [`IntoResponse`] implementations

--- a/axum-core/src/lib.rs
+++ b/axum-core/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(nightly_error_messages, feature(diagnostic_namespace))]
 //! Core types and traits for [`axum`].
 //!
 //! Libraries authors that want to provide [`FromRequest`] or [`IntoResponse`] implementations

--- a/axum/src/accept.rs
+++ b/axum/src/accept.rs
@@ -1,4 +1,4 @@
-use std::fmt::Debug;
+use std::{fmt::Debug, path::PathBuf};
 
 use async_trait::async_trait;
 use hyper::rt::{Read, Write};
@@ -46,10 +46,12 @@ impl Accept for TcpListener {
 #[cfg(feature = "tokio")]
 impl Accept for UnixListener {
     type Target = TokioIo<UnixStream>;
-    type Addr = tokio::net::unix::SocketAddr;
+    type Addr = Option<PathBuf>;
 
     async fn accept(&self) -> std::io::Result<(Self::Target, Self::Addr)> {
-        self.accept().await.map(|t| (TokioIo::new(t.0), t.1))
+        self.accept()
+            .await
+            .map(|t| (TokioIo::new(t.0), t.1.as_pathname().map(|p| p.into())))
     }
 }
 

--- a/axum/src/accept.rs
+++ b/axum/src/accept.rs
@@ -4,8 +4,10 @@ use async_trait::async_trait;
 use hyper::rt::{Read, Write};
 #[cfg(feature = "tokio")]
 use hyper_util::rt::TokioIo;
+#[cfg(all(unix, feature = "tokio"))]
+use tokio::net::{unix::UCred, UnixListener, UnixStream};
 #[cfg(feature = "tokio")]
-use tokio::net::{unix::UCred, TcpListener, TcpStream, UnixListener, UnixStream};
+use tokio::net::{TcpListener, TcpStream};
 
 /// A trait that provides a generic API for accepting connections
 /// from any server type which listens on an address of some kind
@@ -44,7 +46,7 @@ impl Accept for TcpListener {
 
 #[derive(Clone, Debug)]
 #[allow(dead_code)]
-#[cfg(feature = "tokio")]
+#[cfg(all(unix, feature = "tokio"))]
 /// The associate SocketAddr type for the [`UnixStream`] type
 pub struct UdsConnectInfo {
     /// Contains the path to the unix socket
@@ -54,7 +56,7 @@ pub struct UdsConnectInfo {
 }
 
 #[async_trait]
-#[cfg(feature = "tokio")]
+#[cfg(all(unix, feature = "tokio"))]
 impl Accept for UnixListener {
     type Target = TokioIo<UnixStream>;
     type Addr = UdsConnectInfo;
@@ -82,7 +84,7 @@ impl LocalAddr for TokioIo<TcpStream> {
     }
 }
 
-#[cfg(feature = "tokio")]
+#[cfg(all(unix, feature = "tokio"))]
 impl LocalAddr for TokioIo<UnixStream> {
     type Addr = tokio::net::unix::SocketAddr;
 

--- a/axum/src/accept.rs
+++ b/axum/src/accept.rs
@@ -14,7 +14,7 @@ pub trait Accept: Send {
     /// When a connection is accepted from the Listener type, it must
     /// be transformed into the Target type so that [`hyper`] can Read
     /// from it and Write to it
-    type Target: Read + Write + LocalAddr + Unpin + Send;
+    type Target: Read + Write + LocalAddr + Unpin + Send + Sync;
     /// The SocketAddr associated with the given Listener type
     type Addr: Debug + Send;
 

--- a/axum/src/accept.rs
+++ b/axum/src/accept.rs
@@ -12,13 +12,13 @@ use tokio::net::{TcpListener, TcpStream};
 /// A trait that provides a generic API for accepting connections
 /// from any server type which listens on an address of some kind
 #[async_trait]
-pub trait Accept: Send {
+pub trait Accept: Send + Sync + 'static {
     /// When a connection is accepted from the Listener type, it must
     /// be transformed into the Target type so that [`hyper`] can Read
     /// from it and Write to it
     type Target: Read + Write + LocalAddr + Unpin + Send + Sync;
     /// The SocketAddr associated with the given Listener type
-    type Addr: Debug + Send;
+    type Addr: Debug + Send + Sync + Clone;
 
     /// Accept a new incoming connection from this Listener
     async fn accept(&self) -> std::io::Result<(Self::Target, Self::Addr)>;

--- a/axum/src/accept.rs
+++ b/axum/src/accept.rs
@@ -1,0 +1,72 @@
+use std::fmt::Debug;
+
+use async_trait::async_trait;
+use hyper::rt::{Read, Write};
+#[cfg(feature = "tokio")]
+use hyper_util::rt::TokioIo;
+#[cfg(feature = "tokio")]
+use tokio::net::{TcpListener, TcpStream, UnixListener, UnixStream};
+
+/// A trait that provides a generic API for accepting connections
+/// from any server type which listens on an address of some kind
+#[async_trait]
+pub trait Accept: Send {
+    /// When a connection is accepted from the Listener type, it must
+    /// be transformed into the Target type so that [`hyper`] can Read
+    /// from it and Write to it
+    type Target: Read + Write + LocalAddr + Unpin + Send;
+    /// The SocketAddr associated with the given Listener type
+    type Addr: Debug + Send;
+
+    /// Accept a new incoming connection from this Listener
+    async fn accept(&self) -> std::io::Result<(Self::Target, Self::Addr)>;
+}
+
+/// Gets the local SocketAddr off the given type
+pub trait LocalAddr {
+    /// The SocketAddr associated with the given type
+    type Addr;
+
+    /// Calls local_addr on the given type
+    fn local_addr(&self) -> std::io::Result<Self::Addr>;
+}
+
+#[async_trait]
+#[cfg(feature = "tokio")]
+impl Accept for TcpListener {
+    type Target = TokioIo<TcpStream>;
+    type Addr = std::net::SocketAddr;
+
+    async fn accept(&self) -> std::io::Result<(Self::Target, Self::Addr)> {
+        self.accept().await.map(|t| (TokioIo::new(t.0), t.1))
+    }
+}
+
+#[async_trait]
+#[cfg(feature = "tokio")]
+impl Accept for UnixListener {
+    type Target = TokioIo<UnixStream>;
+    type Addr = tokio::net::unix::SocketAddr;
+
+    async fn accept(&self) -> std::io::Result<(Self::Target, Self::Addr)> {
+        self.accept().await.map(|t| (TokioIo::new(t.0), t.1))
+    }
+}
+
+#[cfg(feature = "tokio")]
+impl LocalAddr for TokioIo<TcpStream> {
+    type Addr = std::net::SocketAddr;
+
+    fn local_addr(&self) -> std::io::Result<Self::Addr> {
+        self.inner().local_addr()
+    }
+}
+
+#[cfg(feature = "tokio")]
+impl LocalAddr for TokioIo<UnixStream> {
+    type Addr = tokio::net::unix::SocketAddr;
+
+    fn local_addr(&self) -> std::io::Result<Self::Addr> {
+        self.inner().local_addr()
+    }
+}

--- a/axum/src/docs/routing/into_make_service_with_connect_info.md
+++ b/axum/src/docs/routing/into_make_service_with_connect_info.md
@@ -35,6 +35,7 @@ use axum::{
     serve::IncomingStream,
     Router,
 };
+use std::net::SocketAddr;
 
 let app = Router::new().route("/", get(handler));
 
@@ -49,13 +50,9 @@ struct MyConnectInfo {
     // ...
 }
 
-impl<A: axum::LocalAddr, R> Connected<IncomingStream<'_, A, R>> for MyConnectInfo
-where
-    R: Clone + Send + Sync + 'static,
+impl<A: axum::LocalAddr> Connected<IncomingStream<'_, A, SocketAddr>> for MyConnectInfo
 {
-    type Addr = Self;
-
-    fn connect_info(_target: IncomingStream<'_, A, R>) -> Self::Addr {
+    fn connect_info(_target: IncomingStream<'_, A, SocketAddr>) -> Self {
         MyConnectInfo {
             // ...
         }

--- a/axum/src/docs/routing/into_make_service_with_connect_info.md
+++ b/axum/src/docs/routing/into_make_service_with_connect_info.md
@@ -4,7 +4,7 @@ can extract it.
 
 This enables extracting things like the client's remote address.
 
-Extracting [`std::net::SocketAddr`] is supported out of the box:
+Extracting the listening network's `SocketAddr` type is supported out of the box:
 
 ```rust
 use axum::{
@@ -49,8 +49,13 @@ struct MyConnectInfo {
     // ...
 }
 
-impl Connected<IncomingStream<'_>> for MyConnectInfo {
-    fn connect_info(target: IncomingStream<'_>) -> Self {
+impl<A: axum::LocalAddr, R> Connected<IncomingStream<'_, A, R>> for MyConnectInfo
+where
+    R: Clone + Send + Sync + 'static,
+{
+    type Addr = Self;
+
+    fn connect_info(_target: IncomingStream<'_, A, R>) -> Self::Addr {
         MyConnectInfo {
             // ...
         }

--- a/axum/src/extract/connect_info.rs
+++ b/axum/src/extract/connect_info.rs
@@ -82,55 +82,34 @@ where
 ///
 /// [`Router::into_make_service_with_connect_info`]: crate::routing::Router::into_make_service_with_connect_info
 pub trait Connected<T>: Clone + Send + Sync + 'static {
-    /// The SocketAddr type associated with T
-    type Addr: Clone + Send + Sync;
     /// Create type holding information about the connection.
-    fn connect_info(target: T) -> Self::Addr;
+    fn connect_info(target: T) -> Self;
 }
 
 #[cfg(all(feature = "tokio", any(feature = "http1", feature = "http2")))]
 const _: () = {
     use crate::serve::IncomingStream;
 
-    impl<A, R> Connected<IncomingStream<'_, A, R>> for SocketAddr
+    impl<A, R> Connected<IncomingStream<'_, A, R>> for R
     where
         A: crate::LocalAddr,
         R: Clone + Send + Sync,
     {
-        type Addr = R;
-
-        fn connect_info(target: IncomingStream<'_, A, R>) -> Self::Addr {
-            target.remote_addr()
-        }
-    }
-
-    #[cfg(unix)]
-    impl<A, R> Connected<IncomingStream<'_, A, R>> for UdsConnectInfo
-    where
-        A: crate::LocalAddr,
-        R: Clone + Send + Sync,
-    {
-        type Addr = R;
-
-        fn connect_info(target: IncomingStream<'_, A, R>) -> Self::Addr {
+        fn connect_info(target: IncomingStream<'_, A, R>) -> Self {
             target.remote_addr()
         }
     }
 };
 
 impl Connected<SocketAddr> for SocketAddr {
-    type Addr = SocketAddr;
-
-    fn connect_info(remote_addr: SocketAddr) -> Self::Addr {
+    fn connect_info(remote_addr: SocketAddr) -> Self {
         remote_addr
     }
 }
 
 #[cfg(all(feature = "tokio", any(feature = "http1", feature = "http2"), unix))]
 impl Connected<UdsConnectInfo> for UdsConnectInfo {
-    type Addr = UdsConnectInfo;
-
-    fn connect_info(remote_addr: UdsConnectInfo) -> Self::Addr {
+    fn connect_info(remote_addr: UdsConnectInfo) -> Self {
         remote_addr
     }
 }
@@ -139,11 +118,10 @@ impl<S, C, T> Service<T> for IntoMakeServiceWithConnectInfo<S, C>
 where
     S: Clone,
     C: Connected<T>,
-    C::Addr: 'static,
 {
-    type Response = AddExtension<S, ConnectInfo<C::Addr>>;
+    type Response = AddExtension<S, ConnectInfo<C>>;
     type Error = Infallible;
-    type Future = ResponseFuture<S, C::Addr>;
+    type Future = ResponseFuture<S, C>;
 
     #[inline]
     fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
@@ -300,13 +278,8 @@ mod tests {
             value: &'static str,
         }
 
-        impl<A: crate::LocalAddr, R> Connected<IncomingStream<'_, A, R>> for MyConnectInfo
-        where
-            R: Clone + Send + Sync + 'static,
-        {
-            type Addr = Self;
-
-            fn connect_info(_target: IncomingStream<'_, A, R>) -> Self::Addr {
+        impl<A: crate::LocalAddr> Connected<IncomingStream<'_, A, SocketAddr>> for MyConnectInfo {
+            fn connect_info(_target: IncomingStream<'_, A, SocketAddr>) -> Self {
                 Self {
                     value: "it worked!",
                 }

--- a/axum/src/extract/connect_info.rs
+++ b/axum/src/extract/connect_info.rs
@@ -6,7 +6,7 @@
 
 use crate::extension::AddExtension;
 
-#[cfg(all(feature = "tokio", any(feature = "http1", feature = "http2")))]
+#[cfg(all(feature = "tokio", any(feature = "http1", feature = "http2"), unix))]
 use crate::UdsConnectInfo;
 
 use super::{Extension, FromRequestParts};
@@ -104,6 +104,7 @@ const _: () = {
         }
     }
 
+    #[cfg(unix)]
     impl<A, R> Connected<IncomingStream<'_, A, R>> for UdsConnectInfo
     where
         A: crate::LocalAddr,
@@ -125,7 +126,7 @@ impl Connected<SocketAddr> for SocketAddr {
     }
 }
 
-#[cfg(all(feature = "tokio", any(feature = "http1", feature = "http2")))]
+#[cfg(all(feature = "tokio", any(feature = "http1", feature = "http2"), unix))]
 impl Connected<UdsConnectInfo> for UdsConnectInfo {
     type Addr = UdsConnectInfo;
 

--- a/axum/src/extract/connect_info.rs
+++ b/axum/src/extract/connect_info.rs
@@ -4,7 +4,10 @@
 //!
 //! [`Router::into_make_service_with_connect_info`]: crate::routing::Router::into_make_service_with_connect_info
 
-use crate::{accept::UdsConnectInfo, extension::AddExtension};
+use crate::extension::AddExtension;
+
+#[cfg(feature = "tokio")]
+use crate::UdsConnectInfo;
 
 use super::{Extension, FromRequestParts};
 use async_trait::async_trait;

--- a/axum/src/extract/connect_info.rs
+++ b/axum/src/extract/connect_info.rs
@@ -6,7 +6,7 @@
 
 use crate::extension::AddExtension;
 
-#[cfg(feature = "tokio")]
+#[cfg(all(feature = "tokio", any(feature = "http1", feature = "http2")))]
 use crate::UdsConnectInfo;
 
 use super::{Extension, FromRequestParts};

--- a/axum/src/extract/connect_info.rs
+++ b/axum/src/extract/connect_info.rs
@@ -125,7 +125,7 @@ impl Connected<SocketAddr> for SocketAddr {
     }
 }
 
-#[cfg(feature = "tokio")]
+#[cfg(all(feature = "tokio", any(feature = "http1", feature = "http2")))]
 impl Connected<UdsConnectInfo> for UdsConnectInfo {
     type Addr = UdsConnectInfo;
 

--- a/axum/src/handler/service.rs
+++ b/axum/src/handler/service.rs
@@ -182,10 +182,12 @@ where
 const _: () = {
     use crate::serve::IncomingStream;
 
-    impl<H, T, S> Service<IncomingStream<'_>> for HandlerService<H, T, S>
+    impl<H, T, S, A, R> Service<IncomingStream<'_, A, R>> for HandlerService<H, T, S>
     where
         H: Clone,
         S: Clone,
+        A: crate::LocalAddr,
+        R: Clone + Send + Sync + 'static,
     {
         type Response = Self;
         type Error = Infallible;
@@ -195,7 +197,7 @@ const _: () = {
             Poll::Ready(Ok(()))
         }
 
-        fn call(&mut self, _req: IncomingStream<'_>) -> Self::Future {
+        fn call(&mut self, _req: IncomingStream<'_, A, R>) -> Self::Future {
             std::future::ready(Ok(self.clone()))
         }
     }

--- a/axum/src/lib.rs
+++ b/axum/src/lib.rs
@@ -421,6 +421,7 @@
 #[macro_use]
 pub(crate) mod macros;
 
+#[cfg(any(feature = "http1", feature = "http2"))]
 mod accept;
 mod boxed;
 mod extension;
@@ -471,8 +472,11 @@ pub use axum_macros::debug_handler;
 #[doc(inline)]
 pub use self::serve::serve;
 
+#[cfg(any(feature = "http1", feature = "http2"))]
 pub use self::accept::Accept;
+#[cfg(any(feature = "http1", feature = "http2"))]
 pub use self::accept::LocalAddr;
+#[cfg(any(feature = "http1", feature = "http2"))]
 pub use self::accept::UdsConnectInfo;
 pub use self::service_ext::ServiceExt;
 

--- a/axum/src/lib.rs
+++ b/axum/src/lib.rs
@@ -476,7 +476,7 @@ pub use self::serve::serve;
 pub use self::accept::Accept;
 #[cfg(any(feature = "http1", feature = "http2"))]
 pub use self::accept::LocalAddr;
-#[cfg(any(feature = "http1", feature = "http2"))]
+#[cfg(all(feature = "tokio", any(feature = "http1", feature = "http2")))]
 pub use self::accept::UdsConnectInfo;
 pub use self::service_ext::ServiceExt;
 

--- a/axum/src/lib.rs
+++ b/axum/src/lib.rs
@@ -473,6 +473,7 @@ pub use self::serve::serve;
 
 pub use self::accept::Accept;
 pub use self::accept::LocalAddr;
+pub use self::accept::UdsConnectInfo;
 pub use self::service_ext::ServiceExt;
 
 #[cfg(test)]

--- a/axum/src/lib.rs
+++ b/axum/src/lib.rs
@@ -476,7 +476,7 @@ pub use self::serve::serve;
 pub use self::accept::Accept;
 #[cfg(any(feature = "http1", feature = "http2"))]
 pub use self::accept::LocalAddr;
-#[cfg(all(feature = "tokio", any(feature = "http1", feature = "http2")))]
+#[cfg(all(feature = "tokio", any(feature = "http1", feature = "http2"), unix))]
 pub use self::accept::UdsConnectInfo;
 pub use self::service_ext::ServiceExt;
 

--- a/axum/src/lib.rs
+++ b/axum/src/lib.rs
@@ -421,6 +421,7 @@
 #[macro_use]
 pub(crate) mod macros;
 
+mod accept;
 mod boxed;
 mod extension;
 #[cfg(feature = "form")]
@@ -470,6 +471,8 @@ pub use axum_macros::debug_handler;
 #[doc(inline)]
 pub use self::serve::serve;
 
+pub use self::accept::Accept;
+pub use self::accept::LocalAddr;
 pub use self::service_ext::ServiceExt;
 
 #[cfg(test)]

--- a/axum/src/routing/method_routing.rs
+++ b/axum/src/routing/method_routing.rs
@@ -1229,7 +1229,10 @@ where
 const _: () = {
     use crate::serve::IncomingStream;
 
-    impl Service<IncomingStream<'_>> for MethodRouter<()> {
+    impl<A: crate::LocalAddr, R> Service<IncomingStream<'_, A, R>> for MethodRouter<()>
+    where
+        R: Clone + Send + Sync + 'static,
+    {
         type Response = Self;
         type Error = Infallible;
         type Future = std::future::Ready<Result<Self::Response, Self::Error>>;
@@ -1238,7 +1241,7 @@ const _: () = {
             Poll::Ready(Ok(()))
         }
 
-        fn call(&mut self, _req: IncomingStream<'_>) -> Self::Future {
+        fn call(&mut self, _req: IncomingStream<'_, A, R>) -> Self::Future {
             std::future::ready(Ok(self.clone()))
         }
     }

--- a/axum/src/routing/mod.rs
+++ b/axum/src/routing/mod.rs
@@ -482,7 +482,10 @@ impl Router {
 const _: () = {
     use crate::serve::IncomingStream;
 
-    impl Service<IncomingStream<'_>> for Router<()> {
+    impl<A: crate::LocalAddr, R> Service<IncomingStream<'_, A, R>> for Router<()>
+    where
+        R: Clone + Send + Sync + 'static,
+    {
         type Response = Self;
         type Error = Infallible;
         type Future = std::future::Ready<Result<Self::Response, Self::Error>>;
@@ -491,7 +494,7 @@ const _: () = {
             Poll::Ready(Ok(()))
         }
 
-        fn call(&mut self, _req: IncomingStream<'_>) -> Self::Future {
+        fn call(&mut self, _req: IncomingStream<'_, A, R>) -> Self::Future {
             std::future::ready(Ok(self.clone()))
         }
     }

--- a/axum/src/serve.rs
+++ b/axum/src/serve.rs
@@ -531,7 +531,7 @@ mod tests {
         Router,
     };
     use std::net::SocketAddr;
-    use tokio::net::{TcpListener, TcpStream};
+    use tokio::net::TcpListener;
 
     #[allow(dead_code, unused_must_use)]
     async fn if_it_compiles_it_works() {
@@ -576,6 +576,50 @@ mod tests {
         );
         serve(
             TcpListener::bind(addr).await.unwrap(),
+            handler.into_make_service_with_connect_info::<SocketAddr>(),
+        );
+    }
+
+    #[allow(dead_code, unused_must_use)]
+    #[cfg(unix)]
+    async fn if_it_compiles_it_works_unix() {
+        use tokio::net::UnixListener;
+
+        let router: Router = Router::new();
+
+        let addr = "/tmp/unix";
+
+        // router
+        serve(UnixListener::bind(addr).unwrap(), router.clone());
+        serve(
+            UnixListener::bind(addr).unwrap(),
+            router.clone().into_make_service(),
+        );
+        serve(
+            UnixListener::bind(addr).unwrap(),
+            router.into_make_service_with_connect_info::<SocketAddr>(),
+        );
+
+        // method router
+        serve(UnixListener::bind(addr).unwrap(), get(handler));
+        serve(
+            UnixListener::bind(addr).unwrap(),
+            get(handler).into_make_service(),
+        );
+        serve(
+            UnixListener::bind(addr).unwrap(),
+            get(handler).into_make_service_with_connect_info::<SocketAddr>(),
+        );
+
+        // handler
+        serve(UnixListener::bind(addr).unwrap(), handler.into_service());
+        serve(UnixListener::bind(addr).unwrap(), handler.with_state(()));
+        serve(
+            UnixListener::bind(addr).unwrap(),
+            handler.into_make_service(),
+        );
+        serve(
+            UnixListener::bind(addr).unwrap(),
             handler.into_make_service_with_connect_info::<SocketAddr>(),
         );
     }

--- a/axum/src/serve.rs
+++ b/axum/src/serve.rs
@@ -176,7 +176,6 @@ where
     S::Future: Send,
     A: crate::Accept + Sync + 'static,
     <A as crate::Accept>::Addr: Clone + Send + Sync + 'static,
-    <A as crate::Accept>::Target: Send + Sync + 'static,
 {
     type Output = io::Result<()>;
     type IntoFuture = private::ServeFuture;
@@ -278,7 +277,6 @@ where
     F: Future<Output = ()> + Send + 'static,
     A: crate::Accept + Sync + 'static,
     <A as crate::Accept>::Addr: Clone + Send + Sync + 'static,
-    <A as crate::Accept>::Target: Send + Sync + 'static,
 {
     type Output = io::Result<()>;
     type IntoFuture = private::ServeFuture;

--- a/axum/src/serve.rs
+++ b/axum/src/serve.rs
@@ -174,8 +174,7 @@ where
     for<'a> <M as Service<IncomingStream<'a, A::Target, A::Addr>>>::Future: Send,
     S: Service<Request, Response = Response, Error = Infallible> + Clone + Send + 'static,
     S::Future: Send,
-    A: crate::Accept + Sync + 'static,
-    <A as crate::Accept>::Addr: Clone + Send + Sync + 'static,
+    A: crate::Accept,
 {
     type Output = io::Result<()>;
     type IntoFuture = private::ServeFuture;
@@ -275,8 +274,7 @@ where
     S: Service<Request, Response = Response, Error = Infallible> + Clone + Send + 'static,
     S::Future: Send,
     F: Future<Output = ()> + Send + 'static,
-    A: crate::Accept + Sync + 'static,
-    <A as crate::Accept>::Addr: Clone + Send + Sync + 'static,
+    A: crate::Accept,
 {
     type Output = io::Result<()>;
     type IntoFuture = private::ServeFuture;

--- a/axum/src/serve.rs
+++ b/axum/src/serve.rs
@@ -176,6 +176,7 @@ where
     S::Future: Send,
     A: crate::Accept + Sync + 'static,
     <A as crate::Accept>::Addr: Clone + Send + Sync + 'static,
+    <A as crate::Accept>::Target: Send + Sync + 'static,
 {
     type Output = io::Result<()>;
     type IntoFuture = private::ServeFuture;
@@ -277,6 +278,7 @@ where
     F: Future<Output = ()> + Send + 'static,
     A: crate::Accept + Sync + 'static,
     <A as crate::Accept>::Addr: Clone + Send + Sync + 'static,
+    <A as crate::Accept>::Target: Send + Sync + 'static,
 {
     type Output = io::Result<()>;
     type IntoFuture = private::ServeFuture;

--- a/axum/src/serve.rs
+++ b/axum/src/serve.rs
@@ -6,7 +6,6 @@ use std::{
     future::{poll_fn, Future, IntoFuture},
     io,
     marker::PhantomData,
-    net::SocketAddr,
     pin::Pin,
     sync::Arc,
     task::{Context, Poll},
@@ -16,15 +15,9 @@ use std::{
 use axum_core::{body::Body, extract::Request, response::Response};
 use futures_util::{pin_mut, FutureExt};
 use hyper::body::Incoming;
-use hyper_util::{
-    rt::{TokioExecutor, TokioIo},
-    server::conn::auto::Builder,
-};
+use hyper_util::{rt::TokioExecutor, server::conn::auto::Builder};
 use pin_project_lite::pin_project;
-use tokio::{
-    net::{TcpListener, TcpStream},
-    sync::watch,
-};
+use tokio::sync::watch;
 use tower::util::{Oneshot, ServiceExt};
 use tower_service::Service;
 
@@ -93,11 +86,12 @@ use tower_service::Service;
 /// [`HandlerWithoutStateExt::into_make_service_with_connect_info`]: crate::handler::HandlerWithoutStateExt::into_make_service_with_connect_info
 /// [`HandlerService::into_make_service_with_connect_info`]: crate::handler::HandlerService::into_make_service_with_connect_info
 #[cfg(all(feature = "tokio", any(feature = "http1", feature = "http2")))]
-pub fn serve<M, S>(tcp_listener: TcpListener, make_service: M) -> Serve<M, S>
+pub fn serve<A, M, S>(tcp_listener: A, make_service: M) -> Serve<A, M, S>
 where
-    M: for<'a> Service<IncomingStream<'a>, Error = Infallible, Response = S>,
+    M: for<'a> Service<IncomingStream<'a, A::Target, A::Addr>, Error = Infallible, Response = S>,
     S: Service<Request, Response = Response, Error = Infallible> + Clone + Send + 'static,
     S::Future: Send,
+    A: crate::Accept,
 {
     Serve {
         tcp_listener,
@@ -109,14 +103,14 @@ where
 /// Future returned by [`serve`].
 #[cfg(all(feature = "tokio", any(feature = "http1", feature = "http2")))]
 #[must_use = "futures must be awaited or polled"]
-pub struct Serve<M, S> {
-    tcp_listener: TcpListener,
+pub struct Serve<A, M, S> {
+    tcp_listener: A,
     make_service: M,
     _marker: PhantomData<S>,
 }
 
 #[cfg(all(feature = "tokio", any(feature = "http1", feature = "http2")))]
-impl<M, S> Serve<M, S> {
+impl<A, M, S> Serve<A, M, S> {
     /// Prepares a server to handle graceful shutdown when the provided future completes.
     ///
     /// # Example
@@ -138,7 +132,7 @@ impl<M, S> Serve<M, S> {
     ///     // ...
     /// }
     /// ```
-    pub fn with_graceful_shutdown<F>(self, signal: F) -> WithGracefulShutdown<M, S, F>
+    pub fn with_graceful_shutdown<F>(self, signal: F) -> WithGracefulShutdown<A, M, S, F>
     where
         F: Future<Output = ()> + Send + 'static,
     {
@@ -152,9 +146,10 @@ impl<M, S> Serve<M, S> {
 }
 
 #[cfg(all(feature = "tokio", any(feature = "http1", feature = "http2")))]
-impl<M, S> Debug for Serve<M, S>
+impl<A, M, S> Debug for Serve<A, M, S>
 where
     M: Debug,
+    A: Debug,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let Self {
@@ -171,12 +166,16 @@ where
 }
 
 #[cfg(all(feature = "tokio", any(feature = "http1", feature = "http2")))]
-impl<M, S> IntoFuture for Serve<M, S>
+impl<A, M, S> IntoFuture for Serve<A, M, S>
 where
-    M: for<'a> Service<IncomingStream<'a>, Error = Infallible, Response = S> + Send + 'static,
-    for<'a> <M as Service<IncomingStream<'a>>>::Future: Send,
+    M: for<'a> Service<IncomingStream<'a, A::Target, A::Addr>, Error = Infallible, Response = S>
+        + Send
+        + 'static,
+    for<'a> <M as Service<IncomingStream<'a, A::Target, A::Addr>>>::Future: Send,
     S: Service<Request, Response = Response, Error = Infallible> + Clone + Send + 'static,
     S::Future: Send,
+    A: crate::Accept + Sync + 'static,
+    <A as crate::Accept>::Addr: Clone + Send + Sync + 'static,
 {
     type Output = io::Result<()>;
     type IntoFuture = private::ServeFuture;
@@ -190,11 +189,10 @@ where
             } = self;
 
             loop {
-                let (tcp_stream, remote_addr) = match tcp_accept(&tcp_listener).await {
+                let (tcp_stream, remote_addr) = match accept(&tcp_listener).await {
                     Some(conn) => conn,
                     None => continue,
                 };
-                let tcp_stream = TokioIo::new(tcp_stream);
 
                 poll_fn(|cx| make_service.poll_ready(cx))
                     .await
@@ -202,7 +200,7 @@ where
 
                 let tower_service = make_service
                     .call(IncomingStream {
-                        tcp_stream: &tcp_stream,
+                        stream: &tcp_stream,
                         remote_addr,
                     })
                     .await
@@ -236,19 +234,20 @@ where
 /// Serve future with graceful shutdown enabled.
 #[cfg(all(feature = "tokio", any(feature = "http1", feature = "http2")))]
 #[must_use = "futures must be awaited or polled"]
-pub struct WithGracefulShutdown<M, S, F> {
-    tcp_listener: TcpListener,
+pub struct WithGracefulShutdown<A, M, S, F> {
+    tcp_listener: A,
     make_service: M,
     signal: F,
     _marker: PhantomData<S>,
 }
 
 #[cfg(all(feature = "tokio", any(feature = "http1", feature = "http2")))]
-impl<M, S, F> Debug for WithGracefulShutdown<M, S, F>
+impl<A, M, S, F> Debug for WithGracefulShutdown<A, M, S, F>
 where
     M: Debug,
     S: Debug,
     F: Debug,
+    A: Debug,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let Self {
@@ -267,13 +266,17 @@ where
 }
 
 #[cfg(all(feature = "tokio", any(feature = "http1", feature = "http2")))]
-impl<M, S, F> IntoFuture for WithGracefulShutdown<M, S, F>
+impl<A, M, S, F> IntoFuture for WithGracefulShutdown<A, M, S, F>
 where
-    M: for<'a> Service<IncomingStream<'a>, Error = Infallible, Response = S> + Send + 'static,
-    for<'a> <M as Service<IncomingStream<'a>>>::Future: Send,
+    M: for<'a> Service<IncomingStream<'a, A::Target, A::Addr>, Error = Infallible, Response = S>
+        + Send
+        + 'static,
+    for<'a> <M as Service<IncomingStream<'a, A::Target, A::Addr>>>::Future: Send,
     S: Service<Request, Response = Response, Error = Infallible> + Clone + Send + 'static,
     S::Future: Send,
     F: Future<Output = ()> + Send + 'static,
+    A: crate::Accept + Sync + 'static,
+    <A as crate::Accept>::Addr: Clone + Send + Sync + 'static,
 {
     type Output = io::Result<()>;
     type IntoFuture = private::ServeFuture;
@@ -299,7 +302,7 @@ where
         private::ServeFuture(Box::pin(async move {
             loop {
                 let (tcp_stream, remote_addr) = tokio::select! {
-                    conn = tcp_accept(&tcp_listener) => {
+                    conn = accept(&tcp_listener) => {
                         match conn {
                             Some(conn) => conn,
                             None => continue,
@@ -310,9 +313,8 @@ where
                         break;
                     }
                 };
-                let tcp_stream = TokioIo::new(tcp_stream);
 
-                trace!("connection {remote_addr} accepted");
+                trace!("connection {remote_addr:?} accepted");
 
                 poll_fn(|cx| make_service.poll_ready(cx))
                     .await
@@ -320,8 +322,8 @@ where
 
                 let tower_service = make_service
                     .call(IncomingStream {
-                        tcp_stream: &tcp_stream,
-                        remote_addr,
+                        stream: &tcp_stream,
+                        remote_addr: remote_addr.clone(),
                     })
                     .await
                     .unwrap_or_else(|err| match err {});
@@ -357,7 +359,7 @@ where
                         }
                     }
 
-                    trace!("connection {remote_addr} closed");
+                    trace!("connection {remote_addr:?} closed");
 
                     drop(close_rx);
                 });
@@ -386,7 +388,7 @@ fn is_connection_error(e: &io::Error) -> bool {
     )
 }
 
-async fn tcp_accept(listener: &TcpListener) -> Option<(TcpStream, SocketAddr)> {
+async fn accept<A: crate::Accept>(listener: &A) -> Option<(A::Target, A::Addr)> {
     match listener.accept().await {
         Ok(conn) => Some(conn),
         Err(e) => {
@@ -486,21 +488,37 @@ where
 /// Used with [`serve`] and [`IntoMakeServiceWithConnectInfo`].
 ///
 /// [`IntoMakeServiceWithConnectInfo`]: crate::extract::connect_info::IntoMakeServiceWithConnectInfo
-#[derive(Debug)]
-pub struct IncomingStream<'a> {
-    tcp_stream: &'a TokioIo<TcpStream>,
-    remote_addr: SocketAddr,
+pub struct IncomingStream<'a, A: crate::LocalAddr, R: Clone + Send + Sync + 'static> {
+    stream: &'a A,
+    remote_addr: R,
 }
 
-impl IncomingStream<'_> {
+impl<A, R> Debug for IncomingStream<'_, A, R>
+where
+    A: Debug + crate::LocalAddr,
+    R: Debug + Clone + Send + Sync + 'static,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("IncomingStream")
+            .field("stream", self.stream)
+            .field("remote_addr", &self.remote_addr)
+            .finish()
+    }
+}
+
+impl<A, R> IncomingStream<'_, A, R>
+where
+    A: crate::LocalAddr,
+    R: Clone + Send + Sync + 'static,
+{
     /// Returns the local address that this stream is bound to.
-    pub fn local_addr(&self) -> std::io::Result<SocketAddr> {
-        self.tcp_stream.inner().local_addr()
+    pub fn local_addr(&self) -> std::io::Result<A::Addr> {
+        self.stream.local_addr()
     }
 
     /// Returns the remote address that this stream is bound to.
-    pub fn remote_addr(&self) -> SocketAddr {
-        self.remote_addr
+    pub fn remote_addr(&self) -> R {
+        self.remote_addr.clone()
     }
 }
 
@@ -512,6 +530,8 @@ mod tests {
         routing::get,
         Router,
     };
+    use std::net::SocketAddr;
+    use tokio::net::{TcpListener, TcpStream};
 
     #[allow(dead_code, unused_must_use)]
     async fn if_it_compiles_it_works() {

--- a/axum/src/serve.rs
+++ b/axum/src/serve.rs
@@ -530,12 +530,12 @@ mod tests {
         routing::get,
         Router,
     };
-    use std::net::SocketAddr;
     use tokio::net::TcpListener;
 
     #[allow(dead_code, unused_must_use)]
     async fn if_it_compiles_it_works() {
         let router: Router = Router::new();
+        use std::net::SocketAddr;
 
         let addr = "0.0.0.0:0";
 
@@ -583,6 +583,7 @@ mod tests {
     #[allow(dead_code, unused_must_use)]
     #[cfg(unix)]
     async fn if_it_compiles_it_works_unix() {
+        use crate::UdsConnectInfo;
         use tokio::net::UnixListener;
 
         let router: Router = Router::new();
@@ -597,7 +598,7 @@ mod tests {
         );
         serve(
             UnixListener::bind(addr).unwrap(),
-            router.into_make_service_with_connect_info::<SocketAddr>(),
+            router.into_make_service_with_connect_info::<UdsConnectInfo>(),
         );
 
         // method router
@@ -608,7 +609,7 @@ mod tests {
         );
         serve(
             UnixListener::bind(addr).unwrap(),
-            get(handler).into_make_service_with_connect_info::<SocketAddr>(),
+            get(handler).into_make_service_with_connect_info::<UdsConnectInfo>(),
         );
 
         // handler
@@ -620,7 +621,7 @@ mod tests {
         );
         serve(
             UnixListener::bind(addr).unwrap(),
-            handler.into_make_service_with_connect_info::<SocketAddr>(),
+            handler.into_make_service_with_connect_info::<UdsConnectInfo>(),
         );
     }
 

--- a/examples/unix-domain-socket/src/main.rs
+++ b/examples/unix-domain-socket/src/main.rs
@@ -19,20 +19,15 @@ fn main() {
 mod unix {
     use axum::{
         body::Body,
-        extract::connect_info::{self, ConnectInfo},
+        extract::connect_info::ConnectInfo,
         http::{Method, Request, StatusCode},
         routing::get,
-        Router,
+        Router, UdsConnectInfo,
     };
     use http_body_util::BodyExt;
-    use hyper::body::Incoming;
-    use hyper_util::{
-        rt::{TokioExecutor, TokioIo},
-        server,
-    };
-    use std::{convert::Infallible, path::PathBuf, sync::Arc};
-    use tokio::net::{unix::UCred, UnixListener, UnixStream};
-    use tower::Service;
+    use hyper_util::rt::TokioIo;
+    use std::path::PathBuf;
+    use tokio::net::{UnixListener, UnixStream};
     use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
     pub async fn server() {
@@ -52,35 +47,10 @@ mod unix {
             .unwrap();
 
         let uds = UnixListener::bind(path.clone()).unwrap();
-        tokio::spawn(async move {
-            let app = Router::new().route("/", get(handler));
 
-            let mut make_service = app.into_make_service_with_connect_info::<UdsConnectInfo>();
+        let app = Router::new().route("/", get(handler));
 
-            // See https://github.com/tokio-rs/axum/blob/main/examples/serve-with-hyper/src/main.rs for
-            // more details about this setup
-            loop {
-                let (socket, _remote_addr) = uds.accept().await.unwrap();
-
-                let tower_service = unwrap_infallible(make_service.call(&socket).await);
-
-                tokio::spawn(async move {
-                    let socket = TokioIo::new(socket);
-
-                    let hyper_service =
-                        hyper::service::service_fn(move |request: Request<Incoming>| {
-                            tower_service.clone().call(request)
-                        });
-
-                    if let Err(err) = server::conn::auto::Builder::new(TokioExecutor::new())
-                        .serve_connection_with_upgrades(socket, hyper_service)
-                        .await
-                    {
-                        eprintln!("failed to serve connection: {err:#}");
-                    }
-                });
-            }
-        });
+        tokio::spawn(async move { axum::serve(uds, app.into_make_service()).await.unwrap() });
 
         let stream = TokioIo::new(UnixStream::connect(path).await.unwrap());
         let (mut sender, conn) = hyper::client::conn::http1::handshake(stream).await.unwrap();
@@ -109,31 +79,5 @@ mod unix {
         println!("new connection from `{:?}`", info);
 
         "Hello, World!"
-    }
-
-    #[derive(Clone, Debug)]
-    #[allow(dead_code)]
-    struct UdsConnectInfo {
-        peer_addr: Arc<tokio::net::unix::SocketAddr>,
-        peer_cred: UCred,
-    }
-
-    impl connect_info::Connected<&UnixStream> for UdsConnectInfo {
-        fn connect_info(target: &UnixStream) -> Self {
-            let peer_addr = target.peer_addr().unwrap();
-            let peer_cred = target.peer_cred().unwrap();
-
-            Self {
-                peer_addr: Arc::new(peer_addr),
-                peer_cred,
-            }
-        }
-    }
-
-    fn unwrap_infallible<T>(result: Result<T, Infallible>) -> T {
-        match result {
-            Ok(value) => value,
-            Err(err) => match err {},
-        }
     }
 }

--- a/examples/unix-domain-socket/src/main.rs
+++ b/examples/unix-domain-socket/src/main.rs
@@ -50,7 +50,14 @@ mod unix {
 
         let app = Router::new().route("/", get(handler));
 
-        tokio::spawn(async move { axum::serve(uds, app.into_make_service()).await.unwrap() });
+        tokio::spawn(async move {
+            axum::serve(
+                uds,
+                app.into_make_service_with_connect_info::<UdsConnectInfo>(),
+            )
+            .await
+            .unwrap()
+        });
 
         let stream = TokioIo::new(UnixStream::connect(path).await.unwrap());
         let (mut sender, conn) = hyper::client::conn::http1::handshake(stream).await.unwrap();


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation
I'd like making `axum` applications powered by Unix Sockets to be easier than having to make your own event loop from scratch. This PR allows you to put a `UnixListener` in `axum::serve`, or any other type that you implement `Accept` on.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution
This PR adds the `Accept` trait, which abstracts over the `accept()` function of the Listener type. This PR also adds the `LocalAddr` trait, which get's the associated Listener's Socket type's `SocketAddr` by calling the `local_addr()` function on the type. From there, changes were made all around the codebase to make sure that any type implementing `Accept` could be put into `axum::serve`

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
