### PR TITLE
Avoid some extra clones/allocations

### DIFF
--- a/axum/src/routing/method_routing.rs
+++ b/axum/src/routing/method_routing.rs
@@ -1024,57 +1024,60 @@ where
 
     pub(crate) fn call_with_state(&self, req: Request, state: S) -> RouteFuture<E> {
         macro_rules! call {
-            ($req:expr => ($(
-                $method_variant:ident: $svc:ident $(=> $strip_body:expr)?
-            ),*)) => {
-                // written with a pattern match like this to ensure we call all routes
-                let Self {
-                    $($svc,)*
-                    fallback,
-                    allow_header,
-                } = self;
-
-                match *$req.method() {
-                    $(
-                        Method::$method_variant => {
-                            match $svc {
-                                MethodEndpoint::None => {}
-                                MethodEndpoint::Route(route) => {
-                                    return RouteFuture::from_future(route.clone().oneshot_inner_owned($req))
-                                        $(.strip_body($strip_body))?;
-                                }
-                                MethodEndpoint::BoxedHandler(handler) => {
-                                    let route = handler.clone().into_route(state);
-                                    return RouteFuture::from_future(route.oneshot_inner_owned($req))
-                                        $(.strip_body($strip_body))?;
-                                }
-                            }
-                        },
-                    )*
-                    _ => {}
+            (
+                $req:expr,
+                $method_variant:ident,
+                $svc:expr
+            ) => {
+                if *req.method() == Method::$method_variant {
+                    match $svc {
+                        MethodEndpoint::None => {}
+                        MethodEndpoint::Route(route) => {
+                            return RouteFuture::from_future(
+                                route.clone().oneshot_inner_owned($req),
+                            )
+                            .strip_body(Method::$method_variant == Method::HEAD);
+                        }
+                        MethodEndpoint::BoxedHandler(handler) => {
+                            let route = handler.clone().into_route(state);
+                            return RouteFuture::from_future(route.oneshot_inner_owned($req))
+                                .strip_body(Method::$method_variant == Method::HEAD);
+                        }
+                    }
                 }
-
-                let future = fallback.clone().call_with_state(req, state);
-
-                match allow_header {
-                    AllowHeader::None => future.allow_header(Bytes::new()),
-                    AllowHeader::Skip => future,
-                    AllowHeader::Bytes(allow_header) => future.allow_header(allow_header.clone().freeze()),
-                }
-            }
+            };
         }
 
-        call! {
-            req => (
-                GET: get,
-                HEAD: head => true,
-                DELETE: delete,
-                OPTIONS: options,
-                PATCH: patch,
-                POST: post,
-                PUT: put,
-                TRACE: trace
-            )
+        // written with a pattern match like this to ensure we call all routes
+        let Self {
+            get,
+            head,
+            delete,
+            options,
+            patch,
+            post,
+            put,
+            trace,
+            fallback,
+            allow_header,
+        } = self;
+
+        call!(req, HEAD, head);
+        call!(req, HEAD, get);
+        call!(req, GET, get);
+        call!(req, POST, post);
+        call!(req, OPTIONS, options);
+        call!(req, PATCH, patch);
+        call!(req, PUT, put);
+        call!(req, DELETE, delete);
+        call!(req, TRACE, trace);
+
+        let future = fallback.clone().call_with_state(req, state);
+
+        match allow_header {
+            AllowHeader::None => future.allow_header(Bytes::new()),
+            AllowHeader::Skip => future,
+            AllowHeader::Bytes(allow_header) => future.allow_header(allow_header.clone().freeze()),
         }
     }
 }

--- a/axum/src/routing/mod.rs
+++ b/axum/src/routing/mod.rs
@@ -656,14 +656,14 @@ where
         }
     }
 
-    fn call_with_state(&mut self, req: Request, state: S) -> RouteFuture<E> {
+    fn call_with_state(self, req: Request, state: S) -> RouteFuture<E> {
         match self {
             Fallback::Default(route) | Fallback::Service(route) => {
-                RouteFuture::from_future(route.oneshot_inner(req))
+                RouteFuture::from_future(route.oneshot_inner_owned(req))
             }
             Fallback::BoxedHandler(handler) => {
-                let mut route = handler.clone().into_route(state);
-                RouteFuture::from_future(route.oneshot_inner(req))
+                let route = handler.into_route(state);
+                RouteFuture::from_future(route.oneshot_inner_owned(req))
             }
         }
     }

--- a/axum/src/routing/path_router.rs
+++ b/axum/src/routing/path_router.rs
@@ -331,9 +331,11 @@ where
             }
         }
 
-        let path = req.uri().path().to_owned();
+        // split apart to get multiple mutable references to parts,
+        // this avoids the need to clone the URI/path.
+        let (mut parts, body) = req.into_parts();
 
-        match self.node.at(&path) {
+        match self.node.at(parts.uri.path()) {
             Ok(match_) => {
                 let id = *match_.value;
 
@@ -342,22 +344,24 @@ where
                     crate::extract::matched_path::set_matched_path_for_request(
                         id,
                         &self.node.route_id_to_path,
-                        req.extensions_mut(),
+                        &mut parts.extensions,
                     );
                 }
 
-                url_params::insert_url_params(req.extensions_mut(), match_.params);
+                url_params::insert_url_params(&mut parts.extensions, match_.params);
 
                 let endpoint = self
                     .routes
                     .get(&id)
                     .expect("no route for id. This is a bug in axum. Please file an issue");
 
+                let req = Request::from_parts(parts, body);
+
                 match endpoint {
                     Endpoint::MethodRouter(method_router) => {
                         Ok(method_router.call_with_state(req, state))
                     }
-                    Endpoint::Route(route) => Ok(route.clone().call(req)),
+                    Endpoint::Route(route) => Ok(route.clone().call_owned(req)),
                 }
             }
             // explicitly handle all variants in case matchit adds
@@ -366,7 +370,7 @@ where
                 MatchError::NotFound
                 | MatchError::ExtraTrailingSlash
                 | MatchError::MissingTrailingSlash,
-            ) => Err((req, state)),
+            ) => Err((Request::from_parts(parts, body), state)),
         }
     }
 

--- a/axum/src/routing/route.rs
+++ b/axum/src/routing/route.rs
@@ -42,11 +42,25 @@ impl<E> Route<E> {
         )))
     }
 
+    /// Variant of [`Route::call`] that takes ownership of the route to avoid cloning.
+    pub(crate) fn call_owned(self, req: Request<Body>) -> RouteFuture<E> {
+        let req = req.map(Body::new);
+        RouteFuture::from_future(self.oneshot_inner_owned(req))
+    }
+
     pub(crate) fn oneshot_inner(
         &mut self,
         req: Request,
     ) -> Oneshot<BoxCloneService<Request, Response, E>, Request> {
         self.0.get_mut().unwrap().clone().oneshot(req)
+    }
+
+    /// Variant of [`Route::oneshot_inner`] that takes ownership of the route to avoid cloning.
+    pub(crate) fn oneshot_inner_owned(
+        self,
+        req: Request,
+    ) -> Oneshot<BoxCloneService<Request, Response, E>, Request> {
+        self.0.into_inner().unwrap().oneshot(req)
     }
 
     pub(crate) fn layer<L, NewError>(self, layer: L) -> Route<NewError>

--- a/axum/src/routing/tests/mod.rs
+++ b/axum/src/routing/tests/mod.rs
@@ -952,7 +952,7 @@ async fn state_isnt_cloned_too_much() {
 
     client.get("/").await;
 
-    assert_eq!(COUNT.load(Ordering::SeqCst), 4);
+    assert_eq!(COUNT.load(Ordering::SeqCst), 3);
 }
 
 #[crate::test]


### PR DESCRIPTION
## Motivation

I noticed when writing a `Layer` implementation that it requires `Clone`, and after running a small hello world noticed it cloned _a lot_. After looking at the code I saw that some of the clones were pointless, just to get a mutable reference that then cloned again internally.

## Solution

This adds a couple specialized routines that help avoid a few clones, and cleans up some code elsewhere to avoid a couple more allocations.

~~The most contentious change might be to `MethodRouter::call_with_state`, but a `match` might be more efficient, and the new macro should more easily help catch issues the comment about destructuring was after.~~ Edit: Partially reverted, overlooked something simple.

I'm still looking for places where clones/allocations can be avoided. 
