### PR TITLE
Use `env!("CARGO_CRATE_NAME")` in the example to simplify the tracing setup code

### DIFF
--- a/examples/chat/src/main.rs
+++ b/examples/chat/src/main.rs
@@ -36,7 +36,7 @@ async fn main() {
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| concat!(env!("CARGO_CRATE_NAME"), "=trace").into()),
+                .unwrap_or_else(|_| format!("{}=trace", env!("CARGO_CRATE_NAME")).into()),
         )
         .with(tracing_subscriber::fmt::layer())
         .init();

--- a/examples/chat/src/main.rs
+++ b/examples/chat/src/main.rs
@@ -36,7 +36,7 @@ async fn main() {
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "example_chat=trace".into()),
+                .unwrap_or_else(|_| concat!(env!("CARGO_CRATE_NAME"), "=trace").into()),
         )
         .with(tracing_subscriber::fmt::layer())
         .init();

--- a/examples/compression/src/main.rs
+++ b/examples/compression/src/main.rs
@@ -12,7 +12,7 @@ async fn main() {
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| concat!(env!("CARGO_CRATE_NAME"), "=trace").into()),
+                .unwrap_or_else(|_| format!("{}=trace", env!("CARGO_CRATE_NAME")).into()),
         )
         .with(tracing_subscriber::fmt::layer())
         .init();

--- a/examples/compression/src/main.rs
+++ b/examples/compression/src/main.rs
@@ -12,7 +12,7 @@ async fn main() {
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "example-compression=trace".into()),
+                .unwrap_or_else(|_| concat!(env!("CARGO_CRATE_NAME"), "=trace").into()),
         )
         .with(tracing_subscriber::fmt::layer())
         .init();

--- a/examples/consume-body-in-extractor-or-middleware/src/main.rs
+++ b/examples/consume-body-in-extractor-or-middleware/src/main.rs
@@ -22,7 +22,7 @@ async fn main() {
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "example_consume_body_in_extractor_or_middleware=debug".into()),
+                .unwrap_or_else(|_| concat!(env!("CARGO_CRATE_NAME"), "=debug").into()),
         )
         .with(tracing_subscriber::fmt::layer())
         .init();

--- a/examples/consume-body-in-extractor-or-middleware/src/main.rs
+++ b/examples/consume-body-in-extractor-or-middleware/src/main.rs
@@ -22,7 +22,7 @@ async fn main() {
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| concat!(env!("CARGO_CRATE_NAME"), "=debug").into()),
+                .unwrap_or_else(|_| format!("{}=debug", env!("CARGO_CRATE_NAME")).into()),
         )
         .with(tracing_subscriber::fmt::layer())
         .init();

--- a/examples/customize-extractor-error/src/main.rs
+++ b/examples/customize-extractor-error/src/main.rs
@@ -16,7 +16,7 @@ async fn main() {
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| concat!(env!("CARGO_CRATE_NAME"), "=trace").into()),
+                .unwrap_or_else(|_| format!("{}=trace", env!("CARGO_CRATE_NAME")).into()),
         )
         .with(tracing_subscriber::fmt::layer())
         .init();

--- a/examples/customize-extractor-error/src/main.rs
+++ b/examples/customize-extractor-error/src/main.rs
@@ -16,7 +16,7 @@ async fn main() {
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "example_customize_extractor_error=trace".into()),
+                .unwrap_or_else(|_| concat!(env!("CARGO_CRATE_NAME"), "=trace").into()),
         )
         .with(tracing_subscriber::fmt::layer())
         .init();

--- a/examples/customize-path-rejection/src/main.rs
+++ b/examples/customize-path-rejection/src/main.rs
@@ -20,7 +20,7 @@ async fn main() {
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "example_customize_path_rejection=debug".into()),
+                .unwrap_or_else(|_| concat!(env!("CARGO_CRATE_NAME"), "=debug").into()),
         )
         .with(tracing_subscriber::fmt::layer())
         .init();

--- a/examples/customize-path-rejection/src/main.rs
+++ b/examples/customize-path-rejection/src/main.rs
@@ -20,7 +20,7 @@ async fn main() {
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| concat!(env!("CARGO_CRATE_NAME"), "=debug").into()),
+                .unwrap_or_else(|_| format!("{}=debug", env!("CARGO_CRATE_NAME")).into()),
         )
         .with(tracing_subscriber::fmt::layer())
         .init();

--- a/examples/dependency-injection/src/main.rs
+++ b/examples/dependency-injection/src/main.rs
@@ -25,7 +25,7 @@ async fn main() {
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "example_dependency_injection=debug".into()),
+                .unwrap_or_else(|_| concat!(env!("CARGO_CRATE_NAME"), "=debug").into()),
         )
         .with(tracing_subscriber::fmt::layer())
         .init();

--- a/examples/dependency-injection/src/main.rs
+++ b/examples/dependency-injection/src/main.rs
@@ -25,7 +25,7 @@ async fn main() {
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| concat!(env!("CARGO_CRATE_NAME"), "=debug").into()),
+                .unwrap_or_else(|_| format!("{}=debug", env!("CARGO_CRATE_NAME")).into()),
         )
         .with(tracing_subscriber::fmt::layer())
         .init();

--- a/examples/diesel-async-postgres/src/main.rs
+++ b/examples/diesel-async-postgres/src/main.rs
@@ -57,7 +57,7 @@ async fn main() {
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "example_diesel_async_postgres=debug".into()),
+                .unwrap_or_else(|_| concat!(env!("CARGO_CRATE_NAME"), "=debug").into()),
         )
         .with(tracing_subscriber::fmt::layer())
         .init();

--- a/examples/diesel-async-postgres/src/main.rs
+++ b/examples/diesel-async-postgres/src/main.rs
@@ -57,7 +57,7 @@ async fn main() {
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| concat!(env!("CARGO_CRATE_NAME"), "=debug").into()),
+                .unwrap_or_else(|_| format!("{}=debug", env!("CARGO_CRATE_NAME")).into()),
         )
         .with(tracing_subscriber::fmt::layer())
         .init();

--- a/examples/diesel-postgres/src/main.rs
+++ b/examples/diesel-postgres/src/main.rs
@@ -54,7 +54,7 @@ async fn main() {
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "example_tokio_postgres=debug".into()),
+                .unwrap_or_else(|_| concat!(env!("CARGO_CRATE_NAME"), "=debug").into()),
         )
         .with(tracing_subscriber::fmt::layer())
         .init();

--- a/examples/diesel-postgres/src/main.rs
+++ b/examples/diesel-postgres/src/main.rs
@@ -54,7 +54,7 @@ async fn main() {
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| concat!(env!("CARGO_CRATE_NAME"), "=debug").into()),
+                .unwrap_or_else(|_| format!("{}=debug", env!("CARGO_CRATE_NAME")).into()),
         )
         .with(tracing_subscriber::fmt::layer())
         .init();

--- a/examples/error-handling/src/main.rs
+++ b/examples/error-handling/src/main.rs
@@ -45,8 +45,9 @@ use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 async fn main() {
     tracing_subscriber::registry()
         .with(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "example_error_handling=debug,tower_http=debug".into()),
+            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+                concat!(env!("CARGO_CRATE_NAME"), "=debug,tower_http=debug").into()
+            }),
         )
         .with(tracing_subscriber::fmt::layer())
         .init();

--- a/examples/error-handling/src/main.rs
+++ b/examples/error-handling/src/main.rs
@@ -46,7 +46,7 @@ async fn main() {
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
-                concat!(env!("CARGO_CRATE_NAME"), "=debug,tower_http=debug").into()
+                format!("{}=debug,tower_http=debug", env!("CARGO_CRATE_NAME")).into()
             }),
         )
         .with(tracing_subscriber::fmt::layer())

--- a/examples/form/src/main.rs
+++ b/examples/form/src/main.rs
@@ -13,7 +13,7 @@ async fn main() {
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "example_form=debug".into()),
+                .unwrap_or_else(|_| concat!(env!("CARGO_CRATE_NAME"), "=debug").into()),
         )
         .with(tracing_subscriber::fmt::layer())
         .init();

--- a/examples/form/src/main.rs
+++ b/examples/form/src/main.rs
@@ -13,7 +13,7 @@ async fn main() {
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| concat!(env!("CARGO_CRATE_NAME"), "=debug").into()),
+                .unwrap_or_else(|_| format!("{}=debug", env!("CARGO_CRATE_NAME")).into()),
         )
         .with(tracing_subscriber::fmt::layer())
         .init();

--- a/examples/global-404-handler/src/main.rs
+++ b/examples/global-404-handler/src/main.rs
@@ -17,7 +17,7 @@ async fn main() {
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| concat!(env!("CARGO_CRATE_NAME"), "=debug").into()),
+                .unwrap_or_else(|_| format!("{}=debug", env!("CARGO_CRATE_NAME")).into()),
         )
         .with(tracing_subscriber::fmt::layer())
         .init();

--- a/examples/global-404-handler/src/main.rs
+++ b/examples/global-404-handler/src/main.rs
@@ -17,7 +17,7 @@ async fn main() {
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "example_global_404_handler=debug".into()),
+                .unwrap_or_else(|_| concat!(env!("CARGO_CRATE_NAME"), "=debug").into()),
         )
         .with(tracing_subscriber::fmt::layer())
         .init();

--- a/examples/graceful-shutdown/src/main.rs
+++ b/examples/graceful-shutdown/src/main.rs
@@ -21,7 +21,11 @@ async fn main() {
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
-                "example_graceful_shutdown=debug,tower_http=debug,axum=trace".into()
+                concat!(
+                    env!("CARGO_CRATE_NAME"),
+                    "=debug,tower_http=debug,axum=trace"
+                )
+                .into()
             }),
         )
         .with(tracing_subscriber::fmt::layer().without_time())

--- a/examples/graceful-shutdown/src/main.rs
+++ b/examples/graceful-shutdown/src/main.rs
@@ -21,9 +21,9 @@ async fn main() {
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
-                concat!(
-                    env!("CARGO_CRATE_NAME"),
-                    "=debug,tower_http=debug,axum=trace"
+                format!(
+                    "{}=debug,tower_http=debug,axum=trace",
+                    env!("CARGO_CRATE_NAME")
                 )
                 .into()
             }),

--- a/examples/http-proxy/src/main.rs
+++ b/examples/http-proxy/src/main.rs
@@ -37,7 +37,7 @@ async fn main() {
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
-                concat!(env!("CARGO_CRATE_NAME"), "=trace,tower_http=debug").into()
+                format!("{}=trace,tower_http=debug", env!("CARGO_CRATE_NAME")).into()
             }),
         )
         .with(tracing_subscriber::fmt::layer())

--- a/examples/http-proxy/src/main.rs
+++ b/examples/http-proxy/src/main.rs
@@ -36,8 +36,9 @@ use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 async fn main() {
     tracing_subscriber::registry()
         .with(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "example_http_proxy=trace,tower_http=debug".into()),
+            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+                concat!(env!("CARGO_CRATE_NAME"), "=trace,tower_http=debug").into()
+            }),
         )
         .with(tracing_subscriber::fmt::layer())
         .init();

--- a/examples/jwt/src/main.rs
+++ b/examples/jwt/src/main.rs
@@ -61,7 +61,7 @@ async fn main() {
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "example_jwt=debug".into()),
+                .unwrap_or_else(|_| concat!(env!("CARGO_CRATE_NAME"), "=debug").into()),
         )
         .with(tracing_subscriber::fmt::layer())
         .init();

--- a/examples/jwt/src/main.rs
+++ b/examples/jwt/src/main.rs
@@ -61,7 +61,7 @@ async fn main() {
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| concat!(env!("CARGO_CRATE_NAME"), "=debug").into()),
+                .unwrap_or_else(|_| format!("{}=debug", env!("CARGO_CRATE_NAME")).into()),
         )
         .with(tracing_subscriber::fmt::layer())
         .init();

--- a/examples/key-value-store/src/main.rs
+++ b/examples/key-value-store/src/main.rs
@@ -33,8 +33,9 @@ use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 async fn main() {
     tracing_subscriber::registry()
         .with(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "example_key_value_store=debug,tower_http=debug".into()),
+            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+                concat!(env!("CARGO_CRATE_NAME"), "=debug,tower_http=debug").into()
+            }),
         )
         .with(tracing_subscriber::fmt::layer())
         .init();

--- a/examples/key-value-store/src/main.rs
+++ b/examples/key-value-store/src/main.rs
@@ -34,7 +34,7 @@ async fn main() {
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
-                concat!(env!("CARGO_CRATE_NAME"), "=debug,tower_http=debug").into()
+                format!("{}=debug,tower_http=debug", env!("CARGO_CRATE_NAME")).into()
             }),
         )
         .with(tracing_subscriber::fmt::layer())

--- a/examples/low-level-openssl/src/main.rs
+++ b/examples/low-level-openssl/src/main.rs
@@ -15,7 +15,7 @@ async fn main() {
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "example_low_level_openssl=debug".into()),
+                .unwrap_or_else(|_| concat!(env!("CARGO_CRATE_NAME"), "=debug").into()),
         )
         .with(tracing_subscriber::fmt::layer())
         .init();

--- a/examples/low-level-openssl/src/main.rs
+++ b/examples/low-level-openssl/src/main.rs
@@ -15,7 +15,7 @@ async fn main() {
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| concat!(env!("CARGO_CRATE_NAME"), "=debug").into()),
+                .unwrap_or_else(|_| format!("{}=debug", env!("CARGO_CRATE_NAME")).into()),
         )
         .with(tracing_subscriber::fmt::layer())
         .init();

--- a/examples/low-level-rustls/src/main.rs
+++ b/examples/low-level-rustls/src/main.rs
@@ -29,7 +29,7 @@ async fn main() {
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| concat!(env!("CARGO_CRATE_NAME"), "=debug").into()),
+                .unwrap_or_else(|_| format!("{}=debug", env!("CARGO_CRATE_NAME")).into()),
         )
         .with(tracing_subscriber::fmt::layer())
         .init();

--- a/examples/low-level-rustls/src/main.rs
+++ b/examples/low-level-rustls/src/main.rs
@@ -29,7 +29,7 @@ async fn main() {
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "example_low_level_rustls=debug".into()),
+                .unwrap_or_else(|_| concat!(env!("CARGO_CRATE_NAME"), "=debug").into()),
         )
         .with(tracing_subscriber::fmt::layer())
         .init();

--- a/examples/multipart-form/src/main.rs
+++ b/examples/multipart-form/src/main.rs
@@ -18,7 +18,7 @@ async fn main() {
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
-                concat!(env!("CARGO_CRATE_NAME"), "=debug,tower_http=debug").into()
+                format!("{}=debug,tower_http=debug", env!("CARGO_CRATE_NAME")).into()
             }),
         )
         .with(tracing_subscriber::fmt::layer())

--- a/examples/multipart-form/src/main.rs
+++ b/examples/multipart-form/src/main.rs
@@ -17,8 +17,9 @@ use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 async fn main() {
     tracing_subscriber::registry()
         .with(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "example_multipart_form=debug,tower_http=debug".into()),
+            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+                concat!(env!("CARGO_CRATE_NAME"), "=debug,tower_http=debug").into()
+            }),
         )
         .with(tracing_subscriber::fmt::layer())
         .init();

--- a/examples/oauth/src/main.rs
+++ b/examples/oauth/src/main.rs
@@ -35,7 +35,7 @@ async fn main() {
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| concat!(env!("CARGO_CRATE_NAME"), "=debug").into()),
+                .unwrap_or_else(|_| format!("{}=debug", env!("CARGO_CRATE_NAME")).into()),
         )
         .with(tracing_subscriber::fmt::layer())
         .init();

--- a/examples/oauth/src/main.rs
+++ b/examples/oauth/src/main.rs
@@ -35,7 +35,7 @@ async fn main() {
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "example_oauth=debug".into()),
+                .unwrap_or_else(|_| concat!(env!("CARGO_CRATE_NAME"), "=debug").into()),
         )
         .with(tracing_subscriber::fmt::layer())
         .init();

--- a/examples/parse-body-based-on-content-type/src/main.rs
+++ b/examples/parse-body-based-on-content-type/src/main.rs
@@ -22,7 +22,7 @@ async fn main() {
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
-                concat!(env!("CARGO_CRATE_NAME"), "=debug,tower_http=debug").into()
+                format!("{}=debug,tower_http=debug", env!("CARGO_CRATE_NAME")).into()
             }),
         )
         .with(tracing_subscriber::fmt::layer())

--- a/examples/parse-body-based-on-content-type/src/main.rs
+++ b/examples/parse-body-based-on-content-type/src/main.rs
@@ -22,7 +22,7 @@ async fn main() {
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
-                "example_parse_body_based_on_content_type=debug,tower_http=debug".into()
+                concat!(env!("CARGO_CRATE_NAME"), "=debug,tower_http=debug").into()
             }),
         )
         .with(tracing_subscriber::fmt::layer())

--- a/examples/print-request-response/src/main.rs
+++ b/examples/print-request-response/src/main.rs
@@ -21,7 +21,7 @@ async fn main() {
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
-                concat!(env!("CARGO_CRATE_NAME"), "=debug,tower_http=debug").into()
+                format!("{}=debug,tower_http=debug", env!("CARGO_CRATE_NAME")).into()
             }),
         )
         .with(tracing_subscriber::fmt::layer())

--- a/examples/print-request-response/src/main.rs
+++ b/examples/print-request-response/src/main.rs
@@ -20,8 +20,9 @@ use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 async fn main() {
     tracing_subscriber::registry()
         .with(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "example_print_request_response=debug,tower_http=debug".into()),
+            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+                concat!(env!("CARGO_CRATE_NAME"), "=debug,tower_http=debug").into()
+            }),
         )
         .with(tracing_subscriber::fmt::layer())
         .init();

--- a/examples/prometheus-metrics/src/main.rs
+++ b/examples/prometheus-metrics/src/main.rs
@@ -63,8 +63,9 @@ async fn start_metrics_server() {
 async fn main() {
     tracing_subscriber::registry()
         .with(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "example_prometheus_metrics=debug,tower_http=debug".into()),
+            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+                concat!(env!("CARGO_CRATE_NAME"), "=debug,tower_http=debug").into()
+            }),
         )
         .with(tracing_subscriber::fmt::layer())
         .init();

--- a/examples/prometheus-metrics/src/main.rs
+++ b/examples/prometheus-metrics/src/main.rs
@@ -64,7 +64,7 @@ async fn main() {
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
-                concat!(env!("CARGO_CRATE_NAME"), "=debug,tower_http=debug").into()
+                format!("{}=debug,tower_http=debug", env!("CARGO_CRATE_NAME")).into()
             }),
         )
         .with(tracing_subscriber::fmt::layer())

--- a/examples/reqwest-response/src/main.rs
+++ b/examples/reqwest-response/src/main.rs
@@ -24,7 +24,7 @@ async fn main() {
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
-                concat!(env!("CARGO_CRATE_NAME"), "=debug,tower_http=debug").into()
+                format!("{}=debug,tower_http=debug", env!("CARGO_CRATE_NAME")).into()
             }),
         )
         .with(tracing_subscriber::fmt::layer())

--- a/examples/reqwest-response/src/main.rs
+++ b/examples/reqwest-response/src/main.rs
@@ -23,8 +23,9 @@ use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 async fn main() {
     tracing_subscriber::registry()
         .with(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "example_reqwest_response=debug,tower_http=debug".into()),
+            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+                concat!(env!("CARGO_CRATE_NAME"), "=debug,tower_http=debug").into()
+            }),
         )
         .with(tracing_subscriber::fmt::layer())
         .init();

--- a/examples/sqlx-postgres/src/main.rs
+++ b/examples/sqlx-postgres/src/main.rs
@@ -31,7 +31,7 @@ async fn main() {
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "example_tokio_postgres=debug".into()),
+                .unwrap_or_else(|_| concat!(env!("CARGO_CRATE_NAME"), "=debug").into()),
         )
         .with(tracing_subscriber::fmt::layer())
         .init();

--- a/examples/sqlx-postgres/src/main.rs
+++ b/examples/sqlx-postgres/src/main.rs
@@ -31,7 +31,7 @@ async fn main() {
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| concat!(env!("CARGO_CRATE_NAME"), "=debug").into()),
+                .unwrap_or_else(|_| format!("{}=debug", env!("CARGO_CRATE_NAME")).into()),
         )
         .with(tracing_subscriber::fmt::layer())
         .init();

--- a/examples/sse/src/main.rs
+++ b/examples/sse/src/main.rs
@@ -25,7 +25,7 @@ async fn main() {
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
-                concat!(env!("CARGO_CRATE_NAME"), "=debug,tower_http=debug").into()
+                format!("{}=debug,tower_http=debug", env!("CARGO_CRATE_NAME")).into()
             }),
         )
         .with(tracing_subscriber::fmt::layer())

--- a/examples/sse/src/main.rs
+++ b/examples/sse/src/main.rs
@@ -24,8 +24,9 @@ use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 async fn main() {
     tracing_subscriber::registry()
         .with(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "example_sse=debug,tower_http=debug".into()),
+            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+                concat!(env!("CARGO_CRATE_NAME"), "=debug,tower_http=debug").into()
+            }),
         )
         .with(tracing_subscriber::fmt::layer())
         .init();

--- a/examples/static-file-server/src/main.rs
+++ b/examples/static-file-server/src/main.rs
@@ -20,7 +20,7 @@ async fn main() {
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
-                concat!(env!("CARGO_CRATE_NAME"), "=debug,tower_http=debug").into()
+                format!("{}=debug,tower_http=debug", env!("CARGO_CRATE_NAME")).into()
             }),
         )
         .with(tracing_subscriber::fmt::layer())

--- a/examples/static-file-server/src/main.rs
+++ b/examples/static-file-server/src/main.rs
@@ -19,8 +19,9 @@ use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 async fn main() {
     tracing_subscriber::registry()
         .with(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "example_static_file_server=debug,tower_http=debug".into()),
+            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+                concat!(env!("CARGO_CRATE_NAME"), "=debug,tower_http=debug").into()
+            }),
         )
         .with(tracing_subscriber::fmt::layer())
         .init();

--- a/examples/stream-to-file/src/main.rs
+++ b/examples/stream-to-file/src/main.rs
@@ -25,7 +25,7 @@ async fn main() {
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "example_stream_to_file=debug".into()),
+                .unwrap_or_else(|_| concat!(env!("CARGO_CRATE_NAME"), "=debug").into()),
         )
         .with(tracing_subscriber::fmt::layer())
         .init();

--- a/examples/stream-to-file/src/main.rs
+++ b/examples/stream-to-file/src/main.rs
@@ -25,7 +25,7 @@ async fn main() {
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| concat!(env!("CARGO_CRATE_NAME"), "=debug").into()),
+                .unwrap_or_else(|_| format!("{}=debug", env!("CARGO_CRATE_NAME")).into()),
         )
         .with(tracing_subscriber::fmt::layer())
         .init();

--- a/examples/templates/src/main.rs
+++ b/examples/templates/src/main.rs
@@ -19,7 +19,7 @@ async fn main() {
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| concat!(env!("CARGO_CRATE_NAME"), "=debug").into()),
+                .unwrap_or_else(|_| format!("{}=debug", env!("CARGO_CRATE_NAME")).into()),
         )
         .with(tracing_subscriber::fmt::layer())
         .init();

--- a/examples/templates/src/main.rs
+++ b/examples/templates/src/main.rs
@@ -19,7 +19,7 @@ async fn main() {
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "example_templates=debug".into()),
+                .unwrap_or_else(|_| concat!(env!("CARGO_CRATE_NAME"), "=debug").into()),
         )
         .with(tracing_subscriber::fmt::layer())
         .init();

--- a/examples/testing/src/main.rs
+++ b/examples/testing/src/main.rs
@@ -18,8 +18,9 @@ use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 async fn main() {
     tracing_subscriber::registry()
         .with(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "example_testing=debug,tower_http=debug".into()),
+            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+                concat!(env!("CARGO_CRATE_NAME"), "=debug,tower_http=debug").into()
+            }),
         )
         .with(tracing_subscriber::fmt::layer())
         .init();

--- a/examples/testing/src/main.rs
+++ b/examples/testing/src/main.rs
@@ -19,7 +19,7 @@ async fn main() {
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
-                concat!(env!("CARGO_CRATE_NAME"), "=debug,tower_http=debug").into()
+                format!("{}=debug,tower_http=debug", env!("CARGO_CRATE_NAME")).into()
             }),
         )
         .with(tracing_subscriber::fmt::layer())

--- a/examples/tls-graceful-shutdown/src/main.rs
+++ b/examples/tls-graceful-shutdown/src/main.rs
@@ -28,7 +28,7 @@ async fn main() {
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| concat!(env!("CARGO_CRATE_NAME"), "=debug").into()),
+                .unwrap_or_else(|_| format!("{}=debug", env!("CARGO_CRATE_NAME")).into()),
         )
         .with(tracing_subscriber::fmt::layer())
         .init();

--- a/examples/tls-graceful-shutdown/src/main.rs
+++ b/examples/tls-graceful-shutdown/src/main.rs
@@ -28,7 +28,7 @@ async fn main() {
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "example_tls_graceful_shutdown=debug".into()),
+                .unwrap_or_else(|_| concat!(env!("CARGO_CRATE_NAME"), "=debug").into()),
         )
         .with(tracing_subscriber::fmt::layer())
         .init();

--- a/examples/tls-rustls/src/main.rs
+++ b/examples/tls-rustls/src/main.rs
@@ -30,7 +30,7 @@ async fn main() {
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "example_tls_rustls=debug".into()),
+                .unwrap_or_else(|_| concat!(env!("CARGO_CRATE_NAME"), "=debug").into()),
         )
         .with(tracing_subscriber::fmt::layer())
         .init();

--- a/examples/tls-rustls/src/main.rs
+++ b/examples/tls-rustls/src/main.rs
@@ -30,7 +30,7 @@ async fn main() {
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| concat!(env!("CARGO_CRATE_NAME"), "=debug").into()),
+                .unwrap_or_else(|_| format!("{}=debug", env!("CARGO_CRATE_NAME")).into()),
         )
         .with(tracing_subscriber::fmt::layer())
         .init();

--- a/examples/todos/src/main.rs
+++ b/examples/todos/src/main.rs
@@ -37,7 +37,7 @@ async fn main() {
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
-                concat!(env!("CARGO_CRATE_NAME"), "=debug,tower_http=debug").into()
+                format!("{}=debug,tower_http=debug", env!("CARGO_CRATE_NAME")).into()
             }),
         )
         .with(tracing_subscriber::fmt::layer())

--- a/examples/todos/src/main.rs
+++ b/examples/todos/src/main.rs
@@ -36,8 +36,9 @@ use uuid::Uuid;
 async fn main() {
     tracing_subscriber::registry()
         .with(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "example_todos=debug,tower_http=debug".into()),
+            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+                concat!(env!("CARGO_CRATE_NAME"), "=debug,tower_http=debug").into()
+            }),
         )
         .with(tracing_subscriber::fmt::layer())
         .init();

--- a/examples/tokio-postgres/src/main.rs
+++ b/examples/tokio-postgres/src/main.rs
@@ -21,7 +21,7 @@ async fn main() {
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "example_tokio_postgres=debug".into()),
+                .unwrap_or_else(|_| concat!(env!("CARGO_CRATE_NAME"), "=debug").into()),
         )
         .with(tracing_subscriber::fmt::layer())
         .init();

--- a/examples/tokio-postgres/src/main.rs
+++ b/examples/tokio-postgres/src/main.rs
@@ -21,7 +21,7 @@ async fn main() {
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| concat!(env!("CARGO_CRATE_NAME"), "=debug").into()),
+                .unwrap_or_else(|_| format!("{}=debug", env!("CARGO_CRATE_NAME")).into()),
         )
         .with(tracing_subscriber::fmt::layer())
         .init();

--- a/examples/tokio-redis/src/main.rs
+++ b/examples/tokio-redis/src/main.rs
@@ -23,7 +23,7 @@ async fn main() {
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| concat!(env!("CARGO_CRATE_NAME"), "=debug").into()),
+                .unwrap_or_else(|_| format!("{}=debug", env!("CARGO_CRATE_NAME")).into()),
         )
         .with(tracing_subscriber::fmt::layer())
         .init();

--- a/examples/tokio-redis/src/main.rs
+++ b/examples/tokio-redis/src/main.rs
@@ -23,7 +23,7 @@ async fn main() {
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "example_tokio_redis=debug".into()),
+                .unwrap_or_else(|_| concat!(env!("CARGO_CRATE_NAME"), "=debug").into()),
         )
         .with(tracing_subscriber::fmt::layer())
         .init();

--- a/examples/tracing-aka-logging/src/main.rs
+++ b/examples/tracing-aka-logging/src/main.rs
@@ -25,7 +25,11 @@ async fn main() {
             tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
                 // axum logs rejections from built-in extractors with the `axum::rejection`
                 // target, at `TRACE` level. `axum::rejection=trace` enables showing those events
-                "example_tracing_aka_logging=debug,tower_http=debug,axum::rejection=trace".into()
+                concat!(
+                    env!("CARGO_CRATE_NAME"),
+                    "=debug,tower_http=debug,axum::rejection=trace"
+                )
+                .into()
             }),
         )
         .with(tracing_subscriber::fmt::layer())

--- a/examples/tracing-aka-logging/src/main.rs
+++ b/examples/tracing-aka-logging/src/main.rs
@@ -25,9 +25,9 @@ async fn main() {
             tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
                 // axum logs rejections from built-in extractors with the `axum::rejection`
                 // target, at `TRACE` level. `axum::rejection=trace` enables showing those events
-                concat!(
-                    env!("CARGO_CRATE_NAME"),
-                    "=debug,tower_http=debug,axum::rejection=trace"
+                format!(
+                    "{}=debug,tower_http=debug,axum::rejection=trace",
+                    env!("CARGO_CRATE_NAME")
                 )
                 .into()
             }),

--- a/examples/validator/src/main.rs
+++ b/examples/validator/src/main.rs
@@ -29,7 +29,7 @@ async fn main() {
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| concat!(env!("CARGO_CRATE_NAME"), "=debug").into()),
+                .unwrap_or_else(|_| format!("{}=debug", env!("CARGO_CRATE_NAME")).into()),
         )
         .with(tracing_subscriber::fmt::layer())
         .init();

--- a/examples/validator/src/main.rs
+++ b/examples/validator/src/main.rs
@@ -29,7 +29,7 @@ async fn main() {
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "example_validator=debug".into()),
+                .unwrap_or_else(|_| concat!(env!("CARGO_CRATE_NAME"), "=debug").into()),
         )
         .with(tracing_subscriber::fmt::layer())
         .init();

--- a/examples/versioning/src/main.rs
+++ b/examples/versioning/src/main.rs
@@ -20,7 +20,7 @@ async fn main() {
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| concat!(env!("CARGO_CRATE_NAME"), "=debug").into()),
+                .unwrap_or_else(|_| format!("{}=debug", env!("CARGO_CRATE_NAME")).into()),
         )
         .with(tracing_subscriber::fmt::layer())
         .init();

--- a/examples/versioning/src/main.rs
+++ b/examples/versioning/src/main.rs
@@ -20,7 +20,7 @@ async fn main() {
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "example_versioning=debug".into()),
+                .unwrap_or_else(|_| concat!(env!("CARGO_CRATE_NAME"), "=debug").into()),
         )
         .with(tracing_subscriber::fmt::layer())
         .init();

--- a/examples/websockets/src/main.rs
+++ b/examples/websockets/src/main.rs
@@ -45,8 +45,9 @@ use futures::{sink::SinkExt, stream::StreamExt};
 async fn main() {
     tracing_subscriber::registry()
         .with(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "example_websockets=debug,tower_http=debug".into()),
+            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+                concat!(env!("CARGO_CRATE_NAME"), "=debug,tower_http=debug").into()
+            }),
         )
         .with(tracing_subscriber::fmt::layer())
         .init();

--- a/examples/websockets/src/main.rs
+++ b/examples/websockets/src/main.rs
@@ -46,7 +46,7 @@ async fn main() {
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
-                concat!(env!("CARGO_CRATE_NAME"), "=debug,tower_http=debug").into()
+                format!("{}=debug,tower_http=debug", env!("CARGO_CRATE_NAME")).into()
             }),
         )
         .with(tracing_subscriber::fmt::layer())


### PR DESCRIPTION
…etup code

## Motivation
The example code is full of tracing registration codes, and the log level is hard-coded. I think it can be replaced with the `module_path!` macro.

## Solution
Simplify the code.
