### PR TITLE
Avoid clone in layer

### DIFF
--- a/axum/src/routing/path_router.rs
+++ b/axum/src/routing/path_router.rs
@@ -393,7 +393,7 @@ where
                     Endpoint::MethodRouter(method_router) => {
                         Ok(method_router.call_with_state(req, state))
                     }
-                    Endpoint::Route(route) => Ok(route.clone().call(req)),
+                    Endpoint::Route(route) => Ok(route.clone().call_owned(req)),
                 }
             }
             // explicitly handle all variants in case matchit adds

--- a/axum/src/routing/route.rs
+++ b/axum/src/routing/route.rs
@@ -42,6 +42,12 @@ impl<E> Route<E> {
         ))
     }
 
+    /// Variant of [`Route::call`] that takes ownership of the route to avoid cloning.
+    pub(crate) fn call_owned(self, req: Request<Body>) -> RouteFuture<E> {
+        let req = req.map(Body::new);
+        self.oneshot_inner_owned(req).not_top_level()
+    }
+
     pub(crate) fn oneshot_inner(&mut self, req: Request) -> RouteFuture<E> {
         let method = req.method().clone();
         RouteFuture::new(method, self.0.clone().oneshot(req))

--- a/axum/src/routing/tests/mod.rs
+++ b/axum/src/routing/tests/mod.rs
@@ -942,7 +942,7 @@ async fn state_isnt_cloned_too_much_in_layer() {
 
     client.get("/").await;
 
-    assert_eq!(state.count(), 4);
+    assert_eq!(state.count(), 3);
 }
 
 #[crate::test]

--- a/axum/src/routing/tests/mod.rs
+++ b/axum/src/routing/tests/mod.rs
@@ -3,6 +3,7 @@ use crate::{
     error_handling::HandleErrorLayer,
     extract::{self, DefaultBodyLimit, FromRef, Path, State},
     handler::{Handler, HandlerWithoutStateExt},
+    middleware::{self, Next},
     response::{IntoResponse, Response},
     routing::{
         delete, get, get_service, on, on_service, patch, patch_service,
@@ -922,6 +923,26 @@ async fn state_isnt_cloned_too_much() {
     client.get("/").await;
 
     assert_eq!(state.count(), 3);
+}
+
+#[crate::test]
+async fn state_isnt_cloned_too_much_in_layer() {
+    async fn layer(State(_): State<CountingCloneableState>, req: Request, next: Next) -> Response {
+        next.run(req).await
+    }
+
+    let state = CountingCloneableState::new();
+
+    let app = Router::new().layer(middleware::from_fn_with_state(state.clone(), layer));
+
+    let client = TestClient::new(app);
+
+    // ignore clones made during setup
+    state.setup_done();
+
+    client.get("/").await;
+
+    assert_eq!(state.count(), 4);
 }
 
 #[crate::test]


### PR DESCRIPTION
Part of https://github.com/tokio-rs/axum/pull/2865

The first commit introduces a test to cover the state cloning
The second commit removes one clone