### PR TITLE
axum: fix new formatting string clippy lint

### DIFF
--- a/axum/src/extract/path/mod.rs
+++ b/axum/src/extract/path/mod.rs
@@ -978,8 +978,8 @@ mod tests {
         );
 
         let client = TestClient::new(app);
-        let res = client.get("/resources/123123-123-123123").await;
-        let body = res.text().await;
+        let response = client.get("/resources/123123-123-123123").await;
+        let body = response.text().await;
         assert_eq!(
             body,
             "Invalid URL: Cannot parse `res` with value `123123-123-123123`: UUID parsing failed: invalid group count: expected 5, found 3"
@@ -999,8 +999,8 @@ mod tests {
         );
 
         let client = TestClient::new(app);
-        let res = client.get("/resources/456456-123-456456/sub/123").await;
-        let body = res.text().await;
+        let response = client.get("/resources/456456-123-456456/sub/123").await;
+        let body = response.text().await;
         assert_eq!(
             body,
             "Invalid URL: Cannot parse `res` with value `456456-123-456456`: UUID parsing failed: invalid group count: expected 5, found 3"


### PR DESCRIPTION
## Motivation

New default clippy lint warns about static strings which seem to be formatting strings when variables with the same name are in scope. See example of failed pipeline [here](https://github.com/tokio-rs/axum/actions/runs/12675287129/job/35325966125).

## Solution

Rename two variables so that the lint is not triggered.