### PR TITLE
feature: add `get_route_paths` to `path_router`

### DIFF
--- a/axum/src/routing/mod.rs
+++ b/axum/src/routing/mod.rs
@@ -328,6 +328,11 @@ where
         })
     }
 
+    /// List routes that the router contains.
+    pub fn get_route_paths(&self) -> Vec<Arc<str>> {
+        self.inner.path_router.get_route_paths()
+    }
+
     /// True if the router currently has at least one route added.
     pub fn has_routes(&self) -> bool {
         self.inner.path_router.has_routes()

--- a/axum/src/routing/path_router.rs
+++ b/axum/src/routing/path_router.rs
@@ -341,7 +341,7 @@ where
     }
 
     pub(super) fn get_route_paths(&self) -> Vec<Arc<str>> {
-        self.node.path_to_route_id.keys().into_iter().map(Arc::clone).collect()
+        self.node.path_to_route_id.keys().map(Arc::clone).collect()
     }
 
     pub(super) fn has_routes(&self) -> bool {

--- a/axum/src/routing/path_router.rs
+++ b/axum/src/routing/path_router.rs
@@ -340,6 +340,10 @@ where
         }
     }
 
+    pub(super) fn get_route_paths(&self) -> Vec<Arc<str>> {
+        self.node.path_to_route_id.keys().into_iter().map(Arc::clone).collect()
+    }
+
     pub(super) fn has_routes(&self) -> bool {
         !self.routes.is_empty()
     }


### PR DESCRIPTION
Added a `get_route_paths` method to the `path_router` to return a `Vec` of the current paths associated with a router.

## Motivation

There was a desire to create this feature to support logging frameworks that base their logging off the raw path rather than the path at time of request. I specifically am working on building a client for Apitally in Rust and wanted to support the Axum framework first. I will now be able to supply a list of the applications paths to Apitally. I can see a future where other frameworks desire this functionality as well!

## Solution

The paths are already stored in the `path_to_route_id` of the `path_router`. The `RouteId` is not strictly useful in this scenario and is also private. This implementation grabs the keys of `path_to_route_id` and collects them into a `Vec`.
