### PR TITLE
Expose Router::call_with_state

### DIFF
--- a/axum/src/boxed.rs
+++ b/axum/src/boxed.rs
@@ -121,7 +121,7 @@ where
     }
 
     fn call_with_state(self: Box<Self>, request: Request, state: S) -> RouteFuture<Infallible> {
-        self.router.call_with_state(request, state)
+        self.router.call_with_state_inner(request, state)
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation
See #3279.

## Solution
Rename the existing non-generic `call_with_state` function and add a publicly exposed, generic wrapper around it.