### PR TITLE
Fix recursive call leading to stack overflow when tracing level filter is `TRACE`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -407,6 +407,7 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+ "tracing-subscriber",
  "typed-json",
 ]
 

--- a/axum-extra/Cargo.toml
+++ b/axum-extra/Cargo.toml
@@ -92,6 +92,8 @@ serde_json = "1.0.71"
 tokio = { version = "1.14", features = ["full"] }
 tower = { version = "0.5.2", features = ["util"] }
 tower-http = { version = "0.6.0", features = ["map-response-body", "timeout"] }
+tracing = "0.1.37"
+tracing-subscriber = "0.3.19"
 
 [lints]
 workspace = true

--- a/axum-extra/Cargo.toml
+++ b/axum-extra/Cargo.toml
@@ -38,7 +38,7 @@ multipart = ["dep:multer", "dep:fastrand"]
 protobuf = ["dep:prost"]
 scheme = []
 query = ["dep:form_urlencoded", "dep:serde_html_form", "dep:serde_path_to_error"]
-tracing = ["axum-core/tracing", "axum/tracing"]
+tracing = ["axum-core/tracing", "axum/tracing", "dep:tracing"]
 typed-header = ["dep:headers"]
 typed-routing = ["dep:axum-macros", "dep:percent-encoding", "dep:serde_html_form", "dep:form_urlencoded"]
 
@@ -92,7 +92,6 @@ serde_json = "1.0.71"
 tokio = { version = "1.14", features = ["full"] }
 tower = { version = "0.5.2", features = ["util"] }
 tower-http = { version = "0.6.0", features = ["map-response-body", "timeout"] }
-tracing = "0.1.37"
 tracing-subscriber = "0.3.19"
 
 [lints]

--- a/axum-extra/src/extract/multipart.rs
+++ b/axum-extra/src/extract/multipart.rs
@@ -401,6 +401,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg(feature = "tracing")]
     async fn body_too_large_with_tracing() {
         tracing::subscriber::set_global_default(
             tracing_subscriber::FmtSubscriber::builder()

--- a/axum-extra/src/extract/multipart.rs
+++ b/axum-extra/src/extract/multipart.rs
@@ -243,12 +243,13 @@ impl MultipartError {
 
     /// Get the response body text used for this rejection.
     pub fn body_text(&self) -> String {
+        let body = self.source.to_string();
         axum_core::__log_rejection!(
             rejection_type = Self,
-            body_text = self.body_text(),
+            body_text = body,
             status = self.status(),
         );
-        self.source.to_string()
+        body
     }
 
     /// Get the status code used for this rejection.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation

My server application crashed, when I set a low `DefaultBodyLimit` and tried to turn the `MultipartError` into a response. After debugging I found the recursive call of `body_text` in the tracing event capture causes a stack overflow when a tracing subscriber with level filter `TRACE` is set, which lead to the crash. 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

Create the response body before capturing the tracing event.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
