### PR TITLE
axum-core/macros: Change `$body` to require `literal` token

### DIFF
--- a/axum-core/src/macros.rs
+++ b/axum-core/src/macros.rs
@@ -38,7 +38,7 @@ macro_rules! __log_rejection {
 macro_rules! __define_rejection {
     (
         #[status = $status:ident]
-        #[body = $body:expr]
+        #[body = $body:literal]
         $(#[$m:meta])*
         pub struct $name:ident;
     ) => {
@@ -89,7 +89,7 @@ macro_rules! __define_rejection {
 
     (
         #[status = $status:ident]
-        #[body = $body:expr]
+        #[body = $body:literal]
         $(#[$m:meta])*
         pub struct $name:ident (Error);
     ) => {


### PR DESCRIPTION
Having this be an `expr` will not actually work with our usage of e.g. `concat!`.

