### PR TITLE
ci: Only save cache from main

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,6 +20,8 @@ jobs:
       with:
         components: clippy, rustfmt
     - uses: Swatinem/rust-cache@v2
+      with:
+        save-if: ${{ github.ref == 'refs/heads/main' }}
     - name: Check
       run: cargo clippy --workspace --all-targets --all-features -- -D warnings
     - name: rustfmt
@@ -31,6 +33,8 @@ jobs:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@stable
     - uses: Swatinem/rust-cache@v2
+      with:
+        save-if: ${{ github.ref == 'refs/heads/main' }}
     - name: cargo doc
       env:
         RUSTDOCFLAGS: "-D rustdoc::all -A rustdoc::private-doc-tests"
@@ -43,6 +47,8 @@ jobs:
     - uses: taiki-e/install-action@protoc
     - uses: dtolnay/rust-toolchain@stable
     - uses: Swatinem/rust-cache@v2
+      with:
+        save-if: ${{ github.ref == 'refs/heads/main' }}
     - name: Install cargo-hack
       run: |
         curl -LsSf https://github.com/taiki-e/cargo-hack/releases/latest/download/cargo-hack-x86_64-unknown-linux-gnu.tar.gz | tar xzf - -C ~/.cargo/bin
@@ -61,6 +67,8 @@ jobs:
       with:
         toolchain: nightly-2024-06-06
     - uses: Swatinem/rust-cache@v2
+      with:
+        save-if: ${{ github.ref == 'refs/heads/main' }}
     - name: Install cargo-public-api-crates
       run: |
         cargo install --git https://github.com/davidpdrsn/cargo-public-api-crates
@@ -83,6 +91,8 @@ jobs:
       with:
         toolchain: ${{ matrix.rust }}
     - uses: Swatinem/rust-cache@v2
+      with:
+        save-if: ${{ github.ref == 'refs/heads/main' }}
     - name: Run tests
       run: cargo test --workspace --all-features --all-targets
 
@@ -99,6 +109,8 @@ jobs:
       with:
         toolchain: ${{ steps.rust-toolchain.outputs.version }}
     - uses: Swatinem/rust-cache@v2
+      with:
+        save-if: ${{ github.ref == 'refs/heads/main' }}
     - name: Run nightly tests
       working-directory: axum-macros
       run: cargo test
@@ -116,6 +128,8 @@ jobs:
     - name: "install Rust nightly"
       uses: dtolnay/rust-toolchain@nightly
     - uses: Swatinem/rust-cache@v2
+      with:
+        save-if: ${{ github.ref == 'refs/heads/main' }}
     - name: Select minimal version
       run: cargo +nightly update -Z minimal-versions
     - name: Fix up Cargo.lock
@@ -148,6 +162,8 @@ jobs:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@stable
     - uses: Swatinem/rust-cache@v2
+      with:
+        save-if: ${{ github.ref == 'refs/heads/main' }}
     - name: Run doc tests
       run: cargo test --all-features --doc
 
@@ -176,6 +192,8 @@ jobs:
       with:
         target: armv5te-unknown-linux-musleabi
     - uses: Swatinem/rust-cache@v2
+      with:
+        save-if: ${{ github.ref == 'refs/heads/main' }}
     - name: Check
       env:
         # Clang has native cross-compilation support
@@ -200,6 +218,8 @@ jobs:
       with:
         target: wasm32-unknown-unknown
     - uses: Swatinem/rust-cache@v2
+      with:
+        save-if: ${{ github.ref == 'refs/heads/main' }}
     - name: Check
       run: >
         cargo
@@ -213,6 +233,8 @@ jobs:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@beta
     - uses: Swatinem/rust-cache@v2
+      with:
+        save-if: ${{ github.ref == 'refs/heads/main' }}
     - name: Install cargo-sort
       run: |
         cargo install cargo-sort


### PR DESCRIPTION
Cache entries stored from other branches can only be read from those same branches, so it's pretty wasteful to store the large Rust cache bundles for them.
