### PR TITLE
fix: error[E0658]:  attribute name space is experimental

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 target
 Cargo.lock
 .DS_Store
+.idea
+.vscode

--- a/axum-core/src/lib.rs
+++ b/axum-core/src/lib.rs
@@ -48,6 +48,7 @@
 #![forbid(unsafe_code)]
 #![cfg_attr(test, allow(clippy::float_cmp))]
 #![cfg_attr(not(test), warn(clippy::print_stdout, clippy::dbg_macro))]
+#![feature(diagnostic_namespace)]
 
 #[macro_use]
 pub(crate) mod macros;

--- a/axum/src/lib.rs
+++ b/axum/src/lib.rs
@@ -416,6 +416,7 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg, doc_cfg))]
 #![cfg_attr(test, allow(clippy::float_cmp))]
 #![cfg_attr(not(test), warn(clippy::print_stdout, clippy::dbg_macro))]
+#![feature(diagnostic_namespace)]
 
 #[macro_use]
 pub(crate) mod macros;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation

* Resolve error `error[E0658]:  attribute name space is experimental` . Error logs as bellow: 

```bash
error[E0658]: `#[diagnostic]` attribute name space is experimental
  --> axum-core/src/extract/mod.rs:48:5
   |
48 |     diagnostic::on_unimplemented(
   |     ^^^^^^^^^^
   |
   = note: see issue #111996 <https://github.com/rust-lang/rust/issues/111996> for more information
   = help: add `#![feature(diagnostic_namespace)]` to the crate attributes to enable
   = note: this compiler was built on 2024-02-26; consider upgrading it if it is out of date

```


<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution
1. we can update toolchain to after  2024-02-26.
2. we adopt the older toolchains by `add `#![feature(diagnostic_namespace)]` to the crate attributes to enable` 


Adoption will be suitable for more users. And this pr is for solution#2.


<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
## See more

* https://github.com/tokio-rs/axum/discussions/2682
* https://github.com/tokio-rs/axum/issues/2681
* https://github.com/rust-lang/rust/issues/111996



