### PR TITLE
Add `DefaultBodyLimit::apply`

### DIFF
--- a/axum-core/CHANGELOG.md
+++ b/axum-core/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# Unreleased
+
+- **added:** `DefaultBodyLimit::apply` for changing the `DefaultBodyLimit` inside extractors.
+  ([#3368])
+
+[#3368]: https://github.com/tokio-rs/axum/pull/3366
+
 # 0.5.2
 
 - **added:** Implement `Stream::size_hint` for `BodyDataStream` ([#3195])


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation

I am writing an extractor, and it would be useful to have that extractor change the default body limit. This can be done today with the following code:

```rs
let req = DefaultBodyLimit::max(1024)
	.layer(tower::service_fn(|req| async { Ok::<_, Infallible>(req) }))
	.call(req)
	.await
	.unwrap_or_else(|e| match e {});
```

But it would be nice to have a convenience method for this.

## Solution

```rs
impl DefaultBodyLimit {
    fn apply<B>(self, req: &mut Request<B>);
}
```
