### PR TITLE
PoC of introducing `FromSpoofableRequestParts` and `Spoofable`

### DIFF
--- a/axum-extra/src/extract/mod.rs
+++ b/axum-extra/src/extract/mod.rs
@@ -26,7 +26,7 @@ pub struct Spoofable<E>(pub E);
 impl<S, E> FromRequestParts<S> for Spoofable<E>
 where
     E: spoof::FromSpoofableRequestParts<S>,
-    S: Sync
+    S: Sync,
 {
     type Rejection = E::Rejection;
 

--- a/axum-extra/src/extract/scheme.rs
+++ b/axum-extra/src/extract/scheme.rs
@@ -1,10 +1,9 @@
 //! Extractor that parses the scheme of a request.
 //! See [`Scheme`] for more details.
 
-use axum::{
-    extract::FromRequestParts,
-    response::{IntoResponse, Response},
-};
+use axum::
+    response::{IntoResponse, Response}
+;
 use http::{
     header::{HeaderMap, FORWARDED},
     request::Parts,
@@ -34,7 +33,7 @@ impl IntoResponse for SchemeMissing {
     }
 }
 
-impl<S> FromRequestParts<S> for Scheme
+impl<S> super::spoof::FromSpoofableRequestParts<S> for Scheme
 where
     S: Send + Sync,
 {
@@ -83,12 +82,12 @@ fn parse_forwarded(headers: &HeaderMap) -> Option<&str> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_helpers::TestClient;
+    use crate::{extract::Spoofable, test_helpers::TestClient};
     use axum::{routing::get, Router};
     use http::header::HeaderName;
 
     fn test_client() -> TestClient {
-        async fn scheme_as_body(Scheme(scheme): Scheme) -> String {
+        async fn scheme_as_body(Spoofable(Scheme(scheme)): Spoofable<Scheme>) -> String {
             scheme
         }
 

--- a/axum-extra/src/extract/scheme.rs
+++ b/axum-extra/src/extract/scheme.rs
@@ -1,9 +1,7 @@
 //! Extractor that parses the scheme of a request.
 //! See [`Scheme`] for more details.
 
-use axum::
-    response::{IntoResponse, Response}
-;
+use axum::response::{IntoResponse, Response};
 use http::{
     header::{HeaderMap, FORWARDED},
     request::Parts,

--- a/examples/spoofable-scheme/Cargo.toml
+++ b/examples/spoofable-scheme/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "spoofable-scheme"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+axum = { path = "../../axum" }
+axum-extra = { path = "../../axum-extra", features = ["scheme"] }
+tokio = { version = "1.0", features = ["full"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+

--- a/examples/spoofable-scheme/src/main.rs
+++ b/examples/spoofable-scheme/src/main.rs
@@ -1,0 +1,40 @@
+//! Example of application using spoofable extractors
+//!
+//! Run with
+//!
+//! ```not_rust
+//! cargo run -p spoofable-scheme
+//! ```
+//!
+//! Test with curl:
+//!
+//! ```not_rust
+//! curl -i http://localhost:3000/ -H "X-Forwarded-Proto: http"
+//! ```
+
+use axum::{routing::get, Router};
+use axum_extra::extract::{Scheme, Spoofable};
+use tokio::net::TcpListener;
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::registry()
+        .with(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| format!("{}=debug", env!("CARGO_CRATE_NAME")).into()),
+        )
+        .with(tracing_subscriber::fmt::layer())
+        .init();
+
+    // build our application with some routes
+    let app = Router::new().route("/", get(f));
+
+    let listener = TcpListener::bind("127.0.0.1:3000").await.unwrap();
+    tracing::debug!("listening on {}", listener.local_addr().unwrap());
+    axum::serve(listener, app).await.unwrap();
+}
+
+async fn f(Spoofable(Scheme(scheme)): Spoofable<Scheme>) -> String {
+    scheme
+}


### PR DESCRIPTION
## Motivation

PoC to check which solution to pick for https://github.com/tokio-rs/axum/issues/2998.
Attempts to come as close to the original idea of extractors as possible, without increasing implementation complexity.

## Solution

Add a new trait `FromSpoofableRequestParts` that is private to `axum-extra`.
This trait is only to be implemented by extractors that read from spoofable portions of HTTP requests.
No extractor should ever implement both `FromSpoofableRequestParts` and `FromRequestsParts`.

A blanket implementation of `FromRequestsParts` is provided by `Spoofable` for all extractors that implement `FromSpoofableRequestParts`, so that reading via destructuring i.e. `Spoofable(Extractor(inner))` can continue to be used in handlers.


```rs
use axum::{routing::get, Router};
use axum_extra::extract::{Scheme, Spoofable};
use tokio::net::TcpListener;

#[tokio::main]
async fn main() {
    let app = Router::new().route("/", get(f));

    let listener = TcpListener::bind("127.0.0.1:3000").await.unwrap();
    axum::serve(listener, app).await.unwrap();
}

async fn f(Spoofable(Scheme(scheme)): Spoofable<Scheme>) -> String {
    scheme
}
```

See `examples/spoofable-scheme` for a short demonstration.