### PR TITLE
Avoid reallocation for String body extraction

### DIFF
--- a/axum-core/Cargo.toml
+++ b/axum-core/Cargo.toml
@@ -19,7 +19,7 @@ __private_docs = ["dep:tower-http"]
 
 [dependencies]
 async-trait = "0.1.67"
-bytes = "1.0"
+bytes = "1.2"
 futures-util = { version = "0.3", default-features = false, features = ["alloc"] }
 http = "1.0.0"
 http-body = "1.0.0"

--- a/axum-core/src/extract/request_parts.rs
+++ b/axum-core/src/extract/request_parts.rs
@@ -106,9 +106,7 @@ where
                 }
             })?;
 
-        let string = std::str::from_utf8(&bytes)
-            .map_err(InvalidUtf8::from_err)?
-            .to_owned();
+        let string = String::from_utf8(bytes.into()).map_err(InvalidUtf8::from_err)?;
 
         Ok(string)
     }


### PR DESCRIPTION
The conversion from `Bytes` to `String` does not need an extra allocation if we use `Bytes: Into<Vec<u8>>` and `String::from_utf8`.