### PR TITLE
Improve error handling user experience.

### DIFF
--- a/axum-core/src/error_response.rs
+++ b/axum-core/src/error_response.rs
@@ -1,0 +1,42 @@
+use std::error::Error;
+
+use http::StatusCode;
+
+use crate::response::{IntoResponse, Response};
+
+/// `ErrorResponse` encapsulates an `Error` and a `StatusCode` to be used as a response, typically in a `Result`.
+/// 
+/// If not `StatusCode` is provided, `StatusCode::INTERNAL_SERVER_ERROR` is used.
+#[derive(Debug)]
+pub struct ErrorResponse {
+  status: StatusCode,
+  error: Box<dyn Error>,
+}
+
+impl ErrorResponse {
+  /// Create a new `ErrorResponse` with the given status code and error.
+  pub fn new(status: StatusCode, error: impl Into<Box<dyn Error>>) -> Self {
+    Self {
+      status,
+      error: error.into(),
+    }
+  }
+}
+
+impl<E: Into<Box<dyn Error>>> From<E> for ErrorResponse
+{
+  fn from(error: E) -> Self {
+    Self::new(StatusCode::INTERNAL_SERVER_ERROR, error)
+  }
+}
+
+impl IntoResponse for ErrorResponse {
+  fn into_response(self) -> Response {
+    let error = format!("{:?}", self.error);
+
+    #[cfg(feature = "tracing")]
+    tracing::error!(error = %error);
+
+    (self.status, error).into_response()
+  }
+}

--- a/axum-core/src/ext_traits/mod.rs
+++ b/axum-core/src/ext_traits/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod request;
 pub(crate) mod request_parts;
+pub(crate) mod result;
 
 #[cfg(test)]
 mod tests {

--- a/axum-core/src/ext_traits/result.rs
+++ b/axum-core/src/ext_traits/result.rs
@@ -1,0 +1,20 @@
+use std::error::Error;
+
+use http::StatusCode;
+
+use crate::{response::{IntoResponse, ResultResponse}, error_response::ErrorResponse};
+
+/// A extention trait to Result to easily attach a `StatusCode` to an error by encapsulating the
+///  error into a `ErrorResponse`.
+pub trait ResultExt<T: IntoResponse> {
+  /// maps the error type to a `ErrorResponse` with the given status code.
+  fn err_with_status(self, status: StatusCode) -> ResultResponse<T>;
+}
+
+impl<T: IntoResponse, E: Into<Box<dyn Error>>> ResultExt<T> for std::result::Result<T, E> {
+  fn err_with_status(self, status:StatusCode) -> ResultResponse<T> {
+    self.map_err(|error| {
+      ErrorResponse::new(status, error)
+    })
+  }
+}

--- a/axum-core/src/lib.rs
+++ b/axum-core/src/lib.rs
@@ -53,8 +53,10 @@
 pub(crate) mod macros;
 
 mod error;
+mod error_response;
 mod ext_traits;
 pub use self::error::Error;
+pub use self::error_response::ErrorResponse;
 
 pub mod body;
 pub mod extract;
@@ -63,4 +65,4 @@ pub mod response;
 /// Alias for a type-erased error type.
 pub type BoxError = Box<dyn std::error::Error + Send + Sync>;
 
-pub use self::ext_traits::{request::RequestExt, request_parts::RequestPartsExt};
+pub use self::ext_traits::{request::RequestExt, result::ResultExt, request_parts::RequestPartsExt};

--- a/axum-core/src/response/into_response.rs
+++ b/axum-core/src/response/into_response.rs
@@ -23,43 +23,8 @@ use std::{
 /// You generally shouldn't have to implement `IntoResponse` manually, as axum
 /// provides implementations for many common types.
 ///
-/// However it might be necessary if you have a custom error type that you want
-/// to return from handlers:
-///
-/// ```rust
-/// use axum::{
-///     Router,
-///     body::{self, Bytes},
-///     routing::get,
-///     http::StatusCode,
-///     response::{IntoResponse, Response},
-/// };
-///
-/// enum MyError {
-///     SomethingWentWrong,
-///     SomethingElseWentWrong,
-/// }
-///
-/// impl IntoResponse for MyError {
-///     fn into_response(self) -> Response {
-///         let body = match self {
-///             MyError::SomethingWentWrong => "something went wrong",
-///             MyError::SomethingElseWentWrong => "something else went wrong",
-///         };
-///
-///         // it's often easiest to implement `IntoResponse` by calling other implementations
-///         (StatusCode::INTERNAL_SERVER_ERROR, body).into_response()
-///     }
-/// }
-///
-/// // `Result<impl IntoResponse, MyError>` can now be returned from handlers
-/// let app = Router::new().route("/", get(handler));
-///
-/// async fn handler() -> Result<(), MyError> {
-///     Err(MyError::SomethingWentWrong)
-/// }
-/// # let _: Router = app;
-/// ```
+/// To handle errors and return them as a `Result` from a handler, you can
+/// use `IntoResultResponse` instead.
 ///
 /// Or if you have a custom body type you'll also need to implement
 /// `IntoResponse` for it:

--- a/axum-core/src/response/into_result_response.rs
+++ b/axum-core/src/response/into_result_response.rs
@@ -1,0 +1,18 @@
+use crate::error_response::ErrorResponse;
+
+use super::IntoResponse;
+
+/// Trait for generating fallible responses in handlers.
+///
+/// This trait is bound by `IntoResponse` and therefor can be be interchanged with it
+/// when returning a `Result` from a handler.
+/// 
+/// This trait is only implemented for `ResultResponse<T>` aka `Result<T, ErrorResponse>`
+/// where both `T` and `ErrorResponse` implement `IntoResponse`.
+///
+/// The trait allows to return a `Result` from a handler.
+pub trait IntoResultResponse: IntoResponse {}
+impl<T: IntoResponse> IntoResultResponse for ResultResponse<T> {}
+
+/// A type alias for `Result<T, ErrorResponse>`.
+pub type ResultResponse<T, E = ErrorResponse> = std::result::Result<T, E>;

--- a/axum-core/src/response/mod.rs
+++ b/axum-core/src/response/mod.rs
@@ -9,11 +9,13 @@ use crate::body::Body;
 mod append_headers;
 mod into_response;
 mod into_response_parts;
+mod into_result_response;
 
 pub use self::{
     append_headers::AppendHeaders,
     into_response::IntoResponse,
     into_response_parts::{IntoResponseParts, ResponseParts, TryIntoHeaderError},
+    into_result_response::{IntoResultResponse, ResultResponse},
 };
 
 /// Type alias for [`http::Response`] whose body type defaults to [`Body`], the most common body

--- a/axum/src/lib.rs
+++ b/axum/src/lib.rs
@@ -460,7 +460,7 @@ pub use self::routing::Router;
 pub use self::form::Form;
 
 #[doc(inline)]
-pub use axum_core::{BoxError, Error, RequestExt, RequestPartsExt};
+pub use axum_core::{BoxError, Error, ErrorResponse, RequestExt, RequestPartsExt, ResultExt};
 
 #[cfg(feature = "macros")]
 pub use axum_macros::debug_handler;

--- a/axum/src/response/mod.rs
+++ b/axum/src/response/mod.rs
@@ -21,7 +21,7 @@ pub use crate::Extension;
 
 #[doc(inline)]
 pub use axum_core::response::{
-    AppendHeaders, ErrorResponse, IntoResponse, IntoResponseParts, Response, ResponseParts, Result,
+    AppendHeaders, ErrorResponse, IntoResponse, IntoResponseParts, IntoResultResponse, Response, ResponseParts, Result, ResultResponse,
 };
 
 #[doc(inline)]


### PR DESCRIPTION
## Motivation

I started using `axum` recently (after `warp` and `poem`) and I really like its "style", but I was really surprised to see that the project doesn't natively support returning errors from handlers.

I saw the examples code in the source code and the documentation and there are also a few crates available and code snippets on Reddit, but I wasn't happy with them.

I feel that one solution can be good and generic enough to become officially part of `axum`.

This would reduce friction for new `axum` users and prevent them for copy-pasting suboptimal code.

`Poem` handlers can return `Poem::Result<T>` and it's really nice.



## Solution

I wanted to keep things as `axum`y as possible without chaning any existing API or add any dependencies.

Handlers currently typically return `impl IntoReponse` so my idea was to be able to change that to `impl IntoResultResponse` (I don't like `Result<impl IntoResponse, MyCustomError>`) and then be able to use `?` with any kind of errors in the function.

Errors from `std`, `anyhow`, `eyre` etc are all supported and the return type will be converted into a `Result<impl IntoResponse, ErrorResponse>` where `ErrorResponse` implements `IntoResponse`.

`ErrorResponse` just encapsulates the original error with an associated `StatusCode` (by default `INTERNAL_SERVER_ERROR`) and is then converted to `(self.status, format!("{:?}", self.error))`.

To be able to easily customize the `StatusCode` I also added a `Result` extension trait `ResultExt` that implements `Result<T>::err_with_status(self, status: StatusCode) -> ResultResponse<T>`.

### Resulting user experience

```rust
async fn handler() -> impl IntoResultResponse { // instead of IntoResponse
    try_thing_anyhow()?; // by default this will return a StatusCode::INTERNAL_SERVER_ERROR (500) error
    try_thing_anyhow().err_with_status(StatusCode::BAD_REQUEST)?; // Using the `ResultExt` trait to return a StatusCode::BAD_REQUEST (400) error

    try_thing_stderror()?; // Standard errors also work
    Ok(())
}

fn try_thing_anyhow() -> Result<(), anyhow::Error> {
    anyhow::bail!("it failed!");
}

fn try_thing_stderror() -> Result<(), impl std::error::Error> {
    Err(std::fmt::Error::default())
}
```

### Status of PR

Since this PR add some new elements to the API I don't expect it to be readily accepted.
I therefor skipped many things that should be done if it were to be accepted:
- update all relevant doc
- think more about trait bounds (like `Send`, `Sync` and `'static`)
- integrate better with the project conventions

