### PR TITLE
Add more must_use attributes

### DIFF
--- a/axum-core/CHANGELOG.md
+++ b/axum-core/CHANGELOG.md
@@ -7,9 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
-- **added:** Implement `Copy` for `DefaultBodyLimit`
+- **added:** Derive `Clone` and `Copy` for `AppendHeaders` ([#2776])
+- **added:** `must_use` attribute on `AppendHeaders` ([#2846])
+- **added:** `must_use` attribute on `ErrorResponse` ([#2846])
+- **added:** `must_use` attribute on `IntoResponse::into_response` ([#2846])
+- **added:** `must_use` attribute on `IntoResponseParts` trait methods ([#2846])
+- **added:** Implement `Copy` for `DefaultBodyLimit` ([#2875])
 - **added**: `DefaultBodyLimit::max` and `DefaultBodyLimit::disable` are now
-  allowed in const context
+  allowed in const context ([#2875])
+
+[#2776]: https://github.com/tokio-rs/axum/pull/2776
+[#2846]: https://github.com/tokio-rs/axum/pull/2846
+[#2875]: https://github.com/tokio-rs/axum/pull/2875
 
 # 0.4.3 (13. January, 2024)
 

--- a/axum-core/src/response/into_response.rs
+++ b/axum-core/src/response/into_response.rs
@@ -111,6 +111,7 @@ use std::{
 /// ```
 pub trait IntoResponse {
     /// Create a response.
+    #[must_use]
     fn into_response(self) -> Response;
 }
 

--- a/axum-core/src/response/into_response_parts.rs
+++ b/axum-core/src/response/into_response_parts.rs
@@ -105,21 +105,25 @@ pub struct ResponseParts {
 
 impl ResponseParts {
     /// Gets a reference to the response headers.
+    #[must_use]
     pub fn headers(&self) -> &HeaderMap {
         self.res.headers()
     }
 
     /// Gets a mutable reference to the response headers.
+    #[must_use]
     pub fn headers_mut(&mut self) -> &mut HeaderMap {
         self.res.headers_mut()
     }
 
     /// Gets a reference to the response extensions.
+    #[must_use]
     pub fn extensions(&self) -> &Extensions {
         self.res.extensions()
     }
 
     /// Gets a mutable reference to the response extensions.
+    #[must_use]
     pub fn extensions_mut(&mut self) -> &mut Extensions {
         self.res.extensions_mut()
     }

--- a/axum-core/src/response/mod.rs
+++ b/axum-core/src/response/mod.rs
@@ -117,6 +117,7 @@ where
 ///
 /// See [`Result`] for more details.
 #[derive(Debug)]
+#[must_use]
 pub struct ErrorResponse(Response);
 
 impl<T> From<T> for ErrorResponse

--- a/axum-extra/CHANGELOG.md
+++ b/axum-extra/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning].
 
 # Unreleased
 
-- None.
+- **added:** The `response::Attachment` type ([#2789])
+
+[#2789]: https://github.com/tokio-rs/axum/pull/2789
 
 # 0.9.3 (24. March, 2024)
 

--- a/axum-extra/src/response/attachment.rs
+++ b/axum-extra/src/response/attachment.rs
@@ -33,8 +33,8 @@ use tracing::error;
 /// # Note
 ///
 /// If you use axum with hyper, hyper will set the `Content-Length` if it is known.
-///
 #[derive(Debug)]
+#[must_use]
 pub struct Attachment<T> {
     inner: T,
     filename: Option<HeaderValue>,


### PR DESCRIPTION
… so people get a warning when they accidentally add a semicolon after the response expression in a handler function.

Inspired by #2845.

![Screenshot_2024-07-24_225933](https://github.com/user-attachments/assets/499c6e8d-4f96-47d9-a719-3656666a1d56)
