### PR TITLE
Remove `.close()`, and document clean WebSocket closing

### DIFF
--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -13,10 +13,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and `MethodRouter::connect[_service]` ([#2961])
 - **fixed:** Avoid setting `content-length` before middleware ([#2897]).
   This allows middleware to add bodies to requests without needing to manually set `content-length`
+- **breaking:** Remove `WebSocket::close` ([#2974]).
+  Users should explicitly send close messages themselves.
 
 [#2897]: https://github.com/tokio-rs/axum/pull/2897
 [#2984]: https://github.com/tokio-rs/axum/pull/2984
 [#2961]: https://github.com/tokio-rs/axum/pull/2961
+[#2974]: https://github.com/tokio-rs/axum/pull/2974
 
 # 0.8.0
 

--- a/axum/src/extract/ws.rs
+++ b/axum/src/extract/ws.rs
@@ -623,7 +623,7 @@ pub enum Message {
     /// you may still read messages,
     /// but attempts to send another message will error.
     /// After receiving a close frame,
-    /// Axum will automatically respond with a close frame if necessary
+    /// axum will automatically respond with a close frame if necessary
     /// (you do not have to deal with this yourself).
     /// Since no further messages will be received,
     /// you may either do nothing

--- a/axum/src/extract/ws.rs
+++ b/axum/src/extract/ws.rs
@@ -621,12 +621,12 @@ pub enum Message {
     ///
     /// After sending a close frame,
     /// you may still read messages,
-    /// but any attempts to send a message will error.
+    /// but any attempts to send another message will error.
     /// After receiving a close frame,
-    /// the server will automatically respond with a close frame if necessary
+    /// axum will automatically respond with a close frame if necessary
     /// (you do not have to deal with this yourself).
     /// Since no further messages will be received,
-    /// so you may either do nothing
+    /// you may either do nothing
     /// or explicitly drop the connection.
     Close(Option<CloseFrame<'static>>),
 }

--- a/axum/src/extract/ws.rs
+++ b/axum/src/extract/ws.rs
@@ -621,9 +621,9 @@ pub enum Message {
     ///
     /// After sending a close frame,
     /// you may still read messages,
-    /// but any attempts to send another message will error.
+    /// but attempts to send another message will error.
     /// After receiving a close frame,
-    /// axum will automatically respond with a close frame if necessary
+    /// Axum will automatically respond with a close frame if necessary
     /// (you do not have to deal with this yourself).
     /// Since no further messages will be received,
     /// you may either do nothing


### PR DESCRIPTION
## Motivation

The current `.close()` method is mostly useless, because it does not allow sending a close frame and takes ownership of the WebSocket, which even forbids implementing the normal [WebSocket close handshake](https://datatracker.ietf.org/doc/html/rfc6455#section-1.4).

## Solution

Remove `.close()`, and document the behaviour of WebSocket close handshakes.

Closes: #2964
