### PR TITLE
docs: Remove manual tables of content

### DIFF
--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -8,7 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # Unreleased
 
 - **breaking:** The tuple and tuple_struct `Path` extractor deserializers now check that the number of parameters matches the tuple length exactly ([#2931])
+- **change**: Remove manual tables of content from the documentation, since
+  rustdoc now generates tables of content in the sidebar ([#2921])
 
+[#2921]: https://github.com/tokio-rs/axum/pull/2921
 [#2931]: https://github.com/tokio-rs/axum/pull/2931
 
 # 0.7.6

--- a/axum/src/docs/error_handling.md
+++ b/axum/src/docs/error_handling.md
@@ -1,12 +1,5 @@
 Error handling model and utilities
 
-# Table of contents
-
-- [axum's error handling model](#axums-error-handling-model)
-- [Routing to fallible services](#routing-to-fallible-services)
-- [Applying fallible middleware](#applying-fallible-middleware)
-- [Running extractors for error handling](#running-extractors-for-error-handling)
-
 # axum's error handling model
 
 axum is based on [`tower::Service`] which bundles errors through its associated

--- a/axum/src/docs/extract.md
+++ b/axum/src/docs/extract.md
@@ -1,20 +1,5 @@
 Types and traits for extracting data from requests.
 
-# Table of contents
-
-- [Intro](#intro)
-- [Common extractors](#common-extractors)
-- [Applying multiple extractors](#applying-multiple-extractors)
-- [The order of extractors](#the-order-of-extractors)
-- [Optional extractors](#optional-extractors)
-- [Customizing extractor responses](#customizing-extractor-responses)
-- [Accessing inner errors](#accessing-inner-errors)
-- [Defining custom extractors](#defining-custom-extractors)
-- [Accessing other extractors in `FromRequest` or `FromRequestParts` implementations](#accessing-other-extractors-in-fromrequest-or-fromrequestparts-implementations)
-- [Request body limits](#request-body-limits)
-- [Wrapping extractors](#wrapping-extractors)
-- [Logging rejections](#logging-rejections)
-
 # Intro
 
 A handler function is an async function that takes any number of

--- a/axum/src/docs/middleware.md
+++ b/axum/src/docs/middleware.md
@@ -1,15 +1,3 @@
-# Table of contents
-
-- [Intro](#intro)
-- [Applying middleware](#applying-middleware)
-- [Commonly used middleware](#commonly-used-middleware)
-- [Ordering](#ordering)
-- [Writing middleware](#writing-middleware)
-- [Routing to services/middleware and backpressure](#routing-to-servicesmiddleware-and-backpressure)
-- [Accessing state in middleware](#accessing-state-in-middleware)
-- [Passing state from middleware to handlers](#passing-state-from-middleware-to-handlers)
-- [Rewriting request URI in middleware](#rewriting-request-uri-in-middleware)
-
 # Intro
 
 axum is unique in that it doesn't have its own bespoke middleware system and

--- a/axum/src/docs/response.md
+++ b/axum/src/docs/response.md
@@ -1,11 +1,5 @@
 Types and traits for generating responses.
 
-# Table of contents
-
-- [Building responses](#building-responses)
-- [Returning different response types](#returning-different-response-types)
-- [Regarding `impl IntoResponse`](#regarding-impl-intoresponse)
-
 # Building responses
 
 Anything that implements [`IntoResponse`] can be returned from a handler. axum

--- a/axum/src/lib.rs
+++ b/axum/src/lib.rs
@@ -1,22 +1,5 @@
 //! axum is a web application framework that focuses on ergonomics and modularity.
 //!
-//! # Table of contents
-//!
-//! - [High-level features](#high-level-features)
-//! - [Compatibility](#compatibility)
-//! - [Example](#example)
-//! - [Routing](#routing)
-//! - [Handlers](#handlers)
-//! - [Extractors](#extractors)
-//! - [Responses](#responses)
-//! - [Error handling](#error-handling)
-//! - [Middleware](#middleware)
-//! - [Sharing state with handlers](#sharing-state-with-handlers)
-//! - [Building integrations for axum](#building-integrations-for-axum)
-//! - [Required dependencies](#required-dependencies)
-//! - [Examples](#examples)
-//! - [Feature flags](#feature-flags)
-//!
 //! # High-level features
 //!
 //! - Route requests to handlers with a macro-free API.


### PR DESCRIPTION
docs.rs now generates these:

![Screenshot 2024-09-20 at 22-17-27 axum - Rust](https://github.com/user-attachments/assets/b5f3fe91-7e9a-4f91-817c-12a8758319d0)
