### PR TITLE
Upgrade tower and other dependencies

### DIFF
--- a/axum-extra/Cargo.toml
+++ b/axum-extra/Cargo.toml
@@ -49,7 +49,7 @@ http-body-util = "0.1.0"
 mime = "0.3"
 pin-project-lite = "0.2"
 serde = "1.0"
-tower = { version = "0.4", default-features = false, features = ["util"] }
+tower = { version = "0.5", default-features = false, features = ["util"] }
 tower-layer = "0.3"
 tower-service = "0.3"
 
@@ -60,7 +60,7 @@ form_urlencoded = { version = "1.1.0", optional = true }
 headers = { version = "0.4.0", optional = true }
 multer = { version = "3.0.0", optional = true }
 percent-encoding = { version = "2.1", optional = true }
-prost = { version = "0.12", optional = true }
+prost = { version = "0.13", optional = true }
 serde_html_form = { version = "0.2.0", optional = true }
 serde_json = { version = "1.0.71", optional = true }
 serde_path_to_error = { version = "0.1.8", optional = true }
@@ -76,7 +76,7 @@ reqwest = { version = "0.12", default-features = false, features = ["json", "str
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.71"
 tokio = { version = "1.14", features = ["full"] }
-tower = { version = "0.4", features = ["util"] }
+tower = { version = "0.5", features = ["util"] }
 tower-http = { version = "0.5.0", features = ["map-response-body", "timeout"] }
 
 [package.metadata.docs.rs]

--- a/axum/Cargo.toml
+++ b/axum/Cargo.toml
@@ -57,13 +57,13 @@ pin-project-lite = "0.2.7"
 rustversion = "1.0.9"
 serde = "1.0"
 sync_wrapper = "1.0.0"
-tower = { version = "0.4.13", default-features = false, features = ["util"] }
+tower = { version = "0.5", default-features = false, features = ["util"] }
 tower-layer = "0.3.2"
 tower-service = "0.3"
 
 # optional dependencies
 axum-macros = { path = "../axum-macros", version = "0.4.1", optional = true }
-base64 = { version = "0.21.0", optional = true }
+base64 = { version = "0.22.1", optional = true }
 hyper = { version = "1.1.0", optional = true }
 hyper-util = { version = "0.1.3", features = ["tokio", "server", "service"], optional = true }
 multer = { version = "3.0.0", optional = true }
@@ -132,7 +132,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dev-dependencies.tower]
 package = "tower"
-version = "0.4.10"
+version = "0.5"
 features = [
     "util",
     "timeout",

--- a/axum/src/boxed.rs
+++ b/axum/src/boxed.rs
@@ -2,7 +2,7 @@ use std::{convert::Infallible, fmt};
 
 use crate::extract::Request;
 use crate::util::AxumMutex;
-use tower::Service;
+use tower_service::Service;
 
 use crate::{
     handler::Handler,

--- a/examples/chat/Cargo.toml
+++ b/examples/chat/Cargo.toml
@@ -8,6 +8,6 @@ publish = false
 axum = { path = "../../axum", features = ["ws"] }
 futures = "0.3"
 tokio = { version = "1", features = ["full"] }
-tower = { version = "0.4", features = ["util"] }
+tower = { version = "0.5", features = ["util"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/compression/Cargo.toml
+++ b/examples/compression/Cargo.toml
@@ -9,14 +9,14 @@ axum = { path = "../../axum" }
 axum-extra = { path = "../../axum-extra", features = ["typed-header"] }
 serde_json = "1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
-tower = "0.4"
+tower = "0.5"
 tower-http = { version = "0.5", features = ["compression-full", "decompression-full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]
 assert-json-diff = "2.0"
-brotli = "3.4"
+brotli = "6"
 flate2 = "1"
 http = "1"
 zstd = "0.13"

--- a/examples/consume-body-in-extractor-or-middleware/Cargo.toml
+++ b/examples/consume-body-in-extractor-or-middleware/Cargo.toml
@@ -9,7 +9,7 @@ axum = { path = "../../axum" }
 http-body-util = "0.1.0"
 hyper = "1.0.0"
 tokio = { version = "1.0", features = ["full"] }
-tower = "0.4"
+tower = "0.5"
 tower-http = { version = "0.5.0", features = ["map-request-body", "util"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/diesel-async-postgres/Cargo.toml
+++ b/examples/diesel-async-postgres/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 axum = { path = "../../axum", features = ["macros"] }
 bb8 = "0.8"
 diesel = "2"
-diesel-async = { version = "0.3", features = ["postgres", "bb8"] }
+diesel-async = { version = "0.5", features = ["postgres", "bb8"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1.0", features = ["full"] }

--- a/examples/diesel-postgres/Cargo.toml
+++ b/examples/diesel-postgres/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [dependencies]
 axum = { path = "../../axum", features = ["macros"] }
-deadpool-diesel = { version = "0.4.1", features = ["postgres"] }
+deadpool-diesel = { version = "0.6", features = ["postgres"] }
 diesel = { version = "2", features = ["postgres"] }
 diesel_migrations = "2"
 serde = { version = "1.0", features = ["derive"] }

--- a/examples/global-404-handler/Cargo.toml
+++ b/examples/global-404-handler/Cargo.toml
@@ -7,6 +7,6 @@ publish = false
 [dependencies]
 axum = { path = "../../axum" }
 tokio = { version = "1.0", features = ["full"] }
-tower = { version = "0.4", features = ["util"] }
+tower = { version = "0.5", features = ["util"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/graceful-shutdown/Cargo.toml
+++ b/examples/graceful-shutdown/Cargo.toml
@@ -9,7 +9,7 @@ axum = { path = "../../axum", features = ["tracing"] }
 hyper = { version = "1.0", features = [] }
 hyper-util = { version = "0.1", features = ["tokio", "server-auto", "http1"] }
 tokio = { version = "1.0", features = ["full"] }
-tower = { version = "0.4", features = ["util"] }
+tower = { version = "0.5", features = ["util"] }
 tower-http = { version = "0.5", features = ["timeout", "trace"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/handle-head-request/Cargo.toml
+++ b/examples/handle-head-request/Cargo.toml
@@ -11,4 +11,4 @@ tokio = { version = "1.0", features = ["full"] }
 [dev-dependencies]
 http-body-util = "0.1.0"
 hyper = { version = "1.0.0", features = ["full"] }
-tower = { version = "0.4", features = ["util"] }
+tower = { version = "0.5", features = ["util"] }

--- a/examples/http-proxy/Cargo.toml
+++ b/examples/http-proxy/Cargo.toml
@@ -9,6 +9,6 @@ axum = { path = "../../axum" }
 hyper = { version = "1", features = ["full"] }
 hyper-util = "0.1.1"
 tokio = { version = "1.0", features = ["full"] }
-tower = { version = "0.4", features = ["make"] }
+tower = { version = "0.5", features = ["make"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/jwt/Cargo.toml
+++ b/examples/jwt/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 axum = { path = "../../axum" }
 axum-extra = { path = "../../axum-extra", features = ["typed-header"] }
-jsonwebtoken = "8.0"
+jsonwebtoken = "9.0"
 once_cell = "1.8"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/examples/key-value-store/Cargo.toml
+++ b/examples/key-value-store/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 axum = { path = "../../axum" }
 tokio = { version = "1.0", features = ["full"] }
-tower = { version = "0.4", features = ["util", "timeout", "load-shed", "limit"] }
+tower = { version = "0.5", features = ["util", "timeout", "load-shed", "limit"] }
 tower-http = { version = "0.5.0", features = [
     "add-extension",
     "auth",

--- a/examples/listen-multiple-addrs/Cargo.toml
+++ b/examples/listen-multiple-addrs/Cargo.toml
@@ -9,4 +9,4 @@ axum = { path = "../../axum" }
 hyper = { version = "1.0.0", features = ["full"] }
 hyper-util = { version = "0.1", features = ["tokio", "server-auto", "http1"] }
 tokio = { version = "1", features = ["full"] }
-tower = { version = "0.4", features = ["util"] }
+tower = { version = "0.5", features = ["util"] }

--- a/examples/low-level-openssl/Cargo.toml
+++ b/examples/low-level-openssl/Cargo.toml
@@ -12,6 +12,6 @@ hyper-util = { version = "0.1" }
 openssl = "0.10"
 tokio = { version = "1", features = ["full"] }
 tokio-openssl = "0.6"
-tower = { version = "0.4", features = ["make"] }
+tower = { version = "0.5", features = ["make"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/low-level-rustls/Cargo.toml
+++ b/examples/low-level-rustls/Cargo.toml
@@ -9,10 +9,10 @@ axum = { path = "../../axum" }
 futures-util = { version = "0.3", default-features = false }
 hyper = { version = "1.0.0", features = ["full"] }
 hyper-util = { version = "0.1" }
-rustls-pemfile = "1.0.4"
+rustls-pemfile = "2"
 tokio = { version = "1", features = ["full"] }
-tokio-rustls = "0.24.1"
-tower = { version = "0.4", features = ["make"] }
+tokio-rustls = "0.26"
+tower = { version = "0.5", features = ["make"] }
 tower-service = "0.3.2"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/print-request-response/Cargo.toml
+++ b/examples/print-request-response/Cargo.toml
@@ -9,6 +9,6 @@ axum = { path = "../../axum" }
 http-body-util = "0.1.0"
 hyper = { version = "1.0.0", features = ["full"] }
 tokio = { version = "1.0", features = ["full"] }
-tower = { version = "0.4", features = ["util", "filter"] }
+tower = { version = "0.5", features = ["util", "filter"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/prometheus-metrics/Cargo.toml
+++ b/examples/prometheus-metrics/Cargo.toml
@@ -6,8 +6,8 @@ publish = false
 
 [dependencies]
 axum = { path = "../../axum" }
-metrics = { version = "0.22", default-features = false }
-metrics-exporter-prometheus = { version = "0.13", default-features = false }
+metrics = { version = "0.23", default-features = false }
+metrics-exporter-prometheus = { version = "0.15", default-features = false }
 tokio = { version = "1.0", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/query-params-with-empty-strings/Cargo.toml
+++ b/examples/query-params-with-empty-strings/Cargo.toml
@@ -10,4 +10,4 @@ http-body-util = "0.1.0"
 hyper = "1.0.0"
 serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "1.0", features = ["full"] }
-tower = { version = "0.4", features = ["util"] }
+tower = { version = "0.5", features = ["util"] }

--- a/examples/rest-grpc-multiplex/Cargo.toml
+++ b/examples/rest-grpc-multiplex/Cargo.toml
@@ -8,13 +8,13 @@ publish = false
 axum = { path = "../../axum" }
 futures = "0.3"
 hyper = { version = "1.0.0", features = ["full"] }
-prost = "0.11"
+prost = "0.13"
 tokio = { version = "1", features = ["full"] }
-tonic = { version = "0.9" }
-tonic-reflection = "0.9"
-tower = { version = "0.4", features = ["full"] }
+tonic = { version = "0.12" }
+tonic-reflection = "0.12"
+tower = { version = "0.5", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [build-dependencies]
-tonic-build = { version = "0.9", features = ["prost"] }
+tonic-build = { version = "0.12", features = ["prost"] }

--- a/examples/serve-with-hyper/Cargo.toml
+++ b/examples/serve-with-hyper/Cargo.toml
@@ -9,4 +9,4 @@ axum = { path = "../../axum" }
 hyper = { version = "1.0", features = [] }
 hyper-util = { version = "0.1", features = ["tokio", "server-auto", "http1"] }
 tokio = { version = "1.0", features = ["full"] }
-tower = { version = "0.4", features = ["util"] }
+tower = { version = "0.5", features = ["util"] }

--- a/examples/sqlx-postgres/Cargo.toml
+++ b/examples/sqlx-postgres/Cargo.toml
@@ -10,4 +10,4 @@ tokio = { version = "1.0", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
-sqlx = { version = "0.7", features = ["runtime-tokio-rustls", "any", "postgres"] }
+sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "any", "postgres"] }

--- a/examples/sse/Cargo.toml
+++ b/examples/sse/Cargo.toml
@@ -18,4 +18,4 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 [dev-dependencies]
 eventsource-stream = "0.2"
 reqwest = { version = "0.12", features = ["stream"] }
-reqwest-eventsource = "0.5"
+reqwest-eventsource = "0.6"

--- a/examples/static-file-server/Cargo.toml
+++ b/examples/static-file-server/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 axum = { path = "../../axum" }
 axum-extra = { path = "../../axum-extra" }
 tokio = { version = "1.0", features = ["full"] }
-tower = { version = "0.4", features = ["util"] }
+tower = { version = "0.5", features = ["util"] }
 tower-http = { version = "0.5.0", features = ["fs", "trace"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/templates-minijinja/Cargo.toml
+++ b/examples/templates-minijinja/Cargo.toml
@@ -6,5 +6,5 @@ publish = false
 
 [dependencies]
 axum = { path = "../../axum" }
-minijinja = "1.0.11"
+minijinja = "2"
 tokio = { version = "1.0", features = ["full"] }

--- a/examples/templates/Cargo.toml
+++ b/examples/templates/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-askama = "0.11"
+askama = "0.12"
 axum = { path = "../../axum" }
 tokio = { version = "1.0", features = ["full"] }
 tracing = "0.1"

--- a/examples/testing/Cargo.toml
+++ b/examples/testing/Cargo.toml
@@ -17,4 +17,4 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]
-tower = { version = "0.4", features = ["util"] }
+tower = { version = "0.5", features = ["util"] }

--- a/examples/tls-graceful-shutdown/Cargo.toml
+++ b/examples/tls-graceful-shutdown/Cargo.toml
@@ -6,8 +6,8 @@ publish = false
 
 [dependencies]
 axum = { path = "../../axum" }
-axum-server = { version = "0.6", features = ["tls-rustls"] }
-hyper = { version = "0.14", features = ["full"] }
+axum-server = { version = "0.7", features = ["tls-rustls"] }
+hyper = { version = "1", features = ["full"] }
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/tls-rustls/Cargo.toml
+++ b/examples/tls-rustls/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [dependencies]
 axum = { path = "../../axum" }
-axum-server = { version = "0.6", features = ["tls-rustls"] }
+axum-server = { version = "0.7", features = ["tls-rustls"] }
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/todos/Cargo.toml
+++ b/examples/todos/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 axum = { path = "../../axum" }
 serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "1.0", features = ["full"] }
-tower = { version = "0.4", features = ["util", "timeout"] }
+tower = { version = "0.5", features = ["util", "timeout"] }
 tower-http = { version = "0.5.0", features = ["add-extension", "trace"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/tokio-postgres/Cargo.toml
+++ b/examples/tokio-postgres/Cargo.toml
@@ -6,8 +6,8 @@ publish = false
 
 [dependencies]
 axum = { path = "../../axum" }
-bb8 = "0.7.1"
-bb8-postgres = "0.7.0"
+bb8 = "0.8"
+bb8-postgres = "0.8.0"
 tokio = { version = "1.0", features = ["full"] }
 tokio-postgres = "0.7.2"
 tracing = "0.1"

--- a/examples/tokio-redis/Cargo.toml
+++ b/examples/tokio-redis/Cargo.toml
@@ -6,9 +6,9 @@ publish = false
 
 [dependencies]
 axum = { path = "../../axum" }
-bb8 = "0.7.1"
-bb8-redis = "0.14.0"
-redis = "0.24.0"
+bb8 = "0.8"
+bb8-redis = "0.16"
+redis = "0.26"
 tokio = { version = "1.0", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/unix-domain-socket/Cargo.toml
+++ b/examples/unix-domain-socket/Cargo.toml
@@ -10,6 +10,6 @@ http-body-util = "0.1"
 hyper = { version = "1.0.0", features = ["full"] }
 hyper-util = { version = "0.1", features = ["tokio", "server-auto", "http1"] }
 tokio = { version = "1.0", features = ["full"] }
-tower = { version = "0.4", features = ["util"] }
+tower = { version = "0.5", features = ["util"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/validator/Cargo.toml
+++ b/examples/validator/Cargo.toml
@@ -13,4 +13,4 @@ thiserror = "1.0.29"
 tokio = { version = "1.0", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-validator = { version = "0.14.0", features = ["derive"] }
+validator = { version = "0.18.0", features = ["derive"] }

--- a/examples/websockets/Cargo.toml
+++ b/examples/websockets/Cargo.toml
@@ -12,7 +12,7 @@ futures-util = { version = "0.3", default-features = false, features = ["sink", 
 headers = "0.4"
 tokio = { version = "1.0", features = ["full"] }
 tokio-tungstenite = "0.23"
-tower = { version = "0.4", features = ["util"] }
+tower = { version = "0.5", features = ["util"] }
 tower-http = { version = "0.5.0", features = ["fs", "trace"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }


### PR DESCRIPTION
## Motivation

Upgrade dependencies to reduce duplicate dependencies in binaries depending on `axum` together with other projects using `tower`

## Solution

Upgrade everything to latest version,
I did not upgrade `matchit` to 0.8 as this is a breaking change for routing matching so I'm not sure how to move forward with this, the changes are: https://github.com/ibraheemdev/matchit/releases/tag/v0.8.0
