### PR TITLE
[Reqwest example]: Include headers into response

### DIFF
--- a/examples/reqwest-response/src/main.rs
+++ b/examples/reqwest-response/src/main.rs
@@ -62,17 +62,12 @@ async fn proxy_via_reqwest(State(client): State<Client>) -> Response {
 
     let mut response_builder = Response::builder().status(reqwest_response.status().as_u16());
 
-    {
-        let headers = response_builder.headers_mut().unwrap();
+    let headers = response_builder.headers_mut().unwrap();
 
-        reqwest_response
-            .headers()
-            .into_iter()
-            .for_each(|(name, value)| {
-                let name = HeaderName::from_bytes(name.as_ref()).unwrap();
-                let value = HeaderValue::from_bytes(value.as_ref()).unwrap();
-                headers.insert(name, value);
-            });
+    for (name, value) in reqwest_response.headers() {
+        let name = HeaderName::from_bytes(name.as_ref()).unwrap();
+        let value = HeaderValue::from_bytes(value.as_ref()).unwrap();
+        headers.insert(name, value);
     }
 
     response_builder

--- a/examples/reqwest-response/src/main.rs
+++ b/examples/reqwest-response/src/main.rs
@@ -64,7 +64,6 @@ async fn proxy_via_reqwest(State(client): State<Client>) -> Response {
 
     // Here the mapping of headers is required due to reqwest and axum differ on the http crate versions
     let mut headers = HeaderMap::with_capacity(reqwest_response.headers().len());
-
     headers.extend(reqwest_response.headers().into_iter().map(|(name, value)| {
         let name = HeaderName::from_bytes(name.as_ref()).unwrap();
         let value = HeaderValue::from_bytes(value.as_ref()).unwrap();


### PR DESCRIPTION
## Topic 

Example fix 

## Motivation

While working on a reverse proxy with reqwest I think I noticed that the headers are not actually passed from the request to the response (I'm new to axum so I might be wrong).

Shouldn't be like this?

## Solution

We update the `response_builder`'s `HeadersMap`
