### PR TITLE
core: Fix compile errors from __log_rejection

### DIFF
--- a/axum-core/src/lib.rs
+++ b/axum-core/src/lib.rs
@@ -50,6 +50,11 @@
 
 #[macro_use]
 pub(crate) mod macros;
+#[doc(hidden)] // macro helpers
+pub mod __private {
+    #[cfg(feature = "tracing")]
+    pub use tracing;
+}
 
 mod error;
 mod ext_traits;

--- a/axum-core/src/macros.rs
+++ b/axum-core/src/macros.rs
@@ -9,12 +9,12 @@ macro_rules! __log_rejection {
         status = $status:expr,
     ) => {
         {
-            tracing::event!(
+            $crate::__private::tracing::event!(
                 target: "axum::rejection",
-                tracing::Level::TRACE,
+                $crate::__private::tracing::Level::TRACE,
                 status = $status.as_u16(),
                 body = $body_text,
-                rejection_type = std::any::type_name::<$ty>(),
+                rejection_type = ::std::any::type_name::<$ty>(),
                 "rejecting request",
             );
         }

--- a/axum-extra/Cargo.toml
+++ b/axum-extra/Cargo.toml
@@ -34,7 +34,7 @@ json-lines = [
 multipart = ["dep:multer"]
 protobuf = ["dep:prost"]
 query = ["dep:serde_html_form"]
-tracing = ["dep:tracing", "axum-core/tracing", "axum/tracing"]
+tracing = ["axum-core/tracing", "axum/tracing"]
 typed-header = ["dep:headers"]
 typed-routing = ["dep:axum-macros", "dep:percent-encoding", "dep:serde_html_form", "dep:form_urlencoded"]
 


### PR DESCRIPTION
## Motivation

It was failing to compile if axum-core's tracing feature was enabled, but the tracing feature of axum or axum-extra wasn't when those were part of the dependency tree.

## Solution

Use a private re-export, as commonly done with macros that need to refer to some other crate at the expansion site.

Fixes #2932.