### PR TITLE
README updates

### DIFF
--- a/axum/README.md
+++ b/axum/README.md
@@ -4,7 +4,7 @@
 
 [![Build status](https://github.com/tokio-rs/axum/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/tokio-rs/axum/actions/workflows/CI.yml)
 [![Crates.io](https://img.shields.io/crates/v/axum)](https://crates.io/crates/axum)
-[![Documentation](https://docs.rs/axum/badge.svg)](https://docs.rs/axum)
+[![Documentation](https://docs.rs/axum/badge.svg)][docs]
 
 More information about this crate can be found in the [crate documentation][docs].
 
@@ -23,11 +23,12 @@ In particular the last point is what sets `axum` apart from other frameworks.
 authorization, and more, for free. It also enables you to share middleware with
 applications written using [`hyper`] or [`tonic`].
 
-## Breaking changes
+## ⚠ Breaking changes ⚠
 
 We are currently working towards axum 0.8 so the `main` branch contains breaking
-changes. See the [`0.7.x`] branch for what's released to crates.io and up to
-date changelogs.
+changes. See the [`0.7.x`] branch for what's released to crates.io.
+
+[`0.7.x`]: https://github.com/tokio-rs/axum/tree/v0.7.x
 
 ## Usage example
 


### PR DESCRIPTION
- Dedup docs link definitions
- Add missing link definition for v0.7.x branch
- Make breaking changes section stand out more
- Stop talking about changelogs in breaking changes section
  (changelog updates are synced back after every release now)

cc @SabrinaJewson 