### PR TITLE
Update sse.rs: add space between duration and `:`

### DIFF
--- a/axum/src/response/sse.rs
+++ b/axum/src/response/sse.rs
@@ -307,7 +307,7 @@ impl Event {
         self
     }
 
-    /// Set the event's retry timeout field (`retry:<timeout>`).
+    /// Set the event's retry timeout field (`retry: <timeout>`).
     ///
     /// This sets how long clients will wait before reconnecting if they are disconnected from the
     /// SSE endpoint. Note that this is just a hint: clients are free to wait for longer if they
@@ -323,7 +323,7 @@ impl Event {
         self.flags.insert(EventFlags::HAS_RETRY);
 
         let buffer = self.buffer.as_mut();
-        buffer.extend_from_slice(b"retry:");
+        buffer.extend_from_slice(b"retry: ");
 
         let secs = duration.as_secs();
         let millis = duration.subsec_millis();


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation

retry was the only field for which we did not add a space

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
