### PR TITLE
Enable diagnostic attributes for Rust 1.78+

### DIFF
--- a/axum-core/Cargo.toml
+++ b/axum-core/Cargo.toml
@@ -26,6 +26,7 @@ http-body = "1.0.0"
 http-body-util = "0.1.0"
 mime = "0.3.16"
 pin-project-lite = "0.2.7"
+rustversion = "1.0.9"
 sync_wrapper = "1.0.0"
 tower-layer = "0.3"
 tower-service = "0.3"
@@ -33,9 +34,6 @@ tower-service = "0.3"
 # optional dependencies
 tower-http = { version = "0.5.0", optional = true, features = ["limit"] }
 tracing = { version = "0.1.37", default-features = false, optional = true }
-
-[build-dependencies]
-rustversion = "1.0.9"
 
 [dev-dependencies]
 axum = { path = "../axum", version = "0.7.2" }

--- a/axum-core/build.rs
+++ b/axum-core/build.rs
@@ -1,7 +1,0 @@
-#[rustversion::nightly]
-fn main() {
-    println!("cargo:rustc-cfg=nightly_error_messages");
-}
-
-#[rustversion::not(nightly)]
-fn main() {}

--- a/axum-core/src/extract/mod.rs
+++ b/axum-core/src/extract/mod.rs
@@ -43,8 +43,8 @@ mod private {
 ///
 /// [`axum::extract`]: https://docs.rs/axum/0.7/axum/extract/index.html
 #[async_trait]
-#[cfg_attr(
-    nightly_error_messages,
+#[rustversion::attr(
+    since(1.78),
     diagnostic::on_unimplemented(
         note = "Function argument is not a valid axum extractor. \nSee `https://docs.rs/axum/0.7/axum/extract/index.html` for details",
     )
@@ -70,8 +70,8 @@ pub trait FromRequestParts<S>: Sized {
 ///
 /// [`axum::extract`]: https://docs.rs/axum/0.7/axum/extract/index.html
 #[async_trait]
-#[cfg_attr(
-    nightly_error_messages,
+#[rustversion::attr(
+    since(1.78),
     diagnostic::on_unimplemented(
         note = "Function argument is not a valid axum extractor. \nSee `https://docs.rs/axum/0.7/axum/extract/index.html` for details",
     )

--- a/axum/Cargo.toml
+++ b/axum/Cargo.toml
@@ -54,6 +54,7 @@ memchr = "2.4.1"
 mime = "0.3.16"
 percent-encoding = "2.1"
 pin-project-lite = "0.2.7"
+rustversion = "1.0.9"
 serde = "1.0"
 sync_wrapper = "1.0.0"
 tower = { version = "0.4.13", default-features = false, features = ["util"] }
@@ -109,16 +110,12 @@ features = [
     "validate-request",
 ]
 
-[build-dependencies]
-rustversion = "1.0.9"
-
 [dev-dependencies]
 anyhow = "1.0"
 axum-macros = { path = "../axum-macros", version = "0.4.1", features = ["__private"] }
 quickcheck = "1.0"
 quickcheck_macros = "1.0"
 reqwest = { version = "0.12", default-features = false, features = ["json", "stream", "multipart"] }
-rustversion = "1.0.9"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 time = { version = "0.3", features = ["serde-human-readable"] }

--- a/axum/build.rs
+++ b/axum/build.rs
@@ -1,7 +1,0 @@
-#[rustversion::nightly]
-fn main() {
-    println!("cargo:rustc-cfg=nightly_error_messages");
-}
-
-#[rustversion::not(nightly)]
-fn main() {}

--- a/axum/src/handler/mod.rs
+++ b/axum/src/handler/mod.rs
@@ -125,8 +125,8 @@ pub use self::service::HandlerService;
 ///     )));
 /// # let _: Router = app;
 /// ```
-#[cfg_attr(
-    nightly_error_messages,
+#[rustversion::attr(
+    since(1.78),
     diagnostic::on_unimplemented(
         note = "Consider using `#[axum::debug_handler]` to improve the error message"
     )


### PR DESCRIPTION
Stabilized for 1.78 in https://github.com/rust-lang/rust/pull/119888.

@tisonkun does this fix [your issue](https://github.com/tokio-rs/axum/pull/2650#issuecomment-2026460418)? You can try it by adding

```toml
[patch.crates-io]
axum = { git = "https://github.com/tokio-rs/axum", branch = "jplatte/diagnostic-ver" }
axum-core = { git = "https://github.com/tokio-rs/axum", branch = "jplatte/diagnostic-ver" }
```

to your top-level `Cargo.toml` (the workspace file if you use a Cargo workspace).