### PR TITLE
Derive PartialEq for Json extractor

### DIFF
--- a/axum/src/json.rs
+++ b/axum/src/json.rs
@@ -87,7 +87,7 @@ use serde::{de::DeserializeOwned, Serialize};
 /// let app = Router::new().route("/users/:id", get(get_user));
 /// # let _: Router = app;
 /// ```
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
 #[cfg_attr(docsrs, doc(cfg(feature = "json")))]
 #[must_use]
 pub struct Json<T>(pub T);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

It should be possible to test handlers using
```rust
assert_eq!((StatusCode::OK, Json(MyStruct)), my_handler().await);
```
Currently, this can only be achieved with
```rust
let (status_code, Json(response)) = my_handler().await;
assert_eq!(StatusCode::OK, status_code);
assert_eq!(MyStruct, response);
```

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
