### PR TITLE
Implement `From<Bytes>` for `Message`

### DIFF
--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# Unreleased
+
+- **added:** Implement `From<Bytes>` for `Message` ([#3273])
+
+[#3273]: https://github.com/tokio-rs/axum/pull/3273
+
 # 0.8.2
 
 - **added:** Implement `OptionalFromRequest` for `Json` ([#3142])

--- a/axum/src/extract/ws.rs
+++ b/axum/src/extract/ws.rs
@@ -858,6 +858,12 @@ impl<'b> From<&'b [u8]> for Message {
     }
 }
 
+impl From<Bytes> for Message {
+    fn from(data: Bytes) -> Self {
+        Message::Binary(data)
+    }
+}
+
 impl From<Vec<u8>> for Message {
     fn from(data: Vec<u8>) -> Self {
         Message::Binary(data.into())


### PR DESCRIPTION
## Motivation

Implementation `From<Bytes>` for `Message` is missing.

The internal representation of the binary message is `Bytes`. It would be convenient to have related `From` implementation, especially for application code that is designed to work with `Bytes` as opposed to `Vec<u8>`.

## Solution

Added an implement `From<Bytes>` for `Message`.
