### PR TITLE
docs: remove unnecessary link targets

### DIFF
--- a/axum/src/docs/extract.md
+++ b/axum/src/docs/extract.md
@@ -19,8 +19,7 @@ Types and traits for extracting data from requests.
 
 A handler function is an async function that takes any number of
 "extractors" as arguments. An extractor is a type that implements
-[`FromRequest`](crate::extract::FromRequest)
-or [`FromRequestParts`](crate::extract::FromRequestParts).
+[`FromRequest`] or [`FromRequestParts`].
 
 For example, [`Json`] is an extractor that consumes the request body and
 deserializes it as JSON into some target type:

--- a/axum/src/docs/response.md
+++ b/axum/src/docs/response.md
@@ -166,7 +166,7 @@ In general you can return tuples like:
 This means you cannot accidentally override the status or body as [`IntoResponseParts`] only allows
 setting headers and extensions.
 
-Use [`Response`](crate::response::Response) for more low level control:
+Use [`Response`] for more low level control:
 
 ```rust,no_run
 use axum::{

--- a/axum/src/docs/routing/route.md
+++ b/axum/src/docs/routing/route.md
@@ -5,8 +5,7 @@ can be either static, a capture, or a wildcard.
 
 `method_router` is the [`MethodRouter`] that should receive the request if the
 path matches `path`. `method_router` will commonly be a handler wrapped in a method
-router like [`get`](crate::routing::get). See [`handler`](crate::handler) for
-more details on handlers.
+router like [`get`]. See [`handler`](crate::handler) for more details on handlers.
 
 # Static paths
 


### PR DESCRIPTION
## Motivation

CI is emitting warnings due to unnecessary links in docs due to `#[warn(rustdoc::redundant_explicit_links)]` which is on by default.

## Solution

Remove the unnecessary links. Each changed file is currently included from only a single place so this is ok.

## Alternatives

Suppress this warning.