### PR TITLE
CI: Remove seemingly unused `patch.toml` file

### DIFF
--- a/.github/workflows/patch.toml
+++ b/.github/workflows/patch.toml
@@ -1,4 +1,0 @@
-# Patch dependencies to run all tests against versions of the crate in the
-# repository.
-[patch.crates-io]
-axum = { path = "axum" }


### PR DESCRIPTION
This file was added [when the initial repo was set up](https://github.com/tokio-rs/axum/commit/002e3f92b322fd6a9241d1c6fed36fc15604ef28), but it was never referenced anywhere and neither `actions-rs/toolchain`, nor `actions-rs/cargo`, nor `dtolnay/rust-toolchain` seem to be using this file implicitly either.
