### PR TITLE
Add Attachment type in features documentation

### DIFF
--- a/axum-extra/src/lib.rs
+++ b/axum-extra/src/lib.rs
@@ -10,6 +10,7 @@
 //! Name | Description | Default?
 //! ---|---|---
 //! `async-read-body` | Enables the [`AsyncReadBody`](crate::body::AsyncReadBody) body | No
+//! `attachment` | Enables the [`Attachment`](crate::response::Attachment) response | No
 //! `cookie` | Enables the [`CookieJar`](crate::extract::CookieJar) extractor | No
 //! `cookie-private` | Enables the [`PrivateCookieJar`](crate::extract::PrivateCookieJar) extractor | No
 //! `cookie-signed` | Enables the [`SignedCookieJar`](crate::extract::SignedCookieJar) extractor | No


### PR DESCRIPTION
## Motivation
In #2789 I added an `Attachment` response type but forgot to add this feature to the docs.