### PR TITLE
feat: expose test client under testing feature

### DIFF
--- a/axum/Cargo.toml
+++ b/axum/Cargo.toml
@@ -32,6 +32,7 @@ matched-path = []
 multipart = ["dep:multer"]
 original-uri = []
 query = ["dep:serde_urlencoded"]
+testing = ["dep:reqwest"]
 tokio = ["dep:hyper-util", "dep:tokio", "tokio/net", "tokio/rt", "tower/make", "tokio/macros"]
 tower-log = ["tower/log"]
 tracing = ["dep:tracing", "axum-core/tracing"]
@@ -66,6 +67,7 @@ base64 = { version = "0.21.0", optional = true }
 hyper = { version = "1.1.0", optional = true }
 hyper-util = { version = "0.1.3", features = ["tokio", "server"], optional = true }
 multer = { version = "3.0.0", optional = true }
+reqwest = { version = "0.12", default-features = false, features = ["json", "stream", "multipart"], optional = true }
 serde_json = { version = "1.0", features = ["raw_value"], optional = true }
 serde_path_to_error = { version = "0.1.8", optional = true }
 serde_urlencoded = { version = "0.7", optional = true }
@@ -193,14 +195,12 @@ allowed = [
     # our crates
     "axum_core",
     "axum_macros",
-
     # not 1.0
     "futures_core",
     "futures_sink",
     "futures_util",
     "tower_layer",
     "tower_service",
-
     # >=1.0
     "async_trait",
     "bytes",

--- a/axum/src/lib.rs
+++ b/axum/src/lib.rs
@@ -440,7 +440,9 @@ pub mod routing;
 pub mod serve;
 
 #[cfg(any(test, feature = "testing"))]
-pub mod test_helpers;
+mod test_helpers;
+#[cfg(feature = "testing")]
+pub use test_helpers::test_client;
 
 #[doc(no_inline)]
 pub use async_trait::async_trait;

--- a/axum/src/lib.rs
+++ b/axum/src/lib.rs
@@ -439,8 +439,8 @@ pub mod routing;
 #[cfg(all(feature = "tokio", any(feature = "http1", feature = "http2")))]
 pub mod serve;
 
-#[cfg(test)]
-mod test_helpers;
+#[cfg(any(test, feature = "testing"))]
+pub mod test_helpers;
 
 #[doc(no_inline)]
 pub use async_trait::async_trait;

--- a/axum/src/test_helpers/mod.rs
+++ b/axum/src/test_helpers/mod.rs
@@ -2,8 +2,9 @@
 
 use crate::{extract::Request, response::Response, serve};
 
-mod test_client;
-pub use self::test_client::*;
+pub mod test_client;
+#[cfg(test)]
+pub(crate) use self::test_client::*;
 
 #[cfg(test)]
 pub(crate) mod tracing_helpers;

--- a/axum/src/test_helpers/mod.rs
+++ b/axum/src/test_helpers/mod.rs
@@ -3,12 +3,14 @@
 use crate::{extract::Request, response::Response, serve};
 
 mod test_client;
-pub(crate) use self::test_client::*;
+pub use self::test_client::*;
 
+#[cfg(test)]
 pub(crate) mod tracing_helpers;
 
+#[cfg(test)]
 pub(crate) fn assert_send<T: Send>() {}
+#[cfg(test)]
 pub(crate) fn assert_sync<T: Sync>() {}
-
 #[allow(dead_code)]
 pub(crate) struct NotSendSync(*const ());

--- a/axum/src/test_helpers/test_client.rs
+++ b/axum/src/test_helpers/test_client.rs
@@ -20,7 +20,8 @@ where
     let listener = TcpListener::from_std(std_listener).unwrap();
 
     let addr = listener.local_addr().unwrap();
-    println!("Listening on {addr}");
+    #[cfg(feature = "tracing")]
+    tracing::info!("Listening on {addr}");
 
     tokio::spawn(async move {
         serve(listener, Shared::new(svc))
@@ -31,13 +32,14 @@ where
     addr
 }
 
-pub(crate) struct TestClient {
+#[derive(Debug)]
+pub struct TestClient {
     client: reqwest::Client,
     addr: SocketAddr,
 }
 
 impl TestClient {
-    pub(crate) fn new<S>(svc: S) -> Self
+    pub fn new<S>(svc: S) -> Self
     where
         S: Service<Request, Response = Response, Error = Infallible> + Clone + Send + 'static,
         S::Future: Send,
@@ -52,50 +54,51 @@ impl TestClient {
         TestClient { client, addr }
     }
 
-    pub(crate) fn get(&self, url: &str) -> RequestBuilder {
+    pub fn get(&self, url: &str) -> RequestBuilder {
         RequestBuilder {
             builder: self.client.get(format!("http://{}{}", self.addr, url)),
         }
     }
 
-    pub(crate) fn head(&self, url: &str) -> RequestBuilder {
+    pub fn head(&self, url: &str) -> RequestBuilder {
         RequestBuilder {
             builder: self.client.head(format!("http://{}{}", self.addr, url)),
         }
     }
 
-    pub(crate) fn post(&self, url: &str) -> RequestBuilder {
+    pub fn post(&self, url: &str) -> RequestBuilder {
         RequestBuilder {
             builder: self.client.post(format!("http://{}{}", self.addr, url)),
         }
     }
 
     #[allow(dead_code)]
-    pub(crate) fn put(&self, url: &str) -> RequestBuilder {
+    pub fn put(&self, url: &str) -> RequestBuilder {
         RequestBuilder {
             builder: self.client.put(format!("http://{}{}", self.addr, url)),
         }
     }
 
     #[allow(dead_code)]
-    pub(crate) fn patch(&self, url: &str) -> RequestBuilder {
+    pub fn patch(&self, url: &str) -> RequestBuilder {
         RequestBuilder {
             builder: self.client.patch(format!("http://{}{}", self.addr, url)),
         }
     }
 }
 
-pub(crate) struct RequestBuilder {
+#[derive(Debug)]
+pub struct RequestBuilder {
     builder: reqwest::RequestBuilder,
 }
 
 impl RequestBuilder {
-    pub(crate) fn body(mut self, body: impl Into<reqwest::Body>) -> Self {
+    pub fn body(mut self, body: impl Into<reqwest::Body>) -> Self {
         self.builder = self.builder.body(body);
         self
     }
 
-    pub(crate) fn json<T>(mut self, json: &T) -> Self
+    pub fn json<T>(mut self, json: &T) -> Self
     where
         T: serde::Serialize,
     {
@@ -103,7 +106,7 @@ impl RequestBuilder {
         self
     }
 
-    pub(crate) fn header<K, V>(mut self, key: K, value: V) -> Self
+    pub fn header<K, V>(mut self, key: K, value: V) -> Self
     where
         HeaderName: TryFrom<K>,
         <HeaderName as TryFrom<K>>::Error: Into<http::Error>,
@@ -115,7 +118,7 @@ impl RequestBuilder {
     }
 
     #[allow(dead_code)]
-    pub(crate) fn multipart(mut self, form: reqwest::multipart::Form) -> Self {
+    pub fn multipart(mut self, form: reqwest::multipart::Form) -> Self {
         self.builder = self.builder.multipart(form);
         self
     }
@@ -135,41 +138,41 @@ impl IntoFuture for RequestBuilder {
 }
 
 #[derive(Debug)]
-pub(crate) struct TestResponse {
+pub struct TestResponse {
     response: reqwest::Response,
 }
 
 impl TestResponse {
     #[allow(dead_code)]
-    pub(crate) async fn bytes(self) -> Bytes {
+    pub async fn bytes(self) -> Bytes {
         self.response.bytes().await.unwrap()
     }
 
-    pub(crate) async fn text(self) -> String {
+    pub async fn text(self) -> String {
         self.response.text().await.unwrap()
     }
 
     #[allow(dead_code)]
-    pub(crate) async fn json<T>(self) -> T
+    pub async fn json<T>(self) -> T
     where
         T: serde::de::DeserializeOwned,
     {
         self.response.json().await.unwrap()
     }
 
-    pub(crate) fn status(&self) -> StatusCode {
+    pub fn status(&self) -> StatusCode {
         StatusCode::from_u16(self.response.status().as_u16()).unwrap()
     }
 
-    pub(crate) fn headers(&self) -> http::HeaderMap {
+    pub fn headers(&self) -> http::HeaderMap {
         self.response.headers().clone()
     }
 
-    pub(crate) async fn chunk(&mut self) -> Option<Bytes> {
+    pub async fn chunk(&mut self) -> Option<Bytes> {
         self.response.chunk().await.unwrap()
     }
 
-    pub(crate) async fn chunk_text(&mut self) -> Option<String> {
+    pub async fn chunk_text(&mut self) -> Option<String> {
         let chunk = self.chunk().await?;
         Some(String::from_utf8(chunk.to_vec()).unwrap())
     }


### PR DESCRIPTION
## Motivation

There is a crate [axum-test-helper](https://github.com/cloudwalk/axum-test-helper) for the same purpose and it seems widely used. Since the crate is less actively maintained, I suppose we can implement the same on the upstream so keep it updated.

## Solution

```rust
#[cfg(any(test, feature = "testing"))]
pub mod test_helpers;
```

... and export all inner methods for test clients.

@jplatte 