### PR TITLE
Post-alpha release cleanup

### DIFF
--- a/axum-core/Cargo.toml
+++ b/axum-core/Cargo.toml
@@ -35,7 +35,7 @@ tower-http = { version = "0.6.0", optional = true, features = ["limit"] }
 tracing = { version = "0.1.37", default-features = false, optional = true }
 
 [dev-dependencies]
-axum = { path = "../axum", version = "0.8.0-alpha.1" }
+axum = { path = "../axum" }
 axum-extra = { path = "../axum-extra", features = ["typed-header"] }
 futures-util = { version = "0.3", default-features = false, features = ["alloc"] }
 hyper = "1.0.0"

--- a/axum-extra/Cargo.toml
+++ b/axum-extra/Cargo.toml
@@ -71,7 +71,7 @@ tokio-util = { version = "0.7", optional = true }
 tracing = { version = "0.1.37", default-features = false, optional = true }
 
 [dev-dependencies]
-axum = { path = "../axum", version = "0.8.0-alpha.1" }
+axum = { path = "../axum" }
 hyper = "1.0.0"
 reqwest = { version = "0.12", default-features = false, features = ["json", "stream", "multipart"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/axum-macros/Cargo.toml
+++ b/axum-macros/Cargo.toml
@@ -29,8 +29,8 @@ syn = { version = "2.0", features = [
 ] }
 
 [dev-dependencies]
-axum = { path = "../axum", version = "0.8.0-alpha.1", features = ["macros"] }
-axum-extra = { path = "../axum-extra", version = "0.10.0-alpha.1", features = ["typed-routing", "cookie-private", "typed-header"] }
+axum = { path = "../axum", features = ["macros"] }
+axum-extra = { path = "../axum-extra", features = ["typed-routing", "cookie-private", "typed-header"] }
 rustversion = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -12,9 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **breaking:** Require `Sync` for all handlers and services added to `Router`
   and `MethodRouter` ([#2473])
 - **breaking:** The tuple and tuple_struct `Path` extractor deserializers now check that the number of parameters matches the tuple length exactly ([#2931])
+- **breaking:** Upgrade matchit to 0.8, changing the path parameter syntax from `/:single` and `/*many`
+  to `/{single}` and `/{*many}`; the old syntax produces a panic to avoid silent change in behavior ([#2645])
 - **change:** Update minimum rust version to 1.75 ([#2943])
 
 [#2473]: https://github.com/tokio-rs/axum/pull/2473
+[#2645]: https://github.com/tokio-rs/axum/pull/2645
 [#2931]: https://github.com/tokio-rs/axum/pull/2931
 [#2943]: https://github.com/tokio-rs/axum/pull/2943
 

--- a/axum/Cargo.toml
+++ b/axum/Cargo.toml
@@ -111,7 +111,7 @@ features = [
 
 [dev-dependencies]
 anyhow = "1.0"
-axum-macros = { path = "../axum-macros", version = "0.5.0-alpha.1", features = ["__private"] }
+axum-macros = { path = "../axum-macros", features = ["__private"] }
 quickcheck = "1.0"
 quickcheck_macros = "1.0"
 reqwest = { version = "0.12", default-features = false, features = ["json", "stream", "multipart"] }


### PR DESCRIPTION
I took the liberty of running `cargo publish` already on the two commits in this PR, but I'll put the tags on the parent commit since the actual source code is not touched by this.

I forgot to look into release automation though 😅 