### PR TITLE
feat(axum-extra): add trait GetCachedFromRef to get cached value

### DIFF
--- a/axum-extra/src/extract/mod.rs
+++ b/axum-extra/src/extract/mod.rs
@@ -19,7 +19,11 @@ mod query;
 #[cfg(feature = "multipart")]
 pub mod multipart;
 
-pub use self::{cached::Cached, optional_path::OptionalPath, with_rejection::WithRejection};
+pub use self::{
+    cached::{Cached, GetCachedFromRef},
+    optional_path::OptionalPath,
+    with_rejection::WithRejection,
+};
 
 #[cfg(feature = "cookie")]
 pub use self::cookie::CookieJar;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation

When I use `Cached<T>`, I find that I can't access `Cached<T>` elsewhere because `CachedEntry` is inaccessible.

## Solution

add trait `GetCachedFromRef<T>` to get cached value.
impl `GetCachedFromRef<T>` for [`http::Extensions`, `http::request::Parts`, `axum::Request`]
