### PR TITLE
Replace own TowerToHyperService with upstream version

### DIFF
--- a/axum/Cargo.toml
+++ b/axum/Cargo.toml
@@ -65,7 +65,7 @@ tower-service = "0.3"
 axum-macros = { path = "../axum-macros", version = "0.4.1", optional = true }
 base64 = { version = "0.21.0", optional = true }
 hyper = { version = "1.1.0", optional = true }
-hyper-util = { version = "0.1.3", features = ["tokio", "server"], optional = true }
+hyper-util = { version = "0.1.3", features = ["tokio", "server", "service"], optional = true }
 multer = { version = "3.0.0", optional = true }
 serde_json = { version = "1.0", features = ["raw_value"], optional = true }
 serde_path_to_error = { version = "0.1.8", optional = true }

--- a/axum/src/serve.rs
+++ b/axum/src/serve.rs
@@ -7,9 +7,7 @@ use std::{
     io,
     marker::PhantomData,
     net::SocketAddr,
-    pin::Pin,
     sync::Arc,
-    task::{Context, Poll},
     time::Duration,
 };
 
@@ -18,13 +16,12 @@ use futures_util::{pin_mut, FutureExt};
 use hyper::body::Incoming;
 use hyper_util::rt::{TokioExecutor, TokioIo};
 #[cfg(any(feature = "http1", feature = "http2"))]
-use hyper_util::server::conn::auto::Builder;
-use pin_project_lite::pin_project;
+use hyper_util::{server::conn::auto::Builder, service::TowerToHyperService};
 use tokio::{
     net::{TcpListener, TcpStream},
     sync::watch,
 };
-use tower::util::{Oneshot, ServiceExt};
+use tower::ServiceExt as _;
 use tower_service::Service;
 
 /// Serve the service with the supplied listener.
@@ -243,11 +240,10 @@ where
                         remote_addr,
                     })
                     .await
-                    .unwrap_or_else(|err| match err {});
+                    .unwrap_or_else(|err| match err {})
+                    .map_request(|req: Request<Incoming>| req.map(Body::new));
 
-                let hyper_service = TowerToHyperService {
-                    service: tower_service,
-                };
+                let hyper_service = TowerToHyperService::new(tower_service);
 
                 tokio::spawn(async move {
                     match Builder::new(TokioExecutor::new())
@@ -404,11 +400,10 @@ where
                         remote_addr,
                     })
                     .await
-                    .unwrap_or_else(|err| match err {});
+                    .unwrap_or_else(|err| match err {})
+                    .map_request(|req: Request<Incoming>| req.map(Body::new));
 
-                let hyper_service = TowerToHyperService {
-                    service: tower_service,
-                };
+                let hyper_service = TowerToHyperService::new(tower_service);
 
                 let signal_tx = Arc::clone(&signal_tx);
 
@@ -515,49 +510,6 @@ mod private {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             f.debug_struct("ServeFuture").finish_non_exhaustive()
         }
-    }
-}
-
-#[derive(Debug, Copy, Clone)]
-struct TowerToHyperService<S> {
-    service: S,
-}
-
-impl<S> hyper::service::Service<Request<Incoming>> for TowerToHyperService<S>
-where
-    S: tower_service::Service<Request> + Clone,
-{
-    type Response = S::Response;
-    type Error = S::Error;
-    type Future = TowerToHyperServiceFuture<S, Request>;
-
-    fn call(&self, req: Request<Incoming>) -> Self::Future {
-        let req = req.map(Body::new);
-        TowerToHyperServiceFuture {
-            future: self.service.clone().oneshot(req),
-        }
-    }
-}
-
-pin_project! {
-    struct TowerToHyperServiceFuture<S, R>
-    where
-        S: tower_service::Service<R>,
-    {
-        #[pin]
-        future: Oneshot<S, R>,
-    }
-}
-
-impl<S, R> Future for TowerToHyperServiceFuture<S, R>
-where
-    S: tower_service::Service<R>,
-{
-    type Output = Result<S::Response, S::Error>;
-
-    #[inline]
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        self.project().future.poll(cx)
     }
 }
 


### PR DESCRIPTION
… from hyper-util.

## Motivation

Less code to maintain :)

## Solution

Use `hyper_util::service::TowerToHyperService`, now that it's released.