### PR TITLE
Add ability to set read_buffer_size for websockets

### DIFF
--- a/axum/src/extract/ws.rs
+++ b/axum/src/extract/ws.rs
@@ -152,6 +152,12 @@ impl<F> std::fmt::Debug for WebSocketUpgrade<F> {
 }
 
 impl<F> WebSocketUpgrade<F> {
+    /// Read buffer capacity. The default value is 128 KiB.
+    pub fn read_buffer_size(mut self, size: usize) -> Self {
+        self.config.read_buffer_size = size;
+        self
+    }
+
     /// The target minimum size of the write buffer to reach before writing the data
     /// to the underlying stream.
     ///


### PR DESCRIPTION
## Motivation

https://github.com/snapview/tungstenite-rs/pull/468 changed the read buffer from 64KB to 128KB. It also added a method `read_buffer_size` so the read buffer size can be set. Currently there is no way to my knowledge so that Axum users can change the read buffer size. 

After upgrading to axum 0.8 I noticed increased memory usage for my Websocket server and I assume the high read buffer is contributing to this. Since my websocket only receives small messages I would like to set it to something smaller than 128KB.

## Solution
Added `WebsocketUpgrade::read_buffer_size` so that the read buffer size can be set.
