### PR TITLE
axum-extra: log rejections of `TypedHeader`

### DIFF
--- a/axum-extra/src/typed_header.rs
+++ b/axum-extra/src/typed_header.rs
@@ -158,11 +158,7 @@ impl IntoResponse for TypedHeaderRejection {
     fn into_response(self) -> Response {
         let status = StatusCode::BAD_REQUEST;
         let body = self.to_string();
-        axum_core::__log_rejection!(
-            rejection_type = Self,
-            body_text = body,
-            status = status,
-        );
+        axum_core::__log_rejection!(rejection_type = Self, body_text = body, status = status,);
         (http::StatusCode::BAD_REQUEST, self.to_string()).into_response()
     }
 }

--- a/axum-extra/src/typed_header.rs
+++ b/axum-extra/src/typed_header.rs
@@ -6,7 +6,7 @@ use axum::{
     response::{IntoResponse, IntoResponseParts, Response, ResponseParts},
 };
 use headers::{Header, HeaderMapExt};
-use http::request::Parts;
+use http::{request::Parts, StatusCode};
 use std::convert::Infallible;
 
 /// Extractor and response that works with typed header values from [`headers`].
@@ -156,6 +156,9 @@ impl TypedHeaderRejectionReason {
 
 impl IntoResponse for TypedHeaderRejection {
     fn into_response(self) -> Response {
+        let status = StatusCode::BAD_REQUEST;
+        let body = self.to_string();
+        axum_core::__log_rejection!(rejection_type = Self, body_text = body, status = status,);
         (http::StatusCode::BAD_REQUEST, self.to_string()).into_response()
     }
 }

--- a/axum-extra/src/typed_header.rs
+++ b/axum-extra/src/typed_header.rs
@@ -159,7 +159,7 @@ impl IntoResponse for TypedHeaderRejection {
         let status = StatusCode::BAD_REQUEST;
         let body = self.to_string();
         axum_core::__log_rejection!(rejection_type = Self, body_text = body, status = status,);
-        (http::StatusCode::BAD_REQUEST, self.to_string()).into_response()
+        (status, body).into_response()
     }
 }
 

--- a/axum-extra/src/typed_header.rs
+++ b/axum-extra/src/typed_header.rs
@@ -158,7 +158,11 @@ impl IntoResponse for TypedHeaderRejection {
     fn into_response(self) -> Response {
         let status = StatusCode::BAD_REQUEST;
         let body = self.to_string();
-        axum_core::__log_rejection!(rejection_type = Self, body_text = body, status = status);
+        axum_core::__log_rejection!(
+            rejection_type = Self,
+            body_text = body,
+            status = status,
+        );
         (http::StatusCode::BAD_REQUEST, self.to_string()).into_response()
     }
 }

--- a/axum-extra/src/typed_header.rs
+++ b/axum-extra/src/typed_header.rs
@@ -158,7 +158,7 @@ impl IntoResponse for TypedHeaderRejection {
     fn into_response(self) -> Response {
         let status = StatusCode::BAD_REQUEST;
         let body = self.to_string();
-        axum_core::__log_rejection!(rejection_type = Self, body_text = body, status = status,);
+        axum_core::__log_rejection!(rejection_type = Self, body_text = body, status = status);
         (http::StatusCode::BAD_REQUEST, self.to_string()).into_response()
     }
 }


### PR DESCRIPTION
## Motivation

`TypedHeader` rejections are not logged. This seems to have slipped from #2584.

## Solution

This adds the missing rejection logging.