### PR TITLE
 Update CI workflow link in README

### DIFF
--- a/axum-core/README.md
+++ b/axum-core/README.md
@@ -1,6 +1,6 @@
 # axum-core
 
-[![Build status](https://github.com/tokio-rs/axum/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/tokio-rs/axum-core/actions/workflows/CI.yml)
+[![Build status](https://github.com/tokio-rs/axum/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/tokio-rs/axum/blob/main/.github/workflows/CI.yml)
 [![Crates.io](https://img.shields.io/crates/v/axum-core)](https://crates.io/crates/axum-core)
 [![Documentation](https://docs.rs/axum-core/badge.svg)](https://docs.rs/axum-core)
 


### PR DESCRIPTION

Changes made:
File: axum-core/README.md
- Old: https://github.com/tokio-rs/axum-core/actions/workflows/CI.yml
+ New: https://github.com/tokio-rs/axum/blob/main/.github/workflows/CI.yml

Reason for changes:
Updating the CI workflow link to point to the correct location in the main repository's .github/workflows directory. The old link was pointing to a non-existent path.

If there's a more appropriate or preferred link for the CI workflow, please let me know and I'll update the PR accordingly.