### PR TITLE
Update changelog

### DIFF
--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -9,14 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **added:** Add `method_not_allowed_fallback` to set a fallback when a path matches but there is no handler for the given HTTP method ([#2903])
 - **added:** Add `NoContent` as a self-described shortcut for `StatusCode::NO_CONTENT` ([#2978])
-- **added:** Add support for WebSockets over HTTP/2 ([#2894]).
-  They can be enabled by changing `get(ws_endpoint)` handlers to `any(ws_endpoint)`
+- **added:** Add support for WebSockets over HTTP/2.
+  They can be enabled by changing `get(ws_endpoint)` handlers to `any(ws_endpoint)` ([#2894])
 - **added:** Add `MethodFilter::CONNECT`, `routing::connect[_service]`
   and `MethodRouter::connect[_service]` ([#2961])
-- **fixed:** Avoid setting `content-length` before middleware ([#2897]).
-  This allows middleware to add bodies to requests without needing to manually set `content-length`
-- **breaking:** Remove `WebSocket::close` ([#2974]).
-  Users should explicitly send close messages themselves.
+- **fixed:** Avoid setting `content-length` before middleware.
+  This allows middleware to add bodies to requests without needing to manually set `content-length` ([#2897])
+- **breaking:** Remove `WebSocket::close`.
+  Users should explicitly send close messages themselves. ([#2974])
 
 [#2897]: https://github.com/tokio-rs/axum/pull/2897
 [#2903]: https://github.com/tokio-rs/axum/pull/2903

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
+- **added:** Add `method_not_allowed_fallback` to set a fallback when a path matches but there is no handler for the given HTTP method ([#2903])
 - **added:** Add `NoContent` as a self-described shortcut for `StatusCode::NO_CONTENT` ([#2978])
 - **added:** Add support for WebSockets over HTTP/2 ([#2894]).
   They can be enabled by changing `get(ws_endpoint)` handlers to `any(ws_endpoint)`
@@ -18,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Users should explicitly send close messages themselves.
 
 [#2897]: https://github.com/tokio-rs/axum/pull/2897
+[#2903]: https://github.com/tokio-rs/axum/pull/2903
 [#2984]: https://github.com/tokio-rs/axum/pull/2984
 [#2961]: https://github.com/tokio-rs/axum/pull/2961
 [#2974]: https://github.com/tokio-rs/axum/pull/2974

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [#2897]: https://github.com/tokio-rs/axum/pull/2897
 [#2903]: https://github.com/tokio-rs/axum/pull/2903
-[#2984]: https://github.com/tokio-rs/axum/pull/2984
+[#2894]: https://github.com/tokio-rs/axum/pull/2894
 [#2961]: https://github.com/tokio-rs/axum/pull/2961
 [#2974]: https://github.com/tokio-rs/axum/pull/2974
 [#2978]: https://github.com/tokio-rs/axum/pull/2978


### PR DESCRIPTION
## Motivation

#2903 was missing a changelog entry.

Some newer changelogs had slightly different formatting to previous entries. I think if the intent was to have a heading with the link and then explanation on another line that would be fine, but the way markdown shows the original version was one line with the link in the middle of it.

## Solution

Added one entry, moved links in other entries and fixed one link.