### PR TITLE
Fix typo in serve-with-hyper example

### DIFF
--- a/examples/serve-with-hyper/src/main.rs
+++ b/examples/serve-with-hyper/src/main.rs
@@ -43,7 +43,7 @@ async fn serve_plain() {
         // We don't need to call `poll_ready` because `Router` is always ready.
         let tower_service = app.clone();
 
-        // Spawn a task to handle the connection. That way we can multiple connections
+        // Spawn a task to handle the connection. That way we can handle multiple connections
         // concurrently.
         tokio::spawn(async move {
             // Hyper has its own `AsyncRead` and `AsyncWrite` traits and doesn't use tokio.


### PR DESCRIPTION
Added a missing word in a comment.

## Motivation

Typo.

## Solution

Added the missing word.
