### PR TITLE
Update `route.md` to avoid the confusion of applying a `method_router` for a `path`

### DIFF
--- a/axum/src/docs/routing/route.md
+++ b/axum/src/docs/routing/route.md
@@ -4,7 +4,8 @@ Add another route to the router.
 can be either static, a capture, or a wildcard.
 
 `method_router` is the [`MethodRouter`] that should receive the request if the
-path matches `path`. `method_router` will commonly be a handler wrapped in a method
+path matches `path`.  
+`method_router` will commonly be a handler wrapped in a method
 router like [`get`]. See [`handler`](crate::handler) for more details on handlers.
 
 # Static paths

--- a/axum/src/docs/routing/route.md
+++ b/axum/src/docs/routing/route.md
@@ -4,8 +4,7 @@ Add another route to the router.
 can be either static, a capture, or a wildcard.
 
 `method_router` is the [`MethodRouter`] that should receive the request if the
-path matches `path`.  
-`method_router` will commonly be a handler wrapped in a method
+path matches `path`. Usually, `method_router` will be a handler wrapped in a method
 router like [`get`]. See [`handler`](crate::handler) for more details on handlers.
 
 # Static paths


### PR DESCRIPTION
# Problem
Confusing a "period"`.` for an end of line to a continuation of a function. (e.g. path.someOtherFunc)

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

As I was trying to understand the syntax of how to apply RESTful actions to a route, I couldn't grasp this part for 5 minutes. Then I realized the dot is a period instead of the continuation of a function.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

~~Added line break for `path`. `method_router`~~
From the examination of building the doc locally, a line break that uses two spaces at the end, along with a sigle line break works. However, as suggested by @mladedav, Rephrasing the setence is much easier to understand.

Therefore, changing the setence to "Usually, `method_router` will be..."

to avoid confusing it as 

`path.method_router`
