### PR TITLE
Remove multipart from axum-extra' default features

### DIFF
--- a/axum-extra/CHANGELOG.md
+++ b/axum-extra/CHANGELOG.md
@@ -8,10 +8,12 @@ and this project adheres to [Semantic Versioning].
 # Unreleased
 
 - **fixed:** `Host` extractor includes port number when parsing authority ([#2242])
+- **changed:** The `multipart` feature is no longer on by default ([#3058])
 - **added:** Add `RouterExt::typed_connect` ([#2961])
 - **added:** Add `json!` for easy construction of JSON responses ([#2962])
 
 [#2242]: https://github.com/tokio-rs/axum/pull/2242
+[#3058]: https://github.com/tokio-rs/axum/pull/3058
 [#2961]: https://github.com/tokio-rs/axum/pull/2961
 [#2962]: https://github.com/tokio-rs/axum/pull/2962
 

--- a/axum-extra/Cargo.toml
+++ b/axum-extra/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/tokio-rs/axum"
 version = "0.10.0-alpha.1"
 
 [features]
-default = ["tracing", "multipart"]
+default = ["tracing"]
 
 async-read-body = ["dep:tokio-util", "tokio-util?/io", "dep:tokio"]
 attachment = ["dep:tracing"]


### PR DESCRIPTION
Not sure why it was enabled by default, it was even documented as off-by-default.