### PR TITLE
feat: local_addr for Serve and WithGracefulShutdown

### DIFF
--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -11,10 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **added:** `axum::serve::Serve::tcp_nodelay` and `axum::serve::WithGracefulShutdown::tcp_nodelay` ([#2653])
 - **added:** `Router::has_routes` function ([#2790])
 - **change:** Update tokio-tungstenite to 0.23 ([#2841])
+- **added:** `Serve::local_addr` and `WithGracefulShutdown::local_addr` functions ([#2881])
 
 [#2653]: https://github.com/tokio-rs/axum/pull/2653
 [#2790]: https://github.com/tokio-rs/axum/pull/2790
 [#2841]: https://github.com/tokio-rs/axum/pull/2841
+[#2881]: https://github.com/tokio-rs/axum/pull/2881
 
 # 0.7.5 (24. March, 2024)
 

--- a/axum/src/serve.rs
+++ b/axum/src/serve.rs
@@ -173,6 +173,11 @@ impl<M, S> Serve<M, S> {
             ..self
         }
     }
+
+    /// Returns the local address this server is bound to.
+    pub fn local_addr(&self) -> io::Result<std::net::SocketAddr> {
+        self.tcp_listener.local_addr()
+    }
 }
 
 #[cfg(all(feature = "tokio", any(feature = "http1", feature = "http2")))]
@@ -306,6 +311,11 @@ impl<M, S, F> WithGracefulShutdown<M, S, F> {
             tcp_nodelay: Some(nodelay),
             ..self
         }
+    }
+
+    /// Returns the local address this server is bound to.
+    pub fn local_addr(&self) -> io::Result<std::net::SocketAddr> {
+        self.tcp_listener.local_addr()
     }
 }
 


### PR DESCRIPTION
Adds methods for exposing the address the Axum servers are bound to.

 * add `Serve::local_addr`, which returns the address it is bound to.
 * add `WithGracefulShutdown::local_addr`, which returns the address it is bound to.

Closes #2879

## Motivation

I would like to be able to know the address of a server, as it makes testing code easier to write.

## Solution

I have added methods to expose the `SocketAddr` on `Serve` and `WithGracefulShutdown`.