### PR TITLE
Add information about the meaning of `Router<S>` to `Router` documentation

### DIFF
--- a/axum/src/routing/mod.rs
+++ b/axum/src/routing/mod.rs
@@ -60,8 +60,10 @@ pub(crate) struct RouteId(u32);
 /// The router type for composing handlers and services.
 ///
 /// `Router<S>` means a router that is _missing_ a state of type `S` to be able
-/// to handle requests. Thus, only `Router<()>` (i.e. without missing state) can be
-/// passed to [`axum::serve()`]. See [`Router::with_state()`] for more details.
+/// to handle requests. Thus, only `Router<()>` (i.e. without missing state) can
+/// be passed to [`serve()`]. See [`Router::with_state()`] for more details.
+///
+/// [`serve()`]: crate::serve()
 #[must_use]
 pub struct Router<S = ()> {
     inner: Arc<RouterInner<S>>,

--- a/axum/src/routing/mod.rs
+++ b/axum/src/routing/mod.rs
@@ -63,7 +63,7 @@ pub(crate) struct RouteId(u32);
 /// to handle requests. Thus, only `Router<()>` (i.e. without missing state) can
 /// be passed to [`serve`]. See [`Router::with_state`] for more details.
 ///
-/// [`serve`]: crate::serve
+/// [`serve`]: crate::serve()
 #[must_use]
 pub struct Router<S = ()> {
     inner: Arc<RouterInner<S>>,

--- a/axum/src/routing/mod.rs
+++ b/axum/src/routing/mod.rs
@@ -61,9 +61,9 @@ pub(crate) struct RouteId(u32);
 ///
 /// `Router<S>` means a router that is _missing_ a state of type `S` to be able
 /// to handle requests. Thus, only `Router<()>` (i.e. without missing state) can
-/// be passed to [`serve()`]. See [`Router::with_state()`] for more details.
+/// be passed to [`serve`]. See [`Router::with_state`] for more details.
 ///
-/// [`serve()`]: crate::serve()
+/// [`serve`]: crate::serve
 #[must_use]
 pub struct Router<S = ()> {
     inner: Arc<RouterInner<S>>,

--- a/axum/src/routing/mod.rs
+++ b/axum/src/routing/mod.rs
@@ -58,6 +58,10 @@ macro_rules! panic_on_err {
 pub(crate) struct RouteId(u32);
 
 /// The router type for composing handlers and services.
+///
+/// `Router<S>` means a router that is _missing_ a state of type `S` to be able
+/// to handle requests. Thus, only `Router<()>` (i.e. without missing state) can be
+/// passed to [`axum::serve()`]. See [`Router::with_state()`] for more details.
 #[must_use]
 pub struct Router<S = ()> {
     inner: Arc<RouterInner<S>>,


### PR DESCRIPTION
## Motivation

The meaning of `S` in `Router<S>` can be easily misunderstood,
and the explanation is well-hidden in `Router::with_state()` documentation.

See:
- https://github.com/tokio-rs/axum/discussions/1602
- https://github.com/tokio-rs/axum/discussions/2083
- https://github.com/tokio-rs/axum/discussions/2564
- https://github.com/tokio-rs/axum/discussions/3218
- https://github.com/tokio-rs/axum/issues/1592
- https://github.com/tokio-rs/axum/issues/2412

## Solution

Add proper information to `Router<S>` documentation, that is much more visible to the framework user than a section in `Router::with_state(..)` documentation.
