### PR TITLE
add missing track_caller to PathRouter method

### DIFF
--- a/axum/src/routing/path_router.rs
+++ b/axum/src/routing/path_router.rs
@@ -80,6 +80,7 @@ where
         self.v7_checks = false;
     }
 
+    #[track_caller]
     pub(super) fn route(
         &mut self,
         path: &str,

--- a/axum/src/routing/path_router.rs
+++ b/axum/src/routing/path_router.rs
@@ -160,6 +160,7 @@ where
             .map_err(|err| format!("Invalid route {path:?}: {err}"))
     }
 
+    #[track_caller]
     pub(super) fn merge(
         &mut self,
         other: PathRouter<S, IS_FALLBACK>,


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation
Make internal panics to return the actual offending line instead of redirecting to somewhere inside the library.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->
```rs
pub fn product() -> axum::Router<()> {
    use axum::routing::post;
    axum::Router::new()
        .route("/", post(|| async {}))
        .route("/", post(|| async {}))
         // The resulting message for panic location will display somewhere 
         // internal in the library instead of the user's offendin line.
}
```
## Solution

Add the missing `#[track_caller]` attribute in the call stack (?)
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
