### PR TITLE
Update low-level-rustls example - added http2 feature flag

### DIFF
--- a/examples/low-level-rustls/Cargo.toml
+++ b/examples/low-level-rustls/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 axum = { path = "../../axum" }
 futures-util = { version = "0.3", default-features = false }
 hyper = { version = "1.0.0", features = ["full"] }
-hyper-util = { version = "0.1" }
+hyper-util = { version = "0.1", features = ["http2"] }
 tokio = { version = "1", features = ["full"] }
 tokio-rustls = "0.26"
 tower-service = "0.3.2"


### PR DESCRIPTION
## Motivation

- Upon starting example server and running curl request as specified, request fails and server logs warning "HTTP/2 is not supported".

## Solution

- added "http2" feature flag to hyper-util, which is required feature in order to utilize HTTP2.
