### PR TITLE
axum: remove unnecessary `Arc::clone`

### DIFF
--- a/axum/src/routing/path_router.rs
+++ b/axum/src/routing/path_router.rs
@@ -111,12 +111,10 @@ where
     }
 
     fn set_node(&mut self, path: &str, id: RouteId) -> Result<(), String> {
-        let mut node = (*self.node).clone();
-        if let Err(err) = node.insert(path, id) {
-            return Err(format!("Invalid route {path:?}: {err}"));
-        }
-        self.node = Arc::new(node);
-        Ok(())
+        let node = Arc::make_mut(&mut self.node);
+
+        node.insert(path, id)
+            .map_err(|err| format!("Invalid route {path:?}: {err}"))
     }
 
     pub(super) fn merge(

--- a/axum/src/routing/path_router.rs
+++ b/axum/src/routing/path_router.rs
@@ -111,8 +111,7 @@ where
     }
 
     fn set_node(&mut self, path: &str, id: RouteId) -> Result<(), String> {
-        let mut node =
-            Arc::try_unwrap(Arc::clone(&self.node)).unwrap_or_else(|node| (*node).clone());
+        let mut node = (*self.node).clone();
         if let Err(err) = node.insert(path, id) {
             return Err(format!("Invalid route {path:?}: {err}"));
         }


### PR DESCRIPTION
## Motivation

There was an unnecessary arc clone which is always dropped right afterward.

The `try_unwrap` call returns `Ok` only if the `Arc` has a strong count of exactly 1, but since we have just cloned it we know it will be more than 1. So the `try_unwrap` never works and the more expensive `clone` always happens anyway.

## Solution

I have removed the `Arc` operations.