### PR TITLE
Fix new clippy lints

### DIFF
--- a/axum-extra/src/json_lines.rs
+++ b/axum-extra/src/json_lines.rs
@@ -110,7 +110,7 @@ where
         // so we can call `AsyncRead::lines` and then convert it back to a `Stream`
         let body = req.into_body();
         let stream = body.into_data_stream();
-        let stream = stream.map_err(|err| io::Error::new(io::ErrorKind::Other, err));
+        let stream = stream.map_err(io::Error::other);
         let read = StreamReader::new(stream);
         let lines_stream = LinesStream::new(read.lines());
 

--- a/axum-extra/src/response/error_response.rs
+++ b/axum-extra/src/response/error_response.rs
@@ -41,11 +41,11 @@ impl<T: Error + 'static> IntoResponse for InternalServerError<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::io::{Error, ErrorKind};
+    use std::io::Error;
 
     #[test]
     fn internal_server_error() {
-        let response = InternalServerError(Error::new(ErrorKind::Other, "Test")).into_response();
+        let response = InternalServerError(Error::other("Test")).into_response();
         assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
     }
 }

--- a/axum/src/middleware/map_request.rs
+++ b/axum/src/middleware/map_request.rs
@@ -366,6 +366,7 @@ mod private {
 /// This trait is sealed such that it cannot be implemented outside this crate.
 pub trait IntoMapRequestResult<B>: private::Sealed<B> {
     /// Perform the conversion.
+    #[allow(clippy::result_large_err)]
     fn into_map_request_result(self) -> Result<Request<B>, Response>;
 }
 

--- a/axum/src/routing/path_router.rs
+++ b/axum/src/routing/path_router.rs
@@ -367,6 +367,7 @@ where
         }
     }
 
+    #[allow(clippy::result_large_err)]
     pub(super) fn call_with_state(
         &self,
         #[cfg_attr(not(feature = "original-uri"), allow(unused_mut))] mut req: Request,

--- a/axum/src/test_helpers/tracing_helpers.rs
+++ b/axum/src/test_helpers/tracing_helpers.rs
@@ -120,10 +120,7 @@ impl io::Write for Writer<'_> {
                 vec.extend(buf);
                 Ok(len)
             }
-            None => Err(io::Error::new(
-                io::ErrorKind::Other,
-                "inner writer has been taken",
-            )),
+            None => Err(io::Error::other("inner writer has been taken")),
         }
     }
 

--- a/examples/stream-to-file/src/main.rs
+++ b/examples/stream-to-file/src/main.rs
@@ -111,7 +111,7 @@ where
 
     async {
         // Convert the stream into an `AsyncRead`.
-        let body_with_io_error = stream.map_err(|err| io::Error::new(io::ErrorKind::Other, err));
+        let body_with_io_error = stream.map_err(io::Error::other);
         let body_reader = StreamReader::new(body_with_io_error);
         futures::pin_mut!(body_reader);
 


### PR DESCRIPTION
The `result_large_err` lint cases don't seem hugely important. Though if somebody wants to propose a fix for them, feel free to look into it (but I'd expect some light benchmarking if you want to introduce extra boxes).