### PR TITLE
Release axum 0.8.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,7 +302,7 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "anyhow",
  "axum-core",

--- a/axum-extra/Cargo.toml
+++ b/axum-extra/Cargo.toml
@@ -49,7 +49,7 @@ __private_docs = [
 ]
 
 [dependencies]
-axum = { path = "../axum", version = "0.8.3", default-features = false, features = ["original-uri"] }
+axum = { path = "../axum", version = "0.8.4", default-features = false, features = ["original-uri"] }
 axum-core = { path = "../axum-core", version = "0.5.2" }
 bytes = "1.1.0"
 futures-util = { version = "0.3", default-features = false, features = ["alloc"] }

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -5,11 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-# Unreleased
+# 0.8.4
 
 - **added:** `Router::reset_fallback` ([#3320])
+- **added:** `WebSocketUpgrade::selected_protocol` ([#3248])
+- **fixed:** Panic location for overlapping method routes ([#3319])
+- **fixed:** Don't leak a tokio task when using `serve` without graceful shutdown ([#3129])
 
+[#3319]: https://github.com/tokio-rs/axum/pull/3319
 [#3320]: https://github.com/tokio-rs/axum/pull/3320
+[#3248]: https://github.com/tokio-rs/axum/pull/3248
+[#3129]: https://github.com/tokio-rs/axum/pull/3129
 
 # 0.8.3
 

--- a/axum/Cargo.toml
+++ b/axum/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axum"
-version = "0.8.3" # remember to bump the version that axum-extra depends on
+version = "0.8.4" # remember to bump the version that axum-extra depends on
 categories = ["asynchronous", "network-programming", "web-programming::http-server"]
 description = "Web framework that focuses on ergonomics and modularity"
 edition = "2021"


### PR DESCRIPTION
Release log (to be done post merge):

- [x] Run cargo publish in the right order
- [x] Create git tags
- [ ] Create GitHub releases

After this release, I'd start to merge breaking changes. We can still make 0.8.x releases then, but from a separate release branch.