### PR TITLE
Add Extension<NonCloneType> debug_handler ui test

### DIFF
--- a/axum-macros/tests/debug_handler/fail/extension_not_clone.rs
+++ b/axum-macros/tests/debug_handler/fail/extension_not_clone.rs
@@ -1,0 +1,9 @@
+use axum::extract::Extension;
+use axum_macros::debug_handler;
+
+struct NonCloneType;
+
+#[debug_handler]
+async fn test_extension_non_clone(_: Extension<NonCloneType>) {}
+
+fn main() {}

--- a/axum-macros/tests/debug_handler/fail/extension_not_clone.stderr
+++ b/axum-macros/tests/debug_handler/fail/extension_not_clone.stderr
@@ -1,0 +1,28 @@
+error[E0277]: the trait bound `NonCloneType: Clone` is not satisfied
+ --> tests/debug_handler/fail/extension_not_clone.rs:7:38
+  |
+7 | async fn test_extension_non_clone(_: Extension<NonCloneType>) {}
+  |                                      ^^^^^^^^^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `NonCloneType`, which is required by `Extension<NonCloneType>: FromRequest<(), _>`
+  |
+  = help: the following other types implement trait `FromRequest<S, M>`:
+            axum::body::Bytes
+            Body
+            Form<T>
+            Json<T>
+            axum::http::Request<Body>
+            RawForm
+            String
+            Option<T>
+          and $N others
+  = note: required for `Extension<NonCloneType>` to implement `FromRequestParts<()>`
+  = note: required for `Extension<NonCloneType>` to implement `FromRequest<(), axum_core::extract::private::ViaParts>`
+note: required by a bound in `__axum_macros_check_test_extension_non_clone_0_from_request_check`
+ --> tests/debug_handler/fail/extension_not_clone.rs:7:38
+  |
+7 | async fn test_extension_non_clone(_: Extension<NonCloneType>) {}
+  |                                      ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `__axum_macros_check_test_extension_non_clone_0_from_request_check`
+help: consider annotating `NonCloneType` with `#[derive(Clone)]`
+  |
+4 + #[derive(Clone)]
+5 | struct NonCloneType;
+  |


### PR DESCRIPTION
## Motivation

#2294 indicates that the error message for `T: Clone` constraint on `Extension<T>`'s `FromRequestParts` impl being unmet is bad even with `#[debug_handler]`. I decided to check and found that's false.

## Solution

Add a test to make sure we don't regress.

Closes #2294.
Supersedes #2301.