### PR TITLE
Fix missing `post` imports in `router` docs example

### DIFF
--- a/axum/src/docs/routing/route.md
+++ b/axum/src/docs/routing/route.md
@@ -80,7 +80,7 @@ To accept multiple methods for the same route you can add all handlers at the
 same time:
 
 ```rust
-use axum::{Router, routing::{get, delete}, extract::Path};
+use axum::{Router, routing::{get, post, delete}, extract::Path};
 
 let app = Router::new().route(
     "/",
@@ -115,7 +115,7 @@ let app = Router::new()
 # More examples
 
 ```rust
-use axum::{Router, routing::{get, delete}, extract::Path};
+use axum::{Router, routing::{get, post, delete}, extract::Path};
 
 let app = Router::new()
     .route("/", get(root))


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation
When going through the router docs, I noticed that some of the examples were using post but were not importing them (as if the import statement was copy pasted from a section that didn't use `post`).

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution
Add the `post` import into the examples where it is being used.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
