### PR TITLE
Extractors doc: correct linked example section

### DIFF
--- a/axum/src/docs/extract.md
+++ b/axum/src/docs/extract.md
@@ -269,9 +269,9 @@ If an extractor fails it will return a response with the error and your
 handler will not be called. To customize the error response you have two 
 options:
 
-1. Use `Result<T, T::Rejection>` as your extractor like shown in ["Optional
-   extractors"](#optional-extractors). This works well if you're only using
-   the extractor in a single handler.
+1. Use `Result<T, T::Rejection>` as your extractor like shown in
+   ["Handling extractor rejections"](#handling-extractor-rejections).
+   This works well if you're only using the extractor in a single handler.
 2. Create your own extractor that in its [`FromRequest`] implementation calls
    one of axum's built in extractors but returns a different response for
    rejections. See the [customize-extractor-error] example for more details.


### PR DESCRIPTION
Wrapping the extractor in Result is shown in "Handling extractor rejections", not in "Optional extractors".

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation

Improve documentation

## Solution

Correct linked section
