### PR TITLE
chore(ci):  Bump `crate-ci/typos` from v1.16.2 to v1.20.8

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -227,4 +227,4 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Check the spelling of the files in our repo
-        uses: crate-ci/typos@v1.16.2
+        uses: crate-ci/typos@v1.20.8


### PR DESCRIPTION
## Motivation
I think `crate-ci/typos` have a major update in dictionary

## Solution
Update it.
