### PR TITLE
Macro for JsonDeserializer extractor to avoid boilerplate code

### DIFF
--- a/axum-extra/src/extract/json_deserializer.rs
+++ b/axum-extra/src/extract/json_deserializer.rs
@@ -209,6 +209,16 @@ fn json_content_type(headers: &HeaderMap) -> bool {
     is_json_content_type
 }
 
+#[macro_export]
+macro_rules! deserialize_or_bail {
+      ($payload:expr) => {
+        match $payload.deserialize() {
+            Ok(data) => data,
+            Err(e) => return e.into_response(),
+        }
+    };
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/axum-extra/src/extract/json_deserializer.rs
+++ b/axum-extra/src/extract/json_deserializer.rs
@@ -212,7 +212,7 @@ fn json_content_type(headers: &HeaderMap) -> bool {
 #[doc = "Macro for the JsonDeserializer extractor to avoid boilerplate code in most situations where the handler returns a Response or its derivatives, and returns early in case of failure."]
 #[macro_export]
 macro_rules! deserialize_or_bail {
-      ($payload:expr) => {
+    ($payload:expr) => {
         match $payload.deserialize() {
             Ok(data) => data,
             Err(e) => return e.into_response(),

--- a/axum-extra/src/extract/json_deserializer.rs
+++ b/axum-extra/src/extract/json_deserializer.rs
@@ -209,6 +209,7 @@ fn json_content_type(headers: &HeaderMap) -> bool {
     is_json_content_type
 }
 
+#[doc="Macro for the JsonDeserializer extractor to avoid boilerplate code in most situations where the handler returns a Response or its derivatives, and returns early in case of failure."]
 #[macro_export]
 macro_rules! deserialize_or_bail {
       ($payload:expr) => {

--- a/axum-extra/src/extract/json_deserializer.rs
+++ b/axum-extra/src/extract/json_deserializer.rs
@@ -209,7 +209,7 @@ fn json_content_type(headers: &HeaderMap) -> bool {
     is_json_content_type
 }
 
-#[doc="Macro for the JsonDeserializer extractor to avoid boilerplate code in most situations where the handler returns a Response or its derivatives, and returns early in case of failure."]
+#[doc = "Macro for the JsonDeserializer extractor to avoid boilerplate code in most situations where the handler returns a Response or its derivatives, and returns early in case of failure."]
 #[macro_export]
 macro_rules! deserialize_or_bail {
       ($payload:expr) => {


### PR DESCRIPTION
Macro for the JsonDeserializer extractor to avoid boilerplate code in most situations where the handler returns a Response or its derivatives, and returns early in case of failure.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation

In most situations, the controller layer is responsible for managing the result of the service layer and returning a specific response (not an expected result). Given this scenario, using the JsonDeserializer extractor, we should handle both when the payload is correct and when it is not. 
This macro returns the expected payload, and if not, it returns early a Response structure, avoiding duplicate code.


## Solution

A macro that returns the payload if everything went well, otherwise it returns the error as a Response structure that implements IntoResponse.

