### PR TITLE
Implement `OptionalFromRequest` for the Json extractor

### DIFF
--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
-- **added:** `OptionalFromRequest` impl for `Json`.
+- **added:** Implement `OptionalFromRequest` for `Json` ([#3142])
+
+[#3142]: https://github.com/tokio-rs/axum/pull/3142
 
 # 0.8.0
 

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
+- **added:** `OptionalFromRequest` impl for `Json`.
+
 # 0.8.0
 
 ## since rc.1

--- a/axum/src/extract/rejection.rs
+++ b/axum/src/extract/rejection.rs
@@ -39,16 +39,6 @@ define_rejection! {
     pub struct MissingJsonContentType;
 }
 
-#[cfg(feature = "json")]
-define_rejection! {
-    #[status = BAD_REQUEST]
-    #[body = "Expected non-empty request body for `Content-Type: application/json`"]
-    #[cfg_attr(docsrs, doc(cfg(feature = "json")))]
-    /// Rejection type for [`Json`](super::Json) used if the request body
-    /// is empty.
-    pub struct EmptyJsonBody;
-}
-
 define_rejection! {
     #[status = INTERNAL_SERVER_ERROR]
     #[body = "Missing request extension"]
@@ -143,7 +133,6 @@ composite_rejection! {
     pub enum JsonRejection {
         JsonDataError,
         JsonSyntaxError,
-        EmptyJsonBody,
         MissingJsonContentType,
         BytesRejection,
     }

--- a/axum/src/extract/rejection.rs
+++ b/axum/src/extract/rejection.rs
@@ -39,6 +39,16 @@ define_rejection! {
     pub struct MissingJsonContentType;
 }
 
+#[cfg(feature = "json")]
+define_rejection! {
+    #[status = BAD_REQUEST]
+    #[body = "Expected non-empty request body for `Content-Type: application/json`"]
+    #[cfg_attr(docsrs, doc(cfg(feature = "json")))]
+    /// Rejection type for [`Json`](super::Json) used if the request body
+    /// is empty.
+    pub struct EmptyJsonBody;
+}
+
 define_rejection! {
     #[status = INTERNAL_SERVER_ERROR]
     #[body = "Missing request extension"]
@@ -133,6 +143,7 @@ composite_rejection! {
     pub enum JsonRejection {
         JsonDataError,
         JsonSyntaxError,
+        EmptyJsonBody,
         MissingJsonContentType,
         BytesRejection,
     }

--- a/axum/src/json.rs
+++ b/axum/src/json.rs
@@ -1,5 +1,6 @@
 use crate::extract::Request;
 use crate::extract::{rejection::*, FromRequest};
+use axum_core::extract::OptionalFromRequest;
 use axum_core::response::{IntoResponse, Response};
 use bytes::{BufMut, Bytes, BytesMut};
 use http::{
@@ -108,6 +109,27 @@ where
             Self::from_bytes(&bytes)
         } else {
             Err(MissingJsonContentType.into())
+        }
+    }
+}
+
+impl<T, S> OptionalFromRequest<S> for Json<T>
+where
+    T: DeserializeOwned,
+    S: Send + Sync,
+{
+    type Rejection = JsonRejection;
+
+    async fn from_request(req: Request, state: &S) -> Result<Option<Self>, Self::Rejection> {
+        if json_content_type(req.headers()) {
+            let bytes = Bytes::from_request(req, state).await?;
+            if !bytes.is_empty() {
+                Ok(Some(Self::from_bytes(&bytes)?))
+            } else {
+                Ok(None)
+            }
+        } else {
+            Ok(None)
         }
     }
 }

--- a/axum/src/json.rs
+++ b/axum/src/json.rs
@@ -125,8 +125,7 @@ where
         let bytes = Bytes::from_request(req, state).await?;
 
         match (is_json, bytes.is_empty()) {
-            (true, true) => Err(EmptyJsonBody.into()),
-            (true, false) => Ok(Some(Json::from_bytes(&bytes)?)),
+            (true, _) => Ok(Some(Json::from_bytes(&bytes)?)),
             (false, true) => Ok(None),
             (false, false) => Err(MissingJsonContentType.into()),
         }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

I want to receive requests with an empty body when using the Json extractor without the request getting rejected. I saw that `OptionalFromRequest` has been implemented for `Query` and `Path` and I think this is quite useful to have as it allows me to do something like:

```rs
pub async fn create(
    State(account_service): State<Arc<AccountService>>,
    Path(name): Path<String>,
    WithRejection(payload, _): WithRejection<Option<Json<CreateRequest>>, ServiceError>,
) -> Result<impl IntoResponse, ServiceError> {
...

    let Json(payload) = payload.unwrap_or_default();
...
}
```


## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Implement `OptionalFromRequest` for the Json extractor.

I have tested that this works locally for myself. I don't know if this is absolutely the right way/per standards of how something like this should be approached for axum. However very quick change, so I thought I'd open a PR. Please correct me if I am wrong anywhere, I'll be happy to make any changes/close the PR if not in plans!
