### PR TITLE
Avoid clone in fallback

### DIFF
--- a/axum/src/routing/mod.rs
+++ b/axum/src/routing/mod.rs
@@ -668,12 +668,12 @@ where
         }
     }
 
-    fn call_with_state(&mut self, req: Request, state: S) -> RouteFuture<E> {
+    fn call_with_state(self, req: Request, state: S) -> RouteFuture<E> {
         match self {
-            Fallback::Default(route) | Fallback::Service(route) => route.oneshot_inner(req),
+            Fallback::Default(route) | Fallback::Service(route) => route.oneshot_inner_owned(req),
             Fallback::BoxedHandler(handler) => {
-                let mut route = handler.clone().into_route(state);
-                route.oneshot_inner(req)
+                let route = handler.clone().into_route(state);
+                route.oneshot_inner_owned(req)
             }
         }
     }

--- a/axum/src/routing/tests/fallback.rs
+++ b/axum/src/routing/tests/fallback.rs
@@ -344,5 +344,5 @@ async fn state_isnt_cloned_too_much_with_fallback() {
 
     client.get("/does-not-exist").await;
 
-    assert_eq!(state.count(), 4);
+    assert_eq!(state.count(), 3);
 }

--- a/axum/src/test_helpers/counting_cloneable_state.rs
+++ b/axum/src/test_helpers/counting_cloneable_state.rs
@@ -1,0 +1,52 @@
+use std::sync::{
+    atomic::{AtomicBool, AtomicUsize, Ordering},
+    Arc,
+};
+
+pub(crate) struct CountingCloneableState {
+    state: Arc<InnerState>,
+}
+
+struct InnerState {
+    setup_done: AtomicBool,
+    count: AtomicUsize,
+}
+
+impl CountingCloneableState {
+    pub(crate) fn new() -> Self {
+        let inner_state = InnerState {
+            setup_done: AtomicBool::new(false),
+            count: AtomicUsize::new(0),
+        };
+        CountingCloneableState {
+            state: Arc::new(inner_state),
+        }
+    }
+
+    pub(crate) fn setup_done(&self) {
+        self.state.setup_done.store(true, Ordering::SeqCst);
+    }
+
+    pub(crate) fn count(&self) -> usize {
+        self.state.count.load(Ordering::SeqCst)
+    }
+}
+
+impl Clone for CountingCloneableState {
+    fn clone(&self) -> Self {
+        let state = self.state.clone();
+        if state.setup_done.load(Ordering::SeqCst) {
+            let bt = std::backtrace::Backtrace::force_capture();
+            let bt = bt
+                .to_string()
+                .lines()
+                .filter(|line| line.contains("axum") || line.contains("./src"))
+                .collect::<Vec<_>>()
+                .join("\n");
+            println!("AppState::Clone:\n===============\n{bt}\n");
+            state.count.fetch_add(1, Ordering::SeqCst);
+        }
+
+        CountingCloneableState { state }
+    }
+}

--- a/axum/src/test_helpers/mod.rs
+++ b/axum/src/test_helpers/mod.rs
@@ -7,6 +7,8 @@ pub(crate) use self::test_client::*;
 
 pub(crate) mod tracing_helpers;
 
+pub(crate) mod counting_cloneable_state;
+
 pub(crate) fn assert_send<T: Send>() {}
 pub(crate) fn assert_sync<T: Sync>() {}
 


### PR DESCRIPTION
The first commit creates test coverage on state clone in fallback.
The second commit removes one clone.

This is an extraction of a part of https://github.com/tokio-rs/axum/pull/2865
