### PR TITLE
CI: pin nightly version for `cargo public-api-crates`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -57,7 +57,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     # Pinned version due to failing `cargo-public-api-crates`.
-    - uses: dtolnay/rust-toolchain@nightly-2024-06-06
+    - uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: nightly-2024-06-06
     - uses: Swatinem/rust-cache@v2
     - name: Install cargo-public-api-crates
       run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -56,7 +56,8 @@ jobs:
         crate: [axum, axum-core, axum-extra, axum-macros]
     steps:
     - uses: actions/checkout@v4
-    - uses: dtolnay/rust-toolchain@nightly
+    # Pinned version due to failing `cargo-public-api-crates`.
+    - uses: dtolnay/rust-toolchain@nightly-2024-06-06
     - uses: Swatinem/rust-cache@v2
     - name: Install cargo-public-api-crates
       run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -68,7 +68,7 @@ jobs:
       run: |
         cargo rustdoc --all-features --manifest-path ${{ matrix.crate }}/Cargo.toml -- -Z unstable-options --output-format json
     - name: cargo public-api-crates check
-      run: cargo public-api-crates --manifest-path ${{ matrix.crate }}/Cargo.toml check --skip-build
+      run: cargo public-api-crates --manifest-path ${{ matrix.crate }}/Cargo.toml --skip-build check
 
   test-versions:
     needs: check

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -64,8 +64,11 @@ jobs:
     - name: Install cargo-public-api-crates
       run: |
         cargo install --git https://github.com/davidpdrsn/cargo-public-api-crates
+    - name: Build rustdoc
+      run: |
+        cargo rustdoc --all-features --manifest-path ${{ matrix.crate }}/Cargo.toml -- -Z unstable-options --output-format json
     - name: cargo public-api-crates check
-      run: cargo public-api-crates --manifest-path ${{ matrix.crate }}/Cargo.toml check
+      run: cargo public-api-crates --manifest-path ${{ matrix.crate }}/Cargo.toml check --skip-build
 
   test-versions:
     needs: check


### PR DESCRIPTION
## Motivation

The CI is failing due to changes in `nightly` which `cargo-public-api-crates` is not ready for.

## Solution

Pin the `nightly` version to a prior version that is known to work until the tool is updated to handle current `nightly`.