### PR TITLE
fix: avoid setting content-length before middleware (backport)

### DIFF
--- a/axum/src/routing/tests/mod.rs
+++ b/axum/src/routing/tests/mod.rs
@@ -1094,9 +1094,9 @@ async fn middleware_adding_body() {
     let app = Router::new()
         .route("/", get(()))
         .layer(MapResponseLayer::new(|mut res: Response| -> Response {
-            // If there is a content-length header, its value will be zero and Axum will avoid
-            // overwriting it. But this means our content-length doesn’t match the length of the
-            // body, which leads to panics in Hyper. Thus we have to ensure that Axum doesn’t add
+            // If there is a content-length header, its value will be zero and axum will avoid
+            // overwriting it. But this means our content-length doesn't match the length of the
+            // body, which leads to panics in Hyper. Thus we have to ensure that axum doesn't add
             // on content-length headers until after middleware has been run.
             assert!(!res.headers().contains_key("content-length"));
             *res.body_mut() = "…".into();

--- a/axum/src/routing/tests/mod.rs
+++ b/axum/src/routing/tests/mod.rs
@@ -1087,3 +1087,23 @@ async fn locks_mutex_very_little() {
         assert_eq!(num, 1);
     }
 }
+
+
+#[crate::test]
+async fn middleware_adding_body() {
+    let app = Router::new()
+        .route("/", get(()))
+        .layer(MapResponseLayer::new(|mut res: Response| -> Response {
+            // If there is a content-length header, its value will be zero and Axum will avoid
+            // overwriting it. But this means our content-length doesn’t match the length of the
+            // body, which leads to panics in Hyper. Thus we have to ensure that Axum doesn’t add
+            // on content-length headers until after middleware has been run.
+            assert!(!res.headers().contains_key("content-length"));
+            *res.body_mut() = "…".into();
+            res
+        }));
+
+    let client = TestClient::new(app);
+    let res = client.get("/").await;
+    assert_eq!(res.text().await, "…");
+}

--- a/axum/src/routing/tests/mod.rs
+++ b/axum/src/routing/tests/mod.rs
@@ -1088,7 +1088,6 @@ async fn locks_mutex_very_little() {
     }
 }
 
-
 #[crate::test]
 async fn middleware_adding_body() {
     let app = Router::new()


### PR DESCRIPTION
Backports #2897.