### PR TITLE
Explicit CI runner version

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
     - uses: taiki-e/install-action@protoc
@@ -28,7 +28,7 @@ jobs:
       run: cargo fmt --all --check
 
   check-docs:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@stable
@@ -41,7 +41,7 @@ jobs:
       run: cargo doc --all-features --no-deps
 
   cargo-hack:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
     - uses: taiki-e/install-action@protoc
@@ -56,7 +56,7 @@ jobs:
       run: cargo hack check --each-feature --no-dev-deps --all
 
   cargo-public-api-crates:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         crate: [axum, axum-core, axum-extra, axum-macros]
@@ -80,7 +80,7 @@ jobs:
 
   test-versions:
     needs: check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         rust: [stable, beta]
@@ -99,7 +99,7 @@ jobs:
   # some examples don't support our MSRV so we only test axum itself on our MSRV
   test-nightly:
     needs: check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
     - name: Get rust-toolchain version
@@ -119,7 +119,7 @@ jobs:
   # so we only test axum itself on our MSRV
   test-msrv:
     needs: check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@master
@@ -157,7 +157,7 @@ jobs:
 
   test-docs:
     needs: check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@stable
@@ -169,7 +169,7 @@ jobs:
 
   deny-check:
     name: cargo-deny check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     continue-on-error: ${{ matrix.checks == 'advisories' }}
     strategy:
       matrix:
@@ -185,7 +185,7 @@ jobs:
 
   armv5te-unknown-linux-musleabi:
     needs: check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@stable
@@ -211,7 +211,7 @@ jobs:
 
   wasm32-unknown-unknown:
     needs: check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@stable
@@ -228,7 +228,7 @@ jobs:
         --target wasm32-unknown-unknown
 
   dependencies-are-sorted:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@beta
@@ -247,7 +247,7 @@ jobs:
 
   typos:
     name: Spell Check with Typos
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: github.event_name == 'push' || !github.event.pull_request.draft
 
     steps:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -96,7 +96,7 @@ jobs:
     - name: Run tests
       run: cargo test --workspace --all-features --all-targets
 
-  # some examples doesn't support our MSRV so we only test axum itself on our MSRV
+  # some examples don't support our MSRV so we only test axum itself on our MSRV
   test-nightly:
     needs: check
     runs-on: ubuntu-latest
@@ -115,7 +115,7 @@ jobs:
       working-directory: axum-macros
       run: cargo test
 
-  # some examples doesn't support our MSRV (such as async-graphql)
+  # some examples don't support our MSRV (such as async-graphql)
   # so we only test axum itself on our MSRV
   test-msrv:
     needs: check

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,6 +22,7 @@ jobs:
     - uses: Swatinem/rust-cache@v2
       with:
         save-if: ${{ github.ref == 'refs/heads/main' }}
+        prefix-key: "v0-rust-ubuntu-24.04"
     - name: Check
       run: cargo clippy --workspace --all-targets --all-features -- -D warnings
     - name: rustfmt
@@ -35,6 +36,7 @@ jobs:
     - uses: Swatinem/rust-cache@v2
       with:
         save-if: ${{ github.ref == 'refs/heads/main' }}
+        prefix-key: "v0-rust-ubuntu-24.04"
     - name: cargo doc
       env:
         RUSTDOCFLAGS: "-D rustdoc::all -A rustdoc::private-doc-tests"
@@ -49,6 +51,7 @@ jobs:
     - uses: Swatinem/rust-cache@v2
       with:
         save-if: ${{ github.ref == 'refs/heads/main' }}
+        prefix-key: "v0-rust-ubuntu-24.04"
     - name: Install cargo-hack
       run: |
         curl -LsSf https://github.com/taiki-e/cargo-hack/releases/latest/download/cargo-hack-x86_64-unknown-linux-gnu.tar.gz | tar xzf - -C ~/.cargo/bin
@@ -69,6 +72,7 @@ jobs:
     - uses: Swatinem/rust-cache@v2
       with:
         save-if: ${{ github.ref == 'refs/heads/main' }}
+        prefix-key: "v0-rust-ubuntu-24.04"
     - name: Install cargo-public-api-crates
       run: |
         cargo install --git https://github.com/davidpdrsn/cargo-public-api-crates
@@ -93,6 +97,7 @@ jobs:
     - uses: Swatinem/rust-cache@v2
       with:
         save-if: ${{ github.ref == 'refs/heads/main' }}
+        prefix-key: "v0-rust-ubuntu-24.04"
     - name: Run tests
       run: cargo test --workspace --all-features --all-targets
 
@@ -111,6 +116,7 @@ jobs:
     - uses: Swatinem/rust-cache@v2
       with:
         save-if: ${{ github.ref == 'refs/heads/main' }}
+        prefix-key: "v0-rust-ubuntu-24.04"
     - name: Run nightly tests
       working-directory: axum-macros
       run: cargo test
@@ -130,6 +136,7 @@ jobs:
     - uses: Swatinem/rust-cache@v2
       with:
         save-if: ${{ github.ref == 'refs/heads/main' }}
+        prefix-key: "v0-rust-ubuntu-24.04"
     - name: Select minimal version
       run: cargo +nightly update -Z minimal-versions
     - name: Fix up Cargo.lock
@@ -164,6 +171,7 @@ jobs:
     - uses: Swatinem/rust-cache@v2
       with:
         save-if: ${{ github.ref == 'refs/heads/main' }}
+        prefix-key: "v0-rust-ubuntu-24.04"
     - name: Run doc tests
       run: cargo test --all-features --doc
 
@@ -194,6 +202,7 @@ jobs:
     - uses: Swatinem/rust-cache@v2
       with:
         save-if: ${{ github.ref == 'refs/heads/main' }}
+        prefix-key: "v0-rust-ubuntu-24.04"
     - name: Check
       env:
         # Clang has native cross-compilation support
@@ -220,6 +229,7 @@ jobs:
     - uses: Swatinem/rust-cache@v2
       with:
         save-if: ${{ github.ref == 'refs/heads/main' }}
+        prefix-key: "v0-rust-ubuntu-24.04"
     - name: Check
       run: >
         cargo
@@ -235,6 +245,7 @@ jobs:
     - uses: Swatinem/rust-cache@v2
       with:
         save-if: ${{ github.ref == 'refs/heads/main' }}
+        prefix-key: "v0-rust-ubuntu-24.04"
     - name: Install cargo-sort
       run: |
         cargo install cargo-sort


### PR DESCRIPTION
## Motivation

[Comment with context](https://github.com/tokio-rs/axum/pull/2994#issuecomment-2419223788)

We are currently using `ubuntu-latest` runners which may change and usually do change every two years. This can lead to issues as in #2994 where caches can be reused in a different version of ubuntu which can then break linking.

## Solution

We set the runner version explicitly. This does not prevent similar issue as in the linked PR, but it will happen in the PR that upgrades the runner instead of random other PR that happened to run actions after the change.

I've also included the `ubuntu-24.04` string in the cache key so that the issue doesn't happen again. This makes migration harder because this should be changed when a runner changes and I have not found a good way to deduplicate this because of [this issue](https://github.com/actions/runner/issues/480). But if both strings are correct, we will never use cache with objects built with older libraries.