### PR TITLE
docs: Refine the example comments for `Router::route_service()`

### DIFF
--- a/axum/src/docs/routing/route_service.md
+++ b/axum/src/docs/routing/route_service.md
@@ -20,9 +20,9 @@ let app = Router::new()
     .route(
         // Any request to `/` goes to a service
         "/",
-        // Services whose response body is not `axum::body::BoxBody`
-        // can be wrapped in `axum::routing::any_service` (or one of the other routing filters)
-        // to have the response body mapped
+        // Services whose responses implement `axum::response::IntoResponse` can
+        // be wrapped in `axum::routing::any_service` (or one of the other routing filters)
+        // to turn them into routes.
         any_service(service_fn(|_: Request| async {
             let res = Response::new(Body::from("Hi from `GET /`"));
             Ok::<_, Infallible>(res)
@@ -30,8 +30,8 @@ let app = Router::new()
     )
     .route_service(
         "/foo",
-        // This service's response body is `axum::body::BoxBody` so
-        // it can be routed to directly.
+        // This service's request body is `axum::body::Body`, and its response
+        // can be any type that implements `axum::response::IntoResponse`.
         service_fn(|req: Request| async move {
             let body = Body::from(format!("Hi from `{} /foo`", req.method()));
             let res = Response::new(body);


### PR DESCRIPTION
## Motivation

Comments in the example code of `Router::route_service()` might be confusing. `axum::body::BoxBody` is not a public item and the description of what `axum::routing::any_service` does also seems inaccurate.

## Solution

The PR fixes some factual errors and clarifies the purpose of `axum::routing::any_service`.

This should fix #2536.