### PR TITLE
Simplify `TestClient` implementation

### DIFF
--- a/axum/src/test_helpers/test_client.rs
+++ b/axum/src/test_helpers/test_client.rs
@@ -1,10 +1,7 @@
 use super::{serve, Request, Response};
 use bytes::Bytes;
 use futures_util::future::BoxFuture;
-use http::{
-    header::{HeaderName, HeaderValue},
-    StatusCode,
-};
+use http::header::{HeaderName, HeaderValue};
 use std::ops::Deref;
 use std::{convert::Infallible, future::IntoFuture, net::SocketAddr};
 use tokio::net::TcpListener;
@@ -169,10 +166,6 @@ impl TestResponse {
         T: serde::de::DeserializeOwned,
     {
         self.response.json().await.unwrap()
-    }
-
-    pub(crate) fn status(&self) -> StatusCode {
-        StatusCode::from_u16(self.response.status().as_u16()).unwrap()
     }
 
     pub(crate) fn headers(&self) -> http::HeaderMap {

--- a/axum/src/test_helpers/test_client.rs
+++ b/axum/src/test_helpers/test_client.rs
@@ -5,6 +5,7 @@ use http::{
     header::{HeaderName, HeaderValue},
     StatusCode,
 };
+use std::ops::Deref;
 use std::{convert::Infallible, future::IntoFuture, net::SocketAddr};
 use tokio::net::TcpListener;
 use tower::make::Shared;
@@ -142,6 +143,14 @@ impl IntoFuture for RequestBuilder {
 #[derive(Debug)]
 pub(crate) struct TestResponse {
     response: reqwest::Response,
+}
+
+impl Deref for TestResponse {
+    type Target = reqwest::Response;
+
+    fn deref(&self) -> &Self::Target {
+        &self.response
+    }
 }
 
 impl TestResponse {

--- a/axum/src/test_helpers/test_client.rs
+++ b/axum/src/test_helpers/test_client.rs
@@ -168,10 +168,6 @@ impl TestResponse {
         self.response.json().await.unwrap()
     }
 
-    pub(crate) fn headers(&self) -> http::HeaderMap {
-        self.response.headers().clone()
-    }
-
     pub(crate) async fn chunk(&mut self) -> Option<Bytes> {
         self.response.chunk().await.unwrap()
     }


### PR DESCRIPTION
## Motivation

While working on some other stuff, I noticed that the `TestClient` implementation in the `axum` crate could be simplified a little bit …

## Solution

… by taking advantage of the `Deref` trait.