### PR TITLE
Simplify Handler async blocks

### DIFF
--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -8,8 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # Unreleased
 
 - **added:** Implement `From<Bytes>` for `Message` ([#3273])
+- **changed:** Improved code size / compile time of `Handler` implementations ([#3285])
 
 [#3273]: https://github.com/tokio-rs/axum/pull/3273
+[#3285]: https://github.com/tokio-rs/axum/pull/3285
 
 # 0.8.2
 


### PR DESCRIPTION
For our internal codebase, this significantly decreases the amount of LLVM IR generated for these (as measured by https://github.com/dtolnay/cargo-llvm-lines):

- `<F as axum::handler::Handler<(M,T1,T2,T3),S>>::call::{{closure}}`
  from 29046 to 22078 lines across 52 instantiations
- `<F as axum::handler::Handler<(M,T1,T2,T3,T4),S>>::call::{{closure}}`
  from 30383 to 23077 lines across 46 instantiations
- `<F as axum::handler::Handler<(M,T1,T2,T3,T4,T5),S>>::call::{{closure}}`
  from 29754 to 22586 lines across 39 instantiations
