### PR TITLE
Update low-level-rustls example

### DIFF
--- a/examples/low-level-rustls/Cargo.toml
+++ b/examples/low-level-rustls/Cargo.toml
@@ -9,9 +9,8 @@ axum = { path = "../../axum" }
 futures-util = { version = "0.3", default-features = false }
 hyper = { version = "1.0.0", features = ["full"] }
 hyper-util = { version = "0.1" }
-rustls-pemfile = "1.0.4"
 tokio = { version = "1", features = ["full"] }
-tokio-rustls = "0.24.1"
+tokio-rustls = "0.26"
 tower-service = "0.3.2"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/low-level-rustls/src/main.rs
+++ b/examples/low-level-rustls/src/main.rs
@@ -8,16 +8,14 @@ use axum::{extract::Request, routing::get, Router};
 use futures_util::pin_mut;
 use hyper::body::Incoming;
 use hyper_util::rt::{TokioExecutor, TokioIo};
-use rustls_pemfile::{certs, pkcs8_private_keys};
 use std::{
-    fs::File,
-    io::BufReader,
     path::{Path, PathBuf},
     sync::Arc,
 };
 use tokio::net::TcpListener;
 use tokio_rustls::{
-    rustls::{Certificate, PrivateKey, ServerConfig},
+    rustls::pki_types::{pem::PemObject, CertificateDer, PrivateKeyDer},
+    rustls::ServerConfig,
     TlsAcceptor,
 };
 use tower_service::Service;
@@ -95,18 +93,14 @@ async fn handler() -> &'static str {
 }
 
 fn rustls_server_config(key: impl AsRef<Path>, cert: impl AsRef<Path>) -> Arc<ServerConfig> {
-    let mut key_reader = BufReader::new(File::open(key).unwrap());
-    let mut cert_reader = BufReader::new(File::open(cert).unwrap());
+    let key = PrivateKeyDer::from_pem_file(key).unwrap();
 
-    let key = PrivateKey(pkcs8_private_keys(&mut key_reader).unwrap().remove(0));
-    let certs = certs(&mut cert_reader)
+    let certs = CertificateDer::pem_file_iter(cert)
         .unwrap()
-        .into_iter()
-        .map(Certificate)
+        .map(|cert| cert.unwrap())
         .collect();
 
     let mut config = ServerConfig::builder()
-        .with_safe_defaults()
         .with_no_client_auth()
         .with_single_cert(certs, key)
         .expect("bad certificate/key");


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation

- use latest dependency `tokio-rustls`
- remove unused dependency `rustls-pemfile`

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution
I use `tokio::rustls::pki_types` instead of `rustls_pemfile`.
https://github.com/rustls/pemfile/releases/tag/v%2F2.2.0


I remove simply `ConfiguBuilder::with_safe_defaults`.
https://github.com/rustls/rustls/releases/tag/v%2F0.22.0#:~:text=ConfigBuilder%3A%3Awith_safe_defaults%20%2D%20calls%20to%20this%20can%20simply%20be%20deleted%20since%20safe%20defaults%20are%20now%20implicit.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
