### PR TITLE
Drop unused use in doctests

### DIFF
--- a/axum-core/src/extract/default_body_limit.rs
+++ b/axum-core/src/extract/default_body_limit.rs
@@ -103,7 +103,6 @@ impl DefaultBodyLimit {
     ///     extract::DefaultBodyLimit,
     /// };
     /// use tower_http::limit::RequestBodyLimitLayer;
-    /// use http_body_util::Limited;
     ///
     /// let app: Router<()> = Router::new()
     ///     .route("/", get(|body: Bytes| async {}))
@@ -137,8 +136,6 @@ impl DefaultBodyLimit {
     ///     body::{Bytes, Body},
     ///     extract::DefaultBodyLimit,
     /// };
-    /// use tower_http::limit::RequestBodyLimitLayer;
-    /// use http_body_util::Limited;
     ///
     /// let app: Router<()> = Router::new()
     ///     .route("/", get(|body: Bytes| async {}))


### PR DESCRIPTION
## Motivation

On first glance, the doctest and documentation suggest that these `use`s are necessary. But they are not and only distract from the actual demonstration.

## Solution

Drop unused `use`s.
