### PR TITLE
Fix clippy warning on `FromRef` derive macro

### DIFF
--- a/axum-macros/src/from_ref.rs
+++ b/axum-macros/src/from_ref.rs
@@ -54,7 +54,7 @@ fn expand_field(state: &Ident, idx: usize, field: &Field) -> TokenStream {
     };
 
     quote_spanned! {span=>
-        #[allow(clippy::clone_on_copy)]
+        #[allow(clippy::clone_on_copy, clippy::clone_on_ref_ptr)]
         impl ::axum::extract::FromRef<#state> for #field_ty {
             fn from_ref(state: &#state) -> Self {
                 #body

--- a/axum-macros/tests/debug_handler/fail/json_not_deserialize.stderr
+++ b/axum-macros/tests/debug_handler/fail/json_not_deserialize.stderr
@@ -4,6 +4,8 @@ error[E0277]: the trait bound `for<'de> Struct: serde::de::Deserialize<'de>` is 
 7 | async fn handler(_foo: Json<Struct>) {}
   |                        ^^^^^^^^^^^^ the trait `for<'de> serde::de::Deserialize<'de>` is not implemented for `Struct`, which is required by `Json<Struct>: FromRequest<()>`
   |
+  = note: for local types consider adding `#[derive(serde::Deserialize)]` to your `Struct` type
+  = note: for types from other crates check whether the crate offers a `serde` feature flag
   = help: the following other types implement trait `serde::de::Deserialize<'de>`:
             bool
             char
@@ -25,6 +27,8 @@ error[E0277]: the trait bound `for<'de> Struct: serde::de::Deserialize<'de>` is 
 7 | async fn handler(_foo: Json<Struct>) {}
   |                        ^^^^^^^^^^^^ the trait `for<'de> serde::de::Deserialize<'de>` is not implemented for `Struct`, which is required by `Json<Struct>: FromRequest<()>`
   |
+  = note: for local types consider adding `#[derive(serde::Deserialize)]` to your `Struct` type
+  = note: for types from other crates check whether the crate offers a `serde` feature flag
   = help: the following other types implement trait `serde::de::Deserialize<'de>`:
             bool
             char


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

Fixes a clippy warning caused by the `FromRef` derive macro.

See #2826.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Add the lint to the `#[allow(…)]` attribute above the generated function that triggers it.
