### PR TITLE
Update minimum Rust version to 1.78

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -2,7 +2,7 @@ name: CI
 
 env:
   CARGO_TERM_COLOR: always
-  MSRV: '1.75'
+  MSRV: '1.78'
 
 on:
   push:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -329,7 +329,6 @@ dependencies = [
  "quickcheck",
  "quickcheck_macros",
  "reqwest 0.12.12",
- "rustversion",
  "serde",
  "serde_json",
  "serde_path_to_error",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ exclude = ["examples/async-graphql"]
 resolver = "2"
 
 [workspace.package]
-rust-version = "1.75"
+rust-version = "1.78"
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/axum-core/src/extract/mod.rs
+++ b/axum-core/src/extract/mod.rs
@@ -47,11 +47,8 @@ mod private {
 /// See [`axum::extract`] for more general docs about extractors.
 ///
 /// [`axum::extract`]: https://docs.rs/axum/0.8/axum/extract/index.html
-#[rustversion::attr(
-    since(1.78),
-    diagnostic::on_unimplemented(
-        note = "Function argument is not a valid axum extractor. \nSee `https://docs.rs/axum/0.8/axum/extract/index.html` for details",
-    )
+#[diagnostic::on_unimplemented(
+    note = "Function argument is not a valid axum extractor. \nSee `https://docs.rs/axum/0.8/axum/extract/index.html` for details"
 )]
 pub trait FromRequestParts<S>: Sized {
     /// If the extractor fails it'll use this "rejection" type. A rejection is
@@ -76,11 +73,8 @@ pub trait FromRequestParts<S>: Sized {
 /// See [`axum::extract`] for more general docs about extractors.
 ///
 /// [`axum::extract`]: https://docs.rs/axum/0.8/axum/extract/index.html
-#[rustversion::attr(
-    since(1.78),
-    diagnostic::on_unimplemented(
-        note = "Function argument is not a valid axum extractor. \nSee `https://docs.rs/axum/0.8/axum/extract/index.html` for details",
-    )
+#[diagnostic::on_unimplemented(
+    note = "Function argument is not a valid axum extractor. \nSee `https://docs.rs/axum/0.8/axum/extract/index.html` for details"
 )]
 pub trait FromRequest<S, M = private::ViaRequest>: Sized {
     /// If the extractor fails it'll use this "rejection" type. A rejection is

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -13,11 +13,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **added:** Implement `OptionalFromRequest` for `Multipart` ([#3220])
 - **changed:** `serve` has an additional generic argument and can now work with any response body
   type, not just `axum::body::Body` ([#3205])
+- **change:** Update minimum rust version to 1.78 ([#3412])
 
 [#3158]: https://github.com/tokio-rs/axum/pull/3158
 [#3261]: https://github.com/tokio-rs/axum/pull/3261
 [#3205]: https://github.com/tokio-rs/axum/pull/3205
 [#3220]: https://github.com/tokio-rs/axum/pull/3220
+[#3412]: https://github.com/tokio-rs/axum/pull/3412
 
 # 0.8.4
 

--- a/axum/Cargo.toml
+++ b/axum/Cargo.toml
@@ -100,7 +100,6 @@ memchr = "2.4.1"
 mime = "0.3.16"
 percent-encoding = "2.1"
 pin-project-lite = "0.2.7"
-rustversion = "1.0.9"
 serde = "1.0"
 sync_wrapper = "1.0.0"
 tower = { version = "0.5.2", default-features = false, features = ["util"] }

--- a/axum/README.md
+++ b/axum/README.md
@@ -111,7 +111,7 @@ This crate uses `#![forbid(unsafe_code)]` to ensure everything is implemented in
 
 ## Minimum supported Rust version
 
-axum's MSRV is 1.75.
+axum's MSRV is 1.78.
 
 ## Examples
 

--- a/axum/src/handler/mod.rs
+++ b/axum/src/handler/mod.rs
@@ -125,11 +125,8 @@ pub use self::service::HandlerService;
 ///     )));
 /// # let _: Router = app;
 /// ```
-#[rustversion::attr(
-    since(1.78),
-    diagnostic::on_unimplemented(
-        note = "Consider using `#[axum::debug_handler]` to improve the error message"
-    )
+#[diagnostic::on_unimplemented(
+    note = "Consider using `#[axum::debug_handler]` to improve the error message"
 )]
 pub trait Handler<T, S>: Clone + Send + Sync + Sized + 'static {
     /// The type of future calling this handler returns.


### PR DESCRIPTION
This lets us drop the dependency on rustversion.

`axum-extra` keeps its `rustversion` dependency. Could raise its MSRV independently to 1.80?