### PR TITLE
Release axum-core 0.4.5 and axum 0.7.7

### DIFF
--- a/axum-core/CHANGELOG.md
+++ b/axum-core/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# 0.4.5
+
+- **fixed:** Compile errors from the internal `__log_rejection` macro under
+  certain Cargo feature combinations between axum crates ([#2933])
+
+[#2933]: https://github.com/tokio-rs/axum/pull/2933
+
 # 0.4.4
 
 - **added:** Derive `Clone` and `Copy` for `AppendHeaders` ([#2776])

--- a/axum-core/Cargo.toml
+++ b/axum-core/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 name = "axum-core"
 readme = "README.md"
 repository = "https://github.com/tokio-rs/axum"
-version = "0.4.4" # remember to also bump the version that axum and axum-extra depend on
+version = "0.4.5" # remember to also bump the version that axum and axum-extra depend on
 
 [features]
 tracing = ["dep:tracing"]

--- a/axum-extra/Cargo.toml
+++ b/axum-extra/Cargo.toml
@@ -39,8 +39,8 @@ typed-header = ["dep:headers"]
 typed-routing = ["dep:axum-macros", "dep:percent-encoding", "dep:serde_html_form", "dep:form_urlencoded"]
 
 [dependencies]
-axum = { path = "../axum", version = "0.7.6", default-features = false }
-axum-core = { path = "../axum-core", version = "0.4.4" }
+axum = { path = "../axum", version = "0.7.7", default-features = false }
+axum-core = { path = "../axum-core", version = "0.4.5" }
 bytes = "1.1.0"
 futures-util = { version = "0.3", default-features = false, features = ["alloc"] }
 http = "1.0.0"

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -8,11 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # Unreleased
 
 - **breaking:** The tuple and tuple_struct `Path` extractor deserializers now check that the number of parameters matches the tuple length exactly ([#2931])
+
+[#2931]: https://github.com/tokio-rs/axum/pull/2931
+
+# 0.7.7
+
 - **change**: Remove manual tables of content from the documentation, since
   rustdoc now generates tables of content in the sidebar ([#2921])
 
 [#2921]: https://github.com/tokio-rs/axum/pull/2921
-[#2931]: https://github.com/tokio-rs/axum/pull/2931
 
 # 0.7.6
 

--- a/axum/Cargo.toml
+++ b/axum/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axum"
-version = "0.7.6"
+version = "0.7.7"
 categories = ["asynchronous", "network-programming", "web-programming::http-server"]
 description = "Web framework that focuses on ergonomics and modularity"
 edition = "2021"
@@ -42,7 +42,7 @@ __private_docs = ["tower/full", "dep:tower-http"]
 
 [dependencies]
 async-trait = "0.1.67"
-axum-core = { path = "../axum-core", version = "0.4.4" }
+axum-core = { path = "../axum-core", version = "0.4.5" }
 bytes = "1.0"
 futures-util = { version = "0.3", default-features = false, features = ["alloc"] }
 http = "1.0.0"


### PR DESCRIPTION
This PR shows what's going to be merged back into main after the release of these two crates. The actual changes are here: https://github.com/tokio-rs/axum/compare/axum-v0.7.6...18841c13264aab4d546e0db927696ef8fd6afe30

**Do not merge via GitHub UI**