### PR TITLE
Made DefaultBodyLimit const friendly

### DIFF
--- a/axum-core/CHANGELOG.md
+++ b/axum-core/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
-- None.
+- **added:** Implement `Copy` for `DefaultBodyLimit`
+- **added**: `DefaultBodyLimit::max` and `DefaultBodyLimit::disable` are now
+  allowed in const context
 
 # 0.4.3 (13. January, 2024)
 

--- a/axum-core/src/extract/default_body_limit.rs
+++ b/axum-core/src/extract/default_body_limit.rs
@@ -72,7 +72,7 @@ use tower_layer::Layer;
 /// [`RequestBodyLimit`]: tower_http::limit::RequestBodyLimit
 /// [`RequestExt::with_limited_body`]: crate::RequestExt::with_limited_body
 /// [`RequestExt::into_limited_body`]: crate::RequestExt::into_limited_body
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 #[must_use]
 pub struct DefaultBodyLimit {
     kind: DefaultBodyLimitKind,
@@ -116,7 +116,7 @@ impl DefaultBodyLimit {
     /// [`Bytes`]: bytes::Bytes
     /// [`Json`]: https://docs.rs/axum/0.7/axum/struct.Json.html
     /// [`Form`]: https://docs.rs/axum/0.7/axum/struct.Form.html
-    pub fn disable() -> Self {
+    pub const fn disable() -> Self {
         Self {
             kind: DefaultBodyLimitKind::Disable,
         }
@@ -149,7 +149,7 @@ impl DefaultBodyLimit {
     /// [`Bytes::from_request`]: bytes::Bytes
     /// [`Json`]: https://docs.rs/axum/0.7/axum/struct.Json.html
     /// [`Form`]: https://docs.rs/axum/0.7/axum/struct.Form.html
-    pub fn max(limit: usize) -> Self {
+    pub const fn max(limit: usize) -> Self {
         Self {
             kind: DefaultBodyLimitKind::Limit(limit),
         }


### PR DESCRIPTION
Derived Copy for DefaultBodyLimit
Made DefaultBodyLimit::max and DefaultBodyLimit::disabled const

## Motivation

Making DefaultBodyLimit more const friendly will reduce the code duplication for projects trying to add this layer to multiple endpoints but not to the entire route or router by removing the unnecessary clone calls

## Solution

By deriving Copy and making those methods const we allow the following code to be used:

```rust
const LIMIT: DefaultBodyLimit = DefaultBodyLimit::disable();

Router::new()
    .route(
        "/files",
        get(file::download)
            .post(file::upload.layer(LIMIT))
            .delete(file::delete)
            .patch(file::modify.layer(LIMIT)),
    )
```

instead of

```rust
let limit = DefaultBodyLimit::disable();


Router::new()
    .route(
        "/files",
        get(file::download)
            .post(file::upload.layer(limit.clone()))
            .delete(file::delete)
            .patch(file::modify.layer(limit.clone())),
    )
```