### PR TITLE
Update CI workflow link in README

### DIFF
--- a/axum-macros/README.md
+++ b/axum-macros/README.md
@@ -1,6 +1,6 @@
 # axum-macros
 
-[![Build status](https://github.com/tokio-rs/axum/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/tokio-rs/axum-macros/actions/workflows/CI.yml)
+[![Build status](https://github.com/tokio-rs/axum/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/tokio-rs/axum/actions/workflows/CI.yml)
 [![Crates.io](https://img.shields.io/crates/v/axum-macros)](https://crates.io/crates/axum-macros)
 [![Documentation](https://docs.rs/axum-macros/badge.svg)](https://docs.rs/axum-macros)
 


### PR DESCRIPTION
Replaced the outdated CI badge and link in axum-macros/README.md with the current GitHub Actions workflow URL for axum. This ensures the build status badge and CI reference are accurate and up to date.