### PR TITLE
Simplify todos_index in todos example

### DIFF
--- a/examples/todos/src/main.rs
+++ b/examples/todos/src/main.rs
@@ -82,13 +82,8 @@ pub struct Pagination {
     pub limit: Option<usize>,
 }
 
-async fn todos_index(
-    pagination: Option<Query<Pagination>>,
-    State(db): State<Db>,
-) -> impl IntoResponse {
+async fn todos_index(pagination: Query<Pagination>, State(db): State<Db>) -> impl IntoResponse {
     let todos = db.read().unwrap();
-
-    let Query(pagination) = pagination.unwrap_or_default();
 
     let todos = todos
         .values()


### PR DESCRIPTION
## Motivation

Show people the simple way to do it, not something with needless extra steps.

## Solution

Don't wrap `Query` in `Option`. This just guards against invalid parameters, but it makes more sense to return an error on invalid parameters, rather than assume the default for all parameters.

Proof that it works:

```
% curl -i http://localhost:3000/todos
HTTP/1.1 200 OK
content-type: application/json
content-length: 2
date: Tue, 26 Nov 2024 17:08:42 GMT

[]
```