### PR TITLE
Feature: `Serve::tcp_nodelay`

### DIFF
--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -7,9 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
+- **added:** `axum::serve::Serve::tcp_nodelay` and `axum::serve::WithGracefulShutdown::tcp_nodelay` ([#2653])
 - **fixed:** Fixed layers being cloned when calling `axum::serve` directly with
   a `Router` or `MethodRouter` ([#2586])
 
+[#2653]: https://github.com/tokio-rs/axum/pull/2653
 [#2586]: https://github.com/tokio-rs/axum/pull/2586
 
 # 0.7.4 (13. January, 2024)

--- a/axum/src/serve.rs
+++ b/axum/src/serve.rs
@@ -155,7 +155,7 @@ impl<M, S> Serve<M, S> {
 
     /// Instructs the server to set the value of the `TCP_NODELAY` option on every accepted connection.
     ///
-    /// See also [`TcpStream::set_nodelay`]
+    /// See also [`TcpStream::set_nodelay`].
     ///
     /// # Example
     /// ```
@@ -285,7 +285,7 @@ pub struct WithGracefulShutdown<M, S, F> {
 impl<M, S, F> WithGracefulShutdown<M, S, F> {
     /// Instructs the server to set the value of the `TCP_NODELAY` option on every accepted connection.
     ///
-    /// See also [`TcpStream::set_nodelay`]
+    /// See also [`TcpStream::set_nodelay`].
     ///
     /// # Example
     /// ```

--- a/axum/src/serve.rs
+++ b/axum/src/serve.rs
@@ -639,6 +639,20 @@ mod tests {
             TcpListener::bind(addr).await.unwrap(),
             handler.into_make_service_with_connect_info::<SocketAddr>(),
         );
+
+        // nodelay
+        serve(
+            TcpListener::bind(addr).await.unwrap(),
+            handler.into_service(),
+        )
+        .tcp_nodelay(true);
+
+        serve(
+            TcpListener::bind(addr).await.unwrap(),
+            handler.into_service(),
+        )
+        .with_graceful_shutdown(async { /*...*/ })
+        .tcp_nodelay(true);
     }
 
     async fn handler() {}


### PR DESCRIPTION
Fixes: #2521

## Motivation
See #2521 and linked issue in hyper

## Solution
Adds the `tcp_nodelay` method to `Serve` (and `WithGracefulShutdown`) to enable the user to instruct the server to set `TCP_NODELAY` on incoming connections.

Regarding tests: I wasn't really sure what you would like to have there (since `with_graceful_shutdown` also doesn't seem to have tests or I didn't find them, not sure), so pointers are appreciated.