### PR TITLE
Add hot-patching example

### DIFF
--- a/examples/hot-patch/Cargo.toml
+++ b/examples/hot-patch/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "hot-patch"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+axum = { path = "../../axum" }
+dioxus-devtools = { version = "0.7.0-alpha.0", git = "https://github.com/DioxusLabs/dioxus.git", ref = "77d10a4" }
+tokio = { version = "1.0", features = ["full"] }

--- a/examples/hot-patch/README.md
+++ b/examples/hot-patch/README.md
@@ -1,0 +1,21 @@
+# auto-reload
+
+This example shows how you can set up a development environment with
+hot-patching for certain code paths with subsecond, this allows you to change
+your code without restarting it.
+
+It currently uses the git version of dioxus-cli and both the library and the cli
+must be the same version.
+
+## Setup
+
+```sh
+cargo install dioxus-cli --git https://github.com/DioxusLabs/dioxus --rev 77d10a4
+```
+
+## Running
+
+```sh
+dx serve --hot-patch
+```
+

--- a/examples/hot-patch/src/main.rs
+++ b/examples/hot-patch/src/main.rs
@@ -1,0 +1,18 @@
+use axum::{response::Html, routing::get, Router};
+
+#[tokio::main]
+async fn main() {
+    dioxus_devtools::connect_subsecond();
+    let app = Router::new().route("/", get(handler));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:3000")
+        .await
+        .unwrap();
+    println!("listening on {}", listener.local_addr().unwrap());
+    axum::serve(listener, app).await.unwrap();
+}
+
+async fn handler() -> Html<&'static str> {
+    dioxus_devtools::subsecond::call(|| {
+        Html("<h1>Hello, World!</h1>")
+    })
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

Add an example to do hot-patching using dioxus subsecond.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

A simple hello-world experimental example to get people started, no `#[hot]` macro supported yet.

Still waiting from dioxus maintainer to fix the serde_json conflict.

![image](https://github.com/user-attachments/assets/3a02d66e-621b-43a5-85b5-383c432425ce)

See https://github.com/DioxusLabs/dioxus/issues/4195

It works when running locally, outside of the examples folder.
