### PR TITLE
Improve docs regarding state and extensions

### DIFF
--- a/axum/src/docs/routing/with_state.md
+++ b/axum/src/docs/routing/with_state.md
@@ -1,4 +1,5 @@
-Provide the state for the router.
+Provide the state for the router. State passed to this method is global and will be used
+for all requests this router receives. That means it is not suitable for holding state derived from a request, such as authorization data extracted in a middleware. Use [`Extension`] instead for such data.
 
 ```rust
 use axum::{Router, routing::get, extract::State};
@@ -93,13 +94,6 @@ let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await.unwrap();
 axum::serve(listener, routes).await.unwrap();
 # };
 ```
-
-# State is global within the router
-
-The state passed to this method will be used for all requests this router
-receives. That means it is not suitable for holding state derived from a
-request, such as authorization data extracted in a middleware. Use [`Extension`]
-instead for such data.
 
 # What `S` in `Router<S>` means
 

--- a/axum/src/extract/state.rs
+++ b/axum/src/extract/state.rs
@@ -9,8 +9,12 @@ use std::{
 ///
 /// See ["Accessing state in middleware"][state-from-middleware] for how to
 /// access state in middleware.
+/// 
+/// State is global and used in every request a router with state receives.
+/// For accessing data derived from requests, such as authorization data, see [`Extension`].
 ///
 /// [state-from-middleware]: crate::middleware#accessing-state-in-middleware
+/// [`Extension`]: crate::Extension
 ///
 /// # With `Router`
 ///

--- a/axum/src/extract/state.rs
+++ b/axum/src/extract/state.rs
@@ -9,7 +9,7 @@ use std::{
 ///
 /// See ["Accessing state in middleware"][state-from-middleware] for how to
 /// access state in middleware.
-/// 
+///
 /// State is global and used in every request a router with state receives.
 /// For accessing data derived from requests, such as authorization data, see [`Extension`].
 ///


### PR DESCRIPTION
## Motivation
Issue #2917 mentions that it should be easier to discover the documentation for `Extension` from the docs of `State` and vice versa. Indeed, Extension is very easy to miss as it is only mentioned after a couple of examples.

## Solution
This PR updates the docs by 
- moving the section mentioning extensions up in `Router::with_state`
- Adding a short mention of `Extension` to `extract::State`

Closes #2917 