### PR TITLE
axum: update changelog with the last released version

### DIFF
--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#3157]: https://github.com/tokio-rs/axum/pull/3157
 [#3168]: https://github.com/tokio-rs/axum/pull/3168
 
+# 0.8.1
+
+There are only documentation changes.
+
 # 0.8.0
 
 ## since rc.1


### PR DESCRIPTION

## Motivation

Closes #3175 

The last version is not present in the changelog. It does not have any relevant changes though, it exists just so that README was updated on crates.io.

## Solution

Explicitly state that there are no changes.