### PR TITLE
feat: Add `struct Accepted` as a shortcut

### DIFF
--- a/axum/src/response/mod.rs
+++ b/axum/src/response/mod.rs
@@ -84,6 +84,31 @@ impl IntoResponse for NoContent {
     }
 }
 
+/// An empty response with 202 Accepted status.
+///
+/// Due to historical and implementation reasons, the `IntoResponse` implementation of `()`
+/// (unit type) returns an empty response with 200 [`StatusCode::OK`] status.
+/// If you specifically want a 202 [`StatusCode::ACCEPTED`] status, you can use either `StatusCode` type
+/// directly, or this shortcut struct for self-documentation.
+///
+/// ```
+/// use axum::{extract::Path, response::Accepted};
+///
+/// async fn delete_user(Path(user): Path<String>) -> Result<Accepted, String> {
+///     // ...access database...
+/// # drop(user);
+///     Ok(Accepted)
+/// }
+/// ```
+#[derive(Debug, Clone, Copy)]
+pub struct Accepted;
+
+impl IntoResponse for Accepted {
+    fn into_response(self) -> Response {
+        StatusCode::ACCEPTED.into_response()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::extract::Extension;
@@ -254,6 +279,14 @@ mod tests {
         assert_eq!(
             super::NoContent.into_response().status(),
             StatusCode::NO_CONTENT,
+        )
+    }
+
+    #[test]
+    fn accepted() {
+        assert_eq!(
+            super::Accepted.into_response().status(),
+            StatusCode::ACCEPTED,
         )
     }
 }


### PR DESCRIPTION
Similar to https://github.com/tokio-rs/axum/pull/2978 I am adding a struct for the Accepted response

## Motivation

We have a server that we have to trigger a request and it needs to return `Accepted`. Since there is already a shortcut for `No Content`, I thought of adding a similar one for `Accepted`

## Solution

Adding the additional stuct for shortcut, instead of having to define it always in my code 