### PR TITLE
Update TLS examples to use better HTTP->HTTPS redirect

### DIFF
--- a/examples/tls-rustls/src/main.rs
+++ b/examples/tls-rustls/src/main.rs
@@ -8,7 +8,7 @@
 
 use axum::{
     handler::HandlerWithoutStateExt,
-    http::{StatusCode, Uri},
+    http::{uri::Authority, StatusCode, Uri},
     response::Redirect,
     routing::get,
     BoxError, Router,
@@ -72,7 +72,7 @@ async fn handler() -> &'static str {
 
 #[allow(dead_code)]
 async fn redirect_http_to_https(ports: Ports) {
-    fn make_https(host: String, uri: Uri, ports: Ports) -> Result<Uri, BoxError> {
+    fn make_https(host: &str, uri: Uri, https_port: u16) -> Result<Uri, BoxError> {
         let mut parts = uri.into_parts();
 
         parts.scheme = Some(axum::http::uri::Scheme::HTTPS);
@@ -81,14 +81,24 @@ async fn redirect_http_to_https(ports: Ports) {
             parts.path_and_query = Some("/".parse().unwrap());
         }
 
-        let https_host = host.replace(&ports.http.to_string(), &ports.https.to_string());
-        parts.authority = Some(https_host.parse()?);
+        let authority: Authority = host.parse()?;
+        let bare_host = match authority.port() {
+            Some(port_struct) => authority
+                .as_str()
+                .strip_suffix(port_struct.as_str())
+                .unwrap()
+                .strip_suffix(':')
+                .unwrap(), // if authority.port() is Some(port) then we can be sure authority ends with :{port}
+            None => authority.as_str(),
+        };
+
+        parts.authority = Some(format!("{bare_host}:{https_port}").parse()?);
 
         Ok(Uri::from_parts(parts)?)
     }
 
     let redirect = move |Host(host): Host, uri: Uri| async move {
-        match make_https(host, uri, ports) {
+        match make_https(&host, uri, ports.https) {
             Ok(uri) => Ok(Redirect::permanent(&uri.to_string())),
             Err(error) => {
                 tracing::warn!(%error, "failed to convert URI to HTTPS");


### PR DESCRIPTION
I tried to implement the redirect from the TLS examples in my project, and it didn't work - I like to use port 6789 when I'm testing things locally and this caused big problems. So I thought I'd try fixing it and filing a PR.

tl;dr: The redirect showcased in the TLS examples is very fragile, I am proposing a more robust alternative.

## Motivation:

The HTTP->HTTPS redirect showcased in these examples changes the port with a simple find-and-replace over the entire authority, including the hostname. This works well in the median case but:

* Custom HTTPS ports with default HTTP ports fail to redirect properly, as the HTTP port is not present in the string: `http://example.com` -> `https://example.com` (not `https://example.com:4443` or whatever port you're using.) This is the one that bit me!

* IP addresses can be mangled: `http://80.80.80.80` -> `https://443.443.443.443`, `http://[::80]` -> `https://[::443]`

* As, I think worst of all, can hostnames, like this real and very cool website: `http://io808.com` -> `https://io4438.com` !

## Solution:

I've written an alternative based on parsing into an Authority; this type's `.port()` should guarantee with a `None` return that the authority string is a bare hostname/IP, or with `Some(port)` that the string ends with `:{port}` and so we can safely strip that suffix. Adding new port only conditionally would be easy, but browsers tend to be smart about eliding unnecessary `:443`s, so it seemed an overcomplication?

I also changed the args, since this redirect solution doesn't actually need to know the HTTP port, and since clippy's suggestion to use an `&str` seemed reasonable.

I'm not very expert at Rust, so hopefully my solution doesn't have any glaring problems! It may be better to simply use the `url` crate, as was proposed (and rejected) previously, but it was more fun for me to write this.