### PR TITLE
Fix warnings and errors from beta Rust

### DIFF
--- a/axum/src/extract/ws.rs
+++ b/axum/src/extract/ws.rs
@@ -783,8 +783,9 @@ pub mod close_code {
     pub const PROTOCOL: u16 = 1002;
 
     /// Indicates that an endpoint is terminating the connection because it has received a type of
-    /// data it cannot accept (e.g., an endpoint that understands only text data MAY send this if
-    /// it receives a binary message).
+    /// data that it cannot accept.  
+    ///
+    /// For example, an endpoint MAY send this if it understands only text data, but receives a binary message.
     pub const UNSUPPORTED: u16 = 1003;
 
     /// Indicates that no status code was included in a closing frame.
@@ -794,12 +795,15 @@ pub mod close_code {
     pub const ABNORMAL: u16 = 1006;
 
     /// Indicates that an endpoint is terminating the connection because it has received data
-    /// within a message that was not consistent with the type of the message (e.g., non-UTF-8
-    /// RFC3629 data within a text message).
+    /// within a message that was not consistent with the type of the message.
+    ///
+    /// For example, an endpoint received non-UTF-8 RFC3629 data within a text message.
     pub const INVALID: u16 = 1007;
 
     /// Indicates that an endpoint is terminating the connection because it has received a message
-    /// that violates its policy. This is a generic status code that can be returned when there is
+    /// that violates its policy.
+    ///
+    /// This is a generic status code that can be returned when there is
     /// no other more suitable status code (e.g., `UNSUPPORTED` or `SIZE`) or if there is a need to
     /// hide specific details about the policy.
     pub const POLICY: u16 = 1008;
@@ -808,10 +812,13 @@ pub mod close_code {
     /// that is too big for it to process.
     pub const SIZE: u16 = 1009;
 
-    /// Indicates that an endpoint (client) is terminating the connection because it has expected
-    /// the server to negotiate one or more extension, but the server didn't return them in the
-    /// response message of the WebSocket handshake. The list of extensions that are needed should
-    /// be given as the reason for closing. Note that this status code is not used by the server,
+    /// Indicates that an endpoint (client) is terminating the connection because the server
+    /// did not respond to extension negotiation correctly.
+    ///
+    /// Specifically, the client has expected the server to negotiate one or more extension(s),
+    /// but the server didn't return them in the response message of the WebSocket handshake.
+    /// The list of extensions that are needed should be given as the reason for closing.
+    /// Note that this status code is not used by the server,
     /// because it can fail the WebSocket handshake instead.
     pub const EXTENSION: u16 = 1010;
 

--- a/axum/src/handler/mod.rs
+++ b/axum/src/handler/mod.rs
@@ -328,6 +328,8 @@ where
             ) -> _,
         > = svc.oneshot(req).map(|result| match result {
             Ok(res) => res.into_response(),
+
+            #[allow(unreachable_patterns)]
             Err(err) => match err {},
         });
 

--- a/axum/src/middleware/from_fn.rs
+++ b/axum/src/middleware/from_fn.rs
@@ -341,6 +341,8 @@ impl Next {
     pub async fn run(mut self, req: Request) -> Response {
         match self.inner.call(req).await {
             Ok(res) => res,
+
+            #[allow(unreachable_patterns)]
             Err(err) => match err {},
         }
     }

--- a/axum/src/middleware/map_response.rs
+++ b/axum/src/middleware/map_response.rs
@@ -278,6 +278,8 @@ macro_rules! impl_service {
                         Ok(res) => {
                             f($($ty,)* res).await.into_response()
                         }
+
+                        #[allow(unreachable_patterns)]
                         Err(err) => match err {}
                     }
                 });

--- a/axum/src/routing/route.rs
+++ b/axum/src/routing/route.rs
@@ -236,6 +236,8 @@ impl Future for InfallibleRouteFuture {
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         match futures_util::ready!(self.project().future.poll(cx)) {
             Ok(response) => Poll::Ready(response),
+
+            #[allow(unreachable_patterns)]
             Err(err) => match err {},
         }
     }

--- a/examples/serve-with-hyper/src/main.rs
+++ b/examples/serve-with-hyper/src/main.rs
@@ -11,6 +11,8 @@
 //!
 //! [hyper-util]: https://crates.io/crates/hyper-util
 
+#![allow(unreachable_patterns)]
+
 use std::convert::Infallible;
 use std::net::SocketAddr;
 

--- a/examples/unix-domain-socket/src/main.rs
+++ b/examples/unix-domain-socket/src/main.rs
@@ -3,6 +3,7 @@
 //! ```not_rust
 //! cargo run -p example-unix-domain-socket
 //! ```
+#![allow(unreachable_patterns)]
 
 #[cfg(unix)]
 #[tokio::main]


### PR DESCRIPTION
## Motivation

The CI cannot pass due to the marking of two new warnings / errors, namely pattern exhaustiveness (by `rustc`) and long doc comments (by `clippy`).

## Solution

1. Pattern exhaustiveness
```rs
error: unreachable pattern
   --> axum/src/middleware/map_response.rs:281:25
    |
281 |                         Err(err) => match err {}
    |                         ^^^^^^^^ matches no values because `std::convert::Infallible` is uninhabited
```
Because `unreachable pattern` is a useful compiler warning, and within all of `axum`, there are only 4 occurrences, it is simplest to just mark the match arms with `#[allow]`.
There does not seem to be a way to disable more specific instances of unreachable patterns.

Because the examples are separate from the `axum` lib, it's simplest to just use the same `#[allow]` in each example's `main.rs` at a module level.

NOTE: It seems that this warning has irked enough people for an exception for [empty match arms to be made and nominated for backporting to beta](https://github.com/rust-lang/rust/pull/129103), so hopefully these commits can be reverted soon.

2. `clippy::too-long-first-doc-paragraph`

```rs
error: first doc comment paragraph is too long
   --> axum/src/extract/ws.rs:785:5
    |
785 | /     /// Indicates that an endpoint is terminating the connection because it has received a type of
786 | |     /// data it cannot accept (e.g., an endpoint that understands only text data MAY send this if
787 | |     /// it receives a binary message).
    | |____^
```

This lint is likely here to stay, so this requires actual changes, which were made in accordance with [the fix recommended by the lint's author(s)](https://rust-lang.github.io/rust-clippy/master/index.html#/clippy::too-long-first-doc-paragraph).