### PR TITLE
fix TypedHeader link in FromRequestParts doc comment

### DIFF
--- a/axum-core/src/extract/request_parts.rs
+++ b/axum-core/src/extract/request_parts.rs
@@ -53,7 +53,7 @@ where
 ///
 /// Prefer using [`TypedHeader`] to extract only the headers you need.
 ///
-/// [`TypedHeader`]: https://docs.rs/axum/0.8/axum/extract/struct.TypedHeader.html
+/// [`TypedHeader`]: https://docs.rs/axum-extra/latest/axum_extra/struct.TypedHeader.html
 impl<S> FromRequestParts<S> for HeaderMap
 where
     S: Send + Sync,


### PR DESCRIPTION
The TypedHeader struct no longer lives in axum but has been moved to axum-extra, so update this dead link


(Not sure having a link is really required tbh, also this updates the version from a hardcoded number to latest so please let me know if you have any preference)