### PR TITLE
Upgrade tokio-tungstenite to 0.23

### DIFF
--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -10,11 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **change:** Avoid cloning `Arc` during deserialization of `Path`
 - **added:** `axum::serve::Serve::tcp_nodelay` and `axum::serve::WithGracefulShutdown::tcp_nodelay` ([#2653])
 - **added:** `Router::has_routes` function ([#2790])
-- **change:** Update tokio-tungstenite to 0.23 ([TODO])
+- **change:** Update tokio-tungstenite to 0.23 ([#2841])
 
 [#2653]: https://github.com/tokio-rs/axum/pull/2653
 [#2790]: https://github.com/tokio-rs/axum/pull/2790
-[TODO]: https://github.com/tokio-rs/axum/pull/
+[#2841]: https://github.com/tokio-rs/axum/pull/2841
 
 # 0.7.5 (24. March, 2024)
 

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -10,9 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **change:** Avoid cloning `Arc` during deserialization of `Path`
 - **added:** `axum::serve::Serve::tcp_nodelay` and `axum::serve::WithGracefulShutdown::tcp_nodelay` ([#2653])
 - **added:** `Router::has_routes` function ([#2790])
+- **change:** Update tokio-tungstenite to 0.23 ([TODO])
 
 [#2653]: https://github.com/tokio-rs/axum/pull/2653
 [#2790]: https://github.com/tokio-rs/axum/pull/2790
+[TODO]: https://github.com/tokio-rs/axum/pull/
 
 # 0.7.5 (24. March, 2024)
 

--- a/axum/Cargo.toml
+++ b/axum/Cargo.toml
@@ -72,7 +72,7 @@ serde_path_to_error = { version = "0.1.8", optional = true }
 serde_urlencoded = { version = "0.7", optional = true }
 sha1 = { version = "0.10", optional = true }
 tokio = { package = "tokio", version = "1.25.0", features = ["time"], optional = true }
-tokio-tungstenite = { version = "0.21", optional = true }
+tokio-tungstenite = { version = "0.23", optional = true }
 tracing = { version = "0.1", default-features = false, optional = true }
 
 [dependencies.tower-http]
@@ -121,7 +121,7 @@ serde_json = "1.0"
 time = { version = "0.3", features = ["serde-human-readable"] }
 tokio = { package = "tokio", version = "1.25.0", features = ["macros", "rt", "rt-multi-thread", "net", "test-util"] }
 tokio-stream = "0.1"
-tokio-tungstenite = "0.21"
+tokio-tungstenite = "0.23"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["json"] }
 uuid = { version = "1.0", features = ["serde", "v4"] }

--- a/examples/testing-websockets/Cargo.toml
+++ b/examples/testing-websockets/Cargo.toml
@@ -9,4 +9,4 @@ axum = { path = "../../axum", features = ["ws"] }
 futures = "0.3"
 hyper = { version = "1.0.0", features = ["full"] }
 tokio = { version = "1.0", features = ["full"] }
-tokio-tungstenite = "0.21"
+tokio-tungstenite = "0.23"

--- a/examples/websockets/Cargo.toml
+++ b/examples/websockets/Cargo.toml
@@ -11,7 +11,7 @@ futures = "0.3"
 futures-util = { version = "0.3", default-features = false, features = ["sink", "std"] }
 headers = "0.4"
 tokio = { version = "1.0", features = ["full"] }
-tokio-tungstenite = "0.21"
+tokio-tungstenite = "0.23"
 tower = { version = "0.4", features = ["util"] }
 tower-http = { version = "0.5.0", features = ["fs", "trace"] }
 tracing = "0.1"


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation

The latest version of tokio-tungstenite updates both tungstenite and rustls.

## Solution

Upgrade tokio-tungstenite to 0.23.
