### PR TITLE
perf: pre-allocate right sized buffer when encoding protobuf response

### DIFF
--- a/axum-extra/src/protobuf.rs
+++ b/axum-extra/src/protobuf.rs
@@ -128,7 +128,7 @@ where
     T: Message + Default,
 {
     fn into_response(self) -> Response {
-        let mut buf = BytesMut::with_capacity(128);
+        let mut buf = BytesMut::with_capacity(self.0.encoded_len());
         match &self.0.encode(&mut buf) {
             Ok(()) => buf.into_response(),
             Err(err) => (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()).into_response(),


### PR DESCRIPTION
`prost::Message` provides an `encoded_len()` method, which as its name suggests returns the length of the encoded message. We can use this to allocate the buffer and never need to grow. 