### PR TITLE
Release axum 0.7.8 and axum-extra 0.9.5

### DIFF
--- a/axum-extra/CHANGELOG.md
+++ b/axum-extra/CHANGELOG.md
@@ -25,6 +25,14 @@ and this project adheres to [Semantic Versioning].
 [#2829]: https://github.com/tokio-rs/axum/pull/2829
 [#2943]: https://github.com/tokio-rs/axum/pull/2943
 
+# 0.9.5
+
+- **added:** Add `RouterExt::typed_connect` ([#2961])
+- **added:** Add `json!` for easy construction of JSON responses ([#2962])
+
+[#2961]: https://github.com/tokio-rs/axum/pull/2961
+[#2962]: https://github.com/tokio-rs/axum/pull/2962
+
 # 0.9.4
 
 - **added:** The `response::Attachment` type ([#2789])

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -49,6 +49,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2931]: https://github.com/tokio-rs/axum/pull/2931
 [#2943]: https://github.com/tokio-rs/axum/pull/2943
 
+# 0.7.8
+
+- **fixed:** Skip SSE incompatible chars of `serde_json::RawValue` in `Event::json_data` ([#2992])
+- **added:** Add `method_not_allowed_fallback` to set a fallback when a path matches but there is no handler for the given HTTP method ([#2903])
+- **added:** Add `MethodFilter::CONNECT`, `routing::connect[_service]`
+  and `MethodRouter::connect[_service]` ([#2961])
+- **added:** Add `NoContent` as a self-described shortcut for `StatusCode::NO_CONTENT` ([#2978])
+
+[#2903]: https://github.com/tokio-rs/axum/pull/2903
+[#2961]: https://github.com/tokio-rs/axum/pull/2961
+[#2978]: https://github.com/tokio-rs/axum/pull/2978
+[#2992]: https://github.com/tokio-rs/axum/pull/2992
+
 # 0.7.7
 
 - **change**: Remove manual tables of content from the documentation, since


### PR DESCRIPTION
The diff on this PR shows what's going to be merged back into main after the release of these two crates. The actual diff is here: https://github.com/tokio-rs/axum/compare/axum-v0.7.7...feee742ca14bcf68b826f304e39f92db5f7d76e5

Of particular note is https://github.com/tokio-rs/axum/commit/0d4e224caeaeeb3b40127c00ffeabd01563d5674, which I've had to change a bunch to work / compile. All the same test adjustments are made though, and the tests pass on the `v0.7.x` branch.

**Do not merge via GitHub UI**

Same release process as [last time](https://github.com/tokio-rs/axum/pull/2940#issuecomment-2379984467), though I also ran tests locally since this PR doesn't actually test the `v0.7.x` branch.