### PR TITLE
comment spacing fix in examples/websockets

### DIFF
--- a/examples/websockets/src/main.rs
+++ b/examples/websockets/src/main.rs
@@ -99,7 +99,7 @@ async fn ws_handler(
 
 /// Actual websocket statemachine (one will be spawned per connection)
 async fn handle_socket(mut socket: WebSocket, who: SocketAddr) {
-    //send a ping (unsupported by some browsers) just to kick things off and get a response
+    // send a ping (unsupported by some browsers) just to kick things off and get a response
     if socket.send(Message::Ping(vec![1, 2, 3])).await.is_ok() {
         println!("Pinged {who}...");
     } else {


### PR DESCRIPTION
just fixing the spacing in the comment, no other actual change.