### PR TITLE
ECOSYSTEM: add axum-rails-cookie

### DIFF
--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -49,6 +49,7 @@ If your project isn't listed here and you would like it to be, please feel free 
 - [axum-messages](https://github.com/maxcountryman/axum-messages): One-time notification messages for Axum.
 - [spring-rs](https://github.com/spring-rs/spring-rs): spring-rs is a microservice framework written in rust inspired by java's spring-boot, based on axum
 - [zino](https://github.com/zino-rs/zino): Zino is a next-generation framework for composable applications which provides full integrations with axum.
+- [axum-rails-cookie](https://github.com/endoze/axum-rails-cookie): Extract rails session cookies in axum based apps.
 
 ## Project showcase
 


### PR DESCRIPTION
In order to showcase axum-rails-cookie as part of the axum ecosystem, this commit adds it to the ECOSYSTEM.md.
