### PR TITLE
style: reorder macro-generated items to fix lints

### DIFF
--- a/axum-macros/src/debug_handler.rs
+++ b/axum-macros/src/debug_handler.rs
@@ -681,10 +681,10 @@ fn check_output_impls_into_response(item_fn: &ItemFn) -> TokenStream {
             #[allow(unreachable_code)]
             #[doc(hidden)]
             async fn #name() {
-                let value = #receiver #make_value_name().await;
                 fn check<T>(_: T)
                     where T: ::axum::response::IntoResponse
                 {}
+                let value = #receiver #make_value_name().await;
                 check(value);
             }
         }
@@ -696,11 +696,11 @@ fn check_output_impls_into_response(item_fn: &ItemFn) -> TokenStream {
             async fn #name() {
                 #make
 
-                let value = #make_value_name().await;
-
                 fn check<T>(_: T)
                 where T: ::axum::response::IntoResponse
                 {}
+
+                let value = #make_value_name().await;
 
                 check(value);
             }
@@ -732,10 +732,13 @@ fn check_future_send(item_fn: &ItemFn, kind: FunctionKind) -> TokenStream {
 
     let name = format_ident!("__axum_macros_check_{}_future", item_fn.sig.ident);
 
-    let do_check = quote! {
+    let define_check = quote! {
         fn check<T>(_: T)
             where T: ::std::future::Future + Send
         {}
+    };
+
+    let do_check = quote! {
         check(future);
     };
 
@@ -745,6 +748,7 @@ fn check_future_send(item_fn: &ItemFn, kind: FunctionKind) -> TokenStream {
             #[allow(unreachable_code)]
             #[doc(hidden)]
             fn #name() {
+                #define_check
                 let future = #receiver #handler_name(#(#args),*);
                 #do_check
             }
@@ -756,6 +760,7 @@ fn check_future_send(item_fn: &ItemFn, kind: FunctionKind) -> TokenStream {
             #[doc(hidden)]
             fn #name() {
                 #item_fn
+                #define_check
                 let future = #handler_name(#(#args),*);
                 #do_check
             }


### PR DESCRIPTION
## Motivation

This PR addresses issue #3391.

Some Axum users may wish to enable `#![deny(clippy::pedantic)]`, but currently encounter an error when using `#[debug_handler]`. This happens because the macro generates code with items appearing after statements, triggering Clippy's `items_after_statements` lint to appear. Since Clippy's diagnostics can be misleading when working with macros, the resulting error message is confusing for users of Axum.

## Solution

By reordering some `let` statements and function definitions, we are able to manipulate the ordering of the generated output. However, I also noticed that I had to move the `check` (future send) function definition out of `do_check`. I'm not sure what the style in these macros are, so I simply added another `quote!` call. If this is unwanted, I could try and find another way.

I chose to restructure the macro output instead of just adding `#[allow(clippy::pedantic)]` since fixing the root cause seemed straightforward.

Side note: since this is more of a style change, I didn't add any tests. Please let me know if you'd like me to attempt adding one.