### PR TITLE
Allow querying of HTTP status codes for query and form rejections

### DIFF
--- a/axum-extra/src/extract/query.rs
+++ b/axum-extra/src/extract/query.rs
@@ -111,12 +111,21 @@ pub enum QueryRejection {
     FailedToDeserializeQueryString(Error),
 }
 
+impl QueryRejection {
+    /// Get the status code used for this rejection.
+    pub fn status(&self) -> StatusCode {
+        match self {
+            Self::FailedToDeserializeQueryString(_) => StatusCode::BAD_REQUEST,
+        }
+    }
+}
+
 impl IntoResponse for QueryRejection {
     fn into_response(self) -> Response {
+        let status = self.status();
         match self {
             Self::FailedToDeserializeQueryString(inner) => {
                 let body = format!("Failed to deserialize query string: {inner}");
-                let status = StatusCode::BAD_REQUEST;
                 axum_core::__log_rejection!(
                     rejection_type = Self,
                     body_text = body,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

`axum_extra::{query::QueryRejection, form::FormRejection}` are missing a method that would allow users to query the status code without converting it into a response via `IntoResponse` first.

This is useful when one wants to customize rejection responses.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Add `pub fn status(&self) -> http::StatusCode` methods to both rejections.