### PR TITLE
Fix PrivateCookieJar documentation example comments

### DIFF
--- a/axum-extra/src/extract/cookie/private.rs
+++ b/axum-extra/src/extract/cookie/private.rs
@@ -48,11 +48,11 @@ use std::{convert::Infallible, fmt, marker::PhantomData};
 /// // our application state
 /// #[derive(Clone)]
 /// struct AppState {
-///     // that holds the key used to sign cookies
+///     // that holds the key used to encrypt cookies
 ///     key: Key,
 /// }
 ///
-/// // this impl tells `SignedCookieJar` how to access the key from our state
+/// // this impl tells `PrivateCookieJar` how to access the key from our state
 /// impl FromRef<AppState> for Key {
 ///     fn from_ref(state: &AppState) -> Self {
 ///         state.key.clone()


### PR DESCRIPTION
Update PrivateCookieJar documentation example comments to reflect that key is used for encryption and not signing.

## Motivation
I was looking for a way to encrypt cookies and looked at PrivateCookieJar but got confused that the examples talked about signing. This probably snuck in when copying the documentation from SignedCookieJar as they are similar.

## Solution
Updated comments in example code to reflect what PrivateCookieJar does.
