### PR TITLE
add `has_routes` function and docu to `Router`

### DIFF
--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **change:** Avoid cloning `Arc` during deserialization of `Path`
 - **added:** `axum::serve::Serve::tcp_nodelay` and `axum::serve::WithGracefulShutdown::tcp_nodelay` ([#2653])
-- **added:** `Router::has_routes` function added ([#2790])
+- **added:** `Router::has_routes` function ([#2790])
 
 [#2653]: https://github.com/tokio-rs/axum/pull/2653
 [#2790]: https://github.com/tokio-rs/axum/pull/2790

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -9,8 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **change:** Avoid cloning `Arc` during deserialization of `Path`
 - **added:** `axum::serve::Serve::tcp_nodelay` and `axum::serve::WithGracefulShutdown::tcp_nodelay` ([#2653])
+- **added:** `Router::has_routes` function added ([#2790])
 
 [#2653]: https://github.com/tokio-rs/axum/pull/2653
+[#2790]: https://github.com/tokio-rs/axum/pull/2790
 
 # 0.7.5 (24. March, 2024)
 

--- a/axum/src/docs/routing/route_layer.md
+++ b/axum/src/docs/routing/route_layer.md
@@ -11,6 +11,10 @@ the request matches a route. This is useful for middleware that return early
 (such as authorization) which might otherwise convert a `404 Not Found` into a
 `401 Unauthorized`.
 
+This function will panic if no routes have been declared yet on the router,
+since the new layer will have no effect, and this is typically a bug.
+In generic code, you can test if that is the case first, by calling [`Router::has_routes`].
+
 # Example
 
 ```rust

--- a/axum/src/routing/mod.rs
+++ b/axum/src/routing/mod.rs
@@ -307,6 +307,12 @@ where
         })
     }
 
+    /// True if the router currently has at least one route added.
+    #[track_caller]
+    pub fn has_routes(&self) -> bool {
+        self.inner.path_router.has_routes()
+    }
+
     #[track_caller]
     #[doc = include_str!("../docs/routing/fallback.md")]
     pub fn fallback<H, T>(self, handler: H) -> Self

--- a/axum/src/routing/mod.rs
+++ b/axum/src/routing/mod.rs
@@ -308,7 +308,6 @@ where
     }
 
     /// True if the router currently has at least one route added.
-    #[track_caller]
     pub fn has_routes(&self) -> bool {
         self.inner.path_router.has_routes()
     }

--- a/axum/src/routing/path_router.rs
+++ b/axum/src/routing/path_router.rs
@@ -290,7 +290,6 @@ where
         }
     }
 
-    #[track_caller]
     pub(super) fn has_routes(&self) -> bool {
         !self.routes.is_empty()
     }

--- a/axum/src/routing/path_router.rs
+++ b/axum/src/routing/path_router.rs
@@ -290,6 +290,11 @@ where
         }
     }
 
+    #[track_caller]
+    pub(super) fn has_routes(&self) -> bool {
+        !self.routes.is_empty()
+    }
+
     pub(super) fn with_state<S2>(self, state: S) -> PathRouter<S2, IS_FALLBACK> {
         let routes = self
             .routes


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation

The motivation is to be able to avoid panics in generic code that wants to call `route_layer`.

For example, you might have a generic function that takes a `Router` configured by an application (`/api/v1/my_route`, `/api/v1/my_route2`,...) and adds a bunch of additional configuration that is common to your applications, like an http metrics layer using `route_layer`, followed by infrastructure or diagnostic routes (`/health`, `/ready`, ...) that you do not need metrics for.

`route_layer` currently panics if you call it on `Router::new()`. But in some cases that is legitimate, for example, you may have an application that performs important periodic tasks, and needs to have `/health` and `/ready` to exist in your k8s infrastructure, but doesn't actualy have any HTTP API to expose. So then it would be very logical to pass `Router::new()` to your generic function.

## Solution

With this non-breaking change, the helper function would be able to call `is_empty()` first on the argument, and skip the (panicking) call to `route_layer` if the router is empty. This is a bit nicer than the workaround of adding dummy routes to the `Router::new()` just to avoid a `Router` panic.

Edit: After discussion, changed to a `has_routes` function instead of `is_empty` for a more clear semantic