### PR TITLE
Generalize `Connected` implementation to all `Listener`s

### DIFF
--- a/axum/src/extract/connect_info.rs
+++ b/axum/src/extract/connect_info.rs
@@ -85,21 +85,13 @@ pub trait Connected<T>: Clone + Send + Sync + 'static {
 #[cfg(all(feature = "tokio", any(feature = "http1", feature = "http2")))]
 const _: () = {
     use crate::serve;
-    use tokio::net::TcpListener;
 
-    impl Connected<serve::IncomingStream<'_, TcpListener>> for SocketAddr {
-        fn connect_info(stream: serve::IncomingStream<'_, TcpListener>) -> Self {
-            *stream.remote_addr()
-        }
-    }
-
-    impl<'a, L, F> Connected<serve::IncomingStream<'a, serve::TapIo<L, F>>> for L::Addr
+    impl<L> Connected<serve::IncomingStream<'_, L>> for L::Addr
     where
         L: serve::Listener,
         L::Addr: Clone + Sync + 'static,
-        F: FnMut(&mut L::Io) + Send + 'static,
     {
-        fn connect_info(stream: serve::IncomingStream<'a, serve::TapIo<L, F>>) -> Self {
+        fn connect_info(stream: serve::IncomingStream<'_, L>) -> Self {
             stream.remote_addr().clone()
         }
     }


### PR DESCRIPTION
The previous implementation implemented the trait `Connected` for `TcpListener` and `TapIo`. This was both needlessly specific *and* blocked other implementers of the `Listener` trait from themselves implementing `Connected`.

For example when using axum with
`into_make_service_with_connect_info::<SocketAddr>()` a `Listener` implementation that isn't `TcpListener` will yield a compiler error that `Connected` is not implemented for this other `Listener`. Implementing it for `SocketAddr` directly isn't possible because of the orphan rule. Even with a wrapper type, a library abstraction can't implement it generically for all `Listener`s because it would run into conflicting trait implementations.
