### PR TITLE
Make ConnectInfo work with ListenerExt::tap_io

### DIFF
--- a/axum/src/extract/connect_info.rs
+++ b/axum/src/extract/connect_info.rs
@@ -92,6 +92,17 @@ const _: () = {
             *stream.remote_addr()
         }
     }
+
+    impl<'a, L, F> Connected<serve::IncomingStream<'a, serve::TapIo<L, F>>> for L::Addr
+    where
+        L: serve::Listener,
+        L::Addr: Clone + Sync + 'static,
+        F: FnMut(&mut L::Io) + Send + 'static,
+    {
+        fn connect_info(stream: serve::IncomingStream<'a, serve::TapIo<L, F>>) -> Self {
+            stream.remote_addr().clone()
+        }
+    }
 };
 
 impl Connected<SocketAddr> for SocketAddr {

--- a/axum/src/serve/listener.rs
+++ b/axum/src/serve/listener.rs
@@ -102,7 +102,7 @@ impl<L: Listener> ListenerExt for L {}
 /// Return type of [`ListenerExt::tap_io`].
 ///
 /// See that method for details.
-pub struct TapIo<L: Listener, F> {
+pub struct TapIo<L, F> {
     listener: L,
     tap_fn: F,
 }


### PR DESCRIPTION
Fixes #3056.

I tried various ways of making the existing tokio-feature-flagged `Connected` impl generic over `Listener` instead. It worked but unfortunately stopped the legit `Connected` impl in the UDS example from compiling due to coherence. I could bypass that with a dummy generic parameter, but I don't think it's worth it.