### PR TITLE
Remove once_cell from jwt example

### DIFF
--- a/examples/jwt/Cargo.toml
+++ b/examples/jwt/Cargo.toml
@@ -8,7 +8,6 @@ publish = false
 axum = { path = "../../axum" }
 axum-extra = { path = "../../axum-extra", features = ["typed-header"] }
 jsonwebtoken = "9.3"
-once_cell = "1.8"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1.0", features = ["full"] }

--- a/examples/jwt/src/main.rs
+++ b/examples/jwt/src/main.rs
@@ -18,10 +18,10 @@ use axum_extra::{
     TypedHeader,
 };
 use jsonwebtoken::{decode, encode, DecodingKey, EncodingKey, Header, Validation};
-use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::fmt::Display;
+use std::sync::LazyLock;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 // Quick instructions
@@ -50,7 +50,7 @@ use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 //     -H 'Authorization: Bearer blahblahblah' \
 //     http://localhost:3000/protected
 
-static KEYS: Lazy<Keys> = Lazy::new(|| {
+static KEYS: LazyLock<Keys> = LazyLock::new(|| {
     let secret = std::env::var("JWT_SECRET").expect("JWT_SECRET must be set");
     Keys::new(secret.as_bytes())
 });


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->
I think using `std::sync::LazyLock` can reduce dependency `once_cell`.