### PR TITLE
axum-core: correctly use features for tracing macro

### DIFF
--- a/axum-core/src/macros.rs
+++ b/axum-core/src/macros.rs
@@ -1,4 +1,5 @@
 /// Private API.
+#[cfg(feature = "tracing")]
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __log_rejection {
@@ -7,7 +8,6 @@ macro_rules! __log_rejection {
         body_text = $body_text:expr,
         status = $status:expr,
     ) => {
-        #[cfg(feature = "tracing")]
         {
             tracing::event!(
                 target: "axum::rejection",
@@ -19,6 +19,17 @@ macro_rules! __log_rejection {
             );
         }
     };
+}
+
+#[cfg(not(feature = "tracing"))]
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __log_rejection {
+    (
+        rejection_type = $ty:ident,
+        body_text = $body_text:expr,
+        status = $status:expr,
+    ) => {};
 }
 
 /// Private API.

--- a/axum-extra/Cargo.toml
+++ b/axum-extra/Cargo.toml
@@ -33,7 +33,7 @@ json-lines = [
 multipart = ["dep:multer"]
 protobuf = ["dep:prost"]
 query = ["dep:serde_html_form"]
-tracing = ["dep:tracing", "axum-core/tracing"]
+tracing = ["dep:tracing", "axum-core/tracing", "axum/tracing"]
 typed-header = ["dep:headers"]
 typed-routing = ["dep:axum-macros", "dep:percent-encoding", "dep:serde_html_form", "dep:form_urlencoded"]
 


### PR DESCRIPTION
## Motivation

An alternative to #2655.

Currently, `axum-core` defines a `tracing` feature which is never used, because it was intended only for expansion inside a macro, but the `#[cfg(feature = "tracing")]` attribute is expanded and is evaluated based on whether the consuming crate (in this case either `axum` or `axum-extra`) has the feature enabled.

## Solution

Based on the feature, we can either expand the macro to a `tracing::event!` call or we can just expand to nothing. This way, the feature works as intended.

One difference between this and removing the feature is that with this change, if either `tracing` or `tracing-extra` enables the `tracing` feature, it will transitively enable the same feature in `axum-core` so extractors from both crates will have their rejections logged.

If we instead remove the feature from `axum-core`, each crate's `tracing` feature will be independent which may result in some extractors being logged and others not. So although it gives more control to the user, I personally think the behavior may be surprising.

Also, removing the feature is a breaking change while this is not.