### PR TITLE
chore: fix new clippy lint

### DIFF
--- a/axum-extra/src/extract/cookie/private.rs
+++ b/axum-extra/src/extract/cookie/private.rs
@@ -289,7 +289,7 @@ struct PrivateCookieJarIter<'a, K> {
     iter: cookie::Iter<'a>,
 }
 
-impl<'a, K> Iterator for PrivateCookieJarIter<'a, K> {
+impl<K> Iterator for PrivateCookieJarIter<'_, K> {
     type Item = Cookie<'static>;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/axum-extra/src/extract/cookie/signed.rs
+++ b/axum-extra/src/extract/cookie/signed.rs
@@ -307,7 +307,7 @@ struct SignedCookieJarIter<'a, K> {
     iter: cookie::Iter<'a>,
 }
 
-impl<'a, K> Iterator for SignedCookieJarIter<'a, K> {
+impl<K> Iterator for SignedCookieJarIter<'_, K> {
     type Item = Cookie<'static>;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/axum/src/extract/multipart.rs
+++ b/axum/src/extract/multipart.rs
@@ -107,7 +107,7 @@ pub struct Field<'a> {
     _multipart: &'a mut Multipart,
 }
 
-impl<'a> Stream for Field<'a> {
+impl Stream for Field<'_> {
     type Item = Result<Bytes, MultipartError>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {

--- a/axum/src/routing/mod.rs
+++ b/axum/src/routing/mod.rs
@@ -558,7 +558,7 @@ pub struct RouterAsService<'a, B, S = ()> {
     _marker: PhantomData<B>,
 }
 
-impl<'a, B> Service<Request<B>> for RouterAsService<'a, B, ()>
+impl<B> Service<Request<B>> for RouterAsService<'_, B, ()>
 where
     B: HttpBody<Data = bytes::Bytes> + Send + 'static,
     B::Error: Into<axum_core::BoxError>,
@@ -578,7 +578,7 @@ where
     }
 }
 
-impl<'a, B, S> fmt::Debug for RouterAsService<'a, B, S>
+impl<B, S> fmt::Debug for RouterAsService<'_, B, S>
 where
     S: fmt::Debug,
 {

--- a/axum/src/test_helpers/tracing_helpers.rs
+++ b/axum/src/test_helpers/tracing_helpers.rs
@@ -112,7 +112,7 @@ impl<'a> MakeWriter<'a> for TestMakeWriter {
 
 struct Writer<'a>(&'a TestMakeWriter);
 
-impl<'a> io::Write for Writer<'a> {
+impl io::Write for Writer<'_> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         match &mut *self.0.write.lock().unwrap() {
             Some(vec) => {


### PR DESCRIPTION
## Motivation

`beta` has a new lint about eliding lifetimes in impls.

## Solution

Elided the lifetimes as suggested by clippy.

I've also checked that nightly doesn't trigger any new lints so we should be ok for 3 months again.
