### PR TITLE
ci: Use updated fork of cargo-public-api-crates

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -65,22 +65,16 @@ jobs:
         crate: [axum, axum-core, axum-extra, axum-macros]
     steps:
     - uses: actions/checkout@v4
-    # Pinned version due to failing `cargo-public-api-crates`.
-    - uses: dtolnay/rust-toolchain@master
-      with:
-        toolchain: nightly-2024-06-06
+    - uses: dtolnay/rust-toolchain@nightly
     - uses: Swatinem/rust-cache@v2
       with:
         save-if: ${{ github.ref == 'refs/heads/main' }}
         prefix-key: "v0-rust-ubuntu-24.04"
     - name: Install cargo-public-api-crates
       run: |
-        cargo install --git https://github.com/davidpdrsn/cargo-public-api-crates
-    - name: Build rustdoc
-      run: |
-        cargo rustdoc --all-features --manifest-path ${{ matrix.crate }}/Cargo.toml -- -Z unstable-options --output-format json
+        cargo install --git https://github.com/jplatte/cargo-public-api-crates
     - name: cargo public-api-crates check
-      run: cargo public-api-crates --manifest-path ${{ matrix.crate }}/Cargo.toml --skip-build check
+      run: cargo public-api-crates --manifest-path ${{ matrix.crate }}/Cargo.toml check
 
   test-versions:
     needs: check

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target
 Cargo.lock
 .DS_Store
+.vscode


### PR DESCRIPTION
So we no longer need to pin an old nightly.