### PR TITLE
Add `MethodFilter::CONNECT`

### DIFF
--- a/axum-extra/CHANGELOG.md
+++ b/axum-extra/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning].
 
 # Unreleased
 
-- **added:** Add `RouterExt::typed_connect` ([#2961]).
+- **added:** Add `RouterExt::typed_connect` ([#2961])
 
 [#2961]: https://github.com/tokio-rs/axum/pull/2961
 

--- a/axum-extra/CHANGELOG.md
+++ b/axum-extra/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning].
 
 - **added:** Add `RouterExt::typed_connect` ([#2961]).
 
+[#2961]: https://github.com/tokio-rs/axum/pull/2961
+
 # 0.10.0
 
 # alpha.1

--- a/axum-extra/CHANGELOG.md
+++ b/axum-extra/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog],
 and this project adheres to [Semantic Versioning].
 
+# Unreleased
+
+- **added:** Add `RouterExt::typed_connect` ([#2961]).
+
 # 0.10.0
 
 # alpha.1

--- a/axum-extra/src/routing/mod.rs
+++ b/axum-extra/src/routing/mod.rs
@@ -131,6 +131,19 @@ pub trait RouterExt<S>: sealed::Sealed {
         T: SecondElementIs<P> + 'static,
         P: TypedPath;
 
+    /// Add a typed `CONNECT` route to the router.
+    ///
+    /// The path will be inferred from the first argument to the handler function which must
+    /// implement [`TypedPath`].
+    ///
+    /// See [`TypedPath`] for more details and examples.
+    #[cfg(feature = "typed-routing")]
+    fn typed_connect<H, T, P>(self, handler: H) -> Self
+    where
+        H: axum::handler::Handler<T, S>,
+        T: SecondElementIs<P> + 'static,
+        P: TypedPath;
+
     /// Add another route to the router with an additional "trailing slash redirect" route.
     ///
     /// If you add a route _without_ a trailing slash, such as `/foo`, this method will also add a
@@ -253,6 +266,16 @@ where
         P: TypedPath,
     {
         self.route(P::PATH, axum::routing::trace(handler))
+    }
+
+    #[cfg(feature = "typed-routing")]
+    fn typed_connect<H, T, P>(self, handler: H) -> Self
+    where
+        H: axum::handler::Handler<T, S>,
+        T: SecondElementIs<P> + 'static,
+        P: TypedPath,
+    {
+        self.route(P::PATH, axum::routing::connect(handler))
     }
 
     #[track_caller]

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# Unreleased
+
+- **added:** Add support for WebSockets over HTTP/2 ([#2894]).
+  They can be enabled by changing `get(ws_endpoint)` handlers to `any(ws_endpoint)`.
+- **added:** Add `MethodFilter::CONNECT`, `routing::connect[_service]`
+  and `MethodRouter::connect[_service]` ([#2961]).
+
 # 0.8.0
 
 ## alpha.1
@@ -15,9 +22,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **breaking:** Upgrade matchit to 0.8, changing the path parameter syntax from `/:single` and `/*many`
   to `/{single}` and `/{*many}`; the old syntax produces a panic to avoid silent change in behavior ([#2645])
 - **change:** Update minimum rust version to 1.75 ([#2943])
-- **added:** Add support for WebSockets over HTTP/2.
-  They can be enabled by changing `get(ws_endpoint)` handlers to `any(ws_endpoint)`.
-- **added:** Add `MethodFilter::CONNECT`.
 
 [#2473]: https://github.com/tokio-rs/axum/pull/2473
 [#2645]: https://github.com/tokio-rs/axum/pull/2645

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **added:** Add `MethodFilter::CONNECT`, `routing::connect[_service]`
   and `MethodRouter::connect[_service]` ([#2961]).
 
+[#2984]: https://github.com/tokio-rs/axum/pull/2984
+[#2961]: https://github.com/tokio-rs/axum/pull/2961
+
 # 0.8.0
 
 ## alpha.1

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -15,8 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **breaking:** Upgrade matchit to 0.8, changing the path parameter syntax from `/:single` and `/*many`
   to `/{single}` and `/{*many}`; the old syntax produces a panic to avoid silent change in behavior ([#2645])
 - **change:** Update minimum rust version to 1.75 ([#2943])
-- **added:** Add support WebSockets over HTTP/2.
+- **added:** Add support for WebSockets over HTTP/2.
   They can be enabled by changing `get(ws_endpoint)` handlers to `any(ws_endpoint)`.
+- **added:** Add `MethodFilter::CONNECT`.
 
 [#2473]: https://github.com/tokio-rs/axum/pull/2473
 [#2645]: https://github.com/tokio-rs/axum/pull/2645

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -8,9 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # Unreleased
 
 - **added:** Add support for WebSockets over HTTP/2 ([#2894]).
-  They can be enabled by changing `get(ws_endpoint)` handlers to `any(ws_endpoint)`.
+  They can be enabled by changing `get(ws_endpoint)` handlers to `any(ws_endpoint)`
 - **added:** Add `MethodFilter::CONNECT`, `routing::connect[_service]`
-  and `MethodRouter::connect[_service]` ([#2961]).
+  and `MethodRouter::connect[_service]` ([#2961])
 
 [#2984]: https://github.com/tokio-rs/axum/pull/2984
 [#2961]: https://github.com/tokio-rs/axum/pull/2961

--- a/axum/src/routing/method_filter.rs
+++ b/axum/src/routing/method_filter.rs
@@ -9,6 +9,24 @@ use std::{
 pub struct MethodFilter(u16);
 
 impl MethodFilter {
+    /// Match `CONNECT` requests.
+    ///
+    /// This is useful for implementing HTTP/2’s [extended CONNECT method],
+    /// in which the `:protocol` pseudoheader is read
+    /// (using [`hyper::ext::Protocol`])
+    /// and the connection upgraded to a bidirectional byte stream
+    /// (using [`hyper::upgrade::on`]).
+    ///
+    /// As seen in the [HTTP Upgrade Token Registry],
+    /// common uses include WebSockets and proxying UDP or IP –
+    /// though note that when using [`WebSocketUpgrade`]
+    /// it’s more useful to use [`any`]
+    /// as HTTP/1.1 WebSockets need to support `GET`.
+    ///
+    /// [extended CONNECT]: https://www.rfc-editor.org/rfc/rfc8441.html#section-4
+    /// [HTTP Upgrade Token Registry]: https://www.iana.org/assignments/http-upgrade-tokens/http-upgrade-tokens.xhtml
+    /// [`WebSocketUpgrade`]: crate::extract::WebSocketUpgrade
+    pub const CONNECT: Self = Self::from_bits(0b0_0000_0001);
     /// Match `DELETE` requests.
     pub const DELETE: Self = Self::from_bits(0b0_0000_0010);
     /// Match `GET` requests.
@@ -71,6 +89,7 @@ impl TryFrom<Method> for MethodFilter {
 
     fn try_from(m: Method) -> Result<Self, NoMatchingMethodFilter> {
         match m {
+            Method::CONNECT => Ok(MethodFilter::CONNECT),
             Method::DELETE => Ok(MethodFilter::DELETE),
             Method::GET => Ok(MethodFilter::GET),
             Method::HEAD => Ok(MethodFilter::HEAD),
@@ -90,6 +109,11 @@ mod tests {
 
     #[test]
     fn from_http_method() {
+        assert_eq!(
+            MethodFilter::try_from(Method::CONNECT).unwrap(),
+            MethodFilter::CONNECT
+        );
+
         assert_eq!(
             MethodFilter::try_from(Method::DELETE).unwrap(),
             MethodFilter::DELETE
@@ -130,9 +154,11 @@ mod tests {
             MethodFilter::TRACE
         );
 
-        assert!(MethodFilter::try_from(http::Method::CONNECT)
-            .unwrap_err()
-            .to_string()
-            .contains("CONNECT"));
+        assert!(
+            MethodFilter::try_from(http::Method::from_bytes(b"CUSTOM").unwrap())
+                .unwrap_err()
+                .to_string()
+                .contains("CUSTOM")
+        );
     }
 }

--- a/axum/src/routing/method_filter.rs
+++ b/axum/src/routing/method_filter.rs
@@ -11,7 +11,7 @@ pub struct MethodFilter(u16);
 impl MethodFilter {
     /// Match `CONNECT` requests.
     ///
-    /// This is useful for implementing HTTP/2’s [extended CONNECT method],
+    /// This is useful for implementing HTTP/2's [extended CONNECT method],
     /// in which the `:protocol` pseudoheader is read
     /// (using [`hyper::ext::Protocol`])
     /// and the connection upgraded to a bidirectional byte stream
@@ -20,7 +20,7 @@ impl MethodFilter {
     /// As seen in the [HTTP Upgrade Token Registry],
     /// common uses include WebSockets and proxying UDP or IP –
     /// though note that when using [`WebSocketUpgrade`]
-    /// it’s more useful to use [`any`](crate::routing::any)
+    /// it's more useful to use [`any`](crate::routing::any)
     /// as HTTP/1.1 WebSockets need to support `GET`.
     ///
     /// [extended CONNECT]: https://www.rfc-editor.org/rfc/rfc8441.html#section-4

--- a/axum/src/routing/method_filter.rs
+++ b/axum/src/routing/method_filter.rs
@@ -20,7 +20,7 @@ impl MethodFilter {
     /// As seen in the [HTTP Upgrade Token Registry],
     /// common uses include WebSockets and proxying UDP or IP –
     /// though note that when using [`WebSocketUpgrade`]
-    /// it’s more useful to use [`any`]
+    /// it’s more useful to use [`any`](crate::routing::any)
     /// as HTTP/1.1 WebSockets need to support `GET`.
     ///
     /// [extended CONNECT]: https://www.rfc-editor.org/rfc/rfc8441.html#section-4

--- a/axum/src/routing/mod.rs
+++ b/axum/src/routing/mod.rs
@@ -40,9 +40,9 @@ mod tests;
 pub use self::{into_make_service::IntoMakeService, method_filter::MethodFilter, route::Route};
 
 pub use self::method_routing::{
-    any, any_service, delete, delete_service, get, get_service, head, head_service, on, on_service,
-    options, options_service, patch, patch_service, post, post_service, put, put_service, trace,
-    trace_service, MethodRouter,
+    any, any_service, connect, connect_service, delete, delete_service, get, get_service, head,
+    head_service, on, on_service, options, options_service, patch, patch_service, post,
+    post_service, put, put_service, trace, trace_service, MethodRouter,
 };
 
 macro_rules! panic_on_err {


### PR DESCRIPTION
This makes it easiër to support [HTTP/2 Extended Connect](https://www.rfc-editor.org/rfc/rfc8441.html#section-4) with Axum.

Suggested originally in #2894. I didn’t modify the documentation of WebSockets, because `any(handler)` looks a lot nicer than `on(MethodFilter::GET.or(MethodFilter::CONNECT), handler)` and there aren’t many disadvantages to using `any` (incorrect methods are rejected anyway).