### PR TITLE
axum/routing: Add `content-length` header assertions to `middleware_adding_body` test

### DIFF
--- a/axum/src/routing/tests/mod.rs
+++ b/axum/src/routing/tests/mod.rs
@@ -1091,5 +1091,11 @@ async fn middleware_adding_body() {
 
     let client = TestClient::new(app);
     let res = client.get("/").await;
+
+    let headers = res.headers();
+    let header = headers.get("content-length");
+    assert!(header.is_some());
+    assert_eq!(header.unwrap().to_str().unwrap(), "3");
+
     assert_eq!(res.text().await, "…");
 }


### PR DESCRIPTION
I noticed in our crates.io test suite, that the `content-length` header was no longer set on responses after [the latest update](https://github.com/rust-lang/crates.io/pull/9969) and wondered if https://github.com/tokio-rs/axum/pull/2897 had broken it. I quickly extended the corresponding test to check, and it looks like everything is fine.

> I noticed in our crates.io test suite, that the `content-length` header was no longer set on responses

We are using `router.oneshot(request).await` over there, which seems to have changed behavior due to the PR linked above. The axum test suite is using real `reqwest` calls though, which don't appear to show the same behavior.