### PR TITLE
Release axum 0.7.9 and axum-extra 0.9.6

### DIFF
--- a/axum-extra/CHANGELOG.md
+++ b/axum-extra/CHANGELOG.md
@@ -25,6 +25,12 @@ and this project adheres to [Semantic Versioning].
 [#2829]: https://github.com/tokio-rs/axum/pull/2829
 [#2943]: https://github.com/tokio-rs/axum/pull/2943
 
+# 0.9.6
+
+- **docs:** Add links to features table ([#3030])
+
+[#3030]: https://github.com/tokio-rs/axum/pull/3030
+
 # 0.9.5
 
 - **added:** Add `RouterExt::typed_connect` ([#2961])

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -49,6 +49,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2931]: https://github.com/tokio-rs/axum/pull/2931
 [#2943]: https://github.com/tokio-rs/axum/pull/2943
 
+# 0.7.9
+
+- **fixed:** Avoid setting content-length before middleware ([#3031])
+
+[#3031]:https://github.com/tokio-rs/axum/pull/3031
+
 # 0.7.8
 
 - **fixed:** Skip SSE incompatible chars of `serde_json::RawValue` in `Event::json_data` ([#2992])


### PR DESCRIPTION
The diff on this PR shows what's going to be merged back into main after the release of these two crates. The actual diff is here: https://github.com/tokio-rs/axum/compare/axum-v0.7.8...9983bc1da460becd3a0f08c513d610411e84dd43

**Do not merge via GitHub UI**

Release log:

- [x] Update the changelogs and Cargo.toml's on the right branch
- [x] Make a PR to merge those version changes back into main (this)
- [x] Wait for PR to be approved and CI succeeding
- [x] Run cargo publish in the right order
- [x] Create git tags
- [ ] Create GitHub releases
- [ ] Merge the PR