### PR TITLE
Fix: documentation link to passing state

### DIFF
--- a/axum/src/extension.rs
+++ b/axum/src/extension.rs
@@ -132,7 +132,7 @@ where
 
 /// Middleware for adding some shareable value to [request extensions].
 ///
-/// See [Sharing state with handlers](index.html#sharing-state-with-handlers)
+/// See [Passing state from middleware to handlers](index.html#passing-state-from-middleware-to-handlers)
 /// for more details.
 ///
 /// [request extensions]: https://docs.rs/http/latest/http/struct.Extensions.html


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation
The documentation link for passing state to handlers in AddExtension was linking to a section in middleware documentation that does not exist anymore. 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution
Linked to https://docs.rs/axum/latest/axum/middleware/index.html#passing-state-from-middleware-to-handlers instead which looks like the right section.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
