### PR TITLE
Add `axum_extra::json!`

### DIFF
--- a/axum-extra/CHANGELOG.md
+++ b/axum-extra/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning].
 
 - **added:** Add `json!` for easy construction of JSON responses ([#2962]).
 
+[#2962]: https://github.com/tokio-rs/axum/pull/2962
+
 # 0.10.0
 
 # alpha.1

--- a/axum-extra/CHANGELOG.md
+++ b/axum-extra/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning].
 
 # Unreleased
 
-- **added:** Add `json!` for easy construction of JSON responses ([#2962]).
+- **added:** Add `json!` for easy construction of JSON responses ([#2962])
 
 [#2962]: https://github.com/tokio-rs/axum/pull/2962
 

--- a/axum-extra/CHANGELOG.md
+++ b/axum-extra/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog],
 and this project adheres to [Semantic Versioning].
 
+# Unreleased
+
+- **added:** Add `json!` for easy construction of JSON responses ([#2962]).
+
 # 0.10.0
 
 # alpha.1

--- a/axum-extra/Cargo.toml
+++ b/axum-extra/Cargo.toml
@@ -104,4 +104,8 @@ allowed = [
     "tokio",
     "tower_layer",
     "tower_service",
+    # typed-json does not appear in the public API, but does appear in `#[doc(hidden)]` re-exports
+    # accessed by macros that are not a part of the public API.
+    # See also: https://github.com/davidpdrsn/cargo-public-api-crates/issues/6
+    "typed-json",
 ]

--- a/axum-extra/Cargo.toml
+++ b/axum-extra/Cargo.toml
@@ -104,8 +104,4 @@ allowed = [
     "tokio",
     "tower_layer",
     "tower_service",
-    # typed-json does not appear in the public API, but does appear in `#[doc(hidden)]` re-exports
-    # accessed by macros that are not a part of the public API.
-    # See also: https://github.com/davidpdrsn/cargo-public-api-crates/issues/6
-    "typed-json",
 ]

--- a/axum-extra/Cargo.toml
+++ b/axum-extra/Cargo.toml
@@ -20,7 +20,7 @@ cookie = ["dep:cookie"]
 cookie-private = ["cookie", "cookie?/private"]
 cookie-signed = ["cookie", "cookie?/signed"]
 cookie-key-expansion = ["cookie", "cookie?/key-expansion"]
-erased-json = ["dep:serde_json"]
+erased-json = ["dep:serde_json", "dep:typed-json"]
 form = ["dep:serde_html_form"]
 json-deserializer = ["dep:serde_json", "dep:serde_path_to_error"]
 json-lines = [
@@ -69,9 +69,11 @@ tokio = { version = "1.19", optional = true }
 tokio-stream = { version = "0.1.9", optional = true }
 tokio-util = { version = "0.7", optional = true }
 tracing = { version = "0.1.37", default-features = false, optional = true }
+typed-json = { version = "0.1.1", optional = true }
 
 [dev-dependencies]
-axum = { path = "../axum" }
+axum = { path = "../axum", features = ["macros"] }
+axum-macros = { path = "../axum-macros", features = ["__private"] }
 hyper = "1.0.0"
 reqwest = { version = "0.12", default-features = false, features = ["json", "stream", "multipart"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/axum-extra/src/response/erased_json.rs
+++ b/axum-extra/src/response/erased_json.rs
@@ -13,7 +13,7 @@ use serde::Serialize;
 /// types as JSON from different branches inside a handler.
 ///
 /// Like [`axum::Json`],
-/// if the [`Serialize`] implementation decides to fail
+/// if the [`Serialize`] implementation fails
 /// or if a map with non-string keys is used,
 /// a 500 response will be issued
 /// whose body is the error message in UTF-8.
@@ -87,7 +87,7 @@ impl IntoResponse for ErasedJson {
 /// A `Content-Type: application/json` header is automatically added.
 /// Any variable or expression implementing [`Serialize`]
 /// can be interpolated as a value in the literal.
-/// If the [`Serialize`] implementation decides to fail,
+/// If the [`Serialize`] implementation fails,
 /// or if a map with non-string keys is used,
 /// a 500 response will be issued
 /// whose body is the error message in UTF-8.

--- a/axum-extra/src/response/erased_json.rs
+++ b/axum-extra/src/response/erased_json.rs
@@ -93,8 +93,11 @@ impl IntoResponse for ErasedJson {
 /// whose body is the error message in UTF-8.
 ///
 /// Internally,
-/// this function uses the [`typed_json::json!`] macro
-/// so that no allocations are performed during serialization.
+/// this function uses the [`typed_json::json!`] macro,
+/// allowing it to perform far fewer allocations
+/// than a dynamic macro like [`serde_json::json!`] would –
+/// it’s equivalent to if you had just written
+/// `derive(Serialize)` on a struct.
 ///
 /// # Examples
 ///
@@ -136,6 +139,7 @@ macro_rules! json {
 }
 
 /// Not public API. Re-exported as `crate::response::__private_erased_json`.
+#[doc(hidden)]
 pub mod private {
     pub use typed_json;
 }

--- a/axum-extra/src/response/erased_json.rs
+++ b/axum-extra/src/response/erased_json.rs
@@ -96,7 +96,7 @@ impl IntoResponse for ErasedJson {
 /// this function uses the [`typed_json::json!`] macro,
 /// allowing it to perform far fewer allocations
 /// than a dynamic macro like [`serde_json::json!`] would –
-/// it’s equivalent to if you had just written
+/// it's equivalent to if you had just written
 /// `derive(Serialize)` on a struct.
 ///
 /// # Examples

--- a/axum-extra/src/response/mod.rs
+++ b/axum-extra/src/response/mod.rs
@@ -12,6 +12,11 @@ pub mod multiple;
 #[cfg(feature = "erased-json")]
 pub use erased_json::ErasedJson;
 
+/// _not_ public API
+#[cfg(feature = "erased-json")]
+#[doc(hidden)]
+pub use erased_json::private as __private_erased_json;
+
 #[cfg(feature = "json-lines")]
 #[doc(no_inline)]
 pub use crate::json_lines::JsonLines;

--- a/axum/src/json.rs
+++ b/axum/src/json.rs
@@ -54,6 +54,11 @@ use serde::{de::DeserializeOwned, Serialize};
 /// When used as a response, it can serialize any type that implements [`serde::Serialize`] to
 /// `JSON`, and will automatically set `Content-Type: application/json` header.
 ///
+/// If the [`Serialize`] implementation decides to fail
+/// or if a map with non-string keys is used,
+/// a 500 response will be issued
+/// whose body is the error message in UTF-8.
+///
 /// # Response example
 ///
 /// ```


### PR DESCRIPTION
## Motivation

Closes: #2937

## Solution

Add `axum_extra::json!`, a macro that forwards to `typed_json::json!` to produce an ad-hoc JSON response with zero allocations.

I chose to put this in `axum-extra` rather than core Axum for two reasons:
1. It adds an extra dependency on `typed-json`. It’s a lightweight dependency and not exposed in the public API, but a dependency nonetheless.
2. It allows for `json!` to return an `ErasedJson`. Using `Json<impl Serialize>` isn’t ideal because if the `json!` macro borrows data, the type can’t be returned from a function. Using `Response` directly isn’t ideal because we lose `Clone`.

I had to modify a couple lines in the `Cargo.toml` of `axum-extra` in order to get the tests to compile on my machine – just enabling some feature flags.