### PR TITLE
CI: Remove obsolete `prefix-key` attributes for `rust-cache` action

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,7 +21,6 @@ jobs:
     - uses: Swatinem/rust-cache@v2
       with:
         save-if: ${{ github.ref == 'refs/heads/main' }}
-        prefix-key: "v0-rust-ubuntu-24.04"
     - name: Check
       run: cargo clippy --workspace --all-targets --all-features -- -D warnings
     - name: rustfmt
@@ -35,7 +34,6 @@ jobs:
     - uses: Swatinem/rust-cache@v2
       with:
         save-if: ${{ github.ref == 'refs/heads/main' }}
-        prefix-key: "v0-rust-ubuntu-24.04"
     - name: cargo doc
       env:
         RUSTDOCFLAGS: "-D rustdoc::all -A rustdoc::private-doc-tests"
@@ -52,7 +50,6 @@ jobs:
     - uses: Swatinem/rust-cache@v2
       with:
         save-if: ${{ github.ref == 'refs/heads/main' }}
-        prefix-key: "v0-rust-ubuntu-24.04"
     - name: Install cargo-hack
       run: |
         curl -LsSf https://github.com/taiki-e/cargo-hack/releases/latest/download/cargo-hack-x86_64-unknown-linux-gnu.tar.gz | tar xzf - -C ~/.cargo/bin
@@ -70,7 +67,6 @@ jobs:
     - uses: Swatinem/rust-cache@v2
       with:
         save-if: ${{ github.ref == 'refs/heads/main' }}
-        prefix-key: "v0-rust-ubuntu-24.04"
     - name: Install cargo-public-api-crates
       run: |
         cargo install --git https://github.com/jplatte/cargo-public-api-crates
@@ -91,7 +87,6 @@ jobs:
     - uses: Swatinem/rust-cache@v2
       with:
         save-if: ${{ github.ref == 'refs/heads/main' }}
-        prefix-key: "v0-rust-ubuntu-24.04"
     - name: Run tests
       run: cargo test --workspace --all-features --all-targets
 
@@ -110,7 +105,6 @@ jobs:
     - uses: Swatinem/rust-cache@v2
       with:
         save-if: ${{ github.ref == 'refs/heads/main' }}
-        prefix-key: "v0-rust-ubuntu-24.04"
     - name: Run nightly tests
       working-directory: axum-macros
       run: cargo test
@@ -130,7 +124,6 @@ jobs:
     - uses: Swatinem/rust-cache@v2
       with:
         save-if: ${{ github.ref == 'refs/heads/main' }}
-        prefix-key: "v0-rust-ubuntu-24.04"
     - name: Select minimal version
       run: cargo +nightly update -Z minimal-versions
     - name: Fix up Cargo.lock
@@ -165,7 +158,6 @@ jobs:
     - uses: Swatinem/rust-cache@v2
       with:
         save-if: ${{ github.ref == 'refs/heads/main' }}
-        prefix-key: "v0-rust-ubuntu-24.04"
     - name: Run doc tests
       run: cargo test --all-features --doc
 
@@ -196,7 +188,6 @@ jobs:
     - uses: Swatinem/rust-cache@v2
       with:
         save-if: ${{ github.ref == 'refs/heads/main' }}
-        prefix-key: "v0-rust-ubuntu-24.04"
     - name: Check
       env:
         # Clang has native cross-compilation support
@@ -223,7 +214,6 @@ jobs:
     - uses: Swatinem/rust-cache@v2
       with:
         save-if: ${{ github.ref == 'refs/heads/main' }}
-        prefix-key: "v0-rust-ubuntu-24.04"
     - name: Check
       run: >
         cargo
@@ -239,7 +229,6 @@ jobs:
     - uses: Swatinem/rust-cache@v2
       with:
         save-if: ${{ github.ref == 'refs/heads/main' }}
-        prefix-key: "v0-rust-ubuntu-24.04"
     - name: Install cargo-sort
       run: |
         cargo install cargo-sort


### PR DESCRIPTION
These were added by https://github.com/tokio-rs/axum/pull/2996 to avoid sharing caches between OS versions.
This is now built into rust-cache by default (see https://github.com/Swatinem/rust-cache/pull/220).

