### PR TITLE
Release axum 0.7.6 and other patch versions

### DIFF
--- a/axum-core/CHANGELOG.md
+++ b/axum-core/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-# Unreleased
+# 0.4.4
 
 - **added:** Derive `Clone` and `Copy` for `AppendHeaders` ([#2776])
 - **added:** `must_use` attribute on `AppendHeaders` ([#2846])

--- a/axum-core/Cargo.toml
+++ b/axum-core/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 name = "axum-core"
 readme = "README.md"
 repository = "https://github.com/tokio-rs/axum"
-version = "0.4.3" # remember to also bump the version that axum and axum-extra depend on
+version = "0.4.4" # remember to also bump the version that axum and axum-extra depend on
 
 [features]
 tracing = ["dep:tracing"]

--- a/axum-extra/CHANGELOG.md
+++ b/axum-extra/CHANGELOG.md
@@ -7,12 +7,16 @@ and this project adheres to [Semantic Versioning].
 
 # Unreleased
 
-- **added:** The `response::Attachment` type ([#2789])
 - **breaking:** Update to prost 0.13. Used for the `Protobuf` extractor ([#2829])
 - **change:** Update minimum rust version to 1.70 ([#2829])
 
-[#2789]: https://github.com/tokio-rs/axum/pull/2789
 [#2829]: https://github.com/tokio-rs/axum/pull/2829
+
+# 0.9.4
+
+- **added:** The `response::Attachment` type ([#2789])
+
+[#2789]: https://github.com/tokio-rs/axum/pull/2789
 
 # 0.9.3 (24. March, 2024)
 

--- a/axum-extra/Cargo.toml
+++ b/axum-extra/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 name = "axum-extra"
 readme = "README.md"
 repository = "https://github.com/tokio-rs/axum"
-version = "0.9.3"
+version = "0.9.4"
 
 [features]
 default = ["tracing"]
@@ -39,8 +39,8 @@ typed-header = ["dep:headers"]
 typed-routing = ["dep:axum-macros", "dep:percent-encoding", "dep:serde_html_form", "dep:form_urlencoded"]
 
 [dependencies]
-axum = { path = "../axum", version = "0.7.2", default-features = false }
-axum-core = { path = "../axum-core", version = "0.4.3" }
+axum = { path = "../axum", version = "0.7.6", default-features = false }
+axum-core = { path = "../axum-core", version = "0.4.4" }
 bytes = "1.1.0"
 futures-util = { version = "0.3", default-features = false, features = ["alloc"] }
 http = "1.0.0"
@@ -54,7 +54,7 @@ tower-layer = "0.3"
 tower-service = "0.3"
 
 # optional dependencies
-axum-macros = { path = "../axum-macros", version = "0.4.1", optional = true }
+axum-macros = { path = "../axum-macros", version = "0.4.2", optional = true }
 cookie = { package = "cookie", version = "0.18.0", features = ["percent-encode"], optional = true }
 form_urlencoded = { version = "1.1.0", optional = true }
 headers = { version = "0.4.0", optional = true }

--- a/axum-macros/CHANGELOG.md
+++ b/axum-macros/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-# Unreleased
+# 0.4.2
 
 - **added:** Add `#[debug_middleware]` ([#1993], [#2725])
 

--- a/axum-macros/Cargo.toml
+++ b/axum-macros/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 name = "axum-macros"
 readme = "README.md"
 repository = "https://github.com/tokio-rs/axum"
-version = "0.4.1" # remember to also bump the version that axum and axum-extra depends on
+version = "0.4.2" # remember to also bump the version that axum and axum-extra depends on
 
 [features]
 default = []

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-# Unreleased
+# 0.7.6
 
 - **change:** Avoid cloning `Arc` during deserialization of `Path`
 - **added:** `axum::serve::Serve::tcp_nodelay` and `axum::serve::WithGracefulShutdown::tcp_nodelay` ([#2653])

--- a/axum/Cargo.toml
+++ b/axum/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axum"
-version = "0.7.5"
+version = "0.7.6"
 categories = ["asynchronous", "network-programming", "web-programming::http-server"]
 description = "Web framework that focuses on ergonomics and modularity"
 edition = "2021"
@@ -42,7 +42,7 @@ __private_docs = ["tower/full", "dep:tower-http"]
 
 [dependencies]
 async-trait = "0.1.67"
-axum-core = { path = "../axum-core", version = "0.4.3" }
+axum-core = { path = "../axum-core", version = "0.4.4" }
 bytes = "1.0"
 futures-util = { version = "0.3", default-features = false, features = ["alloc"] }
 http = "1.0.0"
@@ -62,7 +62,7 @@ tower-layer = "0.3.2"
 tower-service = "0.3"
 
 # optional dependencies
-axum-macros = { path = "../axum-macros", version = "0.4.1", optional = true }
+axum-macros = { path = "../axum-macros", version = "0.4.2", optional = true }
 base64 = { version = "0.21.0", optional = true }
 hyper = { version = "1.1.0", optional = true }
 hyper-util = { version = "0.1.3", features = ["tokio", "server", "service"], optional = true }


### PR DESCRIPTION
This PR shows what's going to be merged back into the `main` branch after the releases that I'm planning to do from the `v0.7.x` branch soon.

It is not to be merged through GitHub's UI because we don't allow merge commit merges here, but in this case a merge commit is warranted. Not two though, I'll fast-forward the merge commit from the bottom of the commit list once the release is successful.