### PR TITLE
feat: Add `302 Found` redirect method

### DIFF
--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -11,10 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **added:** Implement `OptionalFromRequest` for `Extension` ([#3157])
 - **changed:** Make the `status` function of rejections a `const` function, such
   as `JsonRejection`, `QueryRejection` and `PathRejection` ([#3168])
+- **added:** Add `302 Found` redirect method to `Redirect` ([#3197])
 
 [#3142]: https://github.com/tokio-rs/axum/pull/3142
 [#3157]: https://github.com/tokio-rs/axum/pull/3157
 [#3168]: https://github.com/tokio-rs/axum/pull/3168
+[#3197]: https://github.com/tokio-rs/axum/pull/3197
 
 # 0.8.1
 

--- a/axum/src/response/redirect.rs
+++ b/axum/src/response/redirect.rs
@@ -25,6 +25,21 @@ pub struct Redirect {
 }
 
 impl Redirect {
+    /// Create a new [`Redirect`] that uses a [`302 Found`][mdn] status code.
+    ///
+    /// This redirect should be used for temporary redirects where the original HTTP method should not be preserved for the
+    /// subsequent redirect request, which is the case for [`Redirect::temporary`].
+    /// Clients will use the `GET` method for the subsequent redirection request.
+    ///
+    /// # Panics
+    ///
+    /// If `uri` isn't a valid [`HeaderValue`].
+    ///
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/302
+    pub fn found(uri: &str) -> Self {
+        Self::with_status_code(StatusCode::FOUND, uri)
+    }
+
     /// Create a new [`Redirect`] that uses a [`303 See Other`][mdn] status code.
     ///
     /// This redirect instructs the client to change the method to GET for the subsequent request


### PR DESCRIPTION
## Motivation

In the HTTP handler I am implementing with Axum, I have the use case for doing redirects with [`302 Found`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/302) HTTP status code. The use case is for temporary redirects where the subsequent HTTP method should always be `GET`.


## Solution

This PR adds a new method to `axum::response::Redirect` to create redirects with the `302` HTTP status code.
