### PR TITLE
Release axum 0.8.3 and related crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,7 +302,7 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "anyhow",
  "axum-core",
@@ -349,7 +349,7 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "axum",
  "axum-extra",
@@ -373,7 +373,7 @@ dependencies = [
 
 [[package]]
 name = "axum-extra"
-version = "0.11.0"
+version = "0.10.1"
 dependencies = [
  "axum",
  "axum-core",

--- a/axum-core/CHANGELOG.md
+++ b/axum-core/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# 0.5.2
+
+- **added:** Implement `Stream::size_hint` for `BodyDataStream` ([#3195])
+
+[#3195]: https://github.com/tokio-rs/axum/pull/3195
+
 # 0.5.1
 
 Yanked from crates.io due to unforeseen breaking change, see [#3190] for details.

--- a/axum-core/Cargo.toml
+++ b/axum-core/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 name = "axum-core"
 readme = "README.md"
 repository = "https://github.com/tokio-rs/axum"
-version = "0.5.1" # remember to bump the version that axum and axum-extra depend on
+version = "0.5.2" # remember to bump the version that axum and axum-extra depend on
 
 [features]
 tracing = ["dep:tracing"]

--- a/axum-extra/CHANGELOG.md
+++ b/axum-extra/CHANGELOG.md
@@ -5,18 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog],
 and this project adheres to [Semantic Versioning].
 
-# Unreleased
-
-- **fixed:** Fix a broken link in the documentation of `ErasedJson` ([#3186])
-- **added:** Add `vpath!` for compile time path verification on static paths. ([#3288])
-
-[#3186]: https://github.com/tokio-rs/axum/pull/3186
-
 # 0.11.0
 
 Yanked from crates.io due to unforeseen breaking change, see [#3190] for details.
 
 [#3190]: https://github.com/tokio-rs/axum/pull/3190
+
+# 0.10.1
+
+- **fixed:** Fix a broken link in the documentation of `ErasedJson` ([#3186])
+- **added:** Add `vpath!` for compile time path verification on static paths. ([#3288])
+
+[#3186]: https://github.com/tokio-rs/axum/pull/3186
+[#3288]: https://github.com/tokio-rs/axum/pull/3288
 
 # 0.10.0
 

--- a/axum-extra/Cargo.toml
+++ b/axum-extra/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 name = "axum-extra"
 readme = "README.md"
 repository = "https://github.com/tokio-rs/axum"
-version = "0.11.0"
+version = "0.10.1"
 
 [features]
 default = ["tracing"]
@@ -49,8 +49,8 @@ __private_docs = [
 ]
 
 [dependencies]
-axum = { path = "../axum", version = "0.8.2", default-features = false, features = ["original-uri"] }
-axum-core = { path = "../axum-core", version = "0.5.1" }
+axum = { path = "../axum", version = "0.8.3", default-features = false, features = ["original-uri"] }
+axum-core = { path = "../axum-core", version = "0.5.2" }
 bytes = "1.1.0"
 futures-util = { version = "0.3", default-features = false, features = ["alloc"] }
 http = "1.0.0"

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -5,16 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-# Unreleased
+# 0.8.3
 
 - **added:** Implement `From<Bytes>` for `Message` ([#3273])
 - **added:** Implement `OptionalFromRequest` for `Json` ([#3142])
 - **added:** Implement `OptionalFromRequest` for `Extension` ([#3157])
+- **added:** Allow setting the read buffer capacity of `WebSocketUpgrade` ([#3178])
 - **changed:** Improved code size / compile time of dependent crates ([#3285], ([#3294]))
 
 [#3273]: https://github.com/tokio-rs/axum/pull/3273
 [#3142]: https://github.com/tokio-rs/axum/pull/3142
 [#3157]: https://github.com/tokio-rs/axum/pull/3157
+[#3178]: https://github.com/tokio-rs/axum/pull/3178
 [#3285]: https://github.com/tokio-rs/axum/pull/3285
 [#3294]: https://github.com/tokio-rs/axum/pull/3294
 

--- a/axum/Cargo.toml
+++ b/axum/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axum"
-version = "0.8.2" # remember to bump the version that axum-extra depends on
+version = "0.8.3" # remember to bump the version that axum-extra depends on
 categories = ["asynchronous", "network-programming", "web-programming::http-server"]
 description = "Web framework that focuses on ergonomics and modularity"
 edition = "2021"
@@ -50,7 +50,7 @@ __private_docs = [
 __private = ["tokio", "http1", "dep:reqwest"]
 
 [dependencies]
-axum-core = { path = "../axum-core", version = "0.5.1" }
+axum-core = { path = "../axum-core", version = "0.5.2" }
 bytes = "1.0"
 futures-util = { version = "0.3", default-features = false, features = ["alloc"] }
 http = "1.0.0"


### PR DESCRIPTION
Release log (to be done post merge):

- [ ] Run cargo publish in the right order
- [ ] Create git tags
- [ ] Create GitHub releases