### PR TITLE
Add "Run with" comment to example-low-level-openssl

### DIFF
--- a/examples/low-level-openssl/src/main.rs
+++ b/examples/low-level-openssl/src/main.rs
@@ -1,3 +1,9 @@
+//! Run with
+//!
+//! ```not_rust
+//! cargo run -p example-low-level-openssl
+//! ```
+
 use axum::{http::Request, routing::get, Router};
 use futures_util::pin_mut;
 use hyper::body::Incoming;


### PR DESCRIPTION
If merged, the low-level-openssl example will include the helpful comment, found in most other examples, instructing how to run this example.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation

Axum noob here 🙂 systematically iterating through examples. I see this particular example does not have the helpful comment in `main.rs` to instruct how to run this example. This PR fixes that.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

This is a helpful code comment, added at the top of `main.rs`, that mimics the comments found in other examples. 

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
