### PR TITLE
Activate more lints

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -2,3 +2,4 @@ allow-mixed-uninlined-format-args = false
 disallowed-types = [
     { path = "tower::util::BoxCloneService", reason = "Use tower::util::BoxCloneSyncService instead" },
 ]
+doc-valid-idents = ["WebSocket", "WebSockets", ".."]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ verbose_file_reads = "warn"
 must_use_candidate = "warn"
 use_self = "warn"
 redundant_else = "warn"
+unnecessary_semicolon = "warn"
 
 # configuration for https://github.com/crate-ci/typos
 [workspace.metadata.typos.default.extend-identifiers]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ semicolon_if_nothing_returned = "warn"
 manual_assert = "warn"
 ignored_unit_patterns = "warn"
 wildcard_imports = "warn"
+return_self_not_must_use = "warn"
 
 # configuration for https://github.com/crate-ci/typos
 [workspace.metadata.typos.default.extend-identifiers]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ must_use_candidate = "warn"
 use_self = "warn"
 redundant_else = "warn"
 unnecessary_semicolon = "warn"
+manual_let_else = "warn"
 
 # configuration for https://github.com/crate-ci/typos
 [workspace.metadata.typos.default.extend-identifiers]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ if_not_else = "warn"
 map_unwrap_or = "warn"
 semicolon_if_nothing_returned = "warn"
 manual_assert = "warn"
+ignored_unit_patterns = "warn"
 
 # configuration for https://github.com/crate-ci/typos
 [workspace.metadata.typos.default.extend-identifiers]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ unnecessary_semicolon = "warn"
 manual_let_else = "warn"
 option_if_let_else = "warn"
 missing_const_for_fn = "warn"
+if_not_else = "warn"
 
 # configuration for https://github.com/crate-ci/typos
 [workspace.metadata.typos.default.extend-identifiers]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ use_self = "warn"
 redundant_else = "warn"
 unnecessary_semicolon = "warn"
 manual_let_else = "warn"
+option_if_let_else = "warn"
 
 # configuration for https://github.com/crate-ci/typos
 [workspace.metadata.typos.default.extend-identifiers]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ map_unwrap_or = "warn"
 semicolon_if_nothing_returned = "warn"
 manual_assert = "warn"
 ignored_unit_patterns = "warn"
+wildcard_imports = "warn"
 
 # configuration for https://github.com/crate-ci/typos
 [workspace.metadata.typos.default.extend-identifiers]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ option_if_let_else = "warn"
 missing_const_for_fn = "warn"
 if_not_else = "warn"
 map_unwrap_or = "warn"
+semicolon_if_nothing_returned = "warn"
 
 # configuration for https://github.com/crate-ci/typos
 [workspace.metadata.typos.default.extend-identifiers]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ redundant_else = "warn"
 unnecessary_semicolon = "warn"
 manual_let_else = "warn"
 option_if_let_else = "warn"
+missing_const_for_fn = "warn"
 
 # configuration for https://github.com/crate-ci/typos
 [workspace.metadata.typos.default.extend-identifiers]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ missing_const_for_fn = "warn"
 if_not_else = "warn"
 map_unwrap_or = "warn"
 semicolon_if_nothing_returned = "warn"
+manual_assert = "warn"
 
 # configuration for https://github.com/crate-ci/typos
 [workspace.metadata.typos.default.extend-identifiers]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ unused_self = "warn"
 verbose_file_reads = "warn"
 must_use_candidate = "warn"
 use_self = "warn"
+redundant_else = "warn"
 
 # configuration for https://github.com/crate-ci/typos
 [workspace.metadata.typos.default.extend-identifiers]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ manual_let_else = "warn"
 option_if_let_else = "warn"
 missing_const_for_fn = "warn"
 if_not_else = "warn"
+map_unwrap_or = "warn"
 
 # configuration for https://github.com/crate-ci/typos
 [workspace.metadata.typos.default.extend-identifiers]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ unnested_or_patterns = "warn"
 unused_self = "warn"
 verbose_file_reads = "warn"
 must_use_candidate = "warn"
+use_self = "warn"
 
 # configuration for https://github.com/crate-ci/typos
 [workspace.metadata.typos.default.extend-identifiers]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ manual_assert = "warn"
 ignored_unit_patterns = "warn"
 wildcard_imports = "warn"
 return_self_not_must_use = "warn"
+doc_markdown = "warn"
 
 # configuration for https://github.com/crate-ci/typos
 [workspace.metadata.typos.default.extend-identifiers]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ uninlined_format_args = "warn"
 unnested_or_patterns = "warn"
 unused_self = "warn"
 verbose_file_reads = "warn"
+must_use_candidate = "warn"
 
 # configuration for https://github.com/crate-ci/typos
 [workspace.metadata.typos.default.extend-identifiers]

--- a/axum-core/src/body.rs
+++ b/axum-core/src/body.rs
@@ -48,6 +48,7 @@ impl Body {
     }
 
     /// Create an empty body.
+    #[must_use]
     pub fn empty() -> Self {
         Self::new(http_body_util::Empty::new())
     }
@@ -72,6 +73,7 @@ impl Body {
     /// you need a [`Stream`] of all frame types.
     ///
     /// [`http_body_util::BodyStream`]: https://docs.rs/http-body-util/latest/http_body_util/struct.BodyStream.html
+    #[must_use]
     pub fn into_data_stream(self) -> BodyDataStream {
         BodyDataStream { inner: self }
     }

--- a/axum-core/src/body.rs
+++ b/axum-core/src/body.rs
@@ -26,11 +26,10 @@ where
     K: Send + 'static,
 {
     let mut k = Some(k);
-    if let Some(k) = <dyn std::any::Any>::downcast_mut::<Option<T>>(&mut k) {
-        Ok(k.take().unwrap())
-    } else {
-        Err(k.unwrap())
-    }
+
+    <dyn std::any::Any>::downcast_mut::<Option<T>>(&mut k)
+        .and_then(Option::take)
+        .map_or_else(|| Err(k.unwrap()), Ok)
 }
 
 /// The body type used in axum requests and responses.

--- a/axum-core/src/body.rs
+++ b/axum-core/src/body.rs
@@ -85,7 +85,7 @@ impl Default for Body {
 }
 
 impl From<()> for Body {
-    fn from(_: ()) -> Self {
+    fn from((): ()) -> Self {
         Self::empty()
     }
 }

--- a/axum-core/src/body.rs
+++ b/axum-core/src/body.rs
@@ -73,7 +73,7 @@ impl Body {
     ///
     /// [`http_body_util::BodyStream`]: https://docs.rs/http-body-util/latest/http_body_util/struct.BodyStream.html
     #[must_use]
-    pub fn into_data_stream(self) -> BodyDataStream {
+    pub const fn into_data_stream(self) -> BodyDataStream {
         BodyDataStream { inner: self }
     }
 }

--- a/axum-core/src/error.rs
+++ b/axum-core/src/error.rs
@@ -16,6 +16,7 @@ impl Error {
     }
 
     /// Convert an `Error` back into the underlying boxed trait object.
+    #[must_use]
     pub fn into_inner(self) -> BoxError {
         self.inner
     }

--- a/axum-core/src/ext_traits/mod.rs
+++ b/axum-core/src/ext_traits/mod.rs
@@ -1,5 +1,8 @@
-pub(crate) mod request;
-pub(crate) mod request_parts;
+mod request;
+mod request_parts;
+
+pub use request::RequestExt;
+pub use request_parts::RequestPartsExt;
 
 #[cfg(test)]
 mod tests {

--- a/axum-core/src/ext_traits/request_parts.rs
+++ b/axum-core/src/ext_traits/request_parts.rs
@@ -147,7 +147,7 @@ mod tests {
 
     #[tokio::test]
     async fn extract_without_state() {
-        let (mut parts, _) = Request::new(()).into_parts();
+        let (mut parts, ()) = Request::new(()).into_parts();
 
         let method: Method = parts.extract().await.unwrap();
 
@@ -156,7 +156,7 @@ mod tests {
 
     #[tokio::test]
     async fn extract_with_state() {
-        let (mut parts, _) = Request::new(()).into_parts();
+        let (mut parts, ()) = Request::new(()).into_parts();
 
         let state = "state".to_owned();
 

--- a/axum-core/src/extract/option.rs
+++ b/axum-core/src/extract/option.rs
@@ -45,7 +45,7 @@ where
     fn from_request_parts(
         parts: &mut Parts,
         state: &S,
-    ) -> impl Future<Output = Result<Option<T>, Self::Rejection>> {
+    ) -> impl Future<Output = Result<Self, Self::Rejection>> {
         T::from_request_parts(parts, state)
     }
 }
@@ -57,7 +57,7 @@ where
 {
     type Rejection = T::Rejection;
 
-    async fn from_request(req: Request, state: &S) -> Result<Option<T>, Self::Rejection> {
+    async fn from_request(req: Request, state: &S) -> Result<Self, Self::Rejection> {
         T::from_request(req, state).await
     }
 }

--- a/axum-core/src/extract/request_parts.rs
+++ b/axum-core/src/extract/request_parts.rs
@@ -1,4 +1,7 @@
-use super::{rejection::*, FromRequest, FromRequestParts, Request};
+use super::{
+    rejection::{BytesRejection, FailedToBufferBody, InvalidUtf8, StringRejection},
+    FromRequest, FromRequestParts, Request,
+};
 use crate::{body::Body, RequestExt};
 use bytes::{BufMut, Bytes, BytesMut};
 use http::{request::Parts, Extensions, HeaderMap, Method, Uri, Version};

--- a/axum-core/src/extract/request_parts.rs
+++ b/axum-core/src/extract/request_parts.rs
@@ -73,7 +73,7 @@ where
 
     async fn from_request(req: Request, _: &S) -> Result<Self, Self::Rejection> {
         let mut body = req.into_limited_body();
-        let mut bytes = BytesMut::new();
+        let mut bytes = Self::new();
         body_to_bytes_mut(&mut body, &mut bytes).await?;
         Ok(bytes)
     }
@@ -128,7 +128,7 @@ where
                 }
             })?;
 
-        let string = String::from_utf8(bytes.into()).map_err(InvalidUtf8::from_err)?;
+        let string = Self::from_utf8(bytes.into()).map_err(InvalidUtf8::from_err)?;
 
         Ok(string)
     }

--- a/axum-core/src/lib.rs
+++ b/axum-core/src/lib.rs
@@ -30,7 +30,7 @@ pub mod response;
 /// Alias for a type-erased error type.
 pub type BoxError = Box<dyn std::error::Error + Send + Sync>;
 
-pub use self::ext_traits::{request::RequestExt, request_parts::RequestPartsExt};
+pub use self::ext_traits::{RequestExt, RequestPartsExt};
 
 #[cfg(test)]
 use axum_macros::__private_axum_test as test;

--- a/axum-core/src/macros.rs
+++ b/axum-core/src/macros.rs
@@ -106,11 +106,13 @@ macro_rules! __define_rejection {
             }
 
             /// Get the response body text used for this rejection.
+            #[must_use]
             pub fn body_text(&self) -> String {
                 self.to_string()
             }
 
             /// Get the status code used for this rejection.
+            #[must_use]
             pub fn status(&self) -> http::StatusCode {
                 http::StatusCode::$status
             }
@@ -179,6 +181,7 @@ macro_rules! __composite_rejection {
 
         impl $name {
             /// Get the response body text used for this rejection.
+            #[must_use]
             pub fn body_text(&self) -> String {
                 match self {
                     $(
@@ -188,6 +191,7 @@ macro_rules! __composite_rejection {
             }
 
             /// Get the status code used for this rejection.
+            #[must_use]
             pub fn status(&self) -> http::StatusCode {
                 match self {
                     $(

--- a/axum-core/src/macros.rs
+++ b/axum-core/src/macros.rs
@@ -54,7 +54,7 @@ macro_rules! __define_rejection {
             }
 
             /// Get the status code used for this rejection.
-            pub fn status(&self) -> http::StatusCode {
+            pub const fn status(&self) -> http::StatusCode {
                 http::StatusCode::$status
             }
         }
@@ -113,7 +113,7 @@ macro_rules! __define_rejection {
 
             /// Get the status code used for this rejection.
             #[must_use]
-            pub fn status(&self) -> http::StatusCode {
+            pub const fn status(&self) -> http::StatusCode {
                 http::StatusCode::$status
             }
         }
@@ -192,7 +192,7 @@ macro_rules! __composite_rejection {
 
             /// Get the status code used for this rejection.
             #[must_use]
-            pub fn status(&self) -> http::StatusCode {
+            pub const fn status(&self) -> http::StatusCode {
                 match self {
                     $(
                         Self::$variant(inner) => inner.status(),

--- a/axum-core/src/response/into_response_parts.rs
+++ b/axum-core/src/response/into_response_parts.rs
@@ -165,13 +165,13 @@ pub struct TryIntoHeaderError<K, V> {
 }
 
 impl<K, V> TryIntoHeaderError<K, V> {
-    pub(super) fn key(err: K) -> Self {
+    pub(super) const fn key(err: K) -> Self {
         Self {
             kind: TryIntoHeaderErrorKind::Key(err),
         }
     }
 
-    pub(super) fn value(err: V) -> Self {
+    pub(super) const fn value(err: V) -> Self {
         Self {
             kind: TryIntoHeaderErrorKind::Value(err),
         }

--- a/axum-extra/src/either.rs
+++ b/axum-extra/src/either.rs
@@ -283,8 +283,8 @@ where
 
     fn layer(&self, inner: S) -> Self::Service {
         match self {
-            Either::E1(layer) => Either::E1(layer.layer(inner)),
-            Either::E2(layer) => Either::E2(layer.layer(inner)),
+            Self::E1(layer) => Either::E1(layer.layer(inner)),
+            Self::E2(layer) => Either::E2(layer.layer(inner)),
         }
     }
 }
@@ -300,15 +300,15 @@ where
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         match self {
-            Either::E1(inner) => inner.poll_ready(cx),
-            Either::E2(inner) => inner.poll_ready(cx),
+            Self::E1(inner) => inner.poll_ready(cx),
+            Self::E2(inner) => inner.poll_ready(cx),
         }
     }
 
     fn call(&mut self, req: R) -> Self::Future {
         match self {
-            Either::E1(inner) => futures_util::future::Either::Left(inner.call(req)),
-            Either::E2(inner) => futures_util::future::Either::Right(inner.call(req)),
+            Self::E1(inner) => futures_util::future::Either::Left(inner.call(req)),
+            Self::E2(inner) => futures_util::future::Either::Right(inner.call(req)),
         }
     }
 }

--- a/axum-extra/src/extract/cached.rs
+++ b/axum-extra/src/extract/cached.rs
@@ -133,7 +133,7 @@ mod tests {
             }
         }
 
-        let (mut parts, _) = Request::new(()).into_parts();
+        let (mut parts, ()) = Request::new(()).into_parts();
 
         let first = Cached::<Extractor>::from_request_parts(&mut parts, &())
             .await

--- a/axum-extra/src/extract/cookie/mod.rs
+++ b/axum-extra/src/extract/cookie/mod.rs
@@ -118,6 +118,7 @@ impl CookieJar {
     /// run extractors. Normally you should create `CookieJar`s through [`FromRequestParts`].
     ///
     /// [`FromRequestParts`]: axum::extract::FromRequestParts
+    #[must_use]
     pub fn from_headers(headers: &HeaderMap) -> Self {
         let mut jar = cookie::CookieJar::new();
         for cookie in cookies_from_request(headers) {
@@ -135,6 +136,7 @@ impl CookieJar {
     /// CookieJar`.
     ///
     /// [`FromRequestParts`]: axum::extract::FromRequestParts
+    #[must_use]
     pub fn new() -> Self {
         Self::default()
     }
@@ -153,6 +155,7 @@ impl CookieJar {
     ///         .map(|cookie| cookie.value().to_owned());
     /// }
     /// ```
+    #[must_use]
     pub fn get(&self, name: &str) -> Option<&Cookie<'static>> {
         self.jar.get(name)
     }

--- a/axum-extra/src/extract/cookie/mod.rs
+++ b/axum-extra/src/extract/cookie/mod.rs
@@ -324,13 +324,13 @@ mod tests {
     }
 
     impl FromRef<AppState> for Key {
-        fn from_ref(state: &AppState) -> Key {
+        fn from_ref(state: &AppState) -> Self {
             state.key.clone()
         }
     }
 
     impl FromRef<AppState> for CustomKey {
-        fn from_ref(state: &AppState) -> CustomKey {
+        fn from_ref(state: &AppState) -> Self {
             state.custom_key.clone()
         }
     }

--- a/axum-extra/src/extract/cookie/private.rs
+++ b/axum-extra/src/extract/cookie/private.rs
@@ -153,6 +153,7 @@ impl PrivateCookieJar {
     /// run extractors. Normally you should create `PrivateCookieJar`s through [`FromRequestParts`].
     ///
     /// [`FromRequestParts`]: axum::extract::FromRequestParts
+    #[must_use]
     pub fn from_headers(headers: &HeaderMap, key: Key) -> Self {
         let mut jar = cookie::CookieJar::new();
         let mut private_jar = jar.private_mut(&key);
@@ -175,6 +176,7 @@ impl PrivateCookieJar {
     /// run extractors. Normally you should create `PrivateCookieJar`s through [`FromRequestParts`].
     ///
     /// [`FromRequestParts`]: axum::extract::FromRequestParts
+    #[must_use]
     pub fn new(key: Key) -> Self {
         Self {
             jar: Default::default(),
@@ -201,6 +203,7 @@ impl<K> PrivateCookieJar<K> {
     ///         .map(|cookie| cookie.value().to_owned());
     /// }
     /// ```
+    #[must_use]
     pub fn get(&self, name: &str) -> Option<Cookie<'static>> {
         self.private_jar().get(name)
     }
@@ -246,6 +249,7 @@ impl<K> PrivateCookieJar<K> {
 
     /// Authenticates and decrypts `cookie`, returning the plaintext version if decryption succeeds
     /// or `None` otherwise.
+    #[must_use]
     pub fn decrypt(&self, cookie: Cookie<'static>) -> Option<Cookie<'static>> {
         self.private_jar().decrypt(cookie)
     }

--- a/axum-extra/src/extract/cookie/private.rs
+++ b/axum-extra/src/extract/cookie/private.rs
@@ -136,7 +136,7 @@ where
             key,
             _marker: _,
         } = PrivateCookieJar::from_headers(&parts.headers, key);
-        Ok(PrivateCookieJar {
+        Ok(Self {
             jar,
             key,
             _marker: PhantomData,

--- a/axum-extra/src/extract/cookie/signed.rs
+++ b/axum-extra/src/extract/cookie/signed.rs
@@ -170,6 +170,7 @@ impl SignedCookieJar {
     /// run extractors. Normally you should create `SignedCookieJar`s through [`FromRequestParts`].
     ///
     /// [`FromRequestParts`]: axum::extract::FromRequestParts
+    #[must_use]
     pub fn from_headers(headers: &HeaderMap, key: Key) -> Self {
         let mut jar = cookie::CookieJar::new();
         let mut signed_jar = jar.signed_mut(&key);
@@ -192,6 +193,7 @@ impl SignedCookieJar {
     /// run extractors. Normally you should create `SignedCookieJar`s through [`FromRequestParts`].
     ///
     /// [`FromRequestParts`]: axum::extract::FromRequestParts
+    #[must_use]
     pub fn new(key: Key) -> Self {
         Self {
             jar: Default::default(),
@@ -219,6 +221,7 @@ impl<K> SignedCookieJar<K> {
     ///         .map(|cookie| cookie.value().to_owned());
     /// }
     /// ```
+    #[must_use]
     pub fn get(&self, name: &str) -> Option<Cookie<'static>> {
         self.signed_jar().get(name)
     }
@@ -264,6 +267,7 @@ impl<K> SignedCookieJar<K> {
 
     /// Verifies the authenticity and integrity of `cookie`, returning the plaintext version if
     /// verification succeeds or `None` otherwise.
+    #[must_use]
     pub fn verify(&self, cookie: Cookie<'static>) -> Option<Cookie<'static>> {
         self.signed_jar().verify(cookie)
     }

--- a/axum-extra/src/extract/cookie/signed.rs
+++ b/axum-extra/src/extract/cookie/signed.rs
@@ -153,7 +153,7 @@ where
             key,
             _marker: _,
         } = SignedCookieJar::from_headers(&parts.headers, key);
-        Ok(SignedCookieJar {
+        Ok(Self {
             jar,
             key,
             _marker: PhantomData,

--- a/axum-extra/src/extract/host.rs
+++ b/axum-extra/src/extract/host.rs
@@ -36,7 +36,7 @@ where
 
     async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
         parts
-            .extract::<Option<Host>>()
+            .extract::<Option<Self>>()
             .await
             .ok()
             .flatten()
@@ -55,7 +55,7 @@ where
         _state: &S,
     ) -> Result<Option<Self>, Self::Rejection> {
         if let Some(host) = parse_forwarded(&parts.headers) {
-            return Ok(Some(Host(host.to_owned())));
+            return Ok(Some(Self(host.to_owned())));
         }
 
         if let Some(host) = parts
@@ -63,7 +63,7 @@ where
             .get(X_FORWARDED_HOST_HEADER_KEY)
             .and_then(|host| host.to_str().ok())
         {
-            return Ok(Some(Host(host.to_owned())));
+            return Ok(Some(Self(host.to_owned())));
         }
 
         if let Some(host) = parts
@@ -71,11 +71,11 @@ where
             .get(http::header::HOST)
             .and_then(|host| host.to_str().ok())
         {
-            return Ok(Some(Host(host.to_owned())));
+            return Ok(Some(Self(host.to_owned())));
         }
 
         if let Some(authority) = parts.uri.authority() {
-            return Ok(Some(Host(parse_authority(authority).to_owned())));
+            return Ok(Some(Self(parse_authority(authority).to_owned())));
         }
 
         Ok(None)

--- a/axum-extra/src/extract/json_deserializer.rs
+++ b/axum-extra/src/extract/json_deserializer.rs
@@ -183,21 +183,15 @@ composite_rejection! {
 }
 
 fn json_content_type(headers: &HeaderMap) -> bool {
-    let content_type = if let Some(content_type) = headers.get(header::CONTENT_TYPE) {
-        content_type
-    } else {
+    let Some(content_type) = headers.get(header::CONTENT_TYPE) else {
         return false;
     };
 
-    let content_type = if let Ok(content_type) = content_type.to_str() {
-        content_type
-    } else {
+    let Ok(content_type) = content_type.to_str() else {
         return false;
     };
 
-    let mime = if let Ok(mime) = content_type.parse::<mime::Mime>() {
-        mime
-    } else {
+    let Ok(mime) = content_type.parse::<mime::Mime>() else {
         return false;
     };
 

--- a/axum-extra/src/extract/multipart.rs
+++ b/axum-extra/src/extract/multipart.rs
@@ -114,11 +114,7 @@ impl Multipart {
             .await
             .map_err(MultipartError::from_multer)?;
 
-        if let Some(field) = field {
-            Ok(Some(Field { inner: field }))
-        } else {
-            Ok(None)
-        }
+        field.map_or_else(|| Ok(None), |field| Ok(Some(Field { inner: field })))
     }
 
     /// Convert the `Multipart` into a stream of its fields.

--- a/axum-extra/src/extract/multipart.rs
+++ b/axum-extra/src/extract/multipart.rs
@@ -237,7 +237,7 @@ pub struct MultipartError {
 }
 
 impl MultipartError {
-    fn from_multer(multer: multer::Error) -> Self {
+    const fn from_multer(multer: multer::Error) -> Self {
         Self { source: multer }
     }
 

--- a/axum-extra/src/extract/multipart.rs
+++ b/axum-extra/src/extract/multipart.rs
@@ -150,6 +150,7 @@ impl Field {
     /// The field name found in the
     /// [`Content-Disposition`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition)
     /// header.
+    #[must_use]
     pub fn name(&self) -> Option<&str> {
         self.inner.name()
     }
@@ -157,16 +158,19 @@ impl Field {
     /// The file name found in the
     /// [`Content-Disposition`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition)
     /// header.
+    #[must_use]
     pub fn file_name(&self) -> Option<&str> {
         self.inner.file_name()
     }
 
     /// Get the [content type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type) of the field.
+    #[must_use]
     pub fn content_type(&self) -> Option<&str> {
         self.inner.content_type().map(|m| m.as_ref())
     }
 
     /// Get a map of headers as [`HeaderMap`].
+    #[must_use]
     pub fn headers(&self) -> &HeaderMap {
         self.inner.headers()
     }
@@ -253,6 +257,7 @@ impl MultipartError {
     }
 
     /// Get the status code used for this rejection.
+    #[must_use]
     pub fn status(&self) -> http::StatusCode {
         status_code_from_multer_error(&self.source)
     }

--- a/axum-extra/src/extract/query.rs
+++ b/axum-extra/src/extract/query.rs
@@ -91,7 +91,7 @@ where
             serde_html_form::Deserializer::new(form_urlencoded::parse(query.as_bytes()));
         let value = serde_path_to_error::deserialize(deserializer)
             .map_err(FailedToDeserializeQueryString::from_err)?;
-        Ok(Query(value))
+        Ok(Self(value))
     }
 }
 
@@ -170,9 +170,9 @@ where
                 serde_html_form::Deserializer::new(form_urlencoded::parse(query.as_bytes()));
             let value = serde_path_to_error::deserialize(deserializer)
                 .map_err(FailedToDeserializeQueryString::from_err)?;
-            Ok(OptionalQuery(Some(value)))
+            Ok(Self(Some(value)))
         } else {
-            Ok(OptionalQuery(None))
+            Ok(Self(None))
         }
     }
 }

--- a/axum-extra/src/extract/query.rs
+++ b/axum-extra/src/extract/query.rs
@@ -269,8 +269,7 @@ mod tests {
         let app = Router::new().route(
             "/",
             post(|OptionalQuery(data): OptionalQuery<Data>| async move {
-                data.map(|Data { values }| values.join(","))
-                    .unwrap_or("None".to_owned())
+                data.map_or("None".to_owned(), |Data { values }| values.join(","))
             }),
         );
 

--- a/axum-extra/src/extract/scheme.rs
+++ b/axum-extra/src/extract/scheme.rs
@@ -38,7 +38,7 @@ where
     async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
         // Within Forwarded header
         if let Some(scheme) = parse_forwarded(&parts.headers) {
-            return Ok(Scheme(scheme.to_owned()));
+            return Ok(Self(scheme.to_owned()));
         }
 
         // X-Forwarded-Proto
@@ -47,12 +47,12 @@ where
             .get(X_FORWARDED_PROTO_HEADER_KEY)
             .and_then(|scheme| scheme.to_str().ok())
         {
-            return Ok(Scheme(scheme.to_owned()));
+            return Ok(Self(scheme.to_owned()));
         }
 
         // From parts of an HTTP/2 request
         if let Some(scheme) = parts.uri.scheme_str() {
-            return Ok(Scheme(scheme.to_owned()));
+            return Ok(Self(scheme.to_owned()));
         }
 
         Err(SchemeMissing)

--- a/axum-extra/src/extract/with_rejection.rs
+++ b/axum-extra/src/extract/with_rejection.rs
@@ -187,7 +187,7 @@ mod tests {
         }
 
         impl From<()> for TestRejection {
-            fn from(_: ()) -> Self {
+            fn from((): ()) -> Self {
                 Self
             }
         }
@@ -196,7 +196,7 @@ mod tests {
         let result = WithRejection::<TestExtractor, TestRejection>::from_request(req, &()).await;
         assert!(matches!(result, Err(TestRejection)));
 
-        let (mut parts, _) = Request::new(()).into_parts();
+        let (mut parts, ()) = Request::new(()).into_parts();
         let result =
             WithRejection::<TestExtractor, TestRejection>::from_request_parts(&mut parts, &())
                 .await;

--- a/axum-extra/src/extract/with_rejection.rs
+++ b/axum-extra/src/extract/with_rejection.rs
@@ -119,7 +119,7 @@ where
 
     async fn from_request(req: Request, state: &S) -> Result<Self, Self::Rejection> {
         let extractor = E::from_request(req, state).await?;
-        Ok(WithRejection(extractor, PhantomData))
+        Ok(Self(extractor, PhantomData))
     }
 }
 
@@ -133,7 +133,7 @@ where
 
     async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
         let extractor = E::from_request_parts(parts, state).await?;
-        Ok(WithRejection(extractor, PhantomData))
+        Ok(Self(extractor, PhantomData))
     }
 }
 
@@ -188,7 +188,7 @@ mod tests {
 
         impl From<()> for TestRejection {
             fn from(_: ()) -> Self {
-                TestRejection
+                Self
             }
         }
 

--- a/axum-extra/src/json_lines.rs
+++ b/axum-extra/src/json_lines.rs
@@ -91,7 +91,7 @@ pub struct AsResponse;
 
 impl<S> JsonLines<S, AsResponse> {
     /// Create a new `JsonLines` from a stream of items.
-    pub fn new(stream: S) -> Self {
+    pub const fn new(stream: S) -> Self {
         Self {
             inner: Inner::Response { stream },
             _marker: PhantomData,

--- a/axum-extra/src/middleware.rs
+++ b/axum-extra/src/middleware.rs
@@ -38,7 +38,5 @@ use tower_layer::Identity;
 /// [`HandleErrorLayer`]: axum::error_handling::HandleErrorLayer
 /// [`Infallible`]: std::convert::Infallible
 pub fn option_layer<L>(layer: Option<L>) -> Either<L, Identity> {
-    layer
-        .map(Either::E1)
-        .unwrap_or_else(|| Either::E2(Identity::new()))
+    layer.map_or_else(|| Either::E2(Identity::new()), Either::E1)
 }

--- a/axum-extra/src/protobuf.rs
+++ b/axum-extra/src/protobuf.rs
@@ -109,7 +109,7 @@ where
             .aggregate();
 
         match T::decode(&mut buf) {
-            Ok(value) => Ok(Protobuf(value)),
+            Ok(value) => Ok(Self(value)),
             Err(err) => Err(ProtobufDecodeError::from_err(err).into()),
         }
     }

--- a/axum-extra/src/response/attachment.rs
+++ b/axum-extra/src/response/attachment.rs
@@ -43,7 +43,7 @@ pub struct Attachment<T> {
 
 impl<T: IntoResponse> Attachment<T> {
     /// Creates a new [`Attachment`].
-    pub fn new(inner: T) -> Self {
+    pub const fn new(inner: T) -> Self {
         Self {
             inner,
             filename: None,

--- a/axum-extra/src/response/attachment.rs
+++ b/axum-extra/src/response/attachment.rs
@@ -60,7 +60,7 @@ impl<T: IntoResponse> Attachment<T> {
                 error!("Attachment filename contains invalid characters");
                 None
             },
-            Some
+            Some,
         );
         self
     }

--- a/axum-extra/src/response/file_stream.rs
+++ b/axum-extra/src/response/file_stream.rs
@@ -118,12 +118,14 @@ where
     /// Set the file name of the [`FileStream`].
     ///
     /// This adds the attachment `Content-Disposition` header with the given `file_name`.
+    #[must_use]
     pub fn file_name(mut self, file_name: impl Into<String>) -> Self {
         self.file_name = Some(file_name.into());
         self
     }
 
     /// Set the size of the file.
+    #[must_use]
     pub const fn content_size(mut self, len: u64) -> Self {
         self.content_size = Some(len);
         self

--- a/axum-extra/src/response/file_stream.rs
+++ b/axum-extra/src/response/file_stream.rs
@@ -133,7 +133,9 @@ where
 
     /// Return a range response.
     ///
+    /// ```rust
     /// range: (start, end, total_size)
+    /// ```
     ///
     /// # Examples
     ///

--- a/axum-extra/src/response/file_stream.rs
+++ b/axum-extra/src/response/file_stream.rs
@@ -61,7 +61,7 @@ where
     S::Error: Into<BoxError>,
 {
     /// Create a new [`FileStream`]
-    pub fn new(stream: S) -> Self {
+    pub const fn new(stream: S) -> Self {
         Self {
             stream,
             file_name: None,
@@ -124,7 +124,7 @@ where
     }
 
     /// Set the size of the file.
-    pub fn content_size(mut self, len: u64) -> Self {
+    pub const fn content_size(mut self, len: u64) -> Self {
         self.content_size = Some(len);
         self
     }

--- a/axum-extra/src/response/multiple.rs
+++ b/axum-extra/src/response/multiple.rs
@@ -24,6 +24,7 @@ impl MultipartForm {
     /// let parts: Vec<Part> = vec![Part::text("foo".to_string(), "abc"), Part::text("bar".to_string(), "def")];
     /// let form = MultipartForm::with_parts(parts);
     /// ```
+    #[must_use]
     pub fn with_parts(parts: Vec<Part>) -> Self {
         MultipartForm { parts }
     }
@@ -103,6 +104,7 @@ impl Part {
     /// let parts: Vec<Part> = vec![Part::text("foo".to_string(), "abc")];
     /// let form = MultipartForm::from_iter(parts);
     /// ```
+    #[must_use]
     pub fn text(name: String, contents: &str) -> Self {
         Self {
             name,
@@ -127,6 +129,7 @@ impl Part {
     /// let parts: Vec<Part> = vec![Part::file("foo", "foo.txt", vec![0x68, 0x68, 0x20, 0x6d, 0x6f, 0x6d])];
     /// let form = MultipartForm::from_iter(parts);
     /// ```
+    #[must_use]
     pub fn file(field_name: &str, file_name: &str, contents: Vec<u8>) -> Self {
         Self {
             name: field_name.to_owned(),

--- a/axum-extra/src/response/multiple.rs
+++ b/axum-extra/src/response/multiple.rs
@@ -26,7 +26,7 @@ impl MultipartForm {
     /// ```
     #[must_use]
     pub fn with_parts(parts: Vec<Part>) -> Self {
-        MultipartForm { parts }
+        Self { parts }
     }
 }
 

--- a/axum-extra/src/response/multiple.rs
+++ b/axum-extra/src/response/multiple.rs
@@ -25,7 +25,7 @@ impl MultipartForm {
     /// let form = MultipartForm::with_parts(parts);
     /// ```
     #[must_use]
-    pub fn with_parts(parts: Vec<Part>) -> Self {
+    pub const fn with_parts(parts: Vec<Part>) -> Self {
         Self { parts }
     }
 }

--- a/axum-extra/src/routing/mod.rs
+++ b/axum-extra/src/routing/mod.rs
@@ -28,6 +28,7 @@ pub use self::typed::{SecondElementIs, TypedPath};
 // Validates a path at compile time, used with the vpath macro.
 #[rustversion::since(1.80)]
 #[doc(hidden)]
+#[must_use]
 pub const fn __private_validate_static_path(path: &'static str) -> &'static str {
     if path.is_empty() {
         panic!("Paths must start with a `/`. Use \"/\" for root routes")

--- a/axum-extra/src/routing/mod.rs
+++ b/axum-extra/src/routing/mod.rs
@@ -371,11 +371,10 @@ where
                 .unwrap_or_else(|| Cow::Owned(format!("{path}/")))
         });
 
-        if let Some(new_uri) = new_uri {
-            Redirect::permanent(&new_uri.to_string()).into_response()
-        } else {
-            StatusCode::BAD_REQUEST.into_response()
-        }
+        new_uri.map_or_else(
+            || StatusCode::BAD_REQUEST.into_response(),
+            |new_uri| Redirect::permanent(&new_uri.to_string()).into_response(),
+        )
     }
 
     if let Some(path_without_trailing_slash) = path.strip_suffix('/') {

--- a/axum-extra/src/routing/mod.rs
+++ b/axum-extra/src/routing/mod.rs
@@ -30,12 +30,11 @@ pub use self::typed::{SecondElementIs, TypedPath};
 #[doc(hidden)]
 #[must_use]
 pub const fn __private_validate_static_path(path: &'static str) -> &'static str {
-    if path.is_empty() {
-        panic!("Paths must start with a `/`. Use \"/\" for root routes")
-    }
-    if path.as_bytes()[0] != b'/' {
-        panic!("Paths must start with /");
-    }
+    assert!(
+        !path.is_empty(),
+        "Paths must start with a `/`. Use \"/\" for root routes"
+    );
+    assert!(path.as_bytes()[0] == b'/', "Paths must start with /");
     path
 }
 
@@ -355,9 +354,10 @@ where
 
 #[track_caller]
 fn validate_tsr_path(path: &str) {
-    if path == "/" {
-        panic!("Cannot add a trailing slash redirect route for `/`")
-    }
+    assert!(
+        path != "/",
+        "Cannot add a trailing slash redirect route for `/`"
+    );
 }
 
 fn add_tsr_redirect_route<S>(router: Router<S>, path: &str) -> Router<S>

--- a/axum-extra/src/routing/mod.rs
+++ b/axum-extra/src/routing/mod.rs
@@ -367,8 +367,7 @@ where
     async fn redirect_handler(OriginalUri(uri): OriginalUri) -> Response {
         let new_uri = map_path(uri, |path| {
             path.strip_suffix('/')
-                .map(Cow::Borrowed)
-                .unwrap_or_else(|| Cow::Owned(format!("{path}/")))
+                .map_or_else(|| Cow::Owned(format!("{path}/")), Cow::Borrowed)
         });
 
         new_uri.map_or_else(

--- a/axum-extra/src/routing/mod.rs
+++ b/axum-extra/src/routing/mod.rs
@@ -84,6 +84,7 @@ pub trait RouterExt<S>: sealed::Sealed {
     ///
     /// See [`TypedPath`] for more details and examples.
     #[cfg(feature = "typed-routing")]
+    #[must_use]
     fn typed_get<H, T, P>(self, handler: H) -> Self
     where
         H: axum::handler::Handler<T, S>,
@@ -97,6 +98,7 @@ pub trait RouterExt<S>: sealed::Sealed {
     ///
     /// See [`TypedPath`] for more details and examples.
     #[cfg(feature = "typed-routing")]
+    #[must_use]
     fn typed_delete<H, T, P>(self, handler: H) -> Self
     where
         H: axum::handler::Handler<T, S>,
@@ -110,6 +112,7 @@ pub trait RouterExt<S>: sealed::Sealed {
     ///
     /// See [`TypedPath`] for more details and examples.
     #[cfg(feature = "typed-routing")]
+    #[must_use]
     fn typed_head<H, T, P>(self, handler: H) -> Self
     where
         H: axum::handler::Handler<T, S>,
@@ -123,6 +126,7 @@ pub trait RouterExt<S>: sealed::Sealed {
     ///
     /// See [`TypedPath`] for more details and examples.
     #[cfg(feature = "typed-routing")]
+    #[must_use]
     fn typed_options<H, T, P>(self, handler: H) -> Self
     where
         H: axum::handler::Handler<T, S>,
@@ -136,6 +140,7 @@ pub trait RouterExt<S>: sealed::Sealed {
     ///
     /// See [`TypedPath`] for more details and examples.
     #[cfg(feature = "typed-routing")]
+    #[must_use]
     fn typed_patch<H, T, P>(self, handler: H) -> Self
     where
         H: axum::handler::Handler<T, S>,
@@ -149,6 +154,7 @@ pub trait RouterExt<S>: sealed::Sealed {
     ///
     /// See [`TypedPath`] for more details and examples.
     #[cfg(feature = "typed-routing")]
+    #[must_use]
     fn typed_post<H, T, P>(self, handler: H) -> Self
     where
         H: axum::handler::Handler<T, S>,
@@ -162,6 +168,7 @@ pub trait RouterExt<S>: sealed::Sealed {
     ///
     /// See [`TypedPath`] for more details and examples.
     #[cfg(feature = "typed-routing")]
+    #[must_use]
     fn typed_put<H, T, P>(self, handler: H) -> Self
     where
         H: axum::handler::Handler<T, S>,
@@ -175,6 +182,7 @@ pub trait RouterExt<S>: sealed::Sealed {
     ///
     /// See [`TypedPath`] for more details and examples.
     #[cfg(feature = "typed-routing")]
+    #[must_use]
     fn typed_trace<H, T, P>(self, handler: H) -> Self
     where
         H: axum::handler::Handler<T, S>,
@@ -188,6 +196,7 @@ pub trait RouterExt<S>: sealed::Sealed {
     ///
     /// See [`TypedPath`] for more details and examples.
     #[cfg(feature = "typed-routing")]
+    #[must_use]
     fn typed_connect<H, T, P>(self, handler: H) -> Self
     where
         H: axum::handler::Handler<T, S>,
@@ -219,6 +228,7 @@ pub trait RouterExt<S>: sealed::Sealed {
     ///     .route_with_tsr("/bar/", get(|| async {}));
     /// # let _: Router = app;
     /// ```
+    #[must_use]
     fn route_with_tsr(self, path: &str, method_router: MethodRouter<S>) -> Self
     where
         Self: Sized;
@@ -226,6 +236,7 @@ pub trait RouterExt<S>: sealed::Sealed {
     /// Add another route to the router with an additional "trailing slash redirect" route.
     ///
     /// This works like [`RouterExt::route_with_tsr`] but accepts any [`Service`].
+    #[must_use]
     fn route_service_with_tsr<T>(self, path: &str, service: T) -> Self
     where
         T: Service<Request, Error = Infallible> + Clone + Send + Sync + 'static,

--- a/axum-extra/src/typed_header.rs
+++ b/axum-extra/src/typed_header.rs
@@ -138,13 +138,13 @@ pub struct TypedHeaderRejection {
 impl TypedHeaderRejection {
     /// Name of the header that caused the rejection
     #[must_use]
-    pub fn name(&self) -> &http::header::HeaderName {
+    pub const fn name(&self) -> &http::header::HeaderName {
         self.name
     }
 
     /// Reason why the header extraction has failed
     #[must_use]
-    pub fn reason(&self) -> &TypedHeaderRejectionReason {
+    pub const fn reason(&self) -> &TypedHeaderRejectionReason {
         &self.reason
     }
 
@@ -152,7 +152,7 @@ impl TypedHeaderRejection {
     ///
     /// [`Missing`]: TypedHeaderRejectionReason::Missing
     #[must_use]
-    pub fn is_missing(&self) -> bool {
+    pub const fn is_missing(&self) -> bool {
         self.reason.is_missing()
     }
 }
@@ -173,7 +173,7 @@ impl TypedHeaderRejectionReason {
     ///
     /// [`Missing`]: TypedHeaderRejectionReason::Missing
     #[must_use]
-    pub fn is_missing(&self) -> bool {
+    pub const fn is_missing(&self) -> bool {
         matches!(self, Self::Missing)
     }
 }

--- a/axum-extra/src/typed_header.rs
+++ b/axum-extra/src/typed_header.rs
@@ -137,11 +137,13 @@ pub struct TypedHeaderRejection {
 
 impl TypedHeaderRejection {
     /// Name of the header that caused the rejection
+    #[must_use]
     pub fn name(&self) -> &http::header::HeaderName {
         self.name
     }
 
     /// Reason why the header extraction has failed
+    #[must_use]
     pub fn reason(&self) -> &TypedHeaderRejectionReason {
         &self.reason
     }

--- a/axum-macros/src/debug_handler.rs
+++ b/axum-macros/src/debug_handler.rs
@@ -97,8 +97,8 @@ pub(crate) enum FunctionKind {
 impl fmt::Display for FunctionKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            FunctionKind::Handler => f.write_str("handler"),
-            FunctionKind::Middleware => f.write_str("middleware"),
+            Self::Handler => f.write_str("handler"),
+            Self::Middleware => f.write_str("middleware"),
         }
     }
 }
@@ -106,8 +106,8 @@ impl fmt::Display for FunctionKind {
 impl FunctionKind {
     fn name_uppercase_plural(&self) -> &'static str {
         match self {
-            FunctionKind::Handler => "Handlers",
-            FunctionKind::Middleware => "Middleware",
+            Self::Handler => "Handlers",
+            Self::Middleware => "Middleware",
         }
     }
 }

--- a/axum-macros/src/debug_handler.rs
+++ b/axum-macros/src/debug_handler.rs
@@ -536,9 +536,8 @@ fn check_input_order(item_fn: &ItemFn, kind: FunctionKind) -> Option<TokenStream
             return Some(quote_spanned! {*span=>
                 compile_error!(#error);
             });
-        } else {
-            return None;
         }
+        return None;
     }
 
     if types_that_consume_the_request.len() == 2 {

--- a/axum-macros/src/debug_handler.rs
+++ b/axum-macros/src/debug_handler.rs
@@ -522,7 +522,7 @@ fn check_input_order(item_fn: &ItemFn, kind: FunctionKind) -> Option<TokenStream
 
     if types_that_consume_the_request.is_empty() {
         return None;
-    };
+    }
 
     // exactly one type that consumes the request
     if types_that_consume_the_request.len() == 1 {

--- a/axum-macros/src/debug_handler.rs
+++ b/axum-macros/src/debug_handler.rs
@@ -107,7 +107,7 @@ impl fmt::Display for FunctionKind {
 }
 
 impl FunctionKind {
-    fn name_uppercase_plural(&self) -> &'static str {
+    const fn name_uppercase_plural(&self) -> &'static str {
         match self {
             Self::Handler => "Handlers",
             Self::Middleware => "Middleware",

--- a/axum-macros/src/from_ref.rs
+++ b/axum-macros/src/from_ref.rs
@@ -39,19 +39,22 @@ fn expand_field(state: &Ident, idx: usize, field: &Field) -> TokenStream {
     let field_ty = &field.ty;
     let span = field.ty.span();
 
-    let body = if let Some(field_ident) = &field.ident {
-        if matches!(field_ty, Type::Reference(_)) {
-            quote_spanned! {span=> state.#field_ident }
-        } else {
-            quote_spanned! {span=> state.#field_ident.clone() }
-        }
-    } else {
-        let idx = syn::Index {
-            index: idx as _,
-            span: field.span(),
-        };
-        quote_spanned! {span=> state.#idx.clone() }
-    };
+    let body = field.ident.as_ref().map_or_else(
+        || {
+            let idx = syn::Index {
+                index: idx as _,
+                span: field.span(),
+            };
+            quote_spanned! {span=> state.#idx.clone() }
+        },
+        |field_ident| {
+            if matches!(field_ty, Type::Reference(_)) {
+                quote_spanned! {span=> state.#field_ident }
+            } else {
+                quote_spanned! {span=> state.#field_ident.clone() }
+            }
+        },
+    );
 
     quote_spanned! {span=>
         #[allow(clippy::clone_on_copy, clippy::clone_on_ref_ptr)]

--- a/axum-macros/src/from_request/mod.rs
+++ b/axum-macros/src/from_request/mod.rs
@@ -1061,4 +1061,4 @@ fn ui() {
 /// }
 /// ```
 #[allow(dead_code)]
-fn test_field_doesnt_impl_from_request() {}
+const fn test_field_doesnt_impl_from_request() {}

--- a/axum-macros/src/from_request/mod.rs
+++ b/axum-macros/src/from_request/mod.rs
@@ -642,9 +642,7 @@ fn extract_fields(
 }
 
 fn peel_option(ty: &syn::Type) -> Option<&syn::Type> {
-    let type_path = if let syn::Type::Path(type_path) = ty {
-        type_path
-    } else {
+    let syn::Type::Path(type_path) = ty else {
         return None;
     };
 
@@ -673,9 +671,7 @@ fn peel_option(ty: &syn::Type) -> Option<&syn::Type> {
 }
 
 fn peel_result_ok(ty: &syn::Type) -> Option<&syn::Type> {
-    let type_path = if let syn::Type::Path(type_path) = ty {
-        type_path
-    } else {
+    let syn::Type::Path(type_path) = ty else {
         return None;
     };
 

--- a/axum-macros/src/from_request/mod.rs
+++ b/axum-macros/src/from_request/mod.rs
@@ -21,8 +21,8 @@ pub(crate) enum Trait {
 impl Trait {
     fn via_marker_type(&self) -> Option<Type> {
         match self {
-            Trait::FromRequest => Some(parse_quote!(M)),
-            Trait::FromRequestParts => None,
+            Self::FromRequest => Some(parse_quote!(M)),
+            Self::FromRequestParts => None,
         }
     }
 }
@@ -30,8 +30,8 @@ impl Trait {
 impl fmt::Display for Trait {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Trait::FromRequest => f.write_str("FromRequest"),
-            Trait::FromRequestParts => f.write_str("FromRequestParts"),
+            Self::FromRequest => f.write_str("FromRequest"),
+            Self::FromRequestParts => f.write_str("FromRequestParts"),
         }
     }
 }
@@ -50,9 +50,9 @@ impl State {
     /// ```
     fn impl_generics(&self) -> impl Iterator<Item = Type> {
         match self {
-            State::Default(inner) => Some(inner.clone()),
-            State::Custom(_) => None,
-            State::CannotInfer => Some(parse_quote!(S)),
+            Self::Default(inner) => Some(inner.clone()),
+            Self::Custom(_) => None,
+            Self::CannotInfer => Some(parse_quote!(S)),
         }
         .into_iter()
     }
@@ -63,18 +63,18 @@ impl State {
     /// ```
     fn trait_generics(&self) -> impl Iterator<Item = Type> {
         match self {
-            State::Default(inner) | State::Custom(inner) => iter::once(inner.clone()),
-            State::CannotInfer => iter::once(parse_quote!(S)),
+            Self::Default(inner) | Self::Custom(inner) => iter::once(inner.clone()),
+            Self::CannotInfer => iter::once(parse_quote!(S)),
         }
     }
 
     fn bounds(&self) -> TokenStream {
         match self {
-            State::Custom(_) => quote! {},
-            State::Default(inner) => quote! {
+            Self::Custom(_) => quote! {},
+            Self::Default(inner) => quote! {
                 #inner: ::std::marker::Send + ::std::marker::Sync,
             },
-            State::CannotInfer => quote! {
+            Self::CannotInfer => quote! {
                 S: ::std::marker::Send + ::std::marker::Sync,
             },
         }
@@ -84,8 +84,8 @@ impl State {
 impl ToTokens for State {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         match self {
-            State::Custom(inner) | State::Default(inner) => inner.to_tokens(tokens),
-            State::CannotInfer => quote! { S }.to_tokens(tokens),
+            Self::Custom(inner) | Self::Default(inner) => inner.to_tokens(tokens),
+            Self::CannotInfer => quote! { S }.to_tokens(tokens),
         }
     }
 }

--- a/axum-macros/src/with_position.rs
+++ b/axum-macros/src/with_position.rs
@@ -40,8 +40,8 @@ impl<I> WithPosition<I>
 where
     I: Iterator,
 {
-    pub(crate) fn new(iter: impl IntoIterator<IntoIter = I>) -> WithPosition<I> {
-        WithPosition {
+    pub(crate) fn new(iter: impl IntoIterator<IntoIter = I>) -> Self {
+        Self {
             handled_first: false,
             peekable: iter.into_iter().fuse().peekable(),
         }
@@ -72,7 +72,7 @@ pub(crate) enum Position<T> {
 impl<T> Position<T> {
     pub(crate) fn into_inner(self) -> T {
         match self {
-            Position::First(x) | Position::Middle(x) | Position::Last(x) | Position::Only(x) => x,
+            Self::First(x) | Self::Middle(x) | Self::Last(x) | Self::Only(x) => x,
         }
     }
 }

--- a/axum-macros/src/with_position.rs
+++ b/axum-macros/src/with_position.rs
@@ -83,7 +83,14 @@ impl<I: Iterator> Iterator for WithPosition<I> {
     fn next(&mut self) -> Option<Self::Item> {
         match self.peekable.next() {
             Some(item) => {
-                if !self.handled_first {
+                if self.handled_first {
+                    // Have seen the first item, and there's something left.
+                    // Peek to see if this is the last item.
+                    match self.peekable.peek() {
+                        Some(_) => Some(Position::Middle(item)),
+                        None => Some(Position::Last(item)),
+                    }
+                } else {
                     // Haven't seen the first item yet, and there is one to give.
                     self.handled_first = true;
                     // Peek to see if this is also the last item,
@@ -91,13 +98,6 @@ impl<I: Iterator> Iterator for WithPosition<I> {
                     match self.peekable.peek() {
                         Some(_) => Some(Position::First(item)),
                         None => Some(Position::Only(item)),
-                    }
-                } else {
-                    // Have seen the first item, and there's something left.
-                    // Peek to see if this is the last item.
-                    match self.peekable.peek() {
-                        Some(_) => Some(Position::Middle(item)),
-                        None => Some(Position::Last(item)),
                     }
                 }
             }

--- a/axum/benches/benches.rs
+++ b/axum/benches/benches.rs
@@ -102,7 +102,7 @@ struct Payload {
     b: bool,
 }
 
-fn benchmark(name: &'static str) -> BenchmarkBuilder {
+const fn benchmark(name: &'static str) -> BenchmarkBuilder {
     BenchmarkBuilder {
         name,
         path: None,
@@ -122,7 +122,7 @@ struct BenchmarkBuilder {
 
 macro_rules! config_method {
     ($name:ident, $ty:ty) => {
-        fn $name(mut self, $name: $ty) -> Self {
+        const fn $name(mut self, $name: $ty) -> Self {
             self.$name = Some($name);
             self
         }

--- a/axum/benches/benches.rs
+++ b/axum/benches/benches.rs
@@ -230,9 +230,7 @@ fn install_rewrk() {
     let status = cmd
         .status()
         .unwrap_or_else(|_| panic!("failed to install rewrk"));
-    if !status.success() {
-        panic!("failed to install rewrk");
-    }
+    assert!(status.success(), "failed to install rewrk");
 }
 
 fn ensure_rewrk_is_installed() {

--- a/axum/src/extension.rs
+++ b/axum/src/extension.rs
@@ -204,7 +204,7 @@ mod tests {
         }
 
         async fn optional_foo(extension: Option<Extension<Foo>>) -> String {
-            extension.map(|foo| foo.0 .0).unwrap_or("none".to_owned())
+            extension.map_or("none".to_owned(), |foo| foo.0 .0)
         }
 
         async fn requires_bar(Extension(bar): Extension<Bar>) -> String {
@@ -212,7 +212,7 @@ mod tests {
         }
 
         async fn optional_bar(extension: Option<Extension<Bar>>) -> String {
-            extension.map(|bar| bar.0 .0).unwrap_or("none".to_owned())
+            extension.map_or("none".to_owned(), |bar| bar.0 .0)
         }
 
         let app = Router::new()

--- a/axum/src/extension.rs
+++ b/axum/src/extension.rs
@@ -1,4 +1,7 @@
-use crate::{extract::rejection::*, response::IntoResponseParts};
+use crate::{
+    extract::rejection::{ExtensionRejection, MissingExtension},
+    response::IntoResponseParts,
+};
 use axum_core::extract::OptionalFromRequestParts;
 use axum_core::{
     extract::FromRequestParts,

--- a/axum/src/extract/connect_info.rs
+++ b/axum/src/extract/connect_info.rs
@@ -105,8 +105,8 @@ const _: () = {
     }
 };
 
-impl Connected<SocketAddr> for SocketAddr {
-    fn connect_info(remote_addr: SocketAddr) -> Self {
+impl Connected<Self> for SocketAddr {
+    fn connect_info(remote_addr: Self) -> Self {
         remote_addr
     }
 }

--- a/axum/src/extract/matched_path.rs
+++ b/axum/src/extract/matched_path.rs
@@ -58,6 +58,7 @@ pub struct MatchedPath(pub(crate) Arc<str>);
 
 impl MatchedPath {
     /// Returns a `str` representation of the path.
+    #[must_use]
     pub fn as_str(&self) -> &str {
         &self.0
     }

--- a/axum/src/extract/matched_path.rs
+++ b/axum/src/extract/matched_path.rs
@@ -123,20 +123,21 @@ pub(crate) fn set_matched_path_for_request(
 
 // a previous `MatchedPath` might exist if we're inside a nested Router
 fn append_nested_matched_path(matched_path: &Arc<str>, extensions: &http::Extensions) -> Arc<str> {
-    if let Some(previous) = extensions
+    extensions
         .get::<MatchedPath>()
         .map(|matched_path| matched_path.as_str())
         .or_else(|| Some(&extensions.get::<MatchedNestedPath>()?.0))
-    {
-        let previous = previous
-            .strip_suffix(NEST_TAIL_PARAM_CAPTURE)
-            .unwrap_or(previous);
+        .map_or_else(
+            || Arc::clone(matched_path),
+            |previous| {
+                let previous = previous
+                    .strip_suffix(NEST_TAIL_PARAM_CAPTURE)
+                    .unwrap_or(previous);
 
-        let matched_path = format!("{previous}{matched_path}");
-        matched_path.into()
-    } else {
-        Arc::clone(matched_path)
-    }
+                let matched_path = format!("{previous}{matched_path}");
+                matched_path.into()
+            },
+        )
 }
 
 #[cfg(test)]

--- a/axum/src/extract/matched_path.rs
+++ b/axum/src/extract/matched_path.rs
@@ -1,4 +1,7 @@
-use super::{rejection::*, FromRequestParts};
+use super::{
+    rejection::{MatchedPathMissing, MatchedPathRejection},
+    FromRequestParts,
+};
 use crate::routing::{RouteId, NEST_TAIL_PARAM_CAPTURE};
 use axum_core::extract::OptionalFromRequestParts;
 use http::request::Parts;

--- a/axum/src/extract/matched_path.rs
+++ b/axum/src/extract/matched_path.rs
@@ -103,9 +103,7 @@ pub(crate) fn set_matched_path_for_request(
     route_id_to_path: &HashMap<RouteId, Arc<str>>,
     extensions: &mut http::Extensions,
 ) {
-    let matched_path = if let Some(matched_path) = route_id_to_path.get(&id) {
-        matched_path
-    } else {
+    let Some(matched_path) = route_id_to_path.get(&id) else {
         #[cfg(debug_assertions)]
         panic!("should always have a matched path for a route id");
         #[cfg(not(debug_assertions))]

--- a/axum/src/extract/mod.rs
+++ b/axum/src/extract/mod.rs
@@ -81,15 +81,11 @@ pub use self::ws::WebSocketUpgrade;
 
 // this is duplicated in `axum-extra/src/extract/form.rs`
 pub(super) fn has_content_type(headers: &HeaderMap, expected_content_type: &mime::Mime) -> bool {
-    let content_type = if let Some(content_type) = headers.get(header::CONTENT_TYPE) {
-        content_type
-    } else {
+    let Some(content_type) = headers.get(header::CONTENT_TYPE) else {
         return false;
     };
 
-    let content_type = if let Ok(content_type) = content_type.to_str() {
-        content_type
-    } else {
+    let Ok(content_type) = content_type.to_str() else {
         return false;
     };
 

--- a/axum/src/extract/multipart.rs
+++ b/axum/src/extract/multipart.rs
@@ -146,6 +146,7 @@ impl Field<'_> {
     /// The field name found in the
     /// [`Content-Disposition`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition)
     /// header.
+    #[must_use]
     pub fn name(&self) -> Option<&str> {
         self.inner.name()
     }
@@ -153,16 +154,19 @@ impl Field<'_> {
     /// The file name found in the
     /// [`Content-Disposition`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition)
     /// header.
+    #[must_use]
     pub fn file_name(&self) -> Option<&str> {
         self.inner.file_name()
     }
 
     /// Get the [content type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type) of the field.
+    #[must_use]
     pub fn content_type(&self) -> Option<&str> {
         self.inner.content_type().map(|m| m.as_ref())
     }
 
     /// Get a map of headers as [`HeaderMap`].
+    #[must_use]
     pub fn headers(&self) -> &HeaderMap {
         self.inner.headers()
     }
@@ -238,11 +242,13 @@ impl MultipartError {
     }
 
     /// Get the response body text used for this rejection.
+    #[must_use]
     pub fn body_text(&self) -> String {
         self.source.to_string()
     }
 
     /// Get the status code used for this rejection.
+    #[must_use]
     pub fn status(&self) -> http::StatusCode {
         status_code_from_multer_error(&self.source)
     }

--- a/axum/src/extract/multipart.rs
+++ b/axum/src/extract/multipart.rs
@@ -112,14 +112,15 @@ impl Multipart {
             .await
             .map_err(MultipartError::from_multer)?;
 
-        if let Some(field) = field {
-            Ok(Some(Field {
-                inner: field,
-                _multipart: self,
-            }))
-        } else {
-            Ok(None)
-        }
+        field.map_or_else(
+            || Ok(None),
+            |field| {
+                Ok(Some(Field {
+                    inner: field,
+                    _multipart: self,
+                }))
+            },
+        )
     }
 }
 

--- a/axum/src/extract/multipart.rs
+++ b/axum/src/extract/multipart.rs
@@ -238,7 +238,7 @@ pub struct MultipartError {
 }
 
 impl MultipartError {
-    fn from_multer(multer: multer::Error) -> Self {
+    const fn from_multer(multer: multer::Error) -> Self {
         Self { source: multer }
     }
 

--- a/axum/src/extract/nested_path.rs
+++ b/axum/src/extract/nested_path.rs
@@ -54,10 +54,12 @@ where
     type Rejection = NestedPathRejection;
 
     async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
-        match parts.extensions.get::<Self>() {
-            Some(nested_path) => Ok(nested_path.clone()),
-            None => Err(NestedPathRejection),
-        }
+        parts
+            .extensions
+            .get::<Self>()
+            .map_or(Err(NestedPathRejection), |nested_path| {
+                Ok(nested_path.clone())
+            })
     }
 }
 

--- a/axum/src/extract/nested_path.rs
+++ b/axum/src/extract/nested_path.rs
@@ -101,7 +101,7 @@ where
         } else {
             req.extensions_mut()
                 .insert(NestedPath(Arc::clone(&self.path)));
-        };
+        }
 
         self.inner.call(req)
     }

--- a/axum/src/extract/nested_path.rs
+++ b/axum/src/extract/nested_path.rs
@@ -41,6 +41,7 @@ pub struct NestedPath(Arc<str>);
 
 impl NestedPath {
     /// Returns a `str` representation of the path.
+    #[must_use]
     pub fn as_str(&self) -> &str {
         &self.0
     }

--- a/axum/src/extract/original_uri.rs
+++ b/axum/src/extract/original_uri.rs
@@ -76,7 +76,7 @@ where
     async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
         let uri = Extension::<Self>::from_request_parts(parts, state)
             .await
-            .unwrap_or_else(|_| Extension(OriginalUri(parts.uri.clone())))
+            .unwrap_or_else(|_| Extension(Self(parts.uri.clone())))
             .0;
         Ok(uri)
     }

--- a/axum/src/extract/path/de.rs
+++ b/axum/src/extract/path/de.rs
@@ -48,7 +48,7 @@ pub(crate) struct PathDeserializer<'de> {
 
 impl<'de> PathDeserializer<'de> {
     #[inline]
-    pub(crate) fn new(url_params: &'de [(Arc<str>, PercentDecodedStr)]) -> Self {
+    pub(crate) const fn new(url_params: &'de [(Arc<str>, PercentDecodedStr)]) -> Self {
         PathDeserializer { url_params }
     }
 }
@@ -637,7 +637,7 @@ enum KeyOrIdx<'de> {
 }
 
 impl<'de> KeyOrIdx<'de> {
-    fn key(&self) -> &'de str {
+    const fn key(&self) -> &'de str {
         match &self {
             Self::Key(key) => key,
             Self::Idx { key, .. } => key,

--- a/axum/src/extract/path/de.rs
+++ b/axum/src/extract/path/de.rs
@@ -460,7 +460,7 @@ impl<'de> Deserializer<'de> for ValueDeserializer<'de> {
                         ));
                     }
                     None => {}
-                };
+                }
 
                 self.value
                     .take()

--- a/axum/src/extract/path/mod.rs
+++ b/axum/src/extract/path/mod.rs
@@ -183,7 +183,7 @@ where
         }
 
         match T::deserialize(de::PathDeserializer::new(get_params(parts)?)) {
-            Ok(val) => Ok(Path(val)),
+            Ok(val) => Ok(Self(val)),
             Err(e) => Err(failed_to_deserialize_path_params(e)),
         }
     }
@@ -356,9 +356,9 @@ pub enum ErrorKind {
 impl fmt::Display for ErrorKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            ErrorKind::Message(error) => error.fmt(f),
-            ErrorKind::InvalidUtf8InPathParam { key } => write!(f, "Invalid UTF-8 in `{key}`"),
-            ErrorKind::WrongNumberOfParameters { got, expected } => {
+            Self::Message(error) => error.fmt(f),
+            Self::InvalidUtf8InPathParam { key } => write!(f, "Invalid UTF-8 in `{key}`"),
+            Self::WrongNumberOfParameters { got, expected } => {
                 write!(
                     f,
                     "Wrong number of path arguments for `Path`. Expected {expected} but got {got}"
@@ -370,8 +370,8 @@ impl fmt::Display for ErrorKind {
 
                 Ok(())
             }
-            ErrorKind::UnsupportedType { name } => write!(f, "Unsupported type `{name}`"),
-            ErrorKind::ParseErrorAtKey {
+            Self::UnsupportedType { name } => write!(f, "Unsupported type `{name}`"),
+            Self::ParseErrorAtKey {
                 key,
                 value,
                 expected_type,
@@ -379,11 +379,11 @@ impl fmt::Display for ErrorKind {
                 f,
                 "Cannot parse `{key}` with value `{value}` to a `{expected_type}`"
             ),
-            ErrorKind::ParseError {
+            Self::ParseError {
                 value,
                 expected_type,
             } => write!(f, "Cannot parse `{value}` to a `{expected_type}`"),
-            ErrorKind::ParseErrorAtIndex {
+            Self::ParseErrorAtIndex {
                 index,
                 value,
                 expected_type,
@@ -391,7 +391,7 @@ impl fmt::Display for ErrorKind {
                 f,
                 "Cannot parse value at index {index} with value `{value}` to a `{expected_type}`"
             ),
-            ErrorKind::DeserializeError {
+            Self::DeserializeError {
                 key,
                 value,
                 message,
@@ -773,7 +773,7 @@ mod tests {
                 D: serde::Deserializer<'de>,
             {
                 let s = <&str as serde::Deserialize>::deserialize(deserializer)?;
-                Ok(Param(s.to_owned()))
+                Ok(Self(s.to_owned()))
             }
         }
 

--- a/axum/src/extract/path/mod.rs
+++ b/axum/src/extract/path/mod.rs
@@ -407,16 +407,19 @@ pub struct FailedToDeserializePathParams(PathDeserializationError);
 
 impl FailedToDeserializePathParams {
     /// Get a reference to the underlying error kind.
+    #[must_use]
     pub fn kind(&self) -> &ErrorKind {
         &self.0.kind
     }
 
     /// Convert this error into the underlying error kind.
+    #[must_use]
     pub fn into_kind(self) -> ErrorKind {
         self.0.kind
     }
 
     /// Get the response body text used for this rejection.
+    #[must_use]
     pub fn body_text(&self) -> String {
         match self.0.kind {
             ErrorKind::Message(_)
@@ -432,6 +435,7 @@ impl FailedToDeserializePathParams {
     }
 
     /// Get the status code used for this rejection.
+    #[must_use]
     pub fn status(&self) -> StatusCode {
         match self.0.kind {
             ErrorKind::Message(_)
@@ -523,6 +527,7 @@ where
 
 impl RawPathParams {
     /// Get an iterator over the path parameters.
+    #[must_use]
     pub fn iter(&self) -> RawPathParamsIter<'_> {
         self.into_iter()
     }
@@ -561,11 +566,13 @@ pub struct InvalidUtf8InPathParam {
 
 impl InvalidUtf8InPathParam {
     /// Get the response body text used for this rejection.
+    #[must_use]
     pub fn body_text(&self) -> String {
         self.to_string()
     }
 
     /// Get the status code used for this rejection.
+    #[must_use]
     pub fn status(&self) -> StatusCode {
         StatusCode::BAD_REQUEST
     }

--- a/axum/src/extract/path/mod.rs
+++ b/axum/src/extract/path/mod.rs
@@ -178,7 +178,7 @@ where
             }
         }
 
-        fn failed_to_deserialize_path_params(err: PathDeserializationError) -> PathRejection {
+        const fn failed_to_deserialize_path_params(err: PathDeserializationError) -> PathRejection {
             PathRejection::FailedToDeserializePathParams(FailedToDeserializePathParams(err))
         }
 
@@ -220,16 +220,16 @@ pub(crate) struct PathDeserializationError {
 }
 
 impl PathDeserializationError {
-    pub(super) fn new(kind: ErrorKind) -> Self {
+    pub(super) const fn new(kind: ErrorKind) -> Self {
         Self { kind }
     }
 
-    pub(super) fn wrong_number_of_parameters() -> WrongNumberOfParameters<()> {
+    pub(super) const fn wrong_number_of_parameters() -> WrongNumberOfParameters<()> {
         WrongNumberOfParameters { got: () }
     }
 
     #[track_caller]
-    pub(super) fn unsupported_type(name: &'static str) -> Self {
+    pub(super) const fn unsupported_type(name: &'static str) -> Self {
         Self::new(ErrorKind::UnsupportedType { name })
     }
 }
@@ -246,7 +246,7 @@ impl<G> WrongNumberOfParameters<G> {
 }
 
 impl WrongNumberOfParameters<usize> {
-    pub(super) fn expected(self, expected: usize) -> PathDeserializationError {
+    pub(super) const fn expected(self, expected: usize) -> PathDeserializationError {
         PathDeserializationError::new(ErrorKind::WrongNumberOfParameters {
             got: self.got,
             expected,
@@ -408,7 +408,7 @@ pub struct FailedToDeserializePathParams(PathDeserializationError);
 impl FailedToDeserializePathParams {
     /// Get a reference to the underlying error kind.
     #[must_use]
-    pub fn kind(&self) -> &ErrorKind {
+    pub const fn kind(&self) -> &ErrorKind {
         &self.0.kind
     }
 
@@ -436,7 +436,7 @@ impl FailedToDeserializePathParams {
 
     /// Get the status code used for this rejection.
     #[must_use]
-    pub fn status(&self) -> StatusCode {
+    pub const fn status(&self) -> StatusCode {
         match self.0.kind {
             ErrorKind::Message(_)
             | ErrorKind::DeserializeError { .. }
@@ -573,7 +573,7 @@ impl InvalidUtf8InPathParam {
 
     /// Get the status code used for this rejection.
     #[must_use]
-    pub fn status(&self) -> StatusCode {
+    pub const fn status(&self) -> StatusCode {
         StatusCode::BAD_REQUEST
     }
 }

--- a/axum/src/extract/path/mod.rs
+++ b/axum/src/extract/path/mod.rs
@@ -4,7 +4,10 @@
 mod de;
 
 use crate::{
-    extract::{rejection::*, FromRequestParts},
+    extract::{
+        rejection::{MissingPathParams, PathRejection, RawPathParamsRejection},
+        FromRequestParts,
+    },
     routing::url_params::UrlParams,
     util::PercentDecodedStr,
 };

--- a/axum/src/extract/query.rs
+++ b/axum/src/extract/query.rs
@@ -1,4 +1,7 @@
-use super::{rejection::*, FromRequestParts};
+use super::{
+    rejection::{FailedToDeserializeQueryString, QueryRejection},
+    FromRequestParts,
+};
 use http::{request::Parts, Uri};
 use serde::de::DeserializeOwned;
 

--- a/axum/src/extract/query.rs
+++ b/axum/src/extract/query.rs
@@ -91,7 +91,7 @@ where
             serde_urlencoded::Deserializer::new(form_urlencoded::parse(query.as_bytes()));
         let params = serde_path_to_error::deserialize(deserializer)
             .map_err(FailedToDeserializeQueryString::from_err)?;
-        Ok(Query(params))
+        Ok(Self(params))
     }
 }
 

--- a/axum/src/extract/raw_form.rs
+++ b/axum/src/extract/raw_form.rs
@@ -99,6 +99,6 @@ mod tests {
         assert!(matches!(
             RawForm::from_request(req, &()).await.unwrap_err(),
             RawFormRejection::InvalidFormContentType(InvalidFormContentType)
-        ))
+        ));
     }
 }

--- a/axum/src/extract/ws.rs
+++ b/axum/src/extract/ws.rs
@@ -90,7 +90,11 @@
 //!
 //! [`StreamExt::split`]: https://docs.rs/futures/0.3.17/futures/stream/trait.StreamExt.html#method.split
 
-use self::rejection::*;
+use self::rejection::{
+    ConnectionNotUpgradable, InvalidConnectionHeader, InvalidProtocolPseudoheader,
+    InvalidUpgradeHeader, InvalidWebSocketVersionHeader, MethodNotConnect, MethodNotGet,
+    WebSocketKeyHeaderMissing, WebSocketUpgradeRejection,
+};
 use super::FromRequestParts;
 use crate::{body::Bytes, response::Response, Error};
 use axum_core::body::Body;

--- a/axum/src/extract/ws.rs
+++ b/axum/src/extract/ws.rs
@@ -575,7 +575,7 @@ impl Sink<Message> for WebSocket {
 
 /// UTF-8 wrapper for [Bytes].
 ///
-/// An [Utf8Bytes] is always guaranteed to contain valid UTF-8.
+/// An [`Utf8Bytes`] is always guaranteed to contain valid UTF-8.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct Utf8Bytes(ts::Utf8Bytes);
 
@@ -809,7 +809,7 @@ impl Message {
         }
     }
 
-    /// Attempt to consume the WebSocket message and convert it to a Utf8Bytes.
+    /// Attempt to consume the WebSocket message and convert it to a [`Utf8Bytes`].
     pub fn into_text(self) -> Result<Utf8Bytes, Error> {
         match self {
             Self::Text(string) => Ok(string),

--- a/axum/src/extract/ws.rs
+++ b/axum/src/extract/ws.rs
@@ -156,6 +156,7 @@ impl<F> std::fmt::Debug for WebSocketUpgrade<F> {
 
 impl<F> WebSocketUpgrade<F> {
     /// Read buffer capacity. The default value is 128KiB
+    #[must_use]
     pub const fn read_buffer_size(mut self, size: usize) -> Self {
         self.config.read_buffer_size = size;
         self
@@ -170,6 +171,7 @@ impl<F> WebSocketUpgrade<F> {
     /// It is often more optimal to allow them to buffer a little, hence the default value.
     ///
     /// Note: [`flush`](SinkExt::flush) will always fully write the buffer regardless.
+    #[must_use]
     pub const fn write_buffer_size(mut self, size: usize) -> Self {
         self.config.write_buffer_size = size;
         self
@@ -186,24 +188,28 @@ impl<F> WebSocketUpgrade<F> {
     ///
     /// Note: Should always be at least [`write_buffer_size + 1 message`](Self::write_buffer_size)
     /// and probably a little more depending on error handling strategy.
+    #[must_use]
     pub const fn max_write_buffer_size(mut self, max: usize) -> Self {
         self.config.max_write_buffer_size = max;
         self
     }
 
     /// Set the maximum message size (defaults to 64 megabytes)
+    #[must_use]
     pub const fn max_message_size(mut self, max: usize) -> Self {
         self.config.max_message_size = Some(max);
         self
     }
 
     /// Set the maximum frame size (defaults to 16 megabytes)
+    #[must_use]
     pub const fn max_frame_size(mut self, max: usize) -> Self {
         self.config.max_frame_size = Some(max);
         self
     }
 
     /// Allow server to accept unmasked frames (defaults to false)
+    #[must_use]
     pub const fn accept_unmasked_frames(mut self, accept: bool) -> Self {
         self.config.accept_unmasked_frames = accept;
         self
@@ -239,6 +245,7 @@ impl<F> WebSocketUpgrade<F> {
     /// }
     /// # let _: Router = app;
     /// ```
+    #[must_use]
     pub fn protocols<I>(mut self, protocols: I) -> Self
     where
         I: IntoIterator,

--- a/axum/src/extract/ws.rs
+++ b/axum/src/extract/ws.rs
@@ -392,7 +392,7 @@ where
     F: FnOnce(Error) + Send + 'static,
 {
     fn call(self, error: Error) {
-        self(error)
+        self(error);
     }
 }
 

--- a/axum/src/extract/ws.rs
+++ b/axum/src/extract/ws.rs
@@ -152,7 +152,7 @@ impl<F> std::fmt::Debug for WebSocketUpgrade<F> {
 
 impl<F> WebSocketUpgrade<F> {
     /// Read buffer capacity. The default value is 128KiB
-    pub fn read_buffer_size(mut self, size: usize) -> Self {
+    pub const fn read_buffer_size(mut self, size: usize) -> Self {
         self.config.read_buffer_size = size;
         self
     }
@@ -166,7 +166,7 @@ impl<F> WebSocketUpgrade<F> {
     /// It is often more optimal to allow them to buffer a little, hence the default value.
     ///
     /// Note: [`flush`](SinkExt::flush) will always fully write the buffer regardless.
-    pub fn write_buffer_size(mut self, size: usize) -> Self {
+    pub const fn write_buffer_size(mut self, size: usize) -> Self {
         self.config.write_buffer_size = size;
         self
     }
@@ -182,25 +182,25 @@ impl<F> WebSocketUpgrade<F> {
     ///
     /// Note: Should always be at least [`write_buffer_size + 1 message`](Self::write_buffer_size)
     /// and probably a little more depending on error handling strategy.
-    pub fn max_write_buffer_size(mut self, max: usize) -> Self {
+    pub const fn max_write_buffer_size(mut self, max: usize) -> Self {
         self.config.max_write_buffer_size = max;
         self
     }
 
     /// Set the maximum message size (defaults to 64 megabytes)
-    pub fn max_message_size(mut self, max: usize) -> Self {
+    pub const fn max_message_size(mut self, max: usize) -> Self {
         self.config.max_message_size = Some(max);
         self
     }
 
     /// Set the maximum frame size (defaults to 16 megabytes)
-    pub fn max_frame_size(mut self, max: usize) -> Self {
+    pub const fn max_frame_size(mut self, max: usize) -> Self {
         self.config.max_frame_size = Some(max);
         self
     }
 
     /// Allow server to accept unmasked frames (defaults to false)
-    pub fn accept_unmasked_frames(mut self, accept: bool) -> Self {
+    pub const fn accept_unmasked_frames(mut self, accept: bool) -> Self {
         self.config.accept_unmasked_frames = accept;
         self
     }
@@ -269,7 +269,7 @@ impl<F> WebSocketUpgrade<F> {
     /// If [`protocols()`][Self::protocols] has been called and a matching
     /// protocol has been selected, the return value will be `Some` containing
     /// said protocol. Otherwise, it will be `None`.
-    pub fn selected_protocol(&self) -> Option<&HeaderValue> {
+    pub const fn selected_protocol(&self) -> Option<&HeaderValue> {
         self.protocol.as_ref()
     }
 
@@ -517,7 +517,7 @@ impl WebSocket {
     }
 
     /// Return the selected WebSocket subprotocol, if one has been chosen.
-    pub fn protocol(&self) -> Option<&HeaderValue> {
+    pub const fn protocol(&self) -> Option<&HeaderValue> {
         self.protocol.as_ref()
     }
 }

--- a/axum/src/extract/ws.rs
+++ b/axum/src/extract/ws.rs
@@ -580,6 +580,7 @@ pub struct Utf8Bytes(ts::Utf8Bytes);
 impl Utf8Bytes {
     /// Creates from a static str.
     #[inline]
+    #[must_use]
     pub const fn from_static(str: &'static str) -> Self {
         Self(ts::Utf8Bytes::from_static(str))
     }

--- a/axum/src/extract/ws.rs
+++ b/axum/src/extract/ws.rs
@@ -833,49 +833,49 @@ impl Message {
     }
 
     /// Create a new text WebSocket message from a stringable.
-    pub fn text<S>(string: S) -> Message
+    pub fn text<S>(string: S) -> Self
     where
         S: Into<Utf8Bytes>,
     {
-        Message::Text(string.into())
+        Self::Text(string.into())
     }
 
     /// Create a new binary WebSocket message by converting to `Bytes`.
-    pub fn binary<B>(bin: B) -> Message
+    pub fn binary<B>(bin: B) -> Self
     where
         B: Into<Bytes>,
     {
-        Message::Binary(bin.into())
+        Self::Binary(bin.into())
     }
 }
 
 impl From<String> for Message {
     fn from(string: String) -> Self {
-        Message::Text(string.into())
+        Self::Text(string.into())
     }
 }
 
 impl<'s> From<&'s str> for Message {
     fn from(string: &'s str) -> Self {
-        Message::Text(string.into())
+        Self::Text(string.into())
     }
 }
 
 impl<'b> From<&'b [u8]> for Message {
     fn from(data: &'b [u8]) -> Self {
-        Message::Binary(Bytes::copy_from_slice(data))
+        Self::Binary(Bytes::copy_from_slice(data))
     }
 }
 
 impl From<Bytes> for Message {
     fn from(data: Bytes) -> Self {
-        Message::Binary(data)
+        Self::Binary(data)
     }
 }
 
 impl From<Vec<u8>> for Message {
     fn from(data: Vec<u8>) -> Self {
-        Message::Binary(data.into())
+        Self::Binary(data.into())
     }
 }
 

--- a/axum/src/extract/ws.rs
+++ b/axum/src/extract/ws.rs
@@ -487,9 +487,7 @@ fn header_eq(headers: &HeaderMap, key: HeaderName, value: &'static str) -> bool 
 }
 
 fn header_contains(headers: &HeaderMap, key: HeaderName, value: &'static str) -> bool {
-    let header = if let Some(header) = headers.get(&key) {
-        header
-    } else {
+    let Some(header) = headers.get(&key) else {
         return false;
     };
 

--- a/axum/src/extract/ws.rs
+++ b/axum/src/extract/ws.rs
@@ -91,10 +91,12 @@
 //! [`StreamExt::split`]: https://docs.rs/futures/0.3.17/futures/stream/trait.StreamExt.html#method.split
 
 use self::rejection::{
-    ConnectionNotUpgradable, InvalidConnectionHeader, InvalidProtocolPseudoheader,
+    ConnectionNotUpgradable, InvalidConnectionHeader,
     InvalidUpgradeHeader, InvalidWebSocketVersionHeader, MethodNotConnect, MethodNotGet,
     WebSocketKeyHeaderMissing, WebSocketUpgradeRejection,
 };
+#[cfg(feature = "http2")]
+use self::rejection::InvalidProtocolPseudoheader;
 use super::FromRequestParts;
 use crate::{body::Bytes, response::Response, Error};
 use axum_core::body::Body;

--- a/axum/src/extract/ws.rs
+++ b/axum/src/extract/ws.rs
@@ -477,9 +477,9 @@ where
 }
 
 fn header_eq(headers: &HeaderMap, key: HeaderName, value: &'static str) -> bool {
-    headers.get(&key).is_some_and(|header| {
-        header.as_bytes().eq_ignore_ascii_case(value.as_bytes())
-    })
+    headers
+        .get(&key)
+        .is_some_and(|header| header.as_bytes().eq_ignore_ascii_case(value.as_bytes()))
 }
 
 fn header_contains(headers: &HeaderMap, key: HeaderName, value: &'static str) -> bool {

--- a/axum/src/form.rs
+++ b/axum/src/form.rs
@@ -95,7 +95,7 @@ where
                         }
                     },
                 )?;
-                Ok(Form(value))
+                Ok(Self(value))
             }
             Err(RawFormRejection::BytesRejection(r)) => Err(FormRejection::BytesRejection(r)),
             Err(RawFormRejection::InvalidFormContentType(r)) => {

--- a/axum/src/form.rs
+++ b/axum/src/form.rs
@@ -1,5 +1,10 @@
 use crate::extract::Request;
-use crate::extract::{rejection::*, FromRequest, RawForm};
+use crate::extract::{
+    rejection::{
+        FailedToDeserializeForm, FailedToDeserializeFormBody, FormRejection, RawFormRejection,
+    },
+    FromRequest, RawForm,
+};
 use axum_core::response::{IntoResponse, Response};
 use axum_core::RequestExt;
 use http::header::CONTENT_TYPE;
@@ -130,6 +135,7 @@ axum_core::__impl_deref!(Form);
 #[cfg(test)]
 mod tests {
     use crate::{
+        extract::rejection::InvalidFormContentType,
         routing::{on, MethodFilter},
         test_helpers::TestClient,
         Router,

--- a/axum/src/handler/service.rs
+++ b/axum/src/handler/service.rs
@@ -60,7 +60,7 @@ impl<H, T, S> HandlerService<H, T, S> {
     /// ```
     ///
     /// [`MakeService`]: tower::make::MakeService
-    pub fn into_make_service(self) -> IntoMakeService<HandlerService<H, T, S>> {
+    pub fn into_make_service(self) -> IntoMakeService<Self> {
         IntoMakeService::new(self)
     }
 
@@ -101,9 +101,7 @@ impl<H, T, S> HandlerService<H, T, S> {
     /// [`MakeService`]: tower::make::MakeService
     /// [`Router::into_make_service_with_connect_info`]: crate::routing::Router::into_make_service_with_connect_info
     #[cfg(feature = "tokio")]
-    pub fn into_make_service_with_connect_info<C>(
-        self,
-    ) -> IntoMakeServiceWithConnectInfo<HandlerService<H, T, S>, C> {
+    pub fn into_make_service_with_connect_info<C>(self) -> IntoMakeServiceWithConnectInfo<Self, C> {
         IntoMakeServiceWithConnectInfo::new(self)
     }
 }

--- a/axum/src/handler/service.rs
+++ b/axum/src/handler/service.rs
@@ -27,7 +27,7 @@ pub struct HandlerService<H, T, S> {
 
 impl<H, T, S> HandlerService<H, T, S> {
     /// Get a reference to the state.
-    pub fn state(&self) -> &S {
+    pub const fn state(&self) -> &S {
         &self.state
     }
 
@@ -60,7 +60,7 @@ impl<H, T, S> HandlerService<H, T, S> {
     /// ```
     ///
     /// [`MakeService`]: tower::make::MakeService
-    pub fn into_make_service(self) -> IntoMakeService<Self> {
+    pub const fn into_make_service(self) -> IntoMakeService<Self> {
         IntoMakeService::new(self)
     }
 

--- a/axum/src/json.rs
+++ b/axum/src/json.rs
@@ -1,5 +1,8 @@
 use crate::extract::Request;
-use crate::extract::{rejection::*, FromRequest};
+use crate::extract::{
+    rejection::{JsonDataError, JsonRejection, JsonSyntaxError, MissingJsonContentType},
+    FromRequest,
+};
 use axum_core::extract::OptionalFromRequest;
 use axum_core::response::{IntoResponse, Response};
 use bytes::{BufMut, Bytes, BytesMut};

--- a/axum/src/json.rs
+++ b/axum/src/json.rs
@@ -184,7 +184,7 @@ where
         let deserializer = &mut serde_json::Deserializer::from_slice(bytes);
 
         match serde_path_to_error::deserialize(deserializer) {
-            Ok(value) => Ok(Json(value)),
+            Ok(value) => Ok(Self(value)),
             Err(err) => Err(make_rejection(err)),
         }
     }

--- a/axum/src/macros.rs
+++ b/axum/src/macros.rs
@@ -17,7 +17,7 @@ macro_rules! opaque_future {
         }
 
         impl<$($param),*> $name<$($param),*> {
-            pub(crate) fn new(future: $actual) -> Self {
+            pub(crate) const fn new(future: $actual) -> Self {
                 Self { future }
             }
         }

--- a/axum/src/middleware/map_request.rs
+++ b/axum/src/middleware/map_request.rs
@@ -380,7 +380,7 @@ where
 }
 
 impl<B> IntoMapRequestResult<B> for Request<B> {
-    fn into_map_request_result(self) -> Result<Request<B>, Response> {
+    fn into_map_request_result(self) -> Result<Self, Response> {
         Ok(self)
     }
 }

--- a/axum/src/response/mod.rs
+++ b/axum/src/response/mod.rs
@@ -252,6 +252,6 @@ mod tests {
         assert_eq!(
             super::NoContent.into_response().status(),
             StatusCode::NO_CONTENT,
-        )
+        );
     }
 }

--- a/axum/src/response/redirect.rs
+++ b/axum/src/response/redirect.rs
@@ -56,11 +56,13 @@ impl Redirect {
     }
 
     /// Returns the HTTP status code of the `Redirect`.
+    #[must_use]
     pub fn status_code(&self) -> StatusCode {
         self.status_code
     }
 
     /// Returns the `Redirect`'s URI.
+    #[must_use]
     pub fn location(&self) -> &str {
         &self.location
     }

--- a/axum/src/response/redirect.rs
+++ b/axum/src/response/redirect.rs
@@ -125,7 +125,7 @@ mod tests {
     fn correct_location() {
         assert_eq!(EXAMPLE_URL, Redirect::permanent(EXAMPLE_URL).location());
 
-        assert_eq!("/redirect", Redirect::permanent("/redirect").location())
+        assert_eq!("/redirect", Redirect::permanent("/redirect").location());
     }
 
     #[test]

--- a/axum/src/response/redirect.rs
+++ b/axum/src/response/redirect.rs
@@ -57,7 +57,7 @@ impl Redirect {
 
     /// Returns the HTTP status code of the `Redirect`.
     #[must_use]
-    pub fn status_code(&self) -> StatusCode {
+    pub const fn status_code(&self) -> StatusCode {
         self.status_code
     }
 

--- a/axum/src/response/sse.rs
+++ b/axum/src/response/sse.rs
@@ -58,7 +58,7 @@ impl<S> Sse<S> {
     /// [`Event`]s.
     ///
     /// See the [module docs](self) for more details.
-    pub fn new(stream: S) -> Self
+    pub const fn new(stream: S) -> Self
     where
         S: TryStream<Ok = Event> + Send + 'static,
         S::Error: Into<BoxError>,
@@ -453,7 +453,7 @@ pub struct KeepAlive {
 
 impl KeepAlive {
     /// Create a new `KeepAlive`.
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
             event: Event::DEFAULT_KEEP_ALIVE,
             max_interval: Duration::from_secs(15),
@@ -463,7 +463,7 @@ impl KeepAlive {
     /// Customize the interval between keep-alive messages.
     ///
     /// Default is 15 seconds.
-    pub fn interval(mut self, time: Duration) -> Self {
+    pub const fn interval(mut self, time: Duration) -> Self {
         self.max_interval = time;
         self
     }
@@ -566,7 +566,7 @@ where
     }
 }
 
-fn memchr_split(needle: u8, haystack: &[u8]) -> MemchrSplit<'_> {
+const fn memchr_split(needle: u8, haystack: &[u8]) -> MemchrSplit<'_> {
     MemchrSplit {
         needle,
         haystack: Some(haystack),

--- a/axum/src/response/sse.rs
+++ b/axum/src/response/sse.rs
@@ -203,9 +203,10 @@ impl Event {
     where
         T: AsRef<str>,
     {
-        if self.flags.contains(EventFlags::HAS_DATA) {
-            panic!("Called `Event::data` multiple times");
-        }
+        assert!(
+            !self.flags.contains(EventFlags::HAS_DATA),
+            "Called `Event::data` multiple times"
+        );
 
         for line in memchr_split(b'\n', data.as_ref().as_bytes()) {
             self.field("data", line);
@@ -246,9 +247,10 @@ impl Event {
                 self.0.flush()
             }
         }
-        if self.flags.contains(EventFlags::HAS_DATA) {
-            panic!("Called `Event::json_data` multiple times");
-        }
+        assert!(
+            !self.flags.contains(EventFlags::HAS_DATA),
+            "Called `Event::json_data` multiple times"
+        );
 
         let buffer = self.buffer.as_mut();
         buffer.extend_from_slice(b"data: ");
@@ -297,9 +299,10 @@ impl Event {
     where
         T: AsRef<str>,
     {
-        if self.flags.contains(EventFlags::HAS_EVENT) {
-            panic!("Called `Event::event` multiple times");
-        }
+        assert!(
+            !self.flags.contains(EventFlags::HAS_EVENT),
+            "Called `Event::event` multiple times"
+        );
         self.flags.insert(EventFlags::HAS_EVENT);
 
         self.field("event", event.as_ref());
@@ -317,9 +320,10 @@ impl Event {
     ///
     /// Panics if this function has already been called on this event.
     pub fn retry(mut self, duration: Duration) -> Self {
-        if self.flags.contains(EventFlags::HAS_RETRY) {
-            panic!("Called `Event::retry` multiple times");
-        }
+        assert!(
+            !self.flags.contains(EventFlags::HAS_RETRY),
+            "Called `Event::retry` multiple times"
+        );
         self.flags.insert(EventFlags::HAS_RETRY);
 
         let buffer = self.buffer.as_mut();
@@ -364,9 +368,10 @@ impl Event {
     where
         T: AsRef<str>,
     {
-        if self.flags.contains(EventFlags::HAS_ID) {
-            panic!("Called `Event::id` multiple times");
-        }
+        assert!(
+            !self.flags.contains(EventFlags::HAS_ID),
+            "Called `Event::id` multiple times"
+        );
         self.flags.insert(EventFlags::HAS_ID);
 
         let id = id.as_ref().as_bytes();

--- a/axum/src/response/sse.rs
+++ b/axum/src/response/sse.rs
@@ -63,7 +63,7 @@ impl<S> Sse<S> {
         S: TryStream<Ok = Event> + Send + 'static,
         S::Error: Into<BoxError>,
     {
-        Sse { stream }
+        Self { stream }
     }
 
     /// Configure the interval between keep-alive messages.
@@ -154,12 +154,12 @@ impl Buffer {
     /// a new active buffer with the previous contents.
     fn as_mut(&mut self) -> &mut BytesMut {
         match self {
-            Buffer::Active(bytes_mut) => bytes_mut,
-            Buffer::Finalized(bytes) => {
-                *self = Buffer::Active(BytesMut::from(mem::take(bytes)));
+            Self::Active(bytes_mut) => bytes_mut,
+            Self::Finalized(bytes) => {
+                *self = Self::Active(BytesMut::from(mem::take(bytes)));
                 match self {
-                    Buffer::Active(bytes_mut) => bytes_mut,
-                    Buffer::Finalized(_) => unreachable!(),
+                    Self::Active(bytes_mut) => bytes_mut,
+                    Self::Finalized(_) => unreachable!(),
                 }
             }
         }
@@ -199,7 +199,7 @@ impl Event {
     /// - Panics if `data` or `json_data` have already been called.
     ///
     /// [`MessageEvent`'s data field]: https://developer.mozilla.org/en-US/docs/Web/API/MessageEvent/data
-    pub fn data<T>(mut self, data: T) -> Event
+    pub fn data<T>(mut self, data: T) -> Self
     where
         T: AsRef<str>,
     {
@@ -226,7 +226,7 @@ impl Event {
     ///
     /// [`MessageEvent`'s data field]: https://developer.mozilla.org/en-US/docs/Web/API/MessageEvent/data
     #[cfg(feature = "json")]
-    pub fn json_data<T>(mut self, data: T) -> Result<Event, axum_core::Error>
+    pub fn json_data<T>(mut self, data: T) -> Result<Self, axum_core::Error>
     where
         T: serde::Serialize,
     {
@@ -271,7 +271,7 @@ impl Event {
     ///
     /// Panics if `comment` contains any newlines or carriage returns, as they are not allowed in
     /// comments.
-    pub fn comment<T>(mut self, comment: T) -> Event
+    pub fn comment<T>(mut self, comment: T) -> Self
     where
         T: AsRef<str>,
     {
@@ -293,7 +293,7 @@ impl Event {
     ///
     /// - Panics if `event` contains any newlines or carriage returns.
     /// - Panics if this function has already been called on this event.
-    pub fn event<T>(mut self, event: T) -> Event
+    pub fn event<T>(mut self, event: T) -> Self
     where
         T: AsRef<str>,
     {
@@ -316,7 +316,7 @@ impl Event {
     /// # Panics
     ///
     /// Panics if this function has already been called on this event.
-    pub fn retry(mut self, duration: Duration) -> Event {
+    pub fn retry(mut self, duration: Duration) -> Self {
         if self.flags.contains(EventFlags::HAS_RETRY) {
             panic!("Called `Event::retry` multiple times");
         }
@@ -360,7 +360,7 @@ impl Event {
     ///
     /// - Panics if `id` contains any newlines, carriage returns or null characters.
     /// - Panics if this function has already been called on this event.
-    pub fn id<T>(mut self, id: T) -> Event
+    pub fn id<T>(mut self, id: T) -> Self
     where
         T: AsRef<str>,
     {

--- a/axum/src/routing/into_make_service.rs
+++ b/axum/src/routing/into_make_service.rs
@@ -14,7 +14,7 @@ pub struct IntoMakeService<S> {
 }
 
 impl<S> IntoMakeService<S> {
-    pub(crate) fn new(svc: S) -> Self {
+    pub(crate) const fn new(svc: S) -> Self {
         Self { svc }
     }
 }

--- a/axum/src/routing/method_filter.rs
+++ b/axum/src/routing/method_filter.rs
@@ -58,6 +58,7 @@ impl MethodFilter {
     }
 
     /// Performs the OR operation between the [`MethodFilter`] in `self` with `other`.
+    #[must_use]
     pub const fn or(self, other: Self) -> Self {
         Self(self.0 | other.0)
     }

--- a/axum/src/routing/method_filter.rs
+++ b/axum/src/routing/method_filter.rs
@@ -72,7 +72,7 @@ pub struct NoMatchingMethodFilter {
 
 impl NoMatchingMethodFilter {
     /// Get the [`Method`] that couldn't be converted to a [`MethodFilter`].
-    pub fn method(&self) -> &Method {
+    pub const fn method(&self) -> &Method {
         &self.method
     }
 }

--- a/axum/src/routing/method_filter.rs
+++ b/axum/src/routing/method_filter.rs
@@ -90,15 +90,15 @@ impl TryFrom<Method> for MethodFilter {
 
     fn try_from(m: Method) -> Result<Self, NoMatchingMethodFilter> {
         match m {
-            Method::CONNECT => Ok(MethodFilter::CONNECT),
-            Method::DELETE => Ok(MethodFilter::DELETE),
-            Method::GET => Ok(MethodFilter::GET),
-            Method::HEAD => Ok(MethodFilter::HEAD),
-            Method::OPTIONS => Ok(MethodFilter::OPTIONS),
-            Method::PATCH => Ok(MethodFilter::PATCH),
-            Method::POST => Ok(MethodFilter::POST),
-            Method::PUT => Ok(MethodFilter::PUT),
-            Method::TRACE => Ok(MethodFilter::TRACE),
+            Method::CONNECT => Ok(Self::CONNECT),
+            Method::DELETE => Ok(Self::DELETE),
+            Method::GET => Ok(Self::GET),
+            Method::HEAD => Ok(Self::HEAD),
+            Method::OPTIONS => Ok(Self::OPTIONS),
+            Method::PATCH => Ok(Self::PATCH),
+            Method::POST => Ok(Self::POST),
+            Method::PUT => Ok(Self::PUT),
+            Method::TRACE => Ok(Self::TRACE),
             other => Err(NoMatchingMethodFilter { method: other }),
         }
     }

--- a/axum/src/routing/method_routing.rs
+++ b/axum/src/routing/method_routing.rs
@@ -1049,20 +1049,21 @@ where
             match (first, second) {
                 (MethodEndpoint::None, MethodEndpoint::None) => Ok(MethodEndpoint::None),
                 (pick, MethodEndpoint::None) | (MethodEndpoint::None, pick) => Ok(pick),
-                _ => {
-                    if let Some(path) = path {
-                        Err(format!(
-                            "Overlapping method route. Handler for `{name} {path}` already exists"
-                        )
-                        .into())
-                    } else {
+                _ => path.map_or_else(
+                    || {
                         Err(format!(
                             "Overlapping method route. Cannot merge two method routes that both \
                              define `{name}`"
                         )
                         .into())
-                    }
-                }
+                    },
+                    |path| {
+                        Err(format!(
+                            "Overlapping method route. Handler for `{name} {path}` already exists"
+                        )
+                        .into())
+                    },
+                ),
             }
         }
 

--- a/axum/src/routing/method_routing.rs
+++ b/axum/src/routing/method_routing.rs
@@ -1233,11 +1233,11 @@ impl<S, E> MethodEndpoint<S, E>
 where
     S: Clone,
 {
-    fn is_some(&self) -> bool {
+    const fn is_some(&self) -> bool {
         matches!(self, Self::Route(_) | Self::BoxedHandler(_))
     }
 
-    fn is_none(&self) -> bool {
+    const fn is_none(&self) -> bool {
         matches!(self, Self::None)
     }
 

--- a/axum/src/routing/method_routing.rs
+++ b/axum/src/routing/method_routing.rs
@@ -836,12 +836,11 @@ where
             S: Clone,
         {
             if endpoint_filter.contains(filter) {
-                if out.is_some() {
-                    panic!(
-                        "Overlapping method route. Cannot add two method routes that both handle \
+                assert!(
+                    !out.is_some(),
+                    "Overlapping method route. Cannot add two method routes that both handle \
                          `{method_name}`",
-                    )
-                }
+                );
                 *out = endpoint.clone();
                 for method in methods {
                     append_allow_header(allow_header, method);

--- a/axum/src/routing/method_routing.rs
+++ b/axum/src/routing/method_routing.rs
@@ -703,6 +703,7 @@ impl MethodRouter<(), Infallible> {
     /// ```
     ///
     /// [`MakeService`]: tower::make::MakeService
+    #[must_use]
     pub fn into_make_service(self) -> IntoMakeService<Self> {
         IntoMakeService::new(self.with_state(()))
     }
@@ -736,6 +737,7 @@ impl MethodRouter<(), Infallible> {
     /// [`MakeService`]: tower::make::MakeService
     /// [`Router::into_make_service_with_connect_info`]: crate::routing::Router::into_make_service_with_connect_info
     #[cfg(feature = "tokio")]
+    #[must_use]
     pub fn into_make_service_with_connect_info<C>(self) -> IntoMakeServiceWithConnectInfo<Self, C> {
         IntoMakeServiceWithConnectInfo::new(self.with_state(()))
     }

--- a/axum/src/routing/mod.rs
+++ b/axum/src/routing/mod.rs
@@ -270,7 +270,7 @@ where
                 (false, false) => {
                     panic!("Cannot merge two `Router`s that both have a fallback")
                 }
-            };
+            }
 
             panic_on_err!(this.path_router.merge(path_router));
 

--- a/axum/src/routing/mod.rs
+++ b/axum/src/routing/mod.rs
@@ -187,14 +187,11 @@ where
         T::Response: IntoResponse,
         T::Future: Send + 'static,
     {
-        let service = match try_downcast::<Self, _>(service) {
-            Ok(_) => {
-                panic!(
-                    "Invalid route: `Router::route_service` cannot be used with `Router`s. \
-                     Use `Router::nest` instead"
-                );
-            }
-            Err(service) => service,
+        let Err(service) = try_downcast::<Self, _>(service) else {
+            panic!(
+                "Invalid route: `Router::route_service` cannot be used with `Router`s. \
+                      Use `Router::nest` instead"
+            );
         };
 
         tap_inner!(self, mut this => {

--- a/axum/src/routing/mod.rs
+++ b/axum/src/routing/mod.rs
@@ -515,7 +515,7 @@ where
     /// This is the same as [`Router::as_service`] instead it returns an owned [`Service`]. See
     /// that method for more details.
     #[must_use]
-    pub fn into_service<B>(self) -> RouterIntoService<B, S> {
+    pub const fn into_service<B>(self) -> RouterIntoService<B, S> {
         RouterIntoService {
             router: self,
             _marker: PhantomData,

--- a/axum/src/routing/mod.rs
+++ b/axum/src/routing/mod.rs
@@ -317,6 +317,7 @@ where
     }
 
     /// True if the router currently has at least one route added.
+    #[must_use]
     pub fn has_routes(&self) -> bool {
         self.inner.path_router.has_routes()
     }
@@ -513,6 +514,7 @@ where
     ///
     /// This is the same as [`Router::as_service`] instead it returns an owned [`Service`]. See
     /// that method for more details.
+    #[must_use]
     pub fn into_service<B>(self) -> RouterIntoService<B, S> {
         RouterIntoService {
             router: self,
@@ -540,6 +542,7 @@ impl Router {
     /// ```
     ///
     /// [`MakeService`]: tower::make::MakeService
+    #[must_use]
     pub fn into_make_service(self) -> IntoMakeService<Self> {
         // call `Router::with_state` such that everything is turned into `Route` eagerly
         // rather than doing that per request
@@ -548,6 +551,7 @@ impl Router {
 
     #[doc = include_str!("../docs/routing/into_make_service_with_connect_info.md")]
     #[cfg(feature = "tokio")]
+    #[must_use]
     pub fn into_make_service_with_connect_info<C>(self) -> IntoMakeServiceWithConnectInfo<Self, C> {
         // call `Router::with_state` such that everything is turned into `Route` eagerly
         // rather than doing that per request

--- a/axum/src/routing/mod.rs
+++ b/axum/src/routing/mod.rs
@@ -203,9 +203,10 @@ where
     #[doc(alias = "scope")] // Some web frameworks like actix-web use this term
     #[track_caller]
     pub fn nest(self, path: &str, router: Self) -> Self {
-        if path.is_empty() || path == "/" {
-            panic!("Nesting at the root is no longer supported. Use merge instead.");
-        }
+        assert!(
+            !(path.is_empty() || path == "/"),
+            "Nesting at the root is no longer supported. Use merge instead."
+        );
 
         let RouterInner {
             path_router,
@@ -229,9 +230,10 @@ where
         T::Response: IntoResponse,
         T::Future: Send + 'static,
     {
-        if path.is_empty() || path == "/" {
-            panic!("Nesting at the root is no longer supported. Use fallback_service instead.");
-        }
+        assert!(
+            !(path.is_empty() || path == "/"),
+            "Nesting at the root is no longer supported. Use fallback_service instead."
+        );
 
         tap_inner!(self, mut this => {
             panic_on_err!(this.path_router.nest_service(path, service));

--- a/axum/src/routing/path_router.rs
+++ b/axum/src/routing/path_router.rs
@@ -282,12 +282,11 @@ where
         <L::Service as Service<Request>>::Error: Into<Infallible> + 'static,
         <L::Service as Service<Request>>::Future: Send + 'static,
     {
-        if self.routes.is_empty() {
-            panic!(
-                "Adding a route_layer before any routes is a no-op. \
+        assert!(
+            !self.routes.is_empty(),
+            "Adding a route_layer before any routes is a no-op. \
                  Add the routes you want the layer to apply to first."
-            );
-        }
+        );
 
         let routes = self
             .routes

--- a/axum/src/routing/path_router.rs
+++ b/axum/src/routing/path_router.rs
@@ -143,8 +143,8 @@ where
             .map_err(|err| format!("Invalid route {path:?}: {err}"))
     }
 
-    pub(super) fn merge(&mut self, other: PathRouter<S>) -> Result<(), Cow<'static, str>> {
-        let PathRouter {
+    pub(super) fn merge(&mut self, other: Self) -> Result<(), Cow<'static, str>> {
+        let Self {
             routes,
             node,
             prev_route_id: _,
@@ -172,11 +172,11 @@ where
     pub(super) fn nest(
         &mut self,
         path_to_nest_at: &str,
-        router: PathRouter<S>,
+        router: Self,
     ) -> Result<(), Cow<'static, str>> {
         let prefix = validate_nest_path(self.v7_checks, path_to_nest_at);
 
-        let PathRouter {
+        let Self {
             routes,
             node,
             prev_route_id: _,
@@ -248,7 +248,7 @@ where
         Ok(())
     }
 
-    pub(super) fn layer<L>(self, layer: L) -> PathRouter<S>
+    pub(super) fn layer<L>(self, layer: L) -> Self
     where
         L: Layer<Route> + Clone + Send + Sync + 'static,
         L::Service: Service<Request> + Clone + Send + Sync + 'static,
@@ -265,7 +265,7 @@ where
             })
             .collect();
 
-        PathRouter {
+        Self {
             routes,
             node: self.node,
             prev_route_id: self.prev_route_id,
@@ -298,7 +298,7 @@ where
             })
             .collect();
 
-        PathRouter {
+        Self {
             routes,
             node: self.node,
             prev_route_id: self.prev_route_id,

--- a/axum/src/routing/route.rs
+++ b/axum/src/routing/route.rs
@@ -59,7 +59,7 @@ impl<E> Route<E> {
 
     pub(crate) fn layer<L, NewError>(self, layer: L) -> Route<NewError>
     where
-        L: Layer<Route<E>> + Clone + Send + 'static,
+        L: Layer<Self> + Clone + Send + 'static,
         L::Service: Service<Request> + Clone + Send + Sync + 'static,
         <L::Service as Service<Request>>::Response: IntoResponse + 'static,
         <L::Service as Service<Request>>::Error: Into<NewError> + 'static,

--- a/axum/src/routing/route.rs
+++ b/axum/src/routing/route.rs
@@ -117,7 +117,7 @@ pin_project! {
 }
 
 impl<E> RouteFuture<E> {
-    fn new(
+    const fn new(
         method: Method,
         inner: Oneshot<BoxCloneSyncService<Request, Response, E>, Request>,
     ) -> Self {
@@ -134,7 +134,7 @@ impl<E> RouteFuture<E> {
         self
     }
 
-    pub(crate) fn not_top_level(mut self) -> Self {
+    pub(crate) const fn not_top_level(mut self) -> Self {
         self.top_level = false;
         self
     }
@@ -216,7 +216,7 @@ pin_project! {
 }
 
 impl InfallibleRouteFuture {
-    pub(crate) fn new(future: RouteFuture<Infallible>) -> Self {
+    pub(crate) const fn new(future: RouteFuture<Infallible>) -> Self {
         Self { future }
     }
 }

--- a/axum/src/routing/tests/handle_error.rs
+++ b/axum/src/routing/tests/handle_error.rs
@@ -4,6 +4,8 @@ use tower::timeout::TimeoutLayer;
 
 async fn unit() {}
 
+// Using a semicolon causes an error.
+#[allow(clippy::semicolon_if_nothing_returned)]
 async fn forever() {
     pending().await
 }

--- a/axum/src/routing/tests/handle_error.rs
+++ b/axum/src/routing/tests/handle_error.rs
@@ -85,7 +85,7 @@ async fn handler_multiple_methods_last() {
 async fn handler_service_ext() {
     let fallible_service = tower::service_fn(|_| async { Err::<(), ()>(()) });
     let handle_error_service =
-        fallible_service.handle_error(|_| async { StatusCode::INTERNAL_SERVER_ERROR });
+        fallible_service.handle_error(|()| async { StatusCode::INTERNAL_SERVER_ERROR });
 
     let app = Router::new().route("/", get_service(handle_error_service));
 

--- a/axum/src/routing/tests/mod.rs
+++ b/axum/src/routing/tests/mod.rs
@@ -1090,7 +1090,7 @@ async fn logging_rejections() {
                 level: "TRACE".to_owned(),
             },
         ])
-    )
+    );
 }
 
 // https://github.com/tokio-rs/axum/issues/1955

--- a/axum/src/routing/url_params.rs
+++ b/axum/src/routing/url_params.rs
@@ -22,11 +22,8 @@ pub(super) fn insert_url_params(extensions: &mut Extensions, params: Params<'_, 
         .filter(|(key, _)| !key.starts_with(super::NEST_TAIL_PARAM))
         .filter(|(key, _)| !key.starts_with(super::FALLBACK_PARAM))
         .map(|(k, v)| {
-            if let Some(decoded) = PercentDecodedStr::new(v) {
-                Ok((Arc::from(k), decoded))
-            } else {
-                Err(Arc::from(k))
-            }
+            PercentDecodedStr::new(v)
+                .map_or_else(|| Err(Arc::from(k)), |decoded| Ok((Arc::from(k), decoded)))
         })
         .collect::<Result<Vec<_>, _>>();
 

--- a/axum/src/serve/mod.rs
+++ b/axum/src/serve/mod.rs
@@ -298,7 +298,7 @@ where
         loop {
             let (io, remote_addr) = tokio::select! {
                 conn = listener.accept() => conn,
-                _ = signal_tx.closed() => {
+                () = signal_tx.closed() => {
                     trace!("signal received, not accepting new connections");
                     break;
                 }
@@ -424,7 +424,7 @@ async fn handle_connection<L, M, S, B>(
                     }
                     break;
                 }
-                _ = &mut signal_closed => {
+                () = &mut signal_closed => {
                     trace!("signal received in task, starting graceful shutdown");
                     conn.as_mut().graceful_shutdown();
                 }

--- a/axum/src/serve/mod.rs
+++ b/axum/src/serve/mod.rs
@@ -96,7 +96,7 @@ pub use self::listener::{Listener, ListenerExt, TapIo};
 /// [`HandlerWithoutStateExt::into_make_service_with_connect_info`]: crate::handler::HandlerWithoutStateExt::into_make_service_with_connect_info
 /// [`HandlerService::into_make_service_with_connect_info`]: crate::handler::HandlerService::into_make_service_with_connect_info
 #[cfg(all(feature = "tokio", any(feature = "http1", feature = "http2")))]
-pub fn serve<L, M, S, B>(listener: L, make_service: M) -> Serve<L, M, S, B>
+pub const fn serve<L, M, S, B>(listener: L, make_service: M) -> Serve<L, M, S, B>
 where
     L: Listener,
     M: for<'a> Service<IncomingStream<'a, L>, Error = Infallible, Response = S>,
@@ -459,7 +459,7 @@ where
     }
 
     /// Returns the remote address that this stream is bound to.
-    pub fn remote_addr(&self) -> &L::Addr {
+    pub const fn remote_addr(&self) -> &L::Addr {
         &self.remote_addr
     }
 }

--- a/axum/src/test_helpers/counting_cloneable_state.rs
+++ b/axum/src/test_helpers/counting_cloneable_state.rs
@@ -18,7 +18,7 @@ impl CountingCloneableState {
             setup_done: AtomicBool::new(false),
             count: AtomicUsize::new(0),
         };
-        CountingCloneableState {
+        Self {
             state: Arc::new(inner_state),
         }
     }
@@ -47,6 +47,6 @@ impl Clone for CountingCloneableState {
             state.count.fetch_add(1, Ordering::SeqCst);
         }
 
-        CountingCloneableState { state }
+        Self { state }
     }
 }

--- a/axum/src/test_helpers/mod.rs
+++ b/axum/src/test_helpers/mod.rs
@@ -12,9 +12,9 @@ pub(crate) mod tracing_helpers;
 pub(crate) mod counting_cloneable_state;
 
 #[cfg(test)]
-pub(crate) fn assert_send<T: Send>() {}
+pub(crate) const fn assert_send<T: Send>() {}
 #[cfg(test)]
-pub(crate) fn assert_sync<T: Sync>() {}
+pub(crate) const fn assert_sync<T: Sync>() {}
 
 #[allow(dead_code)]
 pub(crate) struct NotSendSync(*const ());

--- a/axum/src/test_helpers/test_client.rs
+++ b/axum/src/test_helpers/test_client.rs
@@ -89,7 +89,7 @@ impl TestClient {
 
     #[allow(dead_code)]
     #[must_use]
-    pub fn server_port(&self) -> u16 {
+    pub const fn server_port(&self) -> u16 {
         self.addr.port()
     }
 }

--- a/axum/src/test_helpers/test_client.rs
+++ b/axum/src/test_helpers/test_client.rs
@@ -50,18 +50,21 @@ impl TestClient {
         TestClient { client, addr }
     }
 
+    #[must_use]
     pub fn get(&self, url: &str) -> RequestBuilder {
         RequestBuilder {
             builder: self.client.get(format!("http://{}{url}", self.addr)),
         }
     }
 
+    #[must_use]
     pub fn head(&self, url: &str) -> RequestBuilder {
         RequestBuilder {
             builder: self.client.head(format!("http://{}{url}", self.addr)),
         }
     }
 
+    #[must_use]
     pub fn post(&self, url: &str) -> RequestBuilder {
         RequestBuilder {
             builder: self.client.post(format!("http://{}{url}", self.addr)),
@@ -69,6 +72,7 @@ impl TestClient {
     }
 
     #[allow(dead_code)]
+    #[must_use]
     pub fn put(&self, url: &str) -> RequestBuilder {
         RequestBuilder {
             builder: self.client.put(format!("http://{}{url}", self.addr)),
@@ -76,6 +80,7 @@ impl TestClient {
     }
 
     #[allow(dead_code)]
+    #[must_use]
     pub fn patch(&self, url: &str) -> RequestBuilder {
         RequestBuilder {
             builder: self.client.patch(format!("http://{}{url}", self.addr)),
@@ -83,6 +88,7 @@ impl TestClient {
     }
 
     #[allow(dead_code)]
+    #[must_use]
     pub fn server_port(&self) -> u16 {
         self.addr.port()
     }

--- a/axum/src/test_helpers/test_client.rs
+++ b/axum/src/test_helpers/test_client.rs
@@ -23,7 +23,7 @@ where
     tokio::spawn(async move {
         serve(listener, Shared::new(svc))
             .await
-            .expect("server error")
+            .expect("server error");
     });
 
     addr

--- a/axum/src/test_helpers/test_client.rs
+++ b/axum/src/test_helpers/test_client.rs
@@ -47,7 +47,7 @@ impl TestClient {
             .build()
             .unwrap();
 
-        TestClient { client, addr }
+        Self { client, addr }
     }
 
     #[must_use]

--- a/axum/src/test_helpers/test_client.rs
+++ b/axum/src/test_helpers/test_client.rs
@@ -99,11 +99,13 @@ pub struct RequestBuilder {
 }
 
 impl RequestBuilder {
+    #[must_use]
     pub fn body(mut self, body: impl Into<reqwest::Body>) -> Self {
         self.builder = self.builder.body(body);
         self
     }
 
+    #[must_use]
     pub fn json<T>(mut self, json: &T) -> Self
     where
         T: serde::Serialize,
@@ -112,6 +114,7 @@ impl RequestBuilder {
         self
     }
 
+    #[must_use]
     pub fn header<K, V>(mut self, key: K, value: V) -> Self
     where
         HeaderName: TryFrom<K>,
@@ -123,6 +126,7 @@ impl RequestBuilder {
         self
     }
 
+    #[must_use]
     #[allow(dead_code)]
     pub fn multipart(mut self, form: reqwest::multipart::Form) -> Self {
         self.builder = self.builder.multipart(form);

--- a/axum/src/test_helpers/tracing_helpers.rs
+++ b/axum/src/test_helpers/tracing_helpers.rs
@@ -114,14 +114,14 @@ struct Writer<'a>(&'a TestMakeWriter);
 
 impl io::Write for Writer<'_> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        match &mut *self.0.write.lock().unwrap() {
-            Some(vec) => {
+        (*self.0.write.lock().unwrap()).as_mut().map_or_else(
+            || Err(io::Error::other("inner writer has been taken")),
+            |vec| {
                 let len = buf.len();
                 vec.extend(buf);
                 Ok(len)
-            }
-            None => Err(io::Error::other("inner writer has been taken")),
-        }
+            },
+        )
     }
 
     fn flush(&mut self) -> io::Result<()> {

--- a/axum/src/util.rs
+++ b/axum/src/util.rs
@@ -102,11 +102,9 @@ where
     K: Send + 'static,
 {
     let mut k = Some(k);
-    if let Some(k) = <dyn std::any::Any>::downcast_mut::<Option<T>>(&mut k) {
-        Ok(k.take().unwrap())
-    } else {
-        Err(k.unwrap())
-    }
+    <dyn std::any::Any>::downcast_mut::<Option<T>>(&mut k)
+        .and_then(Option::take)
+        .map_or_else(|| Err(k.unwrap()), Ok)
 }
 
 #[test]

--- a/axum/src/util.rs
+++ b/axum/src/util.rs
@@ -51,7 +51,7 @@ pub(crate) struct MapIntoResponse<S> {
 }
 
 impl<S> MapIntoResponse<S> {
-    pub(crate) fn new(inner: S) -> Self {
+    pub(crate) const fn new(inner: S) -> Self {
         Self { inner }
     }
 }


### PR DESCRIPTION
## Motivation

Draft PR.
Earlier discussion: #3393

The purpose of this PR is to activate and fix more lints for the codebase. This will improve codebase readability and maintainability. The ultimate goal is to have as many lints from the `pedantic` and `nursery` lint groups as possible. For now, only a subset of lints are enabled.

Discussions welcome.

## Solution

New lints:

- [`must_use_candidate`](https://rust-lang.github.io/rust-clippy/master/index.html#must_use_candidate)
- [`use_self`](https://rust-lang.github.io/rust-clippy/master/index.html#use_self)
- [`redundant_else`](https://rust-lang.github.io/rust-clippy/master/index.html#redundant_else)
- [`unnecessary_semicolon`](https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_semicolon)
- [`manual_let_else`](https://rust-lang.github.io/rust-clippy/master/index.html#manual_let_else)
- [`option_if_let_else`](https://rust-lang.github.io/rust-clippy/master/index.html#option_if_let_else)
- [`missing_const_for_fn`](https://rust-lang.github.io/rust-clippy/master/index.html#missing_const_for_fn)

I will update this list once I activate more lints.

## Sub-PRs

- [x] #3395
- [x] #3396
- [x] #3399
- [x] #3406
- [ ] #3408
