### PR TITLE
exposing read_buffer_size

### DIFF
--- a/axum/src/extract/ws.rs
+++ b/axum/src/extract/ws.rs
@@ -152,6 +152,12 @@ impl<F> std::fmt::Debug for WebSocketUpgrade<F> {
 }
 
 impl<F> WebSocketUpgrade<F> {
+    /// Read buffer capacity. The default value is 128KiB
+    pub fn read_buffer_size(mut self, size: usize) -> Self {
+        self.config.read_buffer_size = size;
+        self
+    }
+
     /// The target minimum size of the write buffer to reach before writing the data
     /// to the underlying stream.
     ///


### PR DESCRIPTION
The default `ws` `read_buffer_size` is 128KB which is quite big.
Exposing a method to enable changing it by the user.
Did some comparisons and without it, 10K connections takes about 1.3GB, changing the buffer to 1024 versus the default 128K drops down to 40MB.

https://github.com/ohaddahan/rust-websockets
