### PR TITLE
Update `sync_wrapper` to 1.0.0 from 0.1.1

### DIFF
--- a/axum-core/Cargo.toml
+++ b/axum-core/Cargo.toml
@@ -26,7 +26,7 @@ http-body = "1.0.0"
 http-body-util = "0.1.0"
 mime = "0.3.16"
 pin-project-lite = "0.2.7"
-sync_wrapper = "0.1.1"
+sync_wrapper = "1.0.0"
 tower-layer = "0.3"
 tower-service = "0.3"
 

--- a/axum-core/Cargo.toml
+++ b/axum-core/Cargo.toml
@@ -2,7 +2,7 @@
 categories = ["asynchronous", "network-programming", "web-programming"]
 description = "Core types and traits for axum"
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.57"
 homepage = "https://github.com/tokio-rs/axum"
 keywords = ["http", "web", "framework"]
 license = "MIT"

--- a/axum-core/src/macros.rs
+++ b/axum-core/src/macros.rs
@@ -303,8 +303,6 @@ mod composite_rejection_tests {
 
     #[allow(dead_code, unreachable_pub)]
     mod defs {
-        use crate::{__composite_rejection, __define_rejection};
-
         __define_rejection! {
             #[status = BAD_REQUEST]
             #[body = "error message 1"]

--- a/axum-extra/src/extract/cached.rs
+++ b/axum-extra/src/extract/cached.rs
@@ -111,8 +111,7 @@ axum_core::__impl_deref!(Cached);
 #[cfg(test)]
 mod tests {
     use super::*;
-    use axum::{extract::FromRequestParts, http::Request, routing::get, Router};
-    use http::request::Parts;
+    use axum::{http::Request, routing::get, Router};
     use std::{
         convert::Infallible,
         sync::atomic::{AtomicU32, Ordering},

--- a/axum-extra/src/extract/form.rs
+++ b/axum-extra/src/extract/form.rs
@@ -118,7 +118,7 @@ mod tests {
     use super::*;
     use crate::test_helpers::*;
     use axum::{routing::post, Router};
-    use http::{header::CONTENT_TYPE, StatusCode};
+    use http::header::CONTENT_TYPE;
     use serde::Deserialize;
 
     #[tokio::test]

--- a/axum-extra/src/extract/multipart.rs
+++ b/axum-extra/src/extract/multipart.rs
@@ -413,7 +413,7 @@ impl std::error::Error for InvalidBoundary {}
 mod tests {
     use super::*;
     use crate::test_helpers::*;
-    use axum::{extract::DefaultBodyLimit, response::IntoResponse, routing::post, Router};
+    use axum::{extract::DefaultBodyLimit, routing::post, Router};
 
     #[tokio::test]
     async fn content_type_with_encoding() {

--- a/axum-extra/src/extract/query.rs
+++ b/axum-extra/src/extract/query.rs
@@ -267,7 +267,7 @@ mod tests {
     use super::*;
     use crate::test_helpers::*;
     use axum::{routing::post, Router};
-    use http::{header::CONTENT_TYPE, StatusCode};
+    use http::header::CONTENT_TYPE;
     use serde::Deserialize;
 
     #[tokio::test]

--- a/axum-extra/src/extract/with_rejection.rs
+++ b/axum-extra/src/extract/with_rejection.rs
@@ -161,7 +161,6 @@ where
 mod tests {
     use super::*;
     use axum::body::Body;
-    use axum::extract::FromRequestParts;
     use axum::http::Request;
     use axum::response::Response;
 

--- a/axum-extra/src/extract/with_rejection.rs
+++ b/axum-extra/src/extract/with_rejection.rs
@@ -159,13 +159,11 @@ where
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use axum::body::Body;
     use axum::extract::FromRequestParts;
     use axum::http::Request;
     use axum::response::Response;
-    use http::request::Parts;
-
-    use super::*;
 
     #[tokio::test]
     async fn extractor_rejection_is_transformed() {

--- a/axum-extra/src/json_lines.rs
+++ b/axum-extra/src/json_lines.rs
@@ -184,7 +184,7 @@ mod tests {
     use futures_util::StreamExt;
     use http::StatusCode;
     use serde::Deserialize;
-    use std::{convert::Infallible, error::Error};
+    use std::error::Error;
 
     #[derive(Serialize, Deserialize, PartialEq, Eq, Debug)]
     struct User {

--- a/axum-extra/src/lib.rs
+++ b/axum-extra/src/lib.rs
@@ -97,11 +97,10 @@ pub use typed_header::TypedHeader;
 #[cfg(feature = "protobuf")]
 pub mod protobuf;
 
+/// _not_ public API
 #[cfg(feature = "typed-routing")]
 #[doc(hidden)]
 pub mod __private {
-    //! _not_ public API
-
     use percent_encoding::{AsciiSet, CONTROLS};
 
     pub use percent_encoding::utf8_percent_encode;
@@ -116,9 +115,8 @@ pub mod __private {
 use axum_macros::__private_axum_test as test;
 
 #[cfg(test)]
+#[allow(unused_imports)]
 pub(crate) mod test_helpers {
-    #![allow(unused_imports)]
-
     use axum::{extract::Request, response::Response, serve};
 
     mod test_client {

--- a/axum-extra/src/protobuf.rs
+++ b/axum-extra/src/protobuf.rs
@@ -201,7 +201,6 @@ mod tests {
     use super::*;
     use crate::test_helpers::*;
     use axum::{routing::post, Router};
-    use http::StatusCode;
 
     #[tokio::test]
     async fn decode_body() {

--- a/axum-extra/src/routing/mod.rs
+++ b/axum-extra/src/routing/mod.rs
@@ -342,7 +342,7 @@ mod sealed {
 mod tests {
     use super::*;
     use crate::test_helpers::*;
-    use axum::{extract::Path, http::StatusCode, routing::get};
+    use axum::{extract::Path, routing::get};
 
     #[tokio::test]
     async fn test_tsr() {

--- a/axum-extra/src/routing/resource.rs
+++ b/axum-extra/src/routing/resource.rs
@@ -149,7 +149,7 @@ impl<S> From<Resource<S>> for Router<S> {
 mod tests {
     #[allow(unused_imports)]
     use super::*;
-    use axum::{body::Body, extract::Path, http::Method, Router};
+    use axum::{body::Body, extract::Path, http::Method};
     use http::Request;
     use http_body_util::BodyExt;
     use tower::ServiceExt;

--- a/axum-extra/src/typed_header.rs
+++ b/axum-extra/src/typed_header.rs
@@ -186,7 +186,7 @@ impl std::error::Error for TypedHeaderRejection {
 mod tests {
     use super::*;
     use crate::test_helpers::*;
-    use axum::{response::IntoResponse, routing::get, Router};
+    use axum::{routing::get, Router};
 
     #[tokio::test]
     async fn typed_header() {

--- a/axum-macros/tests/debug_handler/fail/json_not_deserialize.stderr
+++ b/axum-macros/tests/debug_handler/fail/json_not_deserialize.stderr
@@ -17,7 +17,11 @@ error[E0277]: the trait bound `for<'de> Struct: serde::de::Deserialize<'de>` is 
   = note: required for `Struct` to implement `serde::de::DeserializeOwned`
   = note: required for `Json<Struct>` to implement `FromRequest<()>`
   = help: see issue #48214
-  = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
+help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
+  |
+1 + #![feature(trivial_bounds)]
+  |
+
 error[E0277]: the trait bound `for<'de> Struct: serde::de::Deserialize<'de>` is not satisfied
  --> tests/debug_handler/fail/json_not_deserialize.rs:7:24
   |

--- a/axum-macros/tests/debug_handler/fail/json_not_deserialize.stderr
+++ b/axum-macros/tests/debug_handler/fail/json_not_deserialize.stderr
@@ -17,10 +17,7 @@ error[E0277]: the trait bound `for<'de> Struct: serde::de::Deserialize<'de>` is 
   = note: required for `Struct` to implement `serde::de::DeserializeOwned`
   = note: required for `Json<Struct>` to implement `FromRequest<()>`
   = help: see issue #48214
-help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
-  |
-1 + #![feature(trivial_bounds)]
-  |
+  = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
 
 error[E0277]: the trait bound `for<'de> Struct: serde::de::Deserialize<'de>` is not satisfied
  --> tests/debug_handler/fail/json_not_deserialize.rs:7:24

--- a/axum-macros/tests/debug_handler/fail/json_not_deserialize.stderr
+++ b/axum-macros/tests/debug_handler/fail/json_not_deserialize.stderr
@@ -17,7 +17,10 @@ error[E0277]: the trait bound `for<'de> Struct: serde::de::Deserialize<'de>` is 
   = note: required for `Struct` to implement `serde::de::DeserializeOwned`
   = note: required for `Json<Struct>` to implement `FromRequest<()>`
   = help: see issue #48214
-  = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
+help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
+  |
+1 + #![feature(trivial_bounds)]
+  |
 
 error[E0277]: the trait bound `for<'de> Struct: serde::de::Deserialize<'de>` is not satisfied
  --> tests/debug_handler/fail/json_not_deserialize.rs:7:24

--- a/axum-macros/tests/debug_handler/fail/json_not_deserialize.stderr
+++ b/axum-macros/tests/debug_handler/fail/json_not_deserialize.stderr
@@ -17,11 +17,7 @@ error[E0277]: the trait bound `for<'de> Struct: serde::de::Deserialize<'de>` is 
   = note: required for `Struct` to implement `serde::de::DeserializeOwned`
   = note: required for `Json<Struct>` to implement `FromRequest<()>`
   = help: see issue #48214
-help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
-  |
-1 + #![feature(trivial_bounds)]
-  |
-
+  = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
 error[E0277]: the trait bound `for<'de> Struct: serde::de::Deserialize<'de>` is not satisfied
  --> tests/debug_handler/fail/json_not_deserialize.rs:7:24
   |

--- a/axum-macros/tests/debug_handler/fail/single_wrong_return_tuple.stderr
+++ b/axum-macros/tests/debug_handler/fail/single_wrong_return_tuple.stderr
@@ -12,7 +12,7 @@ error[E0277]: the trait bound `NotIntoResponse: IntoResponse` is not satisfied
             axum::extract::rejection::FailedToBufferBody
             axum::extract::rejection::LengthLimitError
             axum::extract::rejection::UnknownBodyError
-            bytes::bytes_mut::BytesMut
+            axum::extract::rejection::InvalidUtf8
           and $N others
 note: required by a bound in `__axum_macros_check_handler_into_response::{closure#0}::check`
  --> tests/debug_handler/fail/single_wrong_return_tuple.rs:6:23

--- a/axum-macros/tests/debug_handler/fail/wrong_return_tuple.stderr
+++ b/axum-macros/tests/debug_handler/fail/wrong_return_tuple.stderr
@@ -21,10 +21,7 @@ error[E0277]: the trait bound `CustomIntoResponse: IntoResponseParts` is not sat
              (T1,)
            and $N others
    = help: see issue #48214
-help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
-   |
-3  + #![feature(trivial_bounds)]
-   |
+   = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
 
 error[E0277]: the trait bound `CustomIntoResponse: IntoResponseParts` is not satisfied
   --> tests/debug_handler/fail/wrong_return_tuple.rs:24:5

--- a/axum-macros/tests/debug_handler/fail/wrong_return_tuple.stderr
+++ b/axum-macros/tests/debug_handler/fail/wrong_return_tuple.stderr
@@ -21,7 +21,10 @@ error[E0277]: the trait bound `CustomIntoResponse: IntoResponseParts` is not sat
              (T1,)
            and $N others
    = help: see issue #48214
-   = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
+help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
+   |
+3  + #![feature(trivial_bounds)]
+   |
 
 error[E0277]: the trait bound `CustomIntoResponse: IntoResponseParts` is not satisfied
   --> tests/debug_handler/fail/wrong_return_tuple.rs:24:5

--- a/axum-macros/tests/debug_handler/fail/wrong_return_type.stderr
+++ b/axum-macros/tests/debug_handler/fail/wrong_return_type.stderr
@@ -12,7 +12,7 @@ error[E0277]: the trait bound `bool: IntoResponse` is not satisfied
             axum::extract::rejection::FailedToBufferBody
             axum::extract::rejection::LengthLimitError
             axum::extract::rejection::UnknownBodyError
-            bytes::bytes_mut::BytesMut
+            axum::extract::rejection::InvalidUtf8
           and $N others
 note: required by a bound in `__axum_macros_check_handler_into_response::{closure#0}::check`
  --> tests/debug_handler/fail/wrong_return_type.rs:4:23

--- a/axum-macros/tests/from_request/pass/override_rejection.rs
+++ b/axum-macros/tests/from_request/pass/override_rejection.rs
@@ -4,7 +4,6 @@ use axum::{
     http::StatusCode,
     response::{IntoResponse, Response},
     routing::get,
-    body::Body,
     Extension, Router,
 };
 

--- a/axum-macros/tests/typed_path/fail/not_deserialize.stderr
+++ b/axum-macros/tests/typed_path/fail/not_deserialize.stderr
@@ -8,3 +8,14 @@ error[E0277]: the trait bound `MyPath: serde::de::DeserializeOwned` is not satis
   = note: required for `MyPath` to implement `serde::de::DeserializeOwned`
   = note: required for `axum::extract::Path<MyPath>` to implement `FromRequestParts<S>`
   = note: this error originates in the derive macro `TypedPath` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `MyPath: serde::de::DeserializeOwned` is not satisfied
+ --> tests/typed_path/fail/not_deserialize.rs:3:10
+  |
+3 | #[derive(TypedPath)]
+  |          ^^^^^^^^^ the trait `for<'de> serde::de::Deserialize<'de>` is not implemented for `MyPath`, which is required by `axum::extract::Path<MyPath>: FromRequestParts<S>`
+  |
+  = help: the trait `FromRequestParts<S>` is implemented for `axum::extract::Path<T>`
+  = note: required for `MyPath` to implement `serde::de::DeserializeOwned`
+  = note: required for `axum::extract::Path<MyPath>` to implement `FromRequestParts<S>`
+  = note: this error originates in the attribute macro `::axum::async_trait` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/axum/Cargo.toml
+++ b/axum/Cargo.toml
@@ -55,7 +55,7 @@ mime = "0.3.16"
 percent-encoding = "2.1"
 pin-project-lite = "0.2.7"
 serde = "1.0"
-sync_wrapper = "0.1.1"
+sync_wrapper = "1.0.0"
 tower = { version = "0.4.13", default-features = false, features = ["util"] }
 tower-layer = "0.3.2"
 tower-service = "0.3"

--- a/axum/src/boxed.rs
+++ b/axum/src/boxed.rs
@@ -64,6 +64,7 @@ pub(crate) trait ErasedIntoRoute<S, E>: Send {
 
     fn into_route(self: Box<Self>, state: S) -> Route<E>;
 
+    #[allow(dead_code)]
     fn call_with_state(self: Box<Self>, request: Request, state: S) -> RouteFuture<E>;
 }
 

--- a/axum/src/extract/connect_info.rs
+++ b/axum/src/extract/connect_info.rs
@@ -225,7 +225,6 @@ where
 mod tests {
     use super::*;
     use crate::{routing::get, serve::IncomingStream, test_helpers::TestClient, Router};
-    use std::net::SocketAddr;
     use tokio::net::TcpListener;
 
     #[crate::test]

--- a/axum/src/extract/multipart.rs
+++ b/axum/src/extract/multipart.rs
@@ -311,7 +311,7 @@ mod tests {
     use axum_core::extract::DefaultBodyLimit;
 
     use super::*;
-    use crate::{response::IntoResponse, routing::post, test_helpers::*, Router};
+    use crate::{routing::post, test_helpers::*, Router};
 
     #[crate::test]
     async fn content_type_with_encoding() {

--- a/axum/src/extract/path/mod.rs
+++ b/axum/src/extract/path/mod.rs
@@ -545,7 +545,6 @@ impl IntoResponse for InvalidUtf8InPathParam {
 mod tests {
     use super::*;
     use crate::{routing::get, test_helpers::*, Router};
-    use http::StatusCode;
     use serde::Deserialize;
     use std::collections::HashMap;
 

--- a/axum/src/extract/ws.rs
+++ b/axum/src/extract/ws.rs
@@ -833,7 +833,7 @@ mod tests {
     use std::future::ready;
 
     use super::*;
-    use crate::{body::Body, routing::get, test_helpers::spawn_service, Router};
+    use crate::{routing::get, test_helpers::spawn_service, Router};
     use http::{Request, Version};
     use tokio_tungstenite::tungstenite;
     use tower::ServiceExt;

--- a/axum/src/response/sse.rs
+++ b/axum/src/response/sse.rs
@@ -559,13 +559,13 @@ mod tests {
 
         let event_fields = parse_event(&stream.chunk_text().await.unwrap());
         assert_eq!(event_fields.get("data").unwrap(), "{\"foo\":\"bar\"}");
-        assert!(event_fields.get("comment").is_none());
+        assert!(!event_fields.contains_key("comment"));
 
         let event_fields = parse_event(&stream.chunk_text().await.unwrap());
         assert_eq!(event_fields.get("event").unwrap(), "three");
         assert_eq!(event_fields.get("retry").unwrap(), "30000");
         assert_eq!(event_fields.get("id").unwrap(), "unique-id");
-        assert!(event_fields.get("comment").is_none());
+        assert!(!event_fields.contains_key("comment"));
 
         assert!(stream.chunk_text().await.is_none());
     }

--- a/axum/src/routing/method_routing.rs
+++ b/axum/src/routing/method_routing.rs
@@ -1248,7 +1248,6 @@ const _: () = {
 mod tests {
     use super::*;
     use crate::{extract::State, handler::HandlerWithoutStateExt};
-    use axum_core::response::IntoResponse;
     use http::{header::ALLOW, HeaderMap};
     use http_body_util::BodyExt;
     use std::time::Duration;

--- a/axum/src/routing/method_routing.rs
+++ b/axum/src/routing/method_routing.rs
@@ -1247,12 +1247,12 @@ const _: () = {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{body::Body, extract::State, handler::HandlerWithoutStateExt};
+    use crate::{extract::State, handler::HandlerWithoutStateExt};
     use axum_core::response::IntoResponse;
     use http::{header::ALLOW, HeaderMap};
     use http_body_util::BodyExt;
     use std::time::Duration;
-    use tower::{Service, ServiceExt};
+    use tower::ServiceExt;
     use tower_http::{
         services::fs::ServeDir, timeout::TimeoutLayer, validate_request::ValidateRequestHeaderLayer,
     };

--- a/axum/src/routing/tests/get_to_head.rs
+++ b/axum/src/routing/tests/get_to_head.rs
@@ -4,7 +4,6 @@ use tower::ServiceExt;
 
 mod for_handlers {
     use super::*;
-    use http::HeaderMap;
 
     #[crate::test]
     async fn get_handles_head() {
@@ -39,7 +38,6 @@ mod for_handlers {
 
 mod for_services {
     use super::*;
-    use crate::routing::get_service;
 
     #[crate::test]
     async fn get_handles_head() {

--- a/axum/src/routing/tests/handle_error.rs
+++ b/axum/src/routing/tests/handle_error.rs
@@ -1,5 +1,5 @@
 use super::*;
-use std::future::{pending, ready};
+use std::future::pending;
 use tower::timeout::TimeoutLayer;
 
 async fn unit() {}

--- a/axum/src/routing/tests/merge.rs
+++ b/axum/src/routing/tests/merge.rs
@@ -1,8 +1,7 @@
 use super::*;
-use crate::{extract::OriginalUri, response::IntoResponse, Json};
+use crate::{extract::OriginalUri, response::IntoResponse};
 use serde_json::{json, Value};
 use tower::limit::ConcurrencyLimitLayer;
-use tower_http::timeout::TimeoutLayer;
 
 #[crate::test]
 async fn basic() {

--- a/axum/src/routing/tests/merge.rs
+++ b/axum/src/routing/tests/merge.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::{extract::OriginalUri, response::IntoResponse};
+use crate::extract::OriginalUri;
 use serde_json::{json, Value};
 use tower::limit::ConcurrencyLimitLayer;
 

--- a/axum/src/routing/tests/nest.rs
+++ b/axum/src/routing/tests/nest.rs
@@ -1,5 +1,4 @@
 use super::*;
-use crate::extract::Extension;
 use std::collections::HashMap;
 use tower_http::services::ServeDir;
 

--- a/axum/src/util.rs
+++ b/axum/src/util.rs
@@ -74,9 +74,8 @@ mod mutex {
 }
 
 #[cfg(test)]
+#[allow(clippy::disallowed_types)]
 mod mutex {
-    #![allow(clippy::disallowed_types)]
-
     use std::sync::{
         atomic::{AtomicUsize, Ordering},
         LockResult, Mutex, MutexGuard,

--- a/examples/sse/src/main.rs
+++ b/examples/sse/src/main.rs
@@ -13,7 +13,7 @@ use axum::{
     routing::get,
     Router,
 };
-use axum_extra::{headers, TypedHeader};
+use axum_extra::TypedHeader;
 use futures::stream::{self, Stream};
 use std::{convert::Infallible, path::PathBuf, time::Duration};
 use tokio_stream::StreamExt as _;

--- a/examples/testing/src/main.rs
+++ b/examples/testing/src/main.rs
@@ -60,7 +60,6 @@ mod tests {
     };
     use http_body_util::BodyExt; // for `collect`
     use serde_json::{json, Value};
-    use std::net::SocketAddr;
     use tokio::net::TcpListener;
     use tower::{Service, ServiceExt}; // for `call`, `oneshot`, and `ready`
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation
`sync_wrapper` had a dependency `future-core` until version 0.1.1.
Now, `future-core` is optional  in `sync_wrapper` from [version 0.1.2](https://github.com/Actyx/sync_wrapper/commit/7ebf2994396d88738067a09cf354cbb0d6ac1084)
`struct SyncStream` is dependent `future-core` but `axum` doesn't use `struct SyncStream`.

Updating to version 0.1.2 or later separates `sync_wrapper` from `future-core`.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution
Update `sync_wrapper` to 1.0.0
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
