### PR TITLE
Add request id example

### DIFF
--- a/examples/request-id/Cargo.toml
+++ b/examples/request-id/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "example-request-id"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+axum = { path = "../../axum" }
+tokio = { version = "1.0", features = ["full"] }
+tower = "0.5"
+tower-http = { version = "0.5", features = ["request-id", "trace"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/request-id/src/main.rs
+++ b/examples/request-id/src/main.rs
@@ -87,5 +87,6 @@ async fn main() {
 }
 
 async fn handler() -> Html<&'static str> {
+    info!("Hello world!");
     Html("<h1>Hello, World!</h1>")
 }

--- a/examples/request-id/src/main.rs
+++ b/examples/request-id/src/main.rs
@@ -5,6 +5,7 @@
 //! ```
 
 use axum::{
+    extract::MatchedPath,
     http::{HeaderName, Request},
     response::Html,
     routing::get,
@@ -15,7 +16,7 @@ use tower_http::{
     request_id::{MakeRequestUuid, PropagateRequestIdLayer, SetRequestIdLayer},
     trace::TraceLayer,
 };
-use tracing::info_span;
+use tracing::{info, info_span};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 const REQUEST_ID_HEADER: &str = "x-request-id";
@@ -46,17 +47,26 @@ async fn main() {
         ))
         .layer(
             TraceLayer::new_for_http().make_span_with(|request: &Request<_>| {
-                // log the request id
+                // Log the matched route's path (with placeholders not filled in).
+                // Use request.uri() or OriginalUri if you want the real path.
+                let matched_path = request
+                    .extensions()
+                    .get::<MatchedPath>()
+                    .map(MatchedPath::as_str);
+
+                // Log the request id as generated.
                 let request_id = request.headers().get(REQUEST_ID_HEADER);
 
                 match request_id {
                     Some(request_id) => info_span!(
                         "http_request",
+                        matched_path,
                         method = ?request.method(),
                         request_id = ?request_id,
                     ),
                     None => info_span!(
                         "http_request",
+                        matched_path,
                         method = ?request.method(),
                     ),
                 }

--- a/examples/request-id/src/main.rs
+++ b/examples/request-id/src/main.rs
@@ -1,0 +1,81 @@
+//! Run with
+//!
+//! ```not_rust
+//! cargo run -p example-request-id
+//! ```
+
+use axum::{
+    http::{HeaderName, Request},
+    response::Html,
+    routing::get,
+    Router,
+};
+use tower::ServiceBuilder;
+use tower_http::{
+    request_id::{MakeRequestUuid, PropagateRequestIdLayer, SetRequestIdLayer},
+    trace::TraceLayer,
+};
+use tracing::info_span;
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+
+const REQUEST_ID_HEADER: &str = "x-request-id";
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::registry()
+        .with(
+            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+                // axum logs rejections from built-in extractors with the `axum::rejection`
+                // target, at `TRACE` level. `axum::rejection=trace` enables showing those events
+                format!(
+                    "{}=debug,tower_http=debug,axum::rejection=trace",
+                    env!("CARGO_CRATE_NAME")
+                )
+                .into()
+            }),
+        )
+        .with(tracing_subscriber::fmt::layer())
+        .init();
+
+    let x_request_id = HeaderName::from_static(REQUEST_ID_HEADER);
+
+    let middleware = ServiceBuilder::new()
+        .layer(SetRequestIdLayer::new(
+            x_request_id.clone(),
+            MakeRequestUuid,
+        ))
+        .layer(
+            TraceLayer::new_for_http().make_span_with(|request: &Request<_>| {
+                // log the request id
+                let request_id = request.headers().get(REQUEST_ID_HEADER);
+
+                match request_id {
+                    Some(request_id) => info_span!(
+                        "http_request",
+                        method = ?request.method(),
+                        request_id = ?request_id,
+                    ),
+                    None => info_span!(
+                        "http_request",
+                        method = ?request.method(),
+                    ),
+                }
+            }),
+        )
+        // send headers from request to response headers
+        .layer(PropagateRequestIdLayer::new(x_request_id));
+
+    // build our application with a route
+    let app = Router::new().route("/", get(handler)).layer(middleware);
+
+    // run it
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:3000")
+        .await
+        .unwrap();
+    println!("listening on {}", listener.local_addr().unwrap());
+    axum::serve(listener, app).await.unwrap();
+}
+
+async fn handler() -> Html<&'static str> {
+    Html("<h1>Hello, World!</h1>")
+}


### PR DESCRIPTION
Add a request-id example using tower, tower-http, and tracing.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation

This is something I've had to do a few times now in axum that I had to figure out through a combination of axum docs and tower-http docs. Having a concrete example shows a way of doing this in a way that axum supports without having to dig through 2 docs.rs pages (or 3 if you're looking in tower as well). 

Figuring out the middleware, the order, and how to write the `TraceLayer` to avoid extra clones has prevented issues for other engineers I've interacted with as well, so the goal is also to clarify an easy way to achieve request ids.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

- Add an example of how to add randomized request ids at `examples/request-id`.
- Utilize `tower` and `tower-http` crates to handle request-id middleware.
- Use `tracing` and `tracing-subscriber` crates to show how to add these request ids to each requests span.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
