### PR TITLE
websocket: add a wrapper around is_terminated

### DIFF
--- a/axum/src/extract/ws.rs
+++ b/axum/src/extract/ws.rs
@@ -531,12 +531,10 @@ impl WebSocket {
 }
 
 impl FusedStream for WebSocket {
-
     /// Returns true if the websocket has been terminated.
     fn is_terminated(&self) -> bool {
         self.inner.is_terminated()
     }
-
 }
 
 impl Stream for WebSocket {

--- a/axum/src/extract/ws.rs
+++ b/axum/src/extract/ws.rs
@@ -528,11 +528,15 @@ impl WebSocket {
     pub fn protocol(&self) -> Option<&HeaderValue> {
         self.protocol.as_ref()
     }
+}
+
+impl FusedStream for WebSocket {
 
     /// Returns true if the websocket has been terminated.
-    pub fn is_terminated(&self) -> bool {
+    fn is_terminated(&self) -> bool {
         self.inner.is_terminated()
     }
+
 }
 
 impl Stream for WebSocket {

--- a/axum/src/extract/ws.rs
+++ b/axum/src/extract/ws.rs
@@ -529,6 +529,7 @@ impl WebSocket {
         self.protocol.as_ref()
     }
 
+    /// Returns true if the websocket has been terminated.
     pub fn is_terminated(&self) -> bool {
         self.inner.is_terminated()
     }

--- a/axum/src/extract/ws.rs
+++ b/axum/src/extract/ws.rs
@@ -94,7 +94,7 @@ use self::rejection::*;
 use super::FromRequestParts;
 use crate::{body::Bytes, response::Response, Error};
 use axum_core::body::Body;
-use futures_core::Stream;
+use futures_core::{FusedStream, Stream};
 use futures_sink::Sink;
 use futures_util::{sink::SinkExt, stream::StreamExt};
 use http::{
@@ -527,6 +527,10 @@ impl WebSocket {
     /// Return the selected WebSocket subprotocol, if one has been chosen.
     pub fn protocol(&self) -> Option<&HeaderValue> {
         self.protocol.as_ref()
+    }
+
+    pub fn is_terminated(&self) -> bool {
+        self.inner.is_terminated()
     }
 }
 


### PR DESCRIPTION
Adding a wrapper function around `is_terminated` for `WebSocket`.

## Motivation

In some of my code, I need to check if the websocket is still open or not. From what I understood there is currently no way to do it without pulling some data from it.

## Solution

Just calling the function provide by tungstenite.