### PR TITLE
Implement the OptionalFromRequestParts trait for the Host extractor

### DIFF
--- a/axum-extra/src/extract/host.rs
+++ b/axum-extra/src/extract/host.rs
@@ -171,10 +171,7 @@ mod tests {
     async fn ip4_uri_host() {
         let mut parts = Request::new(()).into_parts().0;
         parts.uri = "https://127.0.0.1:1234/image.jpg".parse().unwrap();
-        let host =
-            <Host as axum::extract::FromRequestParts<_>>::from_request_parts(&mut parts, &())
-                .await
-                .unwrap();
+        let host = parts.extract::<Host>().await.unwrap();
         assert_eq!(host.0, "127.0.0.1:1234");
     }
 
@@ -182,21 +179,14 @@ mod tests {
     async fn ip6_uri_host() {
         let mut parts = Request::new(()).into_parts().0;
         parts.uri = "http://cool:user@[::1]:456/file.txt".parse().unwrap();
-        let host =
-            <Host as axum::extract::FromRequestParts<_>>::from_request_parts(&mut parts, &())
-                .await
-                .unwrap();
-
+        let host = parts.extract::<Host>().await.unwrap();
         assert_eq!(host.0, "[::1]:456");
     }
 
     #[crate::test]
     async fn missing_host() {
         let mut parts = Request::new(()).into_parts().0;
-        let host =
-            <Host as axum::extract::FromRequestParts<_>>::from_request_parts(&mut parts, &())
-                .await
-                .unwrap_err();
+        let host = parts.extract::<Host>().await.unwrap_err();
         assert!(matches!(host, HostRejection::FailedToResolveHost(_)));
     }
 
@@ -204,20 +194,14 @@ mod tests {
     async fn optional_extractor() {
         let mut parts = Request::new(()).into_parts().0;
         parts.uri = "https://127.0.0.1:1234/image.jpg".parse().unwrap();
-        let host = Option::<Host>::from_request_parts(&mut parts, &())
-            .await
-            .unwrap();
-
+        let host = parts.extract::<Option<Host>>().await.unwrap();
         assert!(host.is_some());
     }
 
     #[crate::test]
     async fn optional_extractor_none() {
         let mut parts = Request::new(()).into_parts().0;
-        let host = Option::<Host>::from_request_parts(&mut parts, &())
-            .await
-            .unwrap();
-
+        let host = parts.extract::<Option<Host>>().await.unwrap();
         assert!(host.is_none());
     }
 

--- a/axum-extra/src/extract/host.rs
+++ b/axum-extra/src/extract/host.rs
@@ -203,7 +203,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert!(matches!(host, Some(Host(_))));
+        assert!(host.is_some());
     }
 
     #[crate::test]
@@ -213,7 +213,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert!(matches!(host, None));
+        assert!(host.is_none());
     }
 
     #[test]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

Fixes: #3170 

## Motivation

To allow for `Option<Host>` extractors we need to implement the OptionalFromRequestParts trait for it.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

Implement OptionalFromRequestParts for the Host Extractor
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
