### PR TITLE
Fix panic location for overlapping method routes

### DIFF
--- a/axum/src/routing/mod.rs
+++ b/axum/src/routing/mod.rs
@@ -127,7 +127,7 @@ macro_rules! tap_inner {
         #[allow(redundant_semicolons)]
         {
             let mut $inner = $self_.into_inner();
-            $($stmt)*
+            $($stmt)*;
             Router {
                 inner: Arc::new($inner),
             }

--- a/axum/src/routing/path_router.rs
+++ b/axum/src/routing/path_router.rs
@@ -98,7 +98,7 @@ where
             let service = Endpoint::MethodRouter(
                 prev_method_router
                     .clone()
-                    .merge_for_path(Some(path), method_router),
+                    .merge_for_path(Some(path), method_router)?,
             );
             self.routes.insert(route_id, service);
             return Ok(());

--- a/axum/tests/panic_location.rs
+++ b/axum/tests/panic_location.rs
@@ -1,0 +1,41 @@
+//! Separate test binary, because the panic hook is a global resource
+
+use std::{
+    panic::{catch_unwind, set_hook, take_hook},
+    path::Path,
+    sync::OnceLock,
+};
+
+use axum::{routing::get, Router};
+
+#[test]
+fn routes_with_overlapping_method_routes() {
+    static PANIC_LOCATION_FILE: OnceLock<String> = OnceLock::new();
+
+    let default_hook = take_hook();
+    set_hook(Box::new(|panic_info| {
+        if let Some(location) = panic_info.location() {
+            _ = PANIC_LOCATION_FILE.set(location.file().to_owned());
+        }
+    }));
+
+    let result = catch_unwind(|| {
+        async fn handler() {}
+
+        let _: Router = Router::new()
+            .route("/foo/bar", get(handler))
+            .route("/foo/bar", get(handler));
+    });
+    set_hook(default_hook);
+
+    let panic_payload = result.unwrap_err();
+    let panic_msg = panic_payload.downcast_ref::<String>().unwrap();
+
+    assert_eq!(
+        panic_msg,
+        "Overlapping method route. Handler for `GET /foo/bar` already exists"
+    );
+
+    let file = PANIC_LOCATION_FILE.get().unwrap();
+    assert_eq!(Path::new(file).file_name().unwrap(), "panic_location.rs");
+}


### PR DESCRIPTION
## Motivation

The panic message currently points into library internals, when it should be pointing at where the user made a mistake.

## Solution

Change one internal function to use `Result` error propagation like the rest, so the actual panicking happens inside a function that's `#[track_caller]`.