### PR TITLE
Add an Attachment type to axum-extra

### DIFF
--- a/axum-extra/Cargo.toml
+++ b/axum-extra/Cargo.toml
@@ -15,7 +15,7 @@ version = "0.9.3"
 default = ["tracing"]
 
 async-read-body = ["dep:tokio-util", "tokio-util?/io", "dep:tokio"]
-attachment = []
+attachment = ["dep:tracing"]
 cookie = ["dep:cookie"]
 cookie-private = ["cookie", "cookie?/private"]
 cookie-signed = ["cookie", "cookie?/signed"]

--- a/axum-extra/Cargo.toml
+++ b/axum-extra/Cargo.toml
@@ -15,6 +15,7 @@ version = "0.9.3"
 default = ["tracing"]
 
 async-read-body = ["dep:tokio-util", "tokio-util?/io", "dep:tokio"]
+attachment = []
 cookie = ["dep:cookie"]
 cookie-private = ["cookie", "cookie?/private"]
 cookie-signed = ["cookie", "cookie?/signed"]

--- a/axum-extra/src/extract/json_deserializer.rs
+++ b/axum-extra/src/extract/json_deserializer.rs
@@ -23,8 +23,7 @@ use std::marker::PhantomData;
 /// Additionally, a `JsonRejection` error will be returned, when calling `deserialize` if:
 ///
 /// - The body doesn't contain syntactically valid JSON.
-/// - The body contains syntactically valid JSON, but it couldn't be deserialized into the target
-/// type.
+/// - The body contains syntactically valid JSON, but it couldn't be deserialized into the target type.
 /// - Attempting to deserialize escaped JSON into a type that must be borrowed (e.g. `&'a str`).
 ///
 /// ⚠️ `serde` will implicitly try to borrow for `&str` and `&[u8]` types, but will error if the

--- a/axum-extra/src/response/attachment.rs
+++ b/axum-extra/src/response/attachment.rs
@@ -5,7 +5,7 @@ use tracing::trace;
 /// A file attachment response type
 ///
 /// This type will set the `Content-Disposition` header for this response. In response a webbrowser
-/// will download the contents localy.
+/// will download the contents locally.
 ///
 /// Use the `filename` and `content_type` methods to set the filename or content-type of the
 /// attachment. If these values are not set they will not be sent.
@@ -34,7 +34,7 @@ use tracing::trace;
 /// use the [`Attachment`] type in a tuple.
 ///
 /// # Note
-/// If the content length is known and this header is manualy set to a different length hyper
+/// If the content length is known and this header is manually set to a different length hyper
 /// panics.
 ///
 /// ```rust

--- a/axum-extra/src/response/attachment.rs
+++ b/axum-extra/src/response/attachment.rs
@@ -66,7 +66,7 @@ impl<T: IntoResponse> Attachment<T> {
 
     /// Sets the content-type of the [`Attachment`]
     pub fn content_type<H: TryInto<HeaderValue>>(mut self, value: H) -> Self {
-        if let Some(content_type) = value.try_into().ok() {
+        if let Ok(content_type) = value.try_into() {
             self.content_type = Some(content_type);
         } else {
             trace!("Attachment content-type contains invalid characters");

--- a/axum-extra/src/response/attachment.rs
+++ b/axum-extra/src/response/attachment.rs
@@ -91,8 +91,7 @@ where
             bytes.extend_from_slice(filename.as_bytes());
             bytes.push(b'\"');
 
-            HeaderValue::from_bytes(&bytes)
-                .expect("This was a HeaderValue so this can not fail")
+            HeaderValue::from_bytes(&bytes).expect("This was a HeaderValue so this can not fail")
         } else {
             HeaderValue::from_static("attachment")
         };

--- a/axum-extra/src/response/attachment.rs
+++ b/axum-extra/src/response/attachment.rs
@@ -1,0 +1,112 @@
+use axum::response::IntoResponse;
+use http::{header, HeaderMap, HeaderValue};
+
+/// A file attachment response type
+///
+/// This type will set the `Content-Disposition` header for this response. In response a webbrowser
+/// will download the contents localy.
+///
+/// Use the `filename` and `content_type` methods to set the filename or content-type of the
+/// attachment. If these values are not set they will not be sent.
+///
+///
+/// # Example
+///
+/// ```rust
+///  use axum::{http::StatusCode, routing::get, Router};
+///  use axum_extra::response::Attachment;
+///
+///  async fn cargo_toml() -> Result<Attachment<String>, (StatusCode, String)> {
+///      let file_contents = tokio::fs::read_to_string("Cargo.toml")
+///          .await
+///          .map_err(|err| (StatusCode::NOT_FOUND, format!("File not found: {err}")))?;
+///      Ok(Attachment::new(file_contents)
+///          .filename("Cargo.toml")
+///          .content_type("text/x-toml"))
+///  }
+///
+///  let app = Router::new().route("/Cargo.toml", get(cargo_toml));
+///  let _: Router = app;
+/// ```
+///
+/// Hyper will set the `Content-Length` header if it knows the length. To manually set this header
+/// use the [`Attachment`] type in a tuple.
+///
+/// # Note
+/// If the content length is known and this header is manualy set to a different length hyper
+/// panics.
+///
+/// ```rust
+/// async fn with_content_length() -> impl IntoResponse {
+///     (
+///         [(header::CONTENT_LENGTH, 3)],
+///         Attachment::new([0, 0, 0])
+///             .filename("Cargo.toml")
+///             .content_type("text/x-toml"),
+///     )
+/// }
+/// ```
+#[derive(Debug)]
+pub struct Attachment<T> {
+    inner: T,
+    filename: Option<HeaderValue>,
+    content_type: Option<HeaderValue>,
+}
+
+impl<T: IntoResponse> Attachment<T> {
+    /// Creates a new [`Attachment`].
+    pub fn new(inner: T) -> Self {
+        Self {
+            inner,
+            filename: None,
+            content_type: None,
+        }
+    }
+
+    /// Sets the filename of the [`Attachment`]
+    ///
+    /// This updates the `Content-Disposition` header to add a filename.
+    pub fn filename<H: TryInto<HeaderValue>>(mut self, value: H) -> Self {
+        // TODO: change
+        self.filename = value.try_into().ok();
+        self
+    }
+
+    /// Sets the content-type of the [`Attachment`]
+    pub fn content_type<H: TryInto<HeaderValue>>(mut self, value: H) -> Self {
+        // TODO: change
+        self.content_type = value.try_into().ok();
+        self
+    }
+}
+
+impl<T> IntoResponse for Attachment<T>
+where
+    T: IntoResponse,
+{
+    fn into_response(self) -> axum::response::Response {
+        let mut headers = HeaderMap::new();
+
+        if let Some(content_type) = self.content_type {
+            headers.append(header::CONTENT_TYPE, content_type);
+        }
+
+        if let Some(filename) = self.filename {
+            let mut bytes = b"attachment; filename=\"".to_vec();
+            bytes.extend_from_slice(filename.as_bytes());
+            bytes.push(b'\"');
+
+            let content_disposition = HeaderValue::from_bytes(&bytes)
+                .expect("This was a HeaderValue so this can not fail");
+
+            headers.append(header::CONTENT_DISPOSITION, content_disposition);
+        } else {
+            headers.append(
+                header::CONTENT_DISPOSITION,
+                HeaderValue::from_static("attachment"),
+            );
+        }
+
+        (headers, self.inner).into_response()
+    }
+}

--- a/axum-extra/src/response/attachment.rs
+++ b/axum-extra/src/response/attachment.rs
@@ -97,7 +97,7 @@ where
             HeaderValue::from_static("attachment")
         };
 
-        headers.append(header::CONTENT_DISPOSITION, content_disposition)
+        headers.append(header::CONTENT_DISPOSITION, content_disposition);
 
         (headers, self.inner).into_response()
     }

--- a/axum-extra/src/response/attachment.rs
+++ b/axum-extra/src/response/attachment.rs
@@ -1,6 +1,6 @@
 use axum::response::IntoResponse;
 use http::{header, HeaderMap, HeaderValue};
-use tracing::trace;
+use tracing::error;
 
 /// A file attachment response.
 ///
@@ -69,7 +69,7 @@ impl<T: IntoResponse> Attachment<T> {
         if let Ok(content_type) = value.try_into() {
             self.content_type = Some(content_type);
         } else {
-            trace!("Attachment content-type contains invalid characters");
+            error!("Attachment content-type contains invalid characters");
         }
         self
     }

--- a/axum-extra/src/response/attachment.rs
+++ b/axum-extra/src/response/attachment.rs
@@ -30,23 +30,10 @@ use tracing::trace;
 ///  let _: Router = app;
 /// ```
 ///
-/// Hyper will set the `Content-Length` header if it knows the length. To manually set this header
-/// use the [`Attachment`] type in a tuple.
-///
 /// # Note
-/// If the content length is known and this header is manually set to a different length hyper
-/// panics.
 ///
-/// ```rust
-/// async fn with_content_length() -> impl IntoResponse {
-///     (
-///         [(header::CONTENT_LENGTH, 3)],
-///         Attachment::new([0, 0, 0])
-///             .filename("Cargo.toml")
-///             .content_type("text/x-toml"),
-///     )
-/// }
-/// ```
+/// When using this type in Axum with hyper, hyper will set the `Content-Length` if it is known.
+///
 #[derive(Debug)]
 pub struct Attachment<T> {
     inner: T,

--- a/axum-extra/src/response/attachment.rs
+++ b/axum-extra/src/response/attachment.rs
@@ -1,5 +1,6 @@
 use axum::response::IntoResponse;
 use http::{header, HeaderMap, HeaderValue};
+use tracing::trace;
 
 /// A file attachment response type
 ///
@@ -67,15 +68,21 @@ impl<T: IntoResponse> Attachment<T> {
     ///
     /// This updates the `Content-Disposition` header to add a filename.
     pub fn filename<H: TryInto<HeaderValue>>(mut self, value: H) -> Self {
-        // TODO: change
-        self.filename = value.try_into().ok();
+        if let Some(filename) = value.try_into().ok() {
+            self.filename = Some(filename);
+        } else {
+            trace!("Attachment filename contains invalid characters");
+        }
         self
     }
 
     /// Sets the content-type of the [`Attachment`]
     pub fn content_type<H: TryInto<HeaderValue>>(mut self, value: H) -> Self {
-        // TODO: change
-        self.content_type = value.try_into().ok();
+        if let Some(content_type) = value.try_into().ok() {
+            self.content_type = Some(content_type);
+        } else {
+            trace!("Attachment content-type contains invalid characters");
+        }
         self
     }
 }

--- a/axum-extra/src/response/attachment.rs
+++ b/axum-extra/src/response/attachment.rs
@@ -58,7 +58,7 @@ impl<T: IntoResponse> Attachment<T> {
         self.filename = if let Ok(filename) = value.try_into() {
             Some(filename)
         } else {
-            trace!("Attachment filename contains invalid characters");
+            error!("Attachment filename contains invalid characters");
             None
         };
         self

--- a/axum-extra/src/response/attachment.rs
+++ b/axum-extra/src/response/attachment.rs
@@ -32,7 +32,7 @@ use tracing::trace;
 ///
 /// # Note
 ///
-/// When using this type in Axum with hyper, hyper will set the `Content-Length` if it is known.
+/// If you use axum with hyper, hyper will set the `Content-Length` if it is known.
 ///
 #[derive(Debug)]
 pub struct Attachment<T> {

--- a/axum-extra/src/response/mod.rs
+++ b/axum-extra/src/response/mod.rs
@@ -3,12 +3,20 @@
 #[cfg(feature = "erased-json")]
 mod erased_json;
 
+#[cfg(feature = "attachment")]
+mod attachment;
+
+
 #[cfg(feature = "erased-json")]
 pub use erased_json::ErasedJson;
 
 #[cfg(feature = "json-lines")]
 #[doc(no_inline)]
 pub use crate::json_lines::JsonLines;
+
+
+#[cfg(feature = "attachment")]
+pub use attachment::Attachment;
 
 macro_rules! mime_response {
     (

--- a/axum-extra/src/response/mod.rs
+++ b/axum-extra/src/response/mod.rs
@@ -6,14 +6,12 @@ mod erased_json;
 #[cfg(feature = "attachment")]
 mod attachment;
 
-
 #[cfg(feature = "erased-json")]
 pub use erased_json::ErasedJson;
 
 #[cfg(feature = "json-lines")]
 #[doc(no_inline)]
 pub use crate::json_lines::JsonLines;
-
 
 #[cfg(feature = "attachment")]
 pub use attachment::Attachment;

--- a/axum-extra/src/routing/typed.rs
+++ b/axum-extra/src/routing/typed.rs
@@ -84,8 +84,13 @@ use serde::Serialize;
 /// The macro expands to:
 ///
 /// - A `TypedPath` implementation.
-/// - A [`FromRequest`] implementation compatible with [`RouterExt::typed_get`], [`RouterExt::typed_post`], etc. This implementation uses [`Path`] and thus your struct must also implement [`serde::Deserialize`], unless it's a unit struct.
-/// - A [`Display`] implementation that interpolates the captures. This can be used to, among other things, create links to known paths and have them verified statically. Note that the [`Display`] implementation for each field must return something that's compatible with its [`Deserialize`] implementation.
+/// - A [`FromRequest`] implementation compatible with [`RouterExt::typed_get`],
+///   [`RouterExt::typed_post`], etc. This implementation uses [`Path`] and thus your struct must
+///   also implement [`serde::Deserialize`], unless it's a unit struct.
+/// - A [`Display`] implementation that interpolates the captures. This can be used to, among other
+///   things, create links to known paths and have them verified statically. Note that the
+///   [`Display`] implementation for each field must return something that's compatible with its
+///   [`Deserialize`] implementation.
 ///
 /// Additionally the macro will verify the captures in the path matches the fields of the struct.
 /// For example this fails to compile since the struct doesn't have a `team_id` field:

--- a/axum-extra/src/routing/typed.rs
+++ b/axum-extra/src/routing/typed.rs
@@ -84,13 +84,8 @@ use serde::Serialize;
 /// The macro expands to:
 ///
 /// - A `TypedPath` implementation.
-/// - A [`FromRequest`] implementation compatible with [`RouterExt::typed_get`],
-/// [`RouterExt::typed_post`], etc. This implementation uses [`Path`] and thus your struct must
-/// also implement [`serde::Deserialize`], unless it's a unit struct.
-/// - A [`Display`] implementation that interpolates the captures. This can be used to, among other
-/// things, create links to known paths and have them verified statically. Note that the
-/// [`Display`] implementation for each field must return something that's compatible with its
-/// [`Deserialize`] implementation.
+/// - A [`FromRequest`] implementation compatible with [`RouterExt::typed_get`], [`RouterExt::typed_post`], etc. This implementation uses [`Path`] and thus your struct must also implement [`serde::Deserialize`], unless it's a unit struct.
+/// - A [`Display`] implementation that interpolates the captures. This can be used to, among other things, create links to known paths and have them verified statically. Note that the [`Display`] implementation for each field must return something that's compatible with its [`Deserialize`] implementation.
 ///
 /// Additionally the macro will verify the captures in the path matches the fields of the struct.
 /// For example this fails to compile since the struct doesn't have a `team_id` field:

--- a/axum/src/boxed.rs
+++ b/axum/src/boxed.rs
@@ -103,6 +103,7 @@ where
     }
 }
 
+#[allow(dead_code)]
 pub(crate) struct MakeErasedRouter<S> {
     pub(crate) router: Router<S>,
     pub(crate) into_route: fn(Router<S>, S) -> Route,

--- a/axum/src/docs/routing/nest.md
+++ b/axum/src/docs/routing/nest.md
@@ -181,7 +181,7 @@ router.
 # Panics
 
 - If the route overlaps with another route. See [`Router::route`]
-for more details.
+  for more details.
 - If the route contains a wildcard (`*`).
 - If `path` is empty.
 

--- a/axum/src/json.rs
+++ b/axum/src/json.rs
@@ -17,8 +17,7 @@ use serde::{de::DeserializeOwned, Serialize};
 ///
 /// - The request doesn't have a `Content-Type: application/json` (or similar) header.
 /// - The body doesn't contain syntactically valid JSON.
-/// - The body contains syntactically valid JSON, but it couldn't be deserialized into the target
-/// type.
+/// - The body contains syntactically valid JSON, but it couldn't be deserialized into the target type.
 /// - Buffering the request body fails.
 ///
 /// ⚠️ Since parsing JSON requires consuming the request body, the `Json` extractor must be


### PR DESCRIPTION
Refs #2768

## Motivation

When trying to send an attachment from Axum it includes,
* Setting a `Content-Disposition` header.
* Using the provided `Html`, `Css`, `JavaScript` or `Wasm` types or setting a `Content-Type` header.

 I think this could be made a bit easier.

## Solution

Add an `Attachment` response type to axum-extra. This type adds a `Content-Disposition` header and optionally a `Content-Type` header to the response.

example:
```rust
async fn cargo_toml() -> Result<Attachment<String>, (StatusCode, String)> {
    let file_contents = tokio::fs::read_to_string("Cargo.toml").await
        .map_err(|err| (StatusCode::NOT_FOUND, format!("File not found: {err}")))?;

    Ok(Attachment::new(file_contents)
        .filename("Cargo.toml")
        .content_type("text/x-toml"))
}
```