### PR TITLE
ci: Remove condition from typos job

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -248,4 +248,4 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Check the spelling of the files in our repo
-        uses: crate-ci/typos@v1.28.4
+        uses: crate-ci/typos@v1.29.4

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -242,7 +242,6 @@ jobs:
   typos:
     name: Spell Check with Typos
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || !github.event.pull_request.draft
 
     steps:
       - name: Checkout Actions Repository


### PR DESCRIPTION
This condition is kind of broken: Un-drafting a PR does not make the job run. I think the only solution to that is making the entire workflow (re-)trigger on draft status change, which seems overkill. I suppose we could split this job out into its own workflow file to make that less costly, but I'm skeptical about skipping this for draft PRs in the first place.