### PR TITLE
Bring back no-op async-stream feature for axum-extra

### DIFF
--- a/axum-extra/CHANGELOG.md
+++ b/axum-extra/CHANGELOG.md
@@ -7,12 +7,8 @@ and this project adheres to [Semantic Versioning].
 
 # Unreleased
 
-- **breaking:** Remove unused `async-stream` feature, which was accidentally
-  introduced as an implicit feature through an optional dependency which was no
-  longer being used ([#3145])
 - **fixed:** Fix a broken link in the documentation of `ErasedJson` ([#3186])
 
-[#3145]: https://github.com/tokio-rs/axum/pull/3145
 [#3186]: https://github.com/tokio-rs/axum/pull/3186
 
 # 0.11.0

--- a/axum-extra/Cargo.toml
+++ b/axum-extra/Cargo.toml
@@ -15,6 +15,7 @@ version = "0.11.0"
 default = ["tracing"]
 
 async-read-body = ["dep:tokio-util", "tokio-util?/io", "dep:tokio"]
+async-stream = [] # unused, remove before the next breaking-change release
 file-stream = ["dep:tokio-util", "tokio-util?/io", "dep:tokio", "tokio?/fs", "tokio?/io-util"]
 attachment = ["dep:tracing"]
 error-response = ["dep:tracing", "tracing/std"]


### PR DESCRIPTION
The next release does not have to be a breaking-change release.
