### PR TITLE
Remove unnecessary brackets in chat example

### DIFF
--- a/examples/chat/src/main.rs
+++ b/examples/chat/src/main.rs
@@ -130,8 +130,8 @@ async fn websocket(stream: WebSocket, state: Arc<AppState>) {
 
     // If any one of the tasks run to completion, we abort the other.
     tokio::select! {
-        _ = (&mut send_task) => recv_task.abort(),
-        _ = (&mut recv_task) => send_task.abort(),
+        _ = &mut send_task => recv_task.abort(),
+        _ = &mut recv_task => send_task.abort(),
     };
 
     // Send "user left" message (similar to "joined" above).


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

Usage examples of the tokio::select macro mentioned in [tokio's documentation](https://docs.rs/tokio/1.37.0/tokio/macro.select.html) indicate that brackets are redundant when writing the macro branches.

e.g. It's more preferred to write

```rust
    let next = tokio::select! {
        v = stream1.next() => v.unwrap(),
        v = stream2.next() => v.unwrap(),
    };
```

than

```rust
    let next = tokio::select! {
        v = (stream1.next()) => v.unwrap(),
        v = (stream2.next()) => v.unwrap(),
    };
```

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Remove the unnecessary brackets in chat example code.
