### PR TITLE
Drop limitation of disallowing generics for the `TypedPath` derive in axum-extra

### DIFF
--- a/axum-macros/src/typed_path.rs
+++ b/axum-macros/src/typed_path.rs
@@ -1,6 +1,11 @@
+use std::collections::HashSet;
+
 use proc_macro2::{Span, TokenStream};
-use quote::{format_ident, quote, quote_spanned};
-use syn::{parse::Parse, ItemStruct, LitStr, Token};
+use quote::{format_ident, quote, quote_spanned, ToTokens};
+use syn::{
+    parse::Parse, parse_quote, punctuated::Punctuated, GenericParam, Generics, ItemStruct, LitStr,
+    Token, WhereClause, WherePredicate,
+};
 
 use crate::attr_parsing::{combine_attribute, parse_parenthesized_attribute, second, Combine};
 
@@ -11,16 +16,9 @@ pub(crate) fn expand(item_struct: ItemStruct) -> syn::Result<TokenStream> {
         generics,
         fields,
         ..
-    } = &item_struct;
+    } = item_struct;
 
-    if !generics.params.is_empty() || generics.where_clause.is_some() {
-        return Err(syn::Error::new_spanned(
-            generics,
-            "`#[derive(TypedPath)]` doesn't support generics",
-        ));
-    }
-
-    let Attrs { path, rejection } = crate::attr_parsing::parse_attrs("typed_path", attrs)?;
+    let Attrs { path, rejection } = crate::attr_parsing::parse_attrs("typed_path", &attrs)?;
 
     let path = path.ok_or_else(|| {
         syn::Error::new(
@@ -32,15 +30,17 @@ pub(crate) fn expand(item_struct: ItemStruct) -> syn::Result<TokenStream> {
     let rejection = rejection.map(second);
 
     match fields {
-        syn::Fields::Named(_) => {
+        syn::Fields::Named(fields) => {
             let segments = parse_path(&path)?;
-            Ok(expand_named_fields(ident, path, &segments, rejection))
+            Ok(expand_named_fields(
+                fields, ident, path, &segments, rejection, generics,
+            ))
         }
         syn::Fields::Unnamed(fields) => {
             let segments = parse_path(&path)?;
-            expand_unnamed_fields(fields, ident, path, &segments, rejection)
+            expand_unnamed_fields(fields, ident, path, &segments, rejection, generics)
         }
-        syn::Fields::Unit => expand_unit_fields(ident, path, rejection),
+        syn::Fields::Unit => expand_unit_fields(ident, path, rejection, generics),
     }
 }
 
@@ -94,24 +94,52 @@ impl Combine for Attrs {
 }
 
 fn expand_named_fields(
-    ident: &syn::Ident,
+    fields: syn::FieldsNamed,
+    ident: syn::Ident,
     path: LitStr,
     segments: &[Segment],
     rejection: Option<syn::Path>,
+    generics: Generics,
 ) -> TokenStream {
     let format_str = format_str_from_path(segments);
     let captures = captures_from_path(segments);
 
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
+    let field_types = fields
+        .named
+        .iter()
+        .map(|field| &field.ty)
+        .cloned()
+        .collect::<HashSet<_>>();
+    let generic_types = extract_generic_types(&generics);
+
+    let path_where_clause = add_where_bounds_for_types(
+        where_clause,
+        // only generate where clause bounds for types that are both in the generics
+        // and used for struct fields directly
+        field_types.intersection(&generic_types),
+        |ty| parse_quote! { #ty: ::std::fmt::Display },
+    );
+
     let typed_path_impl = quote_spanned! {path.span()=>
         #[automatically_derived]
-        impl ::axum_extra::routing::TypedPath for #ident {
+        impl #impl_generics ::axum_extra::routing::TypedPath for #ident #ty_generics #path_where_clause {
             const PATH: &'static str = #path;
         }
     };
 
+    let display_where_clause = add_where_bounds_for_types(
+        where_clause,
+        // only generate where clause bounds for types that are both in the generics
+        // and used for struct fields directly
+        field_types.intersection(&generic_types),
+        |ty| parse_quote! { #ty: ::std::fmt::Display },
+    );
+
     let display_impl = quote_spanned! {path.span()=>
         #[automatically_derived]
-        impl ::std::fmt::Display for #ident {
+        impl #impl_generics ::std::fmt::Display for #ident #ty_generics #display_where_clause {
             #[allow(clippy::unnecessary_to_owned)]
             fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
                 let Self { #(#captures,)* } = self;
@@ -132,18 +160,33 @@ fn expand_named_fields(
     let rejection_assoc_type = rejection_assoc_type(&rejection);
     let map_err_rejection = map_err_rejection(&rejection);
 
+    let mut parts_where_clause = add_where_bounds_for_types(
+        where_clause,
+        // only generate where clause bounds for types that are both in the generics
+        // and used for struct fields directly
+        field_types.intersection(&generic_types),
+        |ty| parse_quote! { for<'de> #ty: Send + Sync + ::serde::Deserialize<'de> },
+    )
+    .unwrap_or_else(empty_where_clause);
+
+    parts_where_clause.predicates.push(parse_quote!(
+        __Derived_S: Send + Sync
+    ));
+
+    let mut parts_generics = generics.clone();
+
+    parts_generics.params.push(parse_quote! {__Derived_S});
+    let (impl_generics, _, _) = parts_generics.split_for_impl();
+
     let from_request_impl = quote! {
         #[::axum::async_trait]
         #[automatically_derived]
-        impl<S> ::axum::extract::FromRequestParts<S> for #ident
-        where
-            S: Send + Sync,
-        {
+        impl #impl_generics ::axum::extract::FromRequestParts<__Derived_S> for #ident #ty_generics #parts_where_clause {
             type Rejection = #rejection_assoc_type;
 
             async fn from_request_parts(
                 parts: &mut ::axum::http::request::Parts,
-                state: &S,
+                state: &__Derived_S,
             ) -> ::std::result::Result<Self, Self::Rejection> {
                 ::axum::extract::Path::from_request_parts(parts, state)
                     .await
@@ -161,11 +204,12 @@ fn expand_named_fields(
 }
 
 fn expand_unnamed_fields(
-    fields: &syn::FieldsUnnamed,
-    ident: &syn::Ident,
+    fields: syn::FieldsUnnamed,
+    ident: syn::Ident,
     path: LitStr,
     segments: &[Segment],
     rejection: Option<syn::Path>,
+    generics: Generics,
 ) -> syn::Result<TokenStream> {
     let num_captures = segments
         .iter()
@@ -204,19 +248,45 @@ fn expand_unnamed_fields(
             }
         });
 
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
+    let field_types = fields
+        .unnamed
+        .iter()
+        .map(|field| &field.ty)
+        .cloned()
+        .collect::<HashSet<_>>();
+    let generic_types = extract_generic_types(&generics);
+
+    let path_where_clause = add_where_bounds_for_types(
+        where_clause,
+        // only generate where clause bounds for types that are both in the generics
+        // and used for struct fields directly
+        field_types.intersection(&generic_types),
+        |ty| parse_quote! { #ty: ::std::fmt::Display },
+    );
+
     let format_str = format_str_from_path(segments);
     let captures = captures_from_path(segments);
 
     let typed_path_impl = quote_spanned! {path.span()=>
         #[automatically_derived]
-        impl ::axum_extra::routing::TypedPath for #ident {
+        impl #impl_generics ::axum_extra::routing::TypedPath for #ident #ty_generics #path_where_clause {
             const PATH: &'static str = #path;
         }
     };
 
+    let display_where_clause = add_where_bounds_for_types(
+        where_clause,
+        // only generate where clause bounds for types that are both in the generics
+        // and used for struct fields directly
+        field_types.intersection(&generic_types),
+        |ty| parse_quote! {#ty: ::std::fmt::Display},
+    );
+
     let display_impl = quote_spanned! {path.span()=>
         #[automatically_derived]
-        impl ::std::fmt::Display for #ident {
+        impl #impl_generics ::std::fmt::Display for #ident #ty_generics #display_where_clause {
             #[allow(clippy::unnecessary_to_owned)]
             fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
                 let Self { #(#destructure_self)* } = self;
@@ -237,18 +307,33 @@ fn expand_unnamed_fields(
     let rejection_assoc_type = rejection_assoc_type(&rejection);
     let map_err_rejection = map_err_rejection(&rejection);
 
+    let mut parts_where_clause = add_where_bounds_for_types(
+        where_clause,
+        // only generate where clause bounds for types that are both in the generics
+        // and used for struct fields directly
+        field_types.intersection(&generic_types),
+        |ty| parse_quote! {for<'de> #ty: Send + Sync + ::serde::Deserialize<'de> },
+    )
+    .unwrap_or_else(empty_where_clause);
+
+    parts_where_clause.predicates.push(parse_quote!(
+        __Derived_S: Send + Sync
+    ));
+
+    let mut parts_generics = generics.clone();
+
+    parts_generics.params.push(parse_quote! {__Derived_S});
+    let (impl_generics, _, _) = parts_generics.split_for_impl();
+
     let from_request_impl = quote! {
         #[::axum::async_trait]
         #[automatically_derived]
-        impl<S> ::axum::extract::FromRequestParts<S> for #ident
-        where
-            S: Send + Sync,
-        {
+        impl #impl_generics ::axum::extract::FromRequestParts<__Derived_S> for #ident #ty_generics #where_clause {
             type Rejection = #rejection_assoc_type;
 
             async fn from_request_parts(
                 parts: &mut ::axum::http::request::Parts,
-                state: &S,
+                state: &__Derived_S,
             ) -> ::std::result::Result<Self, Self::Rejection> {
                 ::axum::extract::Path::from_request_parts(parts, state)
                     .await
@@ -274,9 +359,10 @@ fn simple_pluralize(count: usize, word: &str) -> String {
 }
 
 fn expand_unit_fields(
-    ident: &syn::Ident,
+    ident: syn::Ident,
     path: LitStr,
     rejection: Option<syn::Path>,
+    generics: Generics,
 ) -> syn::Result<TokenStream> {
     for segment in parse_path(&path)? {
         match segment {
@@ -290,16 +376,18 @@ fn expand_unit_fields(
         }
     }
 
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
     let typed_path_impl = quote_spanned! {path.span()=>
         #[automatically_derived]
-        impl ::axum_extra::routing::TypedPath for #ident {
+        impl #impl_generics ::axum_extra::routing::TypedPath for #ident #ty_generics #where_clause {
             const PATH: &'static str = #path;
         }
     };
 
     let display_impl = quote_spanned! {path.span()=>
         #[automatically_derived]
-        impl ::std::fmt::Display for #ident {
+        impl #impl_generics ::std::fmt::Display for #ident #ty_generics #where_clause {
             fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
                 write!(f, #path)
             }
@@ -321,18 +409,26 @@ fn expand_unit_fields(
         }
     };
 
+    let mut parts_where_clause = where_clause.cloned().unwrap_or_else(empty_where_clause);
+
+    parts_where_clause.predicates.push(parse_quote!(
+        __Derived_S: Send + Sync
+    ));
+
+    let mut parts_generics = generics.clone();
+
+    parts_generics.params.push(parse_quote! {__Derived_S});
+    let (impl_generics, _, _) = parts_generics.split_for_impl();
+
     let from_request_impl = quote! {
         #[::axum::async_trait]
         #[automatically_derived]
-        impl<S> ::axum::extract::FromRequestParts<S> for #ident
-        where
-            S: Send + Sync,
-        {
+        impl #impl_generics ::axum::extract::FromRequestParts<__Derived_S> for #ident #ty_generics #parts_where_clause {
             type Rejection = #rejection_assoc_type;
 
             async fn from_request_parts(
                 parts: &mut ::axum::http::request::Parts,
-                _state: &S,
+                _state: &__Derived_S,
             ) -> ::std::result::Result<Self, Self::Rejection> {
                 if parts.uri.path() == <Self as ::axum_extra::routing::TypedPath>::PATH {
                     Ok(Self)
@@ -404,7 +500,7 @@ enum Segment {
 
 fn path_rejection() -> TokenStream {
     quote! {
-        <::axum::extract::Path<Self> as ::axum::extract::FromRequestParts<S>>::Rejection
+        <::axum::extract::Path<Self> as ::axum::extract::FromRequestParts<__Derived_S>>::Rejection
     }
 }
 
@@ -427,6 +523,42 @@ fn map_err_rejection(rejection: &Option<syn::Path>) -> TokenStream {
             }
         })
         .unwrap_or_default()
+}
+
+fn extract_generic_types(generics: &Generics) -> HashSet<syn::Type> {
+    generics
+        .params
+        .iter()
+        .filter_map(|g| match g {
+            GenericParam::Type(t) => syn::parse2(t.ident.to_token_stream()).ok(),
+            _ => None,
+        })
+        .collect()
+}
+
+fn empty_where_clause() -> WhereClause {
+    WhereClause {
+        where_token: Token![where](Span::mixed_site()),
+        predicates: Punctuated::new(),
+    }
+}
+
+fn add_where_bounds_for_types<'a, 'b>(
+    where_clause: Option<&'a WhereClause>,
+    types: impl IntoIterator<Item = &'b syn::Type>,
+    bound: impl Fn(&'b syn::Type) -> WherePredicate,
+) -> Option<WhereClause> {
+    let mut peekable_types = types.into_iter().peekable();
+
+    peekable_types.peek()?;
+
+    let mut where_clause = where_clause.cloned().unwrap_or_else(empty_where_clause);
+
+    for ty in peekable_types {
+        where_clause.predicates.push(bound(ty));
+    }
+
+    Some(where_clause)
 }
 
 #[test]

--- a/axum-macros/tests/typed_path/fail/not_deserialize.stderr
+++ b/axum-macros/tests/typed_path/fail/not_deserialize.stderr
@@ -1,21 +1,21 @@
-error[E0277]: the trait bound `MyPath: serde::de::DeserializeOwned` is not satisfied
+error[E0277]: the trait bound `MyPath: DeserializeOwned` is not satisfied
  --> tests/typed_path/fail/not_deserialize.rs:3:10
   |
 3 | #[derive(TypedPath)]
-  |          ^^^^^^^^^ the trait `for<'de> serde::de::Deserialize<'de>` is not implemented for `MyPath`, which is required by `axum::extract::Path<MyPath>: FromRequestParts<S>`
+  |          ^^^^^^^^^ the trait `for<'de> Deserialize<'de>` is not implemented for `MyPath`, which is required by `axum::extract::Path<MyPath>: FromRequestParts<__Derived_S>`
   |
   = help: the trait `FromRequestParts<S>` is implemented for `axum::extract::Path<T>`
-  = note: required for `MyPath` to implement `serde::de::DeserializeOwned`
-  = note: required for `axum::extract::Path<MyPath>` to implement `FromRequestParts<S>`
+  = note: required for `MyPath` to implement `DeserializeOwned`
+  = note: required for `axum::extract::Path<MyPath>` to implement `FromRequestParts<__Derived_S>`
   = note: this error originates in the derive macro `TypedPath` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `MyPath: serde::de::DeserializeOwned` is not satisfied
+error[E0277]: the trait bound `MyPath: DeserializeOwned` is not satisfied
  --> tests/typed_path/fail/not_deserialize.rs:3:10
   |
 3 | #[derive(TypedPath)]
-  |          ^^^^^^^^^ the trait `for<'de> serde::de::Deserialize<'de>` is not implemented for `MyPath`, which is required by `axum::extract::Path<MyPath>: FromRequestParts<S>`
+  |          ^^^^^^^^^ the trait `for<'de> Deserialize<'de>` is not implemented for `MyPath`, which is required by `axum::extract::Path<MyPath>: FromRequestParts<__Derived_S>`
   |
   = help: the trait `FromRequestParts<S>` is implemented for `axum::extract::Path<T>`
-  = note: required for `MyPath` to implement `serde::de::DeserializeOwned`
-  = note: required for `axum::extract::Path<MyPath>` to implement `FromRequestParts<S>`
+  = note: required for `MyPath` to implement `DeserializeOwned`
+  = note: required for `axum::extract::Path<MyPath>` to implement `FromRequestParts<__Derived_S>`
   = note: this error originates in the attribute macro `::axum::async_trait` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/axum-macros/tests/typed_path/pass/generics.rs
+++ b/axum-macros/tests/typed_path/pass/generics.rs
@@ -1,0 +1,45 @@
+use axum_extra::routing::{RouterExt, TypedPath};
+use serde::Deserialize;
+
+#[derive(TypedPath, Deserialize)]
+#[typed_path("/:foo")]
+struct MyPathNamed<T> {
+    foo: T,
+}
+
+// types with wrappers should not get any where bounds auto-generated
+struct WrapperStruct<T>(T);
+
+impl<'de, T> Deserialize<'de> for WrapperStruct<T> {
+    fn deserialize<D>(_deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        unimplemented!()
+    }
+}
+
+impl<U> std::fmt::Display for WrapperStruct<U> {
+    fn fmt(&self, _: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        unimplemented!()
+    }
+}
+
+#[derive(TypedPath)]
+#[typed_path("/:foo/:bar")]
+struct MyPathUnnamed<T, U>(T, WrapperStruct<U>);
+
+impl<'de, T, U> Deserialize<'de> for MyPathUnnamed<T, U> {
+    fn deserialize<D>(_deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        unimplemented!()
+    }
+}
+
+fn main() {
+    _ = axum::Router::<()>::new()
+        .typed_get(|_: MyPathNamed<i32>| async {})
+        .typed_post(|_: MyPathUnnamed<i32, u32>| async {})
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation

So I've recently tried to create a generic axum handler for any sea-orm Entity, which allows me to for example fetch it. Since a specific entity would not necessarily be indexed by the same primary key type, I wanted to be generic over that as well, which was when I noticed the TypedPath derive doesn't support generic params yet.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

This removes the limitation in the proc-macro using the following 2 changes:

- Drop the check for generics from the macro
- Add the required generics & where bounds where needed

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
