### PR TITLE
Document type parameter `T` on `Handler`

### DIFF
--- a/axum/src/handler/mod.rs
+++ b/axum/src/handler/mod.rs
@@ -138,7 +138,7 @@ pub use self::service::HandlerService;
 /// The type parameter `T` is a workaround for trait coherence rules, allowing us to
 /// write blanket implementations of `Handler` over many types of handler functions
 /// with different numbers of arguments, without the compiler forbidding us from doing
-/// so because one type `F` can in theory implement both `Fn(T1)` and `Fn(T1, T2)`.
+/// so because one type `F` can in theory implement both `Fn(A) -> X` and `Fn(A, B) -> Y`.
 /// `T` is a placeholder taking on a representation of the parameters of the handler function,
 /// as well as other similar 'coherence rule workaround' discriminators,
 /// allowing us to select one function signature to use as a `Handler`.

--- a/axum/src/handler/mod.rs
+++ b/axum/src/handler/mod.rs
@@ -125,6 +125,23 @@ pub use self::service::HandlerService;
 ///     )));
 /// # let _: Router = app;
 /// ```
+///
+/// # About type parameter `T`
+///
+/// **Generally you shouldn't need to worry about `T`**; when calling methods such as
+/// [`post`](crate::routing::method_routing::post) it will be automatically inferred and this is
+/// the intended way for this parameter to be provided in application code.
+///
+/// If you are implementing your own methods that accept implementations of `Handler` as
+/// arguments, then the following may be useful:
+///
+/// The type parameter `T` is a workaround for trait coherence rules, allowing us to
+/// write blanket implementations of `Handler` over many types of handler functions
+/// with different numbers of arguments, without the compiler forbidding us from doing
+/// so because one type `F` can in theory implement both `Fn(T1)` and `Fn(T1, T2)`.
+/// `T` is a placeholder taking on a representation of the parameters of the handler function,
+/// as well as other similar 'coherence rule workaround' discriminators,
+/// allowing us to select one function signature to use as a `Handler`.
 #[diagnostic::on_unimplemented(
     note = "Consider using `#[axum::debug_handler]` to improve the error message"
 )]


### PR DESCRIPTION
## Motivation

As a (slightly advanced) user of the library, one might run into a situation where they need to know enough about `T` to be able to express basic constraints about it, like whether two separate implementations of `Handler` should be constrained to have the same `T` or whether they should be unconstrained/allowed to have separate `T`s.

## Solution

I found someone who already asked about `T` at https://github.com/tokio-rs/axum/discussions/3024,
liked the explanation and thought that it would be worth distilling enough into the doc comment
for users who need to care about this, whilst trying to reassure the 99% of users who do not need to worry
about it.