### PR TITLE
Add ErrorKind::DeserializeError to specialize ErrorKind::Message (`extract::path::ErrorKind`)

### DIFF
--- a/axum-extra/src/extract/optional_path.rs
+++ b/axum-extra/src/extract/optional_path.rs
@@ -94,7 +94,7 @@ mod tests {
         let res = client.get("/NaN").await;
         assert_eq!(
             res.text().await,
-            "Invalid URL: Cannot parse `\"NaN\"` to a `u32`"
+            "Invalid URL: Cannot parse `NaN` to a `u32`"
         );
     }
 }

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   This allows middleware to add bodies to requests without needing to manually set `content-length` ([#2897])
 - **breaking:** Remove `WebSocket::close`.
   Users should explicitly send close messages themselves. ([#2974])
+- **added:** Extend `FailedToDeserializePathParams::kind` enum with (`ErrorKind::DeserializeError`)
+  This new variant captures both `key`, `value`, and `message` from named path parameters parse errors,
+  instead of only deserialization error message in `ErrorKind::Message`. ([#2720])
 
 [#2897]: https://github.com/tokio-rs/axum/pull/2897
 [#2903]: https://github.com/tokio-rs/axum/pull/2903
@@ -28,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2974]: https://github.com/tokio-rs/axum/pull/2974
 [#2978]: https://github.com/tokio-rs/axum/pull/2978
 [#2992]: https://github.com/tokio-rs/axum/pull/2992
+[#2720]: https://github.com/tokio-rs/axum/pull/2720
 
 # 0.8.0
 

--- a/axum/src/extract/path/mod.rs
+++ b/axum/src/extract/path/mod.rs
@@ -341,25 +341,25 @@ impl fmt::Display for ErrorKind {
                 expected_type,
             } => write!(
                 f,
-                "Cannot parse `{key}` with value `{value:?}` to a `{expected_type}`"
+                "Cannot parse `{key}` with value `{value}` to a `{expected_type}`"
             ),
             ErrorKind::ParseError {
                 value,
                 expected_type,
-            } => write!(f, "Cannot parse `{value:?}` to a `{expected_type}`"),
+            } => write!(f, "Cannot parse `{value}` to a `{expected_type}`"),
             ErrorKind::ParseErrorAtIndex {
                 index,
                 value,
                 expected_type,
             } => write!(
                 f,
-                "Cannot parse value at index {index} with value `{value:?}` to a `{expected_type}`"
+                "Cannot parse value at index {index} with value `{value}` to a `{expected_type}`"
             ),
             ErrorKind::DeserializeError {
                 key,
                 value,
                 message,
-            } => write!(f, "Cannot parse `{key}` with value `{value:?}`: {message}"),
+            } => write!(f, "Cannot parse `{key}` with value `{value}`: {message}"),
         }
     }
 }
@@ -949,7 +949,7 @@ mod tests {
         let body = res.text().await;
         assert_eq!(
             body,
-            r#"Invalid URL: Cannot parse `res` with value `"123123-123-123123"`: UUID parsing failed: invalid group count: expected 5, found 3"#
+            r#"Invalid URL: Cannot parse `res` with value `123123-123-123123`: UUID parsing failed: invalid group count: expected 5, found 3"#
         );
     }
 
@@ -970,7 +970,7 @@ mod tests {
         let body = res.text().await;
         assert_eq!(
             body,
-            r#"Invalid URL: Cannot parse `res` with value `"456456-123-456456"`: UUID parsing failed: invalid group count: expected 5, found 3"#
+            r#"Invalid URL: Cannot parse `res` with value `456456-123-456456`: UUID parsing failed: invalid group count: expected 5, found 3"#
         );
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation

Expose the `key` and `value` of the `extract::Path` extrator for when the serde deserialization fails. This allow custom extractors wrapping the `Path` extractor to specialize their responses with more context about the failed operation. Currently, all failed deserializations end up as part of the `extract::path::ErrorKind::Message` variant.

I encountered this situation when attempting to create my own extrator, using it to deserialize `uuid::Uuid` resources, since I require specializing the response for these error conditions.

```rust
//! Manual implementation wrapping `axum::extract::Path` extrator.

use axum::extract::FromRequestParts;
use axum::extract::{path::ErrorKind, rejection::PathRejection};
use axum::http::{request::Parts, StatusCode};
use serde::de::DeserializeOwned;

pub struct Path<T>(pub T);

#[axum::async_trait]
impl<T, S> FromRequestParts<S> for Path<T>
where
    T: DeserializeOwned + Send,
    S: Send + Sync,
{
    type Rejection = (StatusCode, axum::Json<serde_json::Value>);

    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
        match axum::extract::Path::<T>::from_request_parts(parts, state).await {
            Ok(value) => Ok(Self(value.0)),
            Err(rejection) => match &rejection {
                PathRejection::FailedToDeserializePathParams(f) => match f.kind() {
                    ErrorKind::ParseErrorAtKey { key, value, .. } => Err((
                        StatusCode::BAD_REQUEST,
                        axum::Json(serde_json::json!({
                            "code": "MALFORMED_VALUE",
                            "message": format!("Value '{value}' could not be parsed"),
                            "target": key
                        })),
                    )),
                    
                    // Nominal UUID deserialization issuess occur in ErrorKind::Message
                    
                    _ => Err((
                        StatusCode::BAD_REQUEST,
                        axum::Json(serde_json::json!({
                            "code": "MALFORMED_VALUE",
                            "message": f.body_text(),
                            "target": "",
                        })),
                    )),
                },
                PathRejection::MissingPathParams(..) | _ => {
                    Err((
                        StatusCode::INTERNAL_SERVER_ERROR,
                        axum::Json(serde_json::json!({
                            "message": "An internal server error occurred",
                        })),
                    ))
                }
            },
        }
    }
}

// This is the endpoint handler using the custom Path extractor.
async fn find_resource(Path(resource_id): Path<uuid::Uuid>) -> String {
    todo!()
}
```

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

This commit introduces another `extract::path::ErrorKind` variant that captures the serde error nominally captured through the `serde::de::Error` trait impl on `PathDeserializeError`. We augment the deserialization error with the captured (key, value), allowing `extract::Path`, and wrapping extractors, to gain programmatic access to the key name, and attempted deserialized value.

This allows me to expand the handling in the wrapping Path extractor.
```rust
ErrorKind::DeserializeError { key, value, message } => Err((StatusCode::BAD_REQUEST, axum::Json(serde_json::json!({
  "code": "MALFORMED_VALUE",
  "message": format!("Value '{value}' could not be parsed"),
  "target": key
})),
```