### PR TITLE
Further downstream code size improvements

### DIFF
--- a/axum/src/json.rs
+++ b/axum/src/json.rs
@@ -209,28 +209,34 @@ where
     T: Serialize,
 {
     fn into_response(self) -> Response {
+        // Extracted into separate fn so it's only compiled once for all T.
+        fn make_response(buf: BytesMut, ser_result: serde_json::Result<()>) -> Response {
+            match ser_result {
+                Ok(()) => (
+                    [(
+                        header::CONTENT_TYPE,
+                        HeaderValue::from_static(mime::APPLICATION_JSON.as_ref()),
+                    )],
+                    buf.freeze(),
+                )
+                    .into_response(),
+                Err(err) => (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    [(
+                        header::CONTENT_TYPE,
+                        HeaderValue::from_static(mime::TEXT_PLAIN_UTF_8.as_ref()),
+                    )],
+                    err.to_string(),
+                )
+                    .into_response(),
+            }
+        }
+
         // Use a small initial capacity of 128 bytes like serde_json::to_vec
         // https://docs.rs/serde_json/1.0.82/src/serde_json/ser.rs.html#2189
         let mut buf = BytesMut::with_capacity(128).writer();
-        match serde_json::to_writer(&mut buf, &self.0) {
-            Ok(()) => (
-                [(
-                    header::CONTENT_TYPE,
-                    HeaderValue::from_static(mime::APPLICATION_JSON.as_ref()),
-                )],
-                buf.into_inner().freeze(),
-            )
-                .into_response(),
-            Err(err) => (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                [(
-                    header::CONTENT_TYPE,
-                    HeaderValue::from_static(mime::TEXT_PLAIN_UTF_8.as_ref()),
-                )],
-                err.to_string(),
-            )
-                .into_response(),
-        }
+        let res = serde_json::to_writer(&mut buf, &self.0);
+        make_response(buf.into_inner(), res)
     }
 }
 


### PR DESCRIPTION
## Motivation

Help code size and compile times of downstream crates.

## Solution

Extract some non-generic functionality out of generic `IntoResponse` and `FromRequest` impls (and related fns).