### PR TITLE
New redirect inspection

### DIFF
--- a/axum/src/response/redirect.rs
+++ b/axum/src/response/redirect.rs
@@ -74,7 +74,8 @@ impl Redirect {
 
     /// Returns the parsed location header as a &str.
     ///
-    /// This function shouldn't ever return a Err() since Redirect takes a &str, and will be valid UTF-8.
+    /// This function shouldn't ever return a Err() since Redirect takes a &str in it's constructors,
+    /// and will be valid UTF-8.
     pub fn location(&self) -> Result<&str, http::header::ToStrError> {
         self.location.to_str()
     }

--- a/axum/src/response/redirect.rs
+++ b/axum/src/response/redirect.rs
@@ -72,9 +72,9 @@ impl Redirect {
         self.status_code
     }
 
-    /// Attempts to parse the location header to a &str, and returns the result.
+    /// Returns the parsed location header as a &str.
     ///
-    /// This function shouldn't ever return a Err() since Redirect takes a &str.
+    /// This function shouldn't ever return a Err() since Redirect takes a &str, and will be valid UTF-8.
     pub fn location(&self) -> Result<&str, http::header::ToStrError> {
         self.location.to_str()
     }

--- a/axum/src/response/redirect.rs
+++ b/axum/src/response/redirect.rs
@@ -72,9 +72,9 @@ impl Redirect {
         self.status_code
     }
 
-    /// Returns the parsed location header as a &str.
+    /// Returns the parsed Location header as a &str.
     ///
-    /// This function shouldn't ever return a Err() since Redirect takes a &str in it's constructors,
+    /// This function shouldn't ever return a Err since Redirect takes a &str in it's constructors,
     /// and will be valid UTF-8.
     pub fn location(&self) -> Result<&str, http::header::ToStrError> {
         self.location.to_str()

--- a/axum/src/response/redirect.rs
+++ b/axum/src/response/redirect.rs
@@ -68,7 +68,7 @@ impl Redirect {
     }
 
     /// Returns the current Redirect StatusCode
-    pub fn status(&self) -> StatusCode {
+    pub fn status_code(&self) -> StatusCode {
         self.status_code
     }
 

--- a/axum/src/response/redirect.rs
+++ b/axum/src/response/redirect.rs
@@ -67,7 +67,7 @@ impl Redirect {
         Self::with_status_code(StatusCode::PERMANENT_REDIRECT, uri)
     }
 
-    /// Returns the current Redirect StatusCode
+    /// Returns the HTTP status code of the Redirect.
     pub fn status_code(&self) -> StatusCode {
         self.status_code
     }

--- a/axum/src/response/redirect.rs
+++ b/axum/src/response/redirect.rs
@@ -67,6 +67,11 @@ impl Redirect {
         Self::with_status_code(StatusCode::PERMANENT_REDIRECT, uri)
     }
 
+    /// Returns the current Redirect StatusCode
+    pub fn status(&self) -> StatusCode {
+        self.status_code
+    }
+
     // This is intentionally not public since other kinds of redirects might not
     // use the `Location` header, namely `304 Not Modified`.
     //

--- a/axum/src/response/redirect.rs
+++ b/axum/src/response/redirect.rs
@@ -72,6 +72,11 @@ impl Redirect {
         self.status_code
     }
 
+    /// Parses the location header to a String.
+    pub fn location(&self) -> Result<&str, http::header::ToStrError> {
+        self.location.to_str()
+    }
+
     // This is intentionally not public since other kinds of redirects might not
     // use the `Location` header, namely `304 Not Modified`.
     //


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation

This PR was made in response to the [issue #3365](https://github.com/tokio-rs/axum/issues/3365). 

Highlights that in axum most responses are strongly typed (and therefore inspectable) and is turned into HTTP at the IntoResponse stage.

Redirect does not have any methods to inspect StatusCode or the URI after being constructed, and constructs the http headers when created.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

This PR adds testability and inspection of ```Redirect```.
It adds ```status_code()```which returns the current status code of the Redirect, and ```location()``` which returns the result of parsing the Http Header to a &str.
It also adds tests using the new inspection methods.

This PR should also be iterated on, but currently doesn't have any breaking changes to the internals of Redirect, but only adds new methods. We could still make these changes (discussed in the issue above):

- Instead of Redirect constructing the HeaderValue when Redirect is constructed, it could be constructed when Redirect is made into a response in ```IntoResponse```.
- Make redirect a enum to ensure that StatusCode isn't invalid.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
