### PR TITLE
`rust-version` rewrite to 1.66 of axum-core

### DIFF
--- a/axum-core/Cargo.toml
+++ b/axum-core/Cargo.toml
@@ -2,7 +2,7 @@
 categories = ["asynchronous", "network-programming", "web-programming"]
 description = "Core types and traits for axum"
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.66"
 homepage = "https://github.com/tokio-rs/axum"
 keywords = ["http", "web", "framework"]
 license = "MIT"

--- a/axum-core/README.md
+++ b/axum-core/README.md
@@ -14,7 +14,7 @@ This crate uses `#![forbid(unsafe_code)]` to ensure everything is implemented in
 
 ## Minimum supported Rust version
 
-axum-core's MSRV is 1.56.
+axum-core's MSRV is 1.66.
 
 ## Getting Help
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation
I can't compile `axum-core` by Rust version 1.56.
`axum-core` depends on `tower-http`, and rust-version of `tower-http` is 1.66.
`tokio` depends on `socket2`. `socket2` requires version 1.63 or newer.


<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution
I think that MSRV is 1.66.
I rewrite `rust-version` from 1.56 to 1.66.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
