### PR TITLE
Emphasize that Request extractor goes last

### DIFF
--- a/axum/src/middleware/from_fn.rs
+++ b/axum/src/middleware/from_fn.rs
@@ -20,8 +20,8 @@ use tower_service::Service;
 ///
 /// 1. Be an `async fn`.
 /// 2. Take zero or more [`FromRequestParts`] extractors.
-/// 3. Take exactly one [`FromRequest`] extractor as the second final argument.
-/// 4. Take [`Next`](Next) as the final argument.
+/// 3. Take exactly one [`FromRequest`] extractor as the second to last argument.
+/// 4. Take [`Next`](Next) as the last argument.
 /// 5. Return something that implements [`IntoResponse`].
 ///
 /// Note that this function doesn't support extracting [`State`]. For that, use [`from_fn_with_state`].

--- a/axum/src/middleware/from_fn.rs
+++ b/axum/src/middleware/from_fn.rs
@@ -19,11 +19,10 @@ use tower_service::Service;
 /// `from_fn` requires the function given to
 ///
 /// 1. Be an `async fn`.
-/// 2. Take one or more [extractors] as the first arguments.
-/// 3. Take [`Next`](Next) as the final argument.
-/// 4. Return something that implements [`IntoResponse`].
-///
-/// The last extractor (i.e. the second last argument) must be [`Request`] or some type implementing [`FromRequest`].
+/// 2. Take zero or more [`FromRequestParts`] extractors.
+/// 3. Take exactly one [`FromRequest`] extractor as the second final argument.
+/// 4. Take [`Next`](Next) as the final argument.
+/// 5. Return something that implements [`IntoResponse`].
 ///
 /// Note that this function doesn't support extracting [`State`]. For that, use [`from_fn_with_state`].
 ///
@@ -73,7 +72,9 @@ use tower_service::Service;
 /// async fn auth(
 ///     // run the `HeaderMap` extractor
 ///     headers: HeaderMap,
-///     // a `FromRequest` implementation must be the last extractor
+///     // you can also add more extractors here but the last
+///     // extractor must implement `FromRequest` which
+///     // `Request` does
 ///     request: Request,
 ///     next: Next,
 /// ) -> Result<Response, StatusCode> {

--- a/axum/src/middleware/from_fn.rs
+++ b/axum/src/middleware/from_fn.rs
@@ -23,6 +23,8 @@ use tower_service::Service;
 /// 3. Take [`Next`](Next) as the final argument.
 /// 4. Return something that implements [`IntoResponse`].
 ///
+/// The last extractor (i.e. the second last argument) must be [`Request`] or some type implementing [`FromRequest`].
+///
 /// Note that this function doesn't support extracting [`State`]. For that, use [`from_fn_with_state`].
 ///
 /// # Example
@@ -71,9 +73,7 @@ use tower_service::Service;
 /// async fn auth(
 ///     // run the `HeaderMap` extractor
 ///     headers: HeaderMap,
-///     // you can also add more extractors here but the last
-///     // extractor must implement `FromRequest` which
-///     // `Request` does
+///     // a `FromRequest` implementation must be the last extractor
 ///     request: Request,
 ///     next: Next,
 /// ) -> Result<Response, StatusCode> {


### PR DESCRIPTION
## Motivation

The error message you get when passing an invalid fn or closure to `from_fn` is rather far removed from the actual error.  The itemized list in https://docs.rs/axum/latest/axum/middleware/fn.from_fn.html makes no mention of the limitation that `Request` must be the last extractor. This is only mentioned in passing in the auth middleware example a way down the page.

## Solution

Given that putting extractors in the wrong order risks causing a lot of confusion, this PR promotes the ordering requirement to the top of `from_fn` docs so that it is easier to note.