### PR TITLE
Reduce extra allocation when constructing statically known body

### DIFF
--- a/axum-core/src/error.rs
+++ b/axum-core/src/error.rs
@@ -32,3 +32,9 @@ impl StdError for Error {
         Some(&*self.inner)
     }
 }
+
+impl From<std::convert::Infallible> for Error {
+    fn from(_: std::convert::Infallible) -> Self {
+        panic!()
+    }
+}


### PR DESCRIPTION
## Motivation

Constructing empty bodies or bodies which are fully "available" (`String`, `Vec<u8>`, ...) go through an extra indirection (One additional `Box`) which isn't that efficient (but simplifies code). We can reduce this single allocation quite easily without much code complexity and effort, so I hope this won't add additional burden to the maintenance of the code. However, this will ultimately result in a layout size increase (On 64-bit archs this will go from 16 bytes to 40 bytes).

## Solution

Add some specialization, through an enum, for all the types that we can statically embed in the body.
