### PR TITLE
Clarify some subtleties of routing

### DIFF
--- a/axum/src/docs/routing/fallback.md
+++ b/axum/src/docs/routing/fallback.md
@@ -23,7 +23,11 @@ async fn fallback(uri: Uri) -> (StatusCode, String) {
 
 Fallbacks only apply to routes that aren't matched by anything in the
 router. If a handler is matched by a request but returns 404 the
-fallback is not called.
+fallback is not called. Note that this applies to [`MethodRouter`]s too: if the
+request hits a valid path but the [`MethodRouter`] does not have an appropriate
+method handler installed, the fallback is not called (use
+[`MethodRouter::fallback`] for this purpose instead).
+
 
 # Handling all requests without other routes
 

--- a/axum/src/docs/routing/nest.md
+++ b/axum/src/docs/routing/nest.md
@@ -82,6 +82,11 @@ let app = Router::new()
 # let _: Router = app;
 ```
 
+Additionally, while the wildcard route `/foo/*rest` will not match the
+paths `/foo` or `/foo/`, a nested router at `/foo` will match the path `/foo`
+(but not `/foo/`), and a nested router at `/foo/` will match the path `/foo/`
+(but not `/foo`).
+
 # Fallbacks
 
 If a nested router doesn't have its own fallback then it will inherit the


### PR DESCRIPTION
## Motivation

I was confused when using Axum of the following things:

- whether `nest("/foo")` will match `/foo` and/or `/foo/`;
- whether a `fallback` is called when the method is not allowed.

## Solution

Document the behaviours.

---

Also relevant: #2659, #2251