### PR TITLE
CI: allow `pin-project-lite` in public dependencies

### DIFF
--- a/axum-extra/Cargo.toml
+++ b/axum-extra/Cargo.toml
@@ -100,6 +100,7 @@ allowed = [
     "headers_core",
     "http",
     "http_body",
+    "pin_project_lite",
     "prost",
     "serde",
     "tokio",

--- a/axum/Cargo.toml
+++ b/axum/Cargo.toml
@@ -195,6 +195,7 @@ allowed = [
     "futures_core",
     "futures_sink",
     "futures_util",
+    "pin_project_lite",
     "tower_layer",
     "tower_service",
 


### PR DESCRIPTION
## Motivation

CI is currently failing because our public dependencies seem to include `pin-project-lite`. This seems to have started failing without any changes so it might be one of our previous public dependencies changed something which exposed `pin-project-lite` and it is now visible also from `axum`. But I didn't see any information about where the dependency is exposed or anything like that so this is just an assumption on my part.

## Solution

Allow the public dependency to unblock other PRs by fixing the CI.

It should be noted that if the assumption that we're exposing the project indirectly through another dependency, then it is also potentially exposed in the already released versions with latest transitive dependencies so this PR might be just blessing the current state.

## Future Work

We should consider how we want to handle this in the future. The `cargo-public-api-crates` project doesn't seem to have any maintenance for some time. We can continue using it as a check that we didn't do something unintended and in cases like this we can change the expected set without fully understanding where a dependency comes from. Other options include someone stepping up to help maintain the project and discarding the check.
