### PR TITLE
Don't panic when array type is used for path segment

### DIFF
--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # Unreleased
 
 - **fixed:** Skip SSE incompatible chars of `serde_json::RawValue` in `Event::json_data` ([#2992])
+- **fixed:** Don't panic when array type is used for path segment ([#3039])
 - **breaking:** Move `Host` extractor to `axum-extra` ([#2956])
 - **added:** Add `method_not_allowed_fallback` to set a fallback when a path matches but there is no handler for the given HTTP method ([#2903])
 - **added:** Add `NoContent` as a self-described shortcut for `StatusCode::NO_CONTENT` ([#2978])
@@ -32,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2978]: https://github.com/tokio-rs/axum/pull/2978
 [#2992]: https://github.com/tokio-rs/axum/pull/2992
 [#2720]: https://github.com/tokio-rs/axum/pull/2720
+[#3039]: https://github.com/tokio-rs/axum/pull/3039
 
 # 0.8.0
 

--- a/axum/src/extract/path/de.rs
+++ b/axum/src/extract/path/de.rs
@@ -454,9 +454,11 @@ impl<'de> Deserializer<'de> for ValueDeserializer<'de> {
                     Some(KeyOrIdx::Idx { idx: _, key }) => {
                         return seed.deserialize(KeyDeserializer { key }).map(Some);
                     }
-                    // `KeyOrIdx::Key` is only used when deserializing maps so `deserialize_seq`
-                    // wouldn't be called for that
-                    Some(KeyOrIdx::Key(_)) => unreachable!(),
+                    Some(KeyOrIdx::Key(_)) => {
+                        return Err(PathDeserializationError::custom(
+                            "array types are not supported",
+                        ));
+                    }
                     None => {}
                 };
 

--- a/axum/src/extract/path/mod.rs
+++ b/axum/src/extract/path/mod.rs
@@ -973,4 +973,25 @@ mod tests {
             r#"Invalid URL: Cannot parse `res` with value `456456-123-456456`: UUID parsing failed: invalid group count: expected 5, found 3"#
         );
     }
+
+    #[crate::test]
+    async fn regression_3038() {
+        #[derive(Deserialize)]
+        #[allow(dead_code)]
+        struct MoreChars {
+            first_two: [char; 2],
+            second_two: [char; 2],
+            crate_name: String,
+        }
+
+        let app = Router::new().route(
+            "/{first_two}/{second_two}/{crate_name}",
+            get(|Path(_): Path<MoreChars>| async move {}),
+        );
+
+        let client = TestClient::new(app);
+        let res = client.get("/te/st/_thing").await;
+        let body = res.text().await;
+        assert_eq!(body, r#"Invalid URL: array types are not supported"#);
+    }
 }


### PR DESCRIPTION
## Motivation

Closes #3038.

## Solution

Return a deserialization error instead of panicking.