### PR TITLE
Fix a few typos in docs and comments

### DIFF
--- a/axum-macros/src/lib.rs
+++ b/axum-macros/src/lib.rs
@@ -399,7 +399,7 @@ use from_request::Trait::{FromRequest, FromRequestParts};
 ///
 /// # Known limitations
 ///
-/// Generics are only supported on tuple structs with exactly on field. Thus this doesn't work
+/// Generics are only supported on tuple structs with exactly one field. Thus this doesn't work
 ///
 /// ```compile_fail
 /// #[derive(axum_macros::FromRequest)]

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -576,7 +576,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ```rust
   use axum::{Json, http::HeaderMap};
 
-  // This wont compile on 0.6 because both `Json` and `String` need to consume
+  // This won't compile on 0.6 because both `Json` and `String` need to consume
   // the request body. You can use either `Json` or `String`, but not both.
   async fn handler_1(
       json: Json<serde_json::Value>,
@@ -1162,7 +1162,7 @@ Yanked, as it didn't compile in release mode.
   ```rust
   use axum::{Json, http::HeaderMap};
 
-  // This wont compile on 0.6 because both `Json` and `String` need to consume
+  // This won't compile on 0.6 because both `Json` and `String` need to consume
   // the request body. You can use either `Json` or `String`, but not both.
   async fn handler_1(
       json: Json<serde_json::Value>,

--- a/axum/src/docs/middleware.md
+++ b/axum/src/docs/middleware.md
@@ -355,8 +355,8 @@ anyway.
 axum expects that all services used in your app won't care about
 backpressure and so it uses the latter strategy. However that means you
 should avoid routing to a service (or using a middleware) that _does_ care
-about backpressure. At the very least you should [load shed] so requests are
-dropped quickly and don't keep piling up.
+about backpressure. At the very least you should [load shed][tower::load_shed]
+so requests are dropped quickly and don't keep piling up.
 
 It also means that if `poll_ready` returns an error then that error will be
 returned in the response future from `call` and _not_ from `poll_ready`. In

--- a/axum/src/docs/middleware.md
+++ b/axum/src/docs/middleware.md
@@ -352,7 +352,7 @@ readiness inside the response future returned by `Service::call`. This works
 well when your services don't care about backpressure and are always ready
 anyway.
 
-axum expects that all services used in your app wont care about
+axum expects that all services used in your app won't care about
 backpressure and so it uses the latter strategy. However that means you
 should avoid routing to a service (or using a middleware) that _does_ care
 about backpressure. At the very least you should [load shed] so requests are
@@ -388,8 +388,7 @@ let app = ServiceBuilder::new()
 ```
 
 However when applying middleware around your whole application in this way
-you have to take care that errors are still being handled with
-appropriately.
+you have to take care that errors are still being handled appropriately.
 
 Also note that handlers created from async functions don't care about
 backpressure and are always ready. So if you're not using any Tower

--- a/axum/src/docs/routing/with_state.md
+++ b/axum/src/docs/routing/with_state.md
@@ -171,7 +171,7 @@ work:
 # #[derive(Clone)]
 # struct AppState {}
 # 
-// This wont work because we're returning a `Router<AppState>`
+// This won't work because we're returning a `Router<AppState>`
 // i.e. we're saying we're still missing an `AppState`
 fn routes(state: AppState) -> Router<AppState> {
     Router::new()

--- a/axum/src/handler/mod.rs
+++ b/axum/src/handler/mod.rs
@@ -10,8 +10,8 @@
 //! // Handler that immediately returns an empty `200 OK` response.
 //! async fn unit_handler() {}
 //!
-//! // Handler that immediately returns an empty `200 OK` response with a plain
-//! // text body.
+//! // Handler that immediately returns a `200 OK` response with a plain text
+//! // body.
 //! async fn string_handler() -> String {
 //!     "Hello, World!".to_string()
 //! }

--- a/axum/src/middleware/from_extractor.rs
+++ b/axum/src/middleware/from_extractor.rs
@@ -26,7 +26,7 @@ use tower_service::Service;
 /// without repeating it in the function signature.
 ///
 /// Note that if the extractor consumes the request body, as `String` or
-/// [`Bytes`] does, an empty body will be left in its place. Thus wont be
+/// [`Bytes`] does, an empty body will be left in its place. Thus won't be
 /// accessible to subsequent extractors or handlers.
 ///
 /// # Example

--- a/axum/src/routing/strip_prefix.rs
+++ b/axum/src/routing/strip_prefix.rs
@@ -104,7 +104,7 @@ fn strip_prefix(uri: &Uri, prefix: &str) -> Option<Uri> {
     }
 
     // if the prefix matches it will always do so up until a `/`, it cannot match only
-    // part of a segment. Therefore this will always be at a char boundary and `split_at` wont
+    // part of a segment. Therefore this will always be at a char boundary and `split_at` won't
     // panic
     let after_prefix = uri.path().split_at(matching_prefix_length?).1;
 

--- a/examples/consume-body-in-extractor-or-middleware/src/main.rs
+++ b/examples/consume-body-in-extractor-or-middleware/src/main.rs
@@ -50,7 +50,7 @@ async fn print_request_body(request: Request, next: Next) -> Result<impl IntoRes
 async fn buffer_request_body(request: Request) -> Result<Request, Response> {
     let (parts, body) = request.into_parts();
 
-    // this wont work if the body is an long running stream
+    // this won't work if the body is an long running stream
     let bytes = body
         .collect()
         .await

--- a/examples/rest-grpc-multiplex/src/multiplex_service.rs
+++ b/examples/rest-grpc-multiplex/src/multiplex_service.rs
@@ -38,7 +38,7 @@ where
         Self {
             rest: self.rest.clone(),
             grpc: self.grpc.clone(),
-            // the cloned services probably wont be ready
+            // the cloned services probably won't be ready
             rest_ready: false,
             grpc_ready: false,
         }


### PR DESCRIPTION
## Motivation

These are mostly small issues where one word is accidentally used in place of another.

## Solution

Removed unnecessary words, replaced incorrect words, fixed link.