### PR TITLE
MSRV in READMEs

### DIFF
--- a/axum-core/README.md
+++ b/axum-core/README.md
@@ -14,7 +14,7 @@ This crate uses `#![forbid(unsafe_code)]` to ensure everything is implemented in
 
 ## Minimum supported Rust version
 
-axum-core's MSRV is 1.56.
+axum-core's MSRV is 1.75.
 
 ## Getting Help
 

--- a/axum-extra/README.md
+++ b/axum-extra/README.md
@@ -14,7 +14,7 @@ This crate uses `#![forbid(unsafe_code)]` to ensure everything is implemented in
 
 ## Minimum supported Rust version
 
-axum-extra's MSRV is 1.66.
+axum-extra's MSRV is 1.75.
 
 ## Getting Help
 

--- a/axum-macros/README.md
+++ b/axum-macros/README.md
@@ -14,7 +14,7 @@ This crate uses `#![forbid(unsafe_code)]` to ensure everything is implemented in
 
 ## Minimum supported Rust version
 
-axum-macros's MSRV is 1.66.
+axum-macros's MSRV is 1.75.
 
 ## Getting Help
 

--- a/axum/README.md
+++ b/axum/README.md
@@ -111,7 +111,7 @@ This crate uses `#![forbid(unsafe_code)]` to ensure everything is implemented in
 
 ## Minimum supported Rust version
 
-axum's MSRV is 1.66.
+axum's MSRV is 1.75.
 
 ## Examples
 

--- a/axum/src/routing/tests/mod.rs
+++ b/axum/src/routing/tests/mod.rs
@@ -911,30 +911,17 @@ async fn state_isnt_cloned_too_much() {
 
     impl Clone for AppState {
         fn clone(&self) -> Self {
-            #[rustversion::since(1.66)]
-            #[track_caller]
-            fn count() {
-                if SETUP_DONE.load(Ordering::SeqCst) {
-                    let bt = std::backtrace::Backtrace::force_capture();
-                    let bt = bt
-                        .to_string()
-                        .lines()
-                        .filter(|line| line.contains("axum") || line.contains("./src"))
-                        .collect::<Vec<_>>()
-                        .join("\n");
-                    println!("AppState::Clone:\n===============\n{bt}\n");
-                    COUNT.fetch_add(1, Ordering::SeqCst);
-                }
+            if SETUP_DONE.load(Ordering::SeqCst) {
+                let bt = std::backtrace::Backtrace::force_capture();
+                let bt = bt
+                    .to_string()
+                    .lines()
+                    .filter(|line| line.contains("axum") || line.contains("./src"))
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                println!("AppState::Clone:\n===============\n{bt}\n");
+                COUNT.fetch_add(1, Ordering::SeqCst);
             }
-
-            #[rustversion::not(since(1.66))]
-            fn count() {
-                if SETUP_DONE.load(Ordering::SeqCst) {
-                    COUNT.fetch_add(1, Ordering::SeqCst);
-                }
-            }
-
-            count();
 
             Self
         }


### PR DESCRIPTION
## Motivation

Old MSRV was in all READMEs.

## Solution

Update to our actual MSRV.

One  instance of pre-1.66 conditional compilation was also in the code so I got rid of it since we do not support lower versions anymore.