### PR TITLE
Fixing a typo in the documentation of `with_state` method of Router, making it more clear

### DIFF
--- a/axum/src/docs/routing/with_state.md
+++ b/axum/src/docs/routing/with_state.md
@@ -20,7 +20,7 @@ axum::serve(listener, routes).await.unwrap();
 
 # Returning routers with states from functions
 
-When returning `Router`s from functions it is generally recommend not set the
+When returning `Router`s from functions, it is generally recommended not to set the
 state directly:
 
 ```rust


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation
I was reading the documentation and I found this typo so I fixed it.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
