### PR TITLE
clippy: Merge config files

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,1 +1,4 @@
 allow-mixed-uninlined-format-args = false
+disallowed-types = [
+    { path = "tower::util::BoxCloneService", reason = "Use our internal BoxCloneService which is Sync" },
+]

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,3 +1,0 @@
-disallowed-types = [
-    { path = "tower::util::BoxCloneService", reason = "Use our internal BoxCloneService which is Sync" },
-]


### PR DESCRIPTION
The content of `.clippy.toml` was unintentionally overriding the contents of `clippy.toml` 😅

Related:

- https://doc.rust-lang.org/clippy/configuration.html