### PR TITLE
Upgrade reqwest to 0.12

### DIFF
--- a/axum-extra/Cargo.toml
+++ b/axum-extra/Cargo.toml
@@ -71,7 +71,7 @@ tracing = { version = "0.1.37", default-features = false, optional = true }
 [dev-dependencies]
 axum = { path = "../axum", version = "0.7.2" }
 hyper = "1.0.0"
-reqwest = { version = "0.11", default-features = false, features = ["json", "stream", "multipart"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "stream", "multipart"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.71"
 tokio = { version = "1.14", features = ["full"] }

--- a/axum/Cargo.toml
+++ b/axum/Cargo.toml
@@ -117,7 +117,7 @@ anyhow = "1.0"
 axum-macros = { path = "../axum-macros", version = "0.4.1", features = ["__private"] }
 quickcheck = "1.0"
 quickcheck_macros = "1.0"
-reqwest = { version = "0.11.14", default-features = false, features = ["json", "stream", "multipart"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "stream", "multipart"] }
 rustversion = "1.0.9"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/axum/src/test_helpers/test_client.rs
+++ b/axum/src/test_helpers/test_client.rs
@@ -5,7 +5,7 @@ use http::{
     header::{HeaderName, HeaderValue},
     StatusCode,
 };
-use std::{convert::Infallible, future::IntoFuture, net::SocketAddr, str::FromStr};
+use std::{convert::Infallible, future::IntoFuture, net::SocketAddr};
 use tokio::net::TcpListener;
 use tower::make::Shared;
 use tower_service::Service;
@@ -110,15 +110,7 @@ impl RequestBuilder {
         HeaderValue: TryFrom<V>,
         <HeaderValue as TryFrom<V>>::Error: Into<http::Error>,
     {
-        // reqwest still uses http 0.2
-        let key: HeaderName = key.try_into().map_err(Into::into).unwrap();
-        let key = reqwest::header::HeaderName::from_bytes(key.as_ref()).unwrap();
-
-        let value: HeaderValue = value.try_into().map_err(Into::into).unwrap();
-        let value = reqwest::header::HeaderValue::from_bytes(value.as_bytes()).unwrap();
-
         self.builder = self.builder.header(key, value);
-
         self
     }
 
@@ -170,14 +162,7 @@ impl TestResponse {
     }
 
     pub(crate) fn headers(&self) -> http::HeaderMap {
-        // reqwest still uses http 0.2 so have to convert into http 1.0
-        let mut headers = http::HeaderMap::new();
-        for (key, value) in self.response.headers() {
-            let key = http::HeaderName::from_str(key.as_str()).unwrap();
-            let value = http::HeaderValue::from_bytes(value.as_bytes()).unwrap();
-            headers.insert(key, value);
-        }
-        headers
+        self.response.headers().clone()
     }
 
     pub(crate) async fn chunk(&mut self) -> Option<Bytes> {

--- a/examples/oauth/Cargo.toml
+++ b/examples/oauth/Cargo.toml
@@ -12,7 +12,7 @@ axum-extra = { path = "../../axum-extra", features = ["typed-header"] }
 http = "1.0.0"
 oauth2 = "4.1"
 # Use Rustls because it makes it easier to cross-compile on CI
-reqwest = { version = "0.11", default-features = false, features = ["rustls-tls", "json"] }
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
 serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "1.0", features = ["full"] }
 tracing = "0.1"

--- a/examples/reqwest-response/Cargo.toml
+++ b/examples/reqwest-response/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [dependencies]
 axum = { path = "../../axum" }
-reqwest = { version = "0.11", features = ["stream"] }
+reqwest = { version = "0.12", features = ["stream"] }
 tokio = { version = "1.0", features = ["full"] }
 tokio-stream = "0.1"
 tower-http = { version = "0.5.0", features = ["trace"] }

--- a/examples/sse/Cargo.toml
+++ b/examples/sse/Cargo.toml
@@ -17,5 +17,5 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]
 eventsource-stream = "0.2"
-reqwest = { version = "0.11", features = ["stream"] }
+reqwest = { version = "0.12", features = ["stream"] }
 reqwest-eventsource = "0.5"


### PR DESCRIPTION
New reqwest version uses http 1 and hyper 1.

Reduce some intermediate conversions.