### PR TITLE
Improve tests, tracing defaults, examples, and deps; minor fix in path test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,9 +112,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.95"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
+checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
 
 [[package]]
 name = "arc-swap"
@@ -136,46 +136,44 @@ checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "askama"
-version = "0.12.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b79091df18a97caea757e28cd2d5fda49c6cd4bd01ddffd7ff01ace0c0ad2c28"
+checksum = "f75363874b771be265f4ffe307ca705ef6f3baa19011c149da8674a87f1b75c4"
 dependencies = [
  "askama_derive",
- "askama_escape",
- "humansize",
- "num-traits",
+ "itoa",
  "percent-encoding",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
 name = "askama_derive"
-version = "0.12.5"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19fe8d6cb13c4714962c072ea496f3392015f0989b1a2847bb4b2d9effd71d83"
+checksum = "129397200fe83088e8a68407a8e2b1f826cf0086b21ccdb866a722c8bcd3a94f"
 dependencies = [
  "askama_parser",
  "basic-toml",
- "mime",
- "mime_guess",
+ "memchr",
  "proc-macro2",
  "quote",
+ "rustc-hash 2.1.0",
  "serde",
+ "serde_derive",
  "syn 2.0.93",
 ]
 
 [[package]]
-name = "askama_escape"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "619743e34b5ba4e9703bba34deac3427c72507c7159f5fd030aea8cac0cfe341"
-
-[[package]]
 name = "askama_parser"
-version = "0.2.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acb1161c6b64d1c3d83108213c2a2533a342ac225aabd0bda218278c2ddb00c0"
+checksum = "d6ab5630b3d5eaf232620167977f95eb51f3432fc76852328774afbd242d4358"
 dependencies = [
- "nom",
+ "memchr",
+ "serde",
+ "serde_derive",
+ "winnow 0.7.13",
 ]
 
 [[package]]
@@ -261,15 +259,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
-name = "auto-reload"
-version = "0.1.0"
-dependencies = [
- "axum",
- "listenfd",
- "tokio",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -314,10 +303,10 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http 1.2.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
- "hyper 1.5.2",
+ "hyper",
  "hyper-util",
  "itoa",
  "matchit",
@@ -328,19 +317,19 @@ dependencies = [
  "pin-project-lite",
  "quickcheck",
  "quickcheck_macros",
- "reqwest 0.12.12",
+ "reqwest",
  "serde",
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
  "sha1",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "time",
  "tokio",
  "tokio-stream",
  "tokio-tungstenite",
- "tower 0.5.2",
- "tower-http 0.6.2",
+ "tower",
+ "tower-http",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -357,16 +346,16 @@ dependencies = [
  "axum-macros",
  "bytes",
  "futures-core",
- "http 1.2.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
- "hyper 1.5.2",
+ "hyper",
  "mime",
  "pin-project-lite",
  "rustversion",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
- "tower-http 0.6.2",
+ "tower-http",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -386,16 +375,16 @@ dependencies = [
  "futures-core",
  "futures-util",
  "headers",
- "http 1.2.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
- "hyper 1.5.2",
+ "hyper",
  "mime",
  "multer",
  "percent-encoding",
  "pin-project-lite",
  "prost",
- "reqwest 0.12.12",
+ "reqwest",
  "rustversion",
  "serde",
  "serde_html_form",
@@ -404,8 +393,8 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
- "tower 0.5.2",
- "tower-http 0.6.2",
+ "tower",
+ "tower-http",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -431,40 +420,16 @@ dependencies = [
 
 [[package]]
 name = "axum-server"
-version = "0.6.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1ad46c3ec4e12f4a4b6835e173ba21c25e484c9d02b49770bf006ce5367c036"
+checksum = "495c05f60d6df0093e8fb6e74aa5846a0ad06abaf96d76166283720bf740f8ab"
 dependencies = [
  "arc-swap",
  "bytes",
- "futures-util",
- "http 1.2.0",
- "http-body 1.0.1",
- "http-body-util",
- "hyper 1.5.2",
- "hyper-util",
- "pin-project-lite",
- "rustls 0.21.12",
- "rustls-pemfile 2.2.0",
- "tokio",
- "tokio-rustls 0.24.1",
- "tower 0.4.13",
- "tower-service",
-]
-
-[[package]]
-name = "axum-server"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56bac90848f6a9393ac03c63c640925c4b7c8ca21654de40d53f55964667c7d8"
-dependencies = [
- "arc-swap",
- "bytes",
- "futures-util",
- "http 1.2.0",
- "http-body 1.0.1",
- "http-body-util",
- "hyper 1.5.2",
+ "fs-err",
+ "http",
+ "http-body",
+ "hyper",
  "hyper-util",
  "pin-project-lite",
  "rustls 0.23.20",
@@ -472,7 +437,6 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.1",
- "tower 0.4.13",
  "tower-service",
 ]
 
@@ -663,24 +627,24 @@ dependencies = [
 
 [[package]]
 name = "brotli"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74f7971dbd9326d58187408ab83117d8ac1bb9c17b085fdacd1cf2f598719b6b"
-dependencies = [
- "alloc-no-stdlib",
- "alloc-stdlib",
- "brotli-decompressor",
-]
-
-[[package]]
-name = "brotli"
 version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc97b8f16f944bba54f0433f07e30be199b6dc2bd25937444bbad560bcea29bd"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
- "brotli-decompressor",
+ "brotli-decompressor 4.0.1",
+]
+
+[[package]]
+name = "brotli"
+version = "8.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor 5.0.0",
 ]
 
 [[package]]
@@ -694,19 +658,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "bson"
-version = "2.13.0"
+name = "brotli-decompressor"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "068208f2b6fcfa27a7f1ee37488d2bb8ba2640f68f5475d08e1d9130696aba59"
+checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+]
+
+[[package]]
+name = "bson"
+version = "2.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969a9ba84b0ff843813e7249eed1678d9b6607ce5a3b8f0a47af3fcf7978e6e"
 dependencies = [
  "ahash",
- "base64 0.13.1",
+ "base64 0.22.1",
  "bitvec",
+ "getrandom 0.2.15",
+ "getrandom 0.3.3",
  "hex",
  "indexmap 2.7.0",
  "js-sys",
  "once_cell",
- "rand 0.8.5",
+ "rand 0.9.1",
  "serde",
  "serde_bytes",
  "serde_json",
@@ -845,6 +821,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.15",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -946,6 +942,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -1090,6 +1092,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive-syn-parse"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d65d7ce8132b7c0e54497a4d9a55a1c2a0912a0d786cf894472ba818fba45762"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.93",
+]
+
+[[package]]
 name = "derive-where"
 version = "1.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1128,13 +1141,13 @@ dependencies = [
 
 [[package]]
 name = "diesel-async"
-version = "0.5.2"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51a307ac00f7c23f526a04a77761a0519b9f0eb2838ebf5b905a58580095bdcb"
+checksum = "7fcc26599f590c7e5b182a05061cfb445f216bb069df72eb31f38cffde8ca598"
 dependencies = [
- "async-trait",
- "bb8 0.8.6",
+ "bb8 0.9.0",
  "diesel",
+ "futures-core",
  "futures-util",
  "scoped-futures",
  "tokio",
@@ -1335,7 +1348,16 @@ dependencies = [
  "axum",
  "http-body-util",
  "tokio",
- "tower 0.5.2",
+ "tower",
+]
+
+[[package]]
+name = "example-auto-reload"
+version = "0.1.0"
+dependencies = [
+ "axum",
+ "listenfd",
+ "tokio",
 ]
 
 [[package]]
@@ -1355,13 +1377,13 @@ version = "0.1.0"
 dependencies = [
  "assert-json-diff",
  "axum",
- "brotli 6.0.0",
+ "brotli 8.0.2",
  "flate2",
- "http 1.2.0",
+ "http",
  "serde_json",
  "tokio",
- "tower 0.5.2",
- "tower-http 0.6.2",
+ "tower",
+ "tower-http",
  "tracing",
  "tracing-subscriber",
  "zstd",
@@ -1384,7 +1406,7 @@ version = "0.1.0"
 dependencies = [
  "axum",
  "tokio",
- "tower-http 0.6.2",
+ "tower-http",
 ]
 
 [[package]]
@@ -1395,7 +1417,7 @@ dependencies = [
  "axum-extra",
  "serde",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.9",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -1429,7 +1451,7 @@ name = "example-diesel-async-postgres"
 version = "0.1.0"
 dependencies = [
  "axum",
- "bb8 0.8.6",
+ "bb8 0.9.0",
  "diesel",
  "diesel-async",
  "serde",
@@ -1459,7 +1481,7 @@ dependencies = [
  "axum",
  "serde",
  "tokio",
- "tower-http 0.6.2",
+ "tower-http",
  "tracing",
  "tracing-subscriber",
 ]
@@ -1473,7 +1495,7 @@ dependencies = [
  "mime",
  "serde",
  "tokio",
- "tower 0.5.2",
+ "tower",
  "tracing",
  "tracing-subscriber",
 ]
@@ -1494,7 +1516,7 @@ version = "0.1.0"
 dependencies = [
  "axum",
  "tokio",
- "tower-http 0.6.2",
+ "tower-http",
  "tracing-subscriber",
 ]
 
@@ -1504,9 +1526,9 @@ version = "0.1.0"
 dependencies = [
  "axum",
  "http-body-util",
- "hyper 1.5.2",
+ "hyper",
  "tokio",
- "tower 0.5.2",
+ "tower",
 ]
 
 [[package]]
@@ -1522,10 +1544,10 @@ name = "example-http-proxy"
 version = "0.1.0"
 dependencies = [
  "axum",
- "hyper 1.5.2",
+ "hyper",
  "hyper-util",
  "tokio",
- "tower 0.5.2",
+ "tower",
  "tracing",
  "tracing-subscriber",
 ]
@@ -1550,8 +1572,8 @@ version = "0.1.0"
 dependencies = [
  "axum",
  "tokio",
- "tower 0.5.2",
- "tower-http 0.6.2",
+ "tower",
+ "tower-http",
  "tracing",
  "tracing-subscriber",
 ]
@@ -1561,7 +1583,7 @@ name = "example-low-level-native-tls"
 version = "0.1.0"
 dependencies = [
  "axum",
- "hyper 1.5.2",
+ "hyper",
  "hyper-util",
  "tokio",
  "tokio-native-tls",
@@ -1575,12 +1597,12 @@ name = "example-low-level-openssl"
 version = "0.1.0"
 dependencies = [
  "axum",
- "hyper 1.5.2",
+ "hyper",
  "hyper-util",
  "openssl",
  "tokio",
  "tokio-openssl",
- "tower 0.5.2",
+ "tower",
  "tracing",
  "tracing-subscriber",
 ]
@@ -1590,7 +1612,7 @@ name = "example-low-level-rustls"
 version = "0.1.0"
 dependencies = [
  "axum",
- "hyper 1.5.2",
+ "hyper",
  "hyper-util",
  "tokio",
  "tokio-rustls 0.26.1",
@@ -1607,7 +1629,7 @@ dependencies = [
  "mongodb",
  "serde",
  "tokio",
- "tower-http 0.6.2",
+ "tower-http",
  "tracing",
  "tracing-subscriber",
 ]
@@ -1618,7 +1640,7 @@ version = "0.1.0"
 dependencies = [
  "axum",
  "tokio",
- "tower-http 0.6.2",
+ "tower-http",
  "tracing",
  "tracing-subscriber",
 ]
@@ -1631,9 +1653,9 @@ dependencies = [
  "async-session",
  "axum",
  "axum-extra",
- "http 1.2.0",
+ "http",
  "oauth2",
- "reqwest 0.12.12",
+ "reqwest",
  "serde",
  "tokio",
  "tracing",
@@ -1682,7 +1704,7 @@ dependencies = [
  "http-body-util",
  "serde",
  "tokio",
- "tower 0.5.2",
+ "tower",
 ]
 
 [[package]]
@@ -1702,8 +1724,8 @@ version = "0.1.0"
 dependencies = [
  "axum",
  "tokio",
- "tower 0.5.2",
- "tower-http 0.5.2",
+ "tower",
+ "tower-http",
  "tracing",
  "tracing-subscriber",
 ]
@@ -1713,10 +1735,10 @@ name = "example-reqwest-response"
 version = "0.1.0"
 dependencies = [
  "axum",
- "reqwest 0.12.12",
+ "reqwest",
  "tokio",
  "tokio-stream",
- "tower-http 0.6.2",
+ "tower-http",
  "tracing",
  "tracing-subscriber",
 ]
@@ -1726,7 +1748,7 @@ name = "example-reverse-proxy"
 version = "0.1.0"
 dependencies = [
  "axum",
- "hyper 1.5.2",
+ "hyper",
  "hyper-util",
  "tokio",
 ]
@@ -1744,10 +1766,10 @@ name = "example-serve-with-hyper"
 version = "0.1.0"
 dependencies = [
  "axum",
- "hyper 1.5.2",
+ "hyper",
  "hyper-util",
  "tokio",
- "tower 0.5.2",
+ "tower",
 ]
 
 [[package]]
@@ -1757,7 +1779,7 @@ dependencies = [
  "axum",
  "axum-extra",
  "futures-executor",
- "http 1.2.0",
+ "http",
  "tower-service",
 ]
 
@@ -1781,11 +1803,11 @@ dependencies = [
  "eventsource-stream",
  "futures-util",
  "headers",
- "reqwest 0.12.12",
+ "reqwest",
  "reqwest-eventsource",
  "tokio",
  "tokio-stream",
- "tower-http 0.6.2",
+ "tower-http",
  "tracing",
  "tracing-subscriber",
 ]
@@ -1796,8 +1818,8 @@ version = "0.1.0"
 dependencies = [
  "axum",
  "tokio",
- "tower 0.5.2",
- "tower-http 0.6.2",
+ "tower",
+ "tower-http",
  "tracing",
  "tracing-subscriber",
 ]
@@ -1822,7 +1844,7 @@ dependencies = [
  "axum",
  "http-body-util",
  "tokio",
- "tower 0.5.2",
+ "tower",
  "tracing",
  "tracing-subscriber",
 ]
@@ -1846,8 +1868,8 @@ dependencies = [
  "mime",
  "serde_json",
  "tokio",
- "tower 0.5.2",
- "tower-http 0.6.2",
+ "tower",
+ "tower-http",
  "tracing",
  "tracing-subscriber",
 ]
@@ -1869,7 +1891,7 @@ version = "0.1.0"
 dependencies = [
  "axum",
  "axum-extra",
- "axum-server 0.7.1",
+ "axum-server",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -1881,7 +1903,7 @@ version = "0.1.0"
 dependencies = [
  "axum",
  "axum-extra",
- "axum-server 0.7.1",
+ "axum-server",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -1894,8 +1916,8 @@ dependencies = [
  "axum",
  "serde",
  "tokio",
- "tower 0.5.2",
- "tower-http 0.6.2",
+ "tower",
+ "tower-http",
  "tracing",
  "tracing-subscriber",
  "uuid",
@@ -1933,7 +1955,7 @@ version = "0.1.0"
 dependencies = [
  "axum",
  "tokio",
- "tower-http 0.6.2",
+ "tower-http",
  "tracing",
  "tracing-subscriber",
 ]
@@ -1944,7 +1966,7 @@ version = "0.1.0"
 dependencies = [
  "axum",
  "http-body-util",
- "hyper 1.5.2",
+ "hyper",
  "hyper-util",
  "tokio",
  "tracing-subscriber",
@@ -1959,7 +1981,7 @@ dependencies = [
  "serde",
  "thiserror 1.0.69",
  "tokio",
- "tower 0.5.2",
+ "tower",
  "tracing",
  "tracing-subscriber",
  "validator",
@@ -1972,7 +1994,7 @@ dependencies = [
  "axum",
  "http-body-util",
  "tokio",
- "tower 0.5.2",
+ "tower",
  "tracing",
  "tracing-subscriber",
 ]
@@ -1987,7 +2009,7 @@ dependencies = [
  "headers",
  "tokio",
  "tokio-tungstenite",
- "tower-http 0.6.2",
+ "tower-http",
  "tracing",
  "tracing-subscriber",
 ]
@@ -1997,9 +2019,9 @@ name = "example-websockets-http2"
 version = "0.1.0"
 dependencies = [
  "axum",
- "axum-server 0.6.0",
+ "axum-server",
  "tokio",
- "tower-http 0.5.2",
+ "tower-http",
  "tracing",
  "tracing-subscriber",
 ]
@@ -2065,6 +2087,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fs-err"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d7be93788013f265201256d58f04936a8079ad5dc898743aa20525f503b683"
+dependencies = [
+ "autocfg",
+ "tokio",
 ]
 
 [[package]]
@@ -2199,9 +2231,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if 1.0.0",
+ "js-sys",
  "libc",
  "r-efi",
  "wasi 0.14.2+wasi-0.2.4",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2228,25 +2262,6 @@ checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "h2"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http 0.2.12",
- "indexmap 2.7.0",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "h2"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccae279728d634d083c00f6099cb58f01cc99c145b84b8be2f6c74618d79922e"
@@ -2256,7 +2271,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.2.0",
+ "http",
  "indexmap 2.7.0",
  "slab",
  "tokio",
@@ -2314,7 +2329,7 @@ dependencies = [
  "base64 0.21.7",
  "bytes",
  "headers-core",
- "http 1.2.0",
+ "http",
  "httpdate",
  "mime",
  "sha1",
@@ -2326,7 +2341,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
 dependencies = [
- "http 1.2.0",
+ "http",
 ]
 
 [[package]]
@@ -2442,35 +2457,13 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.12"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
 dependencies = [
  "bytes",
  "fnv",
  "itoa",
-]
-
-[[package]]
-name = "http"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f16ca2af56261c99fba8bac40a10251ce8188205a4c448fbb745a2e4daa76fea"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
-name = "http-body"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
-dependencies = [
- "bytes",
- "http 0.2.12",
- "pin-project-lite",
 ]
 
 [[package]]
@@ -2480,7 +2473,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.2.0",
+ "http",
 ]
 
 [[package]]
@@ -2491,8 +2484,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.2.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "pin-project-lite",
 ]
 
@@ -2515,71 +2508,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
-name = "humansize"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb51c9a029ddc91b07a787f1d86b53ccfa49b0e86688c946ebe8d3555685dd7"
-dependencies = [
- "libm",
-]
-
-[[package]]
 name = "hyper"
-version = "0.14.32"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+checksum = "eb3aa54a13a0dfe7fbe3a59e0c76093041720fdc77b110cc0fc260fafb4dc51e"
 dependencies = [
+ "atomic-waker",
  "bytes",
  "futures-channel",
  "futures-core",
- "futures-util",
- "h2 0.3.26",
- "http 0.2.12",
- "http-body 0.4.6",
+ "h2",
+ "http",
+ "http-body",
  "httparse",
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2",
- "tokio",
- "tower-service",
- "tracing",
- "want",
-]
-
-[[package]]
-name = "hyper"
-version = "1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "256fb8d4bd6413123cc9d91832d78325c48ff41677595be797d90f42969beae0"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-util",
- "h2 0.4.7",
- "http 1.2.0",
- "http-body 1.0.1",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
+ "pin-utils",
  "smallvec",
  "tokio",
  "want",
-]
-
-[[package]]
-name = "hyper-rustls"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
-dependencies = [
- "futures-util",
- "http 0.2.12",
- "hyper 0.14.32",
- "rustls 0.21.12",
- "tokio",
- "tokio-rustls 0.24.1",
 ]
 
 [[package]]
@@ -2589,8 +2537,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
 dependencies = [
  "futures-util",
- "http 1.2.0",
- "hyper 1.5.2",
+ "http",
+ "hyper",
  "hyper-util",
  "rustls 0.23.20",
  "rustls-pki-types",
@@ -2608,7 +2556,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper 1.5.2",
+ "hyper",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -2618,18 +2566,20 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.10"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
+checksum = "8d9b05277c7e8da2c93a568989bb6207bef0112e8d17df7a6eda4a3cf143bc5e"
 dependencies = [
  "bytes",
  "futures-channel",
+ "futures-core",
  "futures-util",
- "http 1.2.0",
- "http-body 1.0.1",
- "hyper 1.5.2",
+ "http",
+ "http-body",
+ "hyper",
+ "libc",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.0",
  "tokio",
  "tower-service",
  "tracing",
@@ -2835,12 +2785,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-uring"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
+dependencies = [
+ "bitflags 2.6.0",
+ "cfg-if 1.0.0",
+ "libc",
+]
+
+[[package]]
 name = "ipconfig"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
 dependencies = [
- "socket2",
+ "socket2 0.5.8",
  "widestring",
  "windows-sys 0.48.0",
  "winreg",
@@ -2897,9 +2858,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.76"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6717b6b5b077764fb5966237269cb3c64edddde4b14ce42647430a78ced9e7b7"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -2937,9 +2898,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
 name = "libloading"
@@ -2982,9 +2943,9 @@ checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "listenfd"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0500463acd96259d219abb05dc57e5a076ef04b2db9a2112846929b5f174c96"
+checksum = "b87bc54a4629b4294d0b3ef041b64c40c611097a677d9dc07b2c67739fe39dba"
 dependencies = [
  "libc",
  "uuid",
@@ -3020,6 +2981,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
 dependencies = [
  "linked-hash-map",
+]
+
+[[package]]
+name = "macro_magic"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc33f9f0351468d26fbc53d9ce00a096c8522ecb42f19b50f34f2c422f76d21d"
+dependencies = [
+ "macro_magic_core",
+ "macro_magic_macros",
+ "quote",
+ "syn 2.0.93",
+]
+
+[[package]]
+name = "macro_magic_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1687dc887e42f352865a393acae7cf79d98fab6351cde1f58e9e057da89bf150"
+dependencies = [
+ "const-random",
+ "derive-syn-parse",
+ "macro_magic_core_macros",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.93",
+]
+
+[[package]]
+name = "macro_magic_core_macros"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b02abfe41815b5bd98dbd4260173db2c116dda171dc0fe7838cb206333b83308"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.93",
+]
+
+[[package]]
+name = "macro_magic_macros"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ea28ee64b88876bf45277ed9a5817c1817df061a74f2b988971a12570e5869"
+dependencies = [
+ "macro_magic_core",
+ "quote",
+ "syn 2.0.93",
 ]
 
 [[package]]
@@ -3137,9 +3146,9 @@ dependencies = [
 
 [[package]]
 name = "minijinja"
-version = "2.5.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c37e1b517d1dcd0e51dc36c4567b9d5a29262b3ec8da6cb5d35e27a8fb529b5"
+checksum = "4e60ac08614cc09062820e51d5d94c2fce16b94ea4e5003bb81b99a95f84e876"
 dependencies = [
  "serde",
 ]
@@ -3172,9 +3181,9 @@ dependencies = [
 
 [[package]]
 name = "mongodb"
-version = "3.1.1"
+version = "3.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff1f6edf7fe8828429647a2200f684681ca6d5a33b45edc3140c81390d852301"
+checksum = "f6e3788f35159bbcf461227af84711950525343b64451fdd90de4e237a0b8a13"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -3191,6 +3200,7 @@ dependencies = [
  "hickory-proto",
  "hickory-resolver",
  "hmac 0.12.1",
+ "macro_magic",
  "md-5",
  "mongodb-internal-macros",
  "once_cell",
@@ -3203,9 +3213,9 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_with",
- "sha-1",
+ "sha1",
  "sha2 0.10.8",
- "socket2",
+ "socket2 0.5.8",
  "stringprep",
  "strsim",
  "take_mut",
@@ -3220,10 +3230,11 @@ dependencies = [
 
 [[package]]
 name = "mongodb-internal-macros"
-version = "3.1.1"
+version = "3.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b07bfd601af78e39384707a8e80041946c98260e3e0190e294ee7435823e6bf"
+checksum = "fdfb13b7c0436b3e395f4ce5f4366431b9c9db47adc4cb33afc6b5b913d44969"
 dependencies = [
+ "macro_magic",
  "proc-macro2",
  "quote",
  "syn 2.0.93",
@@ -3238,7 +3249,7 @@ dependencies = [
  "bytes",
  "encoding_rs",
  "futures-util",
- "http 1.2.0",
+ "http",
  "httparse",
  "memchr",
  "mime",
@@ -3358,16 +3369,16 @@ dependencies = [
 
 [[package]]
 name = "oauth2"
-version = "4.4.2"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c38841cdd844847e3e7c8d29cef9dcfed8877f8f56f9071f77843ecf3baf937f"
+checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.22.1",
  "chrono",
  "getrandom 0.2.15",
- "http 0.2.12",
+ "http",
  "rand 0.8.5",
- "reqwest 0.11.27",
+ "reqwest",
  "serde",
  "serde_json",
  "serde_path_to_error",
@@ -3532,26 +3543,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
 dependencies = [
  "siphasher",
-]
-
-[[package]]
-name = "pin-project"
-version = "1.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be57f64e946e500c8ee36ef6331845d40a93055567ec57e8fae13efd33759b95"
-dependencies = [
- "pin-project-internal",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "1.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c0f5fad0874fc7abcd4d750e76917eaebbecaa2c20bde22e1dbeeba8beb758c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.93",
 ]
 
 [[package]]
@@ -3783,7 +3774,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.0",
  "rustls 0.23.20",
- "socket2",
+ "socket2 0.5.8",
  "thiserror 2.0.9",
  "tokio",
  "tracing",
@@ -3818,7 +3809,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.5.8",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -3930,7 +3921,7 @@ dependencies = [
  "pin-project-lite",
  "ryu",
  "sha1_smol",
- "socket2",
+ "socket2 0.5.8",
  "tokio",
  "tokio-util",
  "url",
@@ -3991,47 +3982,6 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
-version = "0.11.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
-dependencies = [
- "base64 0.21.7",
- "bytes",
- "encoding_rs",
- "futures-core",
- "futures-util",
- "h2 0.3.26",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.32",
- "hyper-rustls 0.24.2",
- "ipnet",
- "js-sys",
- "log",
- "mime",
- "once_cell",
- "percent-encoding",
- "pin-project-lite",
- "rustls 0.21.12",
- "rustls-pemfile 1.0.4",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper 0.1.2",
- "system-configuration 0.5.1",
- "tokio",
- "tokio-rustls 0.24.1",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "webpki-roots 0.25.4",
- "winreg",
-]
-
-[[package]]
-name = "reqwest"
 version = "0.12.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da"
@@ -4041,12 +3991,12 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2 0.4.7",
- "http 1.2.0",
- "http-body 1.0.1",
+ "h2",
+ "http",
+ "http-body",
  "http-body-util",
- "hyper 1.5.2",
- "hyper-rustls 0.27.5",
+ "hyper",
+ "hyper-rustls",
  "hyper-tls",
  "hyper-util",
  "ipnet",
@@ -4065,13 +4015,13 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper 1.0.2",
- "system-configuration 0.6.1",
+ "sync_wrapper",
+ "system-configuration",
  "tokio",
  "tokio-native-tls",
  "tokio-rustls 0.26.1",
  "tokio-util",
- "tower 0.5.2",
+ "tower",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -4094,7 +4044,7 @@ dependencies = [
  "mime",
  "nom",
  "pin-project-lite",
- "reqwest 0.12.12",
+ "reqwest",
  "thiserror 1.0.69",
 ]
 
@@ -4388,9 +4338,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.134"
+version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d00f4175c42ee48b15416f6193a959ba3a0d67fc699a0db9ad12df9f83991c7d"
+checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
 dependencies = [
  "indexmap 2.7.0",
  "itoa",
@@ -4458,17 +4408,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.93",
-]
-
-[[package]]
-name = "sha-1"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
-dependencies = [
- "cfg-if 1.0.0",
- "cpufeatures",
- "digest 0.10.7",
 ]
 
 [[package]]
@@ -4596,6 +4535,16 @@ checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4877,12 +4826,6 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
-
-[[package]]
-name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
@@ -4903,34 +4846,13 @@ dependencies = [
 
 [[package]]
 name = "system-configuration"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation",
- "system-configuration-sys 0.5.0",
-]
-
-[[package]]
-name = "system-configuration"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
  "bitflags 2.6.0",
  "core-foundation",
- "system-configuration-sys 0.6.0",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
-dependencies = [
- "core-foundation-sys",
- "libc",
+ "system-configuration-sys",
 ]
 
 [[package]]
@@ -5065,6 +4987,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5091,20 +5022,22 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.44.2"
+version = "1.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
+checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
 dependencies = [
  "backtrace",
  "bytes",
+ "io-uring",
  "libc",
  "mio",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "slab",
+ "socket2 0.6.0",
  "tokio-macros",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5159,7 +5092,7 @@ dependencies = [
  "postgres-protocol",
  "postgres-types",
  "rand 0.8.5",
- "socket2",
+ "socket2 0.5.8",
  "tokio",
  "tokio-util",
  "whoami",
@@ -5253,22 +5186,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow",
-]
-
-[[package]]
-name = "tower"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
-dependencies = [
- "futures-core",
- "futures-util",
- "pin-project",
- "pin-project-lite",
- "tower-layer",
- "tower-service",
- "tracing",
+ "winnow 0.6.21",
 ]
 
 [[package]]
@@ -5283,7 +5201,7 @@ dependencies = [
  "indexmap 2.7.0",
  "pin-project-lite",
  "slab",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tokio-util",
  "tower-layer",
@@ -5293,35 +5211,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.5.2"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
-dependencies = [
- "bitflags 2.6.0",
- "bytes",
- "futures-util",
- "http 1.2.0",
- "http-body 1.0.1",
- "http-body-util",
- "http-range-header",
- "httpdate",
- "mime",
- "mime_guess",
- "percent-encoding",
- "pin-project-lite",
- "tokio",
- "tokio-util",
- "tower-layer",
- "tower-service",
- "tracing",
- "uuid",
-]
-
-[[package]]
-name = "tower-http"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "403fa3b783d4b626a8ad51d766ab03cb6d2dbfc46b1c5d4448395e6628dc9697"
+checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
 dependencies = [
  "async-compression",
  "base64 0.22.1",
@@ -5329,8 +5221,8 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http 1.2.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
  "http-range-header",
  "httpdate",
@@ -5341,7 +5233,7 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-util",
- "tower 0.5.2",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -5464,7 +5356,7 @@ checksum = "eadc29d668c91fcc564941132e17b28a7ceb2f3ebf0b9dae3e03fd7a6748eb0d"
 dependencies = [
  "bytes",
  "data-encoding",
- "http 1.2.0",
+ "http",
  "httparse",
  "log",
  "rand 0.9.1",
@@ -5587,12 +5479,14 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.11.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
+checksum = "f33196643e165781c20a5ead5582283a7dacbb87855d867fbc2df3f81eddc1be"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.3.3",
+ "js-sys",
  "serde",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -5675,20 +5569,21 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a474f6281d1d70c17ae7aa6a613c87fce69a127e2624002df63dcb39d6cf6396"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if 1.0.0",
  "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f89bb38646b4f81674e8f5c3fb81b562be1fd936d84320f3264486418519c79"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
@@ -5700,9 +5595,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.49"
+version = "0.4.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38176d9b44ea84e9184eff0bc34cc167ed044f816accfe5922e54d84cf48eca2"
+checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -5713,9 +5608,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cc6181fd9a7492eef6fef1f33961e3695e4579b9872a6f7c83aee556666d4fe"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5723,9 +5618,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5736,9 +5631,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "943aab3fdaaa029a6e0271b35ea10b72b943135afe9bffca82384098ad0e06a6"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "wasm-streams"
@@ -5755,9 +5653,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.76"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dd7223427d52553d3702c004d3b2fe07c148165faa56313cb00211e31c12bc"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6040,6 +5938,15 @@ name = "winnow"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6f5bb5257f2407a5425c6e749bfd9692192a73e70a6060516ac04f889087d68"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "0.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
 dependencies = [
  "memchr",
 ]

--- a/axum/src/extract/path/mod.rs
+++ b/axum/src/extract/path/mod.rs
@@ -710,7 +710,7 @@ mod tests {
     async fn captures_match_empty_inner_segments() {
         let app = Router::new().route(
             "/{key}/method",
-            get(|Path(param): Path<String>| async move { param.to_string() }),
+            get(|Path(param): Path<String>| async move { param.clone() }),
         );
 
         let client = TestClient::new(app);
@@ -726,7 +726,7 @@ mod tests {
     async fn captures_match_empty_inner_segments_near_end() {
         let app = Router::new().route(
             "/method/{key}/",
-            get(|Path(param): Path<String>| async move { param.to_string() }),
+            get(|Path(param): Path<String>| async move { param.clone() }),
         );
 
         let client = TestClient::new(app);
@@ -745,7 +745,7 @@ mod tests {
     async fn captures_match_empty_trailing_segment() {
         let app = Router::new().route(
             "/method/{key}",
-            get(|Path(param): Path<String>| async move { param.to_string() }),
+            get(|Path(param): Path<String>| async move { param.clone() }),
         );
 
         let client = TestClient::new(app);

--- a/examples/anyhow-error-response/Cargo.toml
+++ b/examples/anyhow-error-response/Cargo.toml
@@ -7,8 +7,8 @@ publish = false
 [dependencies]
 anyhow = "1.0"
 axum = { path = "../../axum" }
-tokio = { version = "1.0", features = ["full"] }
+tokio = { version = "1", features = ["full"] }
 
 [dev-dependencies]
-http-body-util = "0.1.0"
+http-body-util = "0.1.3"
 tower = { version = "0.5.2", features = ["util"] }

--- a/examples/auto-reload/Cargo.toml
+++ b/examples/auto-reload/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "auto-reload"
+name = "example-auto-reload"
 version = "0.1.0"
 edition = "2021"
 publish = false
 
 [dependencies]
 axum = { path = "../../axum" }
-listenfd = "1.0.1"
-tokio = { version = "1.0", features = ["full"] }
+listenfd = "1.0.2"
+tokio = { version = "1", features = ["full"] }

--- a/examples/auto-reload/src/main.rs
+++ b/examples/auto-reload/src/main.rs
@@ -1,7 +1,7 @@
 //! Run with
 //!
 //! ```not_rust
-//! cargo run -p auto-reload
+//! cargo run -p example-auto-reload
 //! ```
 
 use axum::{response::Html, routing::get, Router};

--- a/examples/chat/Cargo.toml
+++ b/examples/chat/Cargo.toml
@@ -6,7 +6,10 @@ publish = false
 
 [dependencies]
 axum = { path = "../../axum", features = ["ws"] }
-futures-util = { version = "0.3", default-features = false, features = ["sink", "std"] }
+futures-util = { version = "0.3.31", default-features = false, features = [
+    "sink",
+    "std",
+] }
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/chat/chat.html
+++ b/examples/chat/chat.html
@@ -1,52 +1,72 @@
 <!DOCTYPE html>
 <html lang="en">
-    <head>
-        <meta charset="UTF-8">
-        <title>WebSocket Chat</title>
-    </head>
-    <body>
-        <h1>WebSocket Chat Example</h1>
+  <head>
+    <meta charset="UTF-8" />
+    <title>WebSocket Chat</title>
+  </head>
+  <body>
+    <h1>WebSocket Chat Example</h1>
 
-        <input id="username" style="display:block; width:100px; box-sizing: border-box" type="text" placeholder="username">
-        <button id="join-chat" type="button">Join Chat</button>
-        <textarea id="chat" style="display:block; width:600px; height:400px; box-sizing: border-box" cols="30" rows="10"></textarea>
-        <input id="input" style="display:block; width:600px; box-sizing: border-box" type="text" placeholder="chat">
+    <input
+      id="username"
+      style="display: block; width: 100px; box-sizing: border-box"
+      type="text"
+      placeholder="username"
+    />
+    <button id="join-chat" type="button">Join Chat</button>
+    <textarea
+      id="chat"
+      style="
+        display: block;
+        width: 600px;
+        height: 400px;
+        box-sizing: border-box;
+      "
+      cols="30"
+      rows="10"
+    ></textarea>
+    <input
+      id="input"
+      style="display: block; width: 600px; box-sizing: border-box"
+      type="text"
+      placeholder="chat"
+    />
 
-        <script>
-            const username = document.querySelector("#username");
-            const join_btn = document.querySelector("#join-chat");
-            const textarea = document.querySelector("#chat");
-            const input = document.querySelector("#input");
+    <script>
+      const username = document.querySelector("#username");
+      const join_btn = document.querySelector("#join-chat");
+      const textarea = document.querySelector("#chat");
+      const input = document.querySelector("#input");
 
-            join_btn.addEventListener("click", function(e) {
-                this.disabled = true;
+      join_btn.addEventListener("click", (event) => {
+        this.disabled = true;
 
-                const websocket = new WebSocket("ws://localhost:3000/websocket");
+        const websocket = new WebSocket("ws://localhost:3000/websocket");
 
-                websocket.onopen = function() {
-                    console.log("connection opened");
-                    websocket.send(username.value);
-                }
+        websocket.onopen = (_event) => {
+          console.log("connection opened");
+          websocket.send(username.value);
+        };
 
-                const btn = this;
+        const btn = this;
 
-                websocket.onclose = function() {
-                    console.log("connection closed");
-                    btn.disabled = false;
-                }
+        websocket.onclose = (_event) => {
+          console.log("connection closed");
+          btn.disabled = false;
+        };
 
-                websocket.onmessage = function(e) {
-                    console.log("received message: "+e.data);
-                    textarea.value += e.data+"\r\n";
-                }
+        websocket.onmessage = (event) => {
+          console.log("received message: " + event.data);
+          textarea.value += event.data + "\r\n";
+        };
 
-                input.onkeydown = function(e) {
-                    if (e.key == "Enter") {
-                        websocket.send(input.value);
-                        input.value = "";
-                    }
-                }
-            });
-        </script>
-    </body>
+        input.onkeydown = (event) => {
+          if (event.key == "Enter") {
+            websocket.send(input.value);
+            input.value = "";
+          }
+        };
+      });
+    </script>
+  </body>
 </html>

--- a/examples/chat/src/main.rs
+++ b/examples/chat/src/main.rs
@@ -36,7 +36,7 @@ async fn main() {
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| format!("{}=trace", env!("CARGO_CRATE_NAME")).into()),
+                .unwrap_or_else(|_| format!("{}=debug", env!("CARGO_CRATE_NAME")).into()),
         )
         .with(tracing_subscriber::fmt::layer())
         .init();

--- a/examples/compression/Cargo.toml
+++ b/examples/compression/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 axum = { path = "../../axum" }
 serde_json = "1"
-tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 tower = "0.5.2"
 tower-http = { version = "0.6.6", features = [
     "compression-full",

--- a/examples/compression/Cargo.toml
+++ b/examples/compression/Cargo.toml
@@ -7,15 +7,18 @@ publish = false
 [dependencies]
 axum = { path = "../../axum" }
 serde_json = "1"
-tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 tower = "0.5.2"
-tower-http = { version = "0.6.1", features = ["compression-full", "decompression-full"] }
+tower-http = { version = "0.6.6", features = [
+    "compression-full",
+    "decompression-full",
+] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]
 assert-json-diff = "2.0"
-brotli = "6.0"
+brotli = "8.0.2"
 flate2 = "1"
 http = "1"
 zstd = "0.13"

--- a/examples/compression/README.md
+++ b/examples/compression/README.md
@@ -1,6 +1,7 @@
 # compression
 
 This example shows how to:
+
 - automatically decompress request bodies when necessary
 - compress response bodies based on the `accept` header.
 

--- a/examples/compression/src/main.rs
+++ b/examples/compression/src/main.rs
@@ -12,7 +12,7 @@ async fn main() {
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| format!("{}=trace", env!("CARGO_CRATE_NAME")).into()),
+                .unwrap_or_else(|_| format!("{}=debug", env!("CARGO_CRATE_NAME")).into()),
         )
         .with(tracing_subscriber::fmt::layer())
         .init();

--- a/examples/consume-body-in-extractor-or-middleware/Cargo.toml
+++ b/examples/consume-body-in-extractor-or-middleware/Cargo.toml
@@ -7,6 +7,6 @@ publish = false
 [dependencies]
 axum = { path = "../../axum" }
 http-body-util = "0.1.0"
-tokio = { version = "1.0", features = ["full"] }
+tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/cors/Cargo.toml
+++ b/examples/cors/Cargo.toml
@@ -6,5 +6,5 @@ publish = false
 
 [dependencies]
 axum = { path = "../../axum" }
-tokio = { version = "1.0", features = ["full"] }
-tower-http = { version = "0.6.1", features = ["cors"] }
+tokio = { version = "1", features = ["full"] }
+tower-http = { version = "0.6.6", features = ["cors"] }

--- a/examples/cors/src/main.rs
+++ b/examples/cors/src/main.rs
@@ -25,11 +25,14 @@ async fn main() {
             // see https://docs.rs/tower-http/latest/tower_http/cors/index.html
             // for more details
             //
-            // pay attention that for some request types like posting content-type: application/json
+            // pay attention that for some request types like posting "Content-Type: application/json"
             // it is required to add ".allow_headers([http::header::CONTENT_TYPE])"
             // or see this issue https://github.com/tokio-rs/axum/issues/849
             CorsLayer::new()
-                .allow_origin("http://localhost:3000".parse::<HeaderValue>().unwrap())
+                .allow_origin([
+                    "http://localhost:3000".parse::<HeaderValue>().unwrap(),
+                    "http://127.0.0.1:3000".parse::<HeaderValue>().unwrap(),
+                ])
                 .allow_methods([Method::GET]),
         );
         serve(app, 4000).await;

--- a/examples/customize-extractor-error/Cargo.toml
+++ b/examples/customize-extractor-error/Cargo.toml
@@ -9,7 +9,7 @@ axum = { path = "../../axum", features = ["macros"] }
 axum-extra = { path = "../../axum-extra" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-thiserror = "1.0"
-tokio = { version = "1.20", features = ["full"] }
+thiserror = "2.0"
+tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/customize-extractor-error/src/main.rs
+++ b/examples/customize-extractor-error/src/main.rs
@@ -16,7 +16,7 @@ async fn main() {
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| format!("{}=trace", env!("CARGO_CRATE_NAME")).into()),
+                .unwrap_or_else(|_| format!("{}=debug", env!("CARGO_CRATE_NAME")).into()),
         )
         .with(tracing_subscriber::fmt::layer())
         .init();

--- a/examples/customize-extractor-error/src/with_rejection.rs
+++ b/examples/customize-extractor-error/src/with_rejection.rs
@@ -9,14 +9,13 @@
 //! - Verbose types: types become much larger, which makes them difficult to
 //!   read. Current limitations on type aliasing makes impossible to destructure
 //!   a type alias. See [#1116]
-//!   
+//!
 //! [`thiserror`]: https://crates.io/crates/thiserror
 //! [#1116]: https://github.com/tokio-rs/axum/issues/1116#issuecomment-1186197684
 
 use axum::{extract::rejection::JsonRejection, response::IntoResponse, Json};
 use axum_extra::extract::WithRejection;
 use serde_json::{json, Value};
-use thiserror::Error;
 
 pub async fn handler(
     // `WithRejection` will extract `Json<Value>` from the request. If it fails,
@@ -30,7 +29,7 @@ pub async fn handler(
 }
 
 // We derive `thiserror::Error`
-#[derive(Debug, Error)]
+#[derive(Debug, thiserror::Error)]
 pub enum ApiError {
     // The `#[from]` attribute generates `From<JsonRejection> for ApiError`
     // implementation. See `thiserror` docs for more information

--- a/examples/customize-path-rejection/Cargo.toml
+++ b/examples/customize-path-rejection/Cargo.toml
@@ -7,6 +7,6 @@ publish = false
 [dependencies]
 axum = { path = "../../axum" }
 serde = { version = "1.0", features = ["derive"] }
-tokio = { version = "1.0", features = ["full"] }
+tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/dependency-injection/Cargo.toml
+++ b/examples/dependency-injection/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 axum = { path = "../../axum", features = ["tracing", "macros"] }
 serde = { version = "1.0", features = ["derive"] }
-tokio = { version = "1.0", features = ["full"] }
+tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-uuid = { version = "1.0", features = ["serde", "v4"] }
+uuid = { version = "1.18", features = ["serde", "v4"] }

--- a/examples/diesel-async-postgres/Cargo.toml
+++ b/examples/diesel-async-postgres/Cargo.toml
@@ -6,10 +6,10 @@ publish = false
 
 [dependencies]
 axum = { path = "../../axum", features = ["macros"] }
-bb8 = "0.8"
+bb8 = "0.9"
 diesel = "2"
-diesel-async = { version = "0.5", features = ["postgres", "bb8"] }
+diesel-async = { version = "0.6", features = ["postgres", "bb8"] }
 serde = { version = "1.0", features = ["derive"] }
-tokio = { version = "1.0", features = ["full"] }
+tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/diesel-postgres/Cargo.toml
+++ b/examples/diesel-postgres/Cargo.toml
@@ -10,6 +10,6 @@ deadpool-diesel = { version = "0.6.1", features = ["postgres"] }
 diesel = { version = "2", features = ["postgres"] }
 diesel_migrations = "2"
 serde = { version = "1.0", features = ["derive"] }
-tokio = { version = "1.0", features = ["full"] }
+tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/error-handling/Cargo.toml
+++ b/examples/error-handling/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 axum = { path = "../../axum", features = ["macros"] }
 serde = { version = "1.0", features = ["derive"] }
-tokio = { version = "1.0", features = ["full"] }
-tower-http = { version = "0.6.1", features = ["trace"] }
+tokio = { version = "1", features = ["full"] }
+tower-http = { version = "0.6.6", features = ["trace"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/form/Cargo.toml
+++ b/examples/form/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 axum = { path = "../../axum" }
 serde = { version = "1.0", features = ["derive"] }
-tokio = { version = "1.0", features = ["full"] }
+tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 

--- a/examples/global-404-handler/Cargo.toml
+++ b/examples/global-404-handler/Cargo.toml
@@ -6,6 +6,6 @@ publish = false
 
 [dependencies]
 axum = { path = "../../axum" }
-tokio = { version = "1.0", features = ["full"] }
+tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/graceful-shutdown/Cargo.toml
+++ b/examples/graceful-shutdown/Cargo.toml
@@ -6,6 +6,6 @@ publish = false
 
 [dependencies]
 axum = { path = "../../axum", features = ["tracing"] }
-tokio = { version = "1.0", features = ["full"] }
-tower-http = { version = "0.6.1", features = ["timeout", "trace"] }
+tokio = { version = "1", features = ["full"] }
+tower-http = { version = "0.6.6", features = ["timeout", "trace"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/graceful-shutdown/src/main.rs
+++ b/examples/graceful-shutdown/src/main.rs
@@ -21,8 +21,10 @@ async fn main() {
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+                // axum logs rejections from built-in extractors with the `axum::rejection`
+                // target, at `TRACE` level. `axum::rejection=trace` enables showing those events
                 format!(
-                    "{}=debug,tower_http=debug,axum=trace",
+                    "{}=debug,tower_http=debug,axum::rejection=trace",
                     env!("CARGO_CRATE_NAME")
                 )
                 .into()

--- a/examples/handle-head-request/Cargo.toml
+++ b/examples/handle-head-request/Cargo.toml
@@ -6,9 +6,9 @@ publish = false
 
 [dependencies]
 axum = { path = "../../axum" }
-tokio = { version = "1.0", features = ["full"] }
+tokio = { version = "1", features = ["full"] }
 
 [dev-dependencies]
-http-body-util = "0.1.0"
-hyper = { version = "1.0.0", features = ["full"] }
+http-body-util = "0.1.3"
+hyper = { version = "1", features = ["full"] }
 tower = { version = "0.5.2", features = ["util"] }

--- a/examples/hello-world/Cargo.toml
+++ b/examples/hello-world/Cargo.toml
@@ -6,4 +6,4 @@ publish = false
 
 [dependencies]
 axum = { path = "../../axum" }
-tokio = { version = "1.0", features = ["full"] }
+tokio = { version = "1", features = ["full"] }

--- a/examples/http-proxy/Cargo.toml
+++ b/examples/http-proxy/Cargo.toml
@@ -7,8 +7,8 @@ publish = false
 [dependencies]
 axum = { path = "../../axum" }
 hyper = { version = "1", features = ["full"] }
-hyper-util = "0.1.1"
-tokio = { version = "1.0", features = ["full"] }
+hyper-util = "0.1"
+tokio = { version = "1", features = ["full"] }
 tower = { version = "0.5.2", features = ["make", "util"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/jwt/Cargo.toml
+++ b/examples/jwt/Cargo.toml
@@ -10,6 +10,6 @@ axum-extra = { path = "../../axum-extra", features = ["typed-header"] }
 jsonwebtoken = "9.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-tokio = { version = "1.0", features = ["full"] }
+tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/key-value-store/Cargo.toml
+++ b/examples/key-value-store/Cargo.toml
@@ -6,9 +6,14 @@ publish = false
 
 [dependencies]
 axum = { path = "../../axum" }
-tokio = { version = "1.0", features = ["full"] }
-tower = { version = "0.5.2", features = ["util", "timeout", "load-shed", "limit"] }
-tower-http = { version = "0.6.1", features = [
+tokio = { version = "1", features = ["full"] }
+tower = { version = "0.5.2", features = [
+    "util",
+    "timeout",
+    "load-shed",
+    "limit",
+] }
+tower-http = { version = "0.6.6", features = [
     "add-extension",
     "auth",
     "compression-full",

--- a/examples/low-level-native-tls/Cargo.toml
+++ b/examples/low-level-native-tls/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [dependencies]
 axum = { path = "../../axum" }
-hyper = { version = "1.0.0", features = ["full"] }
+hyper = { version = "1", features = ["full"] }
 hyper-util = { version = "0.1" }
 tokio = { version = "1", features = ["full"] }
 tokio-native-tls = "0.3.1"

--- a/examples/low-level-native-tls/src/main.rs
+++ b/examples/low-level-native-tls/src/main.rs
@@ -14,7 +14,6 @@ use tokio_native_tls::{
     TlsAcceptor,
 };
 use tower_service::Service;
-use tracing::{error, info, warn};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 #[tokio::main]
@@ -39,7 +38,7 @@ async fn main() {
     let tls_acceptor = TlsAcceptor::from(tls_acceptor);
     let bind = "[::1]:3000";
     let tcp_listener = TcpListener::bind(bind).await.unwrap();
-    info!("HTTPS server listening on {bind}. To contact curl -k https://localhost:3000");
+    tracing::info!("HTTPS server listening on {bind}. To contact curl -k https://localhost:3000");
     let app = Router::new().route("/", get(handler));
 
     loop {
@@ -52,7 +51,7 @@ async fn main() {
         tokio::spawn(async move {
             // Wait for tls handshake to happen
             let Ok(stream) = tls_acceptor.accept(cnx).await else {
-                error!("error during tls handshake connection from {}", addr);
+                tracing::error!("error during tls handshake connection from {}", addr);
                 return;
             };
 
@@ -76,7 +75,7 @@ async fn main() {
                 .await;
 
             if let Err(err) = ret {
-                warn!("error serving connection from {addr}: {err}");
+                tracing::warn!("error serving connection from {addr}: {err}");
             }
         });
     }

--- a/examples/low-level-openssl/Cargo.toml
+++ b/examples/low-level-openssl/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [dependencies]
 axum = { path = "../../axum" }
-hyper = { version = "1.0.0", features = ["full"] }
+hyper = { version = "1", features = ["full"] }
 hyper-util = { version = "0.1" }
 openssl = "0.10"
 tokio = { version = "1", features = ["full"] }

--- a/examples/low-level-openssl/src/main.rs
+++ b/examples/low-level-openssl/src/main.rs
@@ -12,7 +12,6 @@ use std::{path::PathBuf, pin::Pin};
 use tokio::net::TcpListener;
 use tokio_openssl::SslStream;
 use tower::Service;
-use tracing::{error, info, warn};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 #[tokio::main]
@@ -51,7 +50,7 @@ async fn main() {
 
     let bind = "[::1]:3000";
     let tcp_listener = TcpListener::bind(bind).await.unwrap();
-    info!("HTTPS server listening on {bind}. To contact curl -k https://localhost:3000");
+    tracing::info!("HTTPS server listening on {bind}. To contact curl -k https://localhost:3000");
     let app = Router::new().route("/", get(handler));
 
     loop {
@@ -65,9 +64,10 @@ async fn main() {
             let ssl = Ssl::new(tls_acceptor.context()).unwrap();
             let mut tls_stream = SslStream::new(ssl, cnx).unwrap();
             if let Err(err) = SslStream::accept(Pin::new(&mut tls_stream)).await {
-                error!(
+                tracing::error!(
                     "error during tls handshake connection from {}: {}",
-                    addr, err
+                    addr,
+                    err
                 );
                 return;
             }
@@ -92,7 +92,7 @@ async fn main() {
                 .await;
 
             if let Err(err) = ret {
-                warn!("error serving connection from {}: {}", addr, err);
+                tracing::warn!("error serving connection from {}: {}", addr, err);
             }
         });
     }

--- a/examples/low-level-rustls/Cargo.toml
+++ b/examples/low-level-rustls/Cargo.toml
@@ -6,10 +6,10 @@ publish = false
 
 [dependencies]
 axum = { path = "../../axum" }
-hyper = { version = "1.0.0", features = ["full"] }
+hyper = { version = "1", features = ["full"] }
 hyper-util = { version = "0.1", features = ["http2"] }
 tokio = { version = "1", features = ["full"] }
 tokio-rustls = "0.26"
-tower-service = "0.3.2"
+tower-service = "0.3.3"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/low-level-rustls/src/main.rs
+++ b/examples/low-level-rustls/src/main.rs
@@ -18,7 +18,6 @@ use tokio_rustls::{
     TlsAcceptor,
 };
 use tower_service::Service;
-use tracing::{error, info, warn};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 #[tokio::main]
@@ -43,7 +42,7 @@ async fn main() {
     let tls_acceptor = TlsAcceptor::from(rustls_config);
     let bind = "[::1]:3000";
     let tcp_listener = TcpListener::bind(bind).await.unwrap();
-    info!("HTTPS server listening on {bind}. To contact curl -k https://localhost:3000");
+    tracing::info!("HTTPS server listening on {bind}. To contact curl -k https://localhost:3000");
     let app = Router::new().route("/", get(handler));
 
     loop {
@@ -56,7 +55,7 @@ async fn main() {
         tokio::spawn(async move {
             // Wait for tls handshake to happen
             let Ok(stream) = tls_acceptor.accept(cnx).await else {
-                error!("error during tls handshake connection from {}", addr);
+                tracing::error!("error during tls handshake connection from {}", addr);
                 return;
             };
 
@@ -80,7 +79,7 @@ async fn main() {
                 .await;
 
             if let Err(err) = ret {
-                warn!("error serving connection from {}: {}", addr, err);
+                tracing::warn!("error serving connection from {}: {}", addr, err);
             }
         });
     }

--- a/examples/mongodb/Cargo.toml
+++ b/examples/mongodb/Cargo.toml
@@ -6,9 +6,9 @@ publish = false
 
 [dependencies]
 axum = { path = "../../axum" }
-mongodb = "3.1.0"
+mongodb = "3.2.5"
 serde = { version = "1.0", features = ["derive"] }
-tokio = { version = "1.0", features = ["full"] }
-tower-http = { version = "0.6.1", features = ["add-extension", "trace"] }
+tokio = { version = "1", features = ["full"] }
+tower-http = { version = "0.6.6", features = ["add-extension", "trace"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/multipart-form/Cargo.toml
+++ b/examples/multipart-form/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [dependencies]
 axum = { path = "../../axum", features = ["multipart"] }
-tokio = { version = "1.0", features = ["full"] }
-tower-http = { version = "0.6.1", features = ["limit", "trace"] }
+tokio = { version = "1", features = ["full"] }
+tower-http = { version = "0.6.6", features = ["limit", "trace"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/oauth/Cargo.toml
+++ b/examples/oauth/Cargo.toml
@@ -5,15 +5,18 @@ edition = "2021"
 publish = false
 
 [dependencies]
-anyhow = "1"
+anyhow = "1.0"
 async-session = "3.0.0"
 axum = { path = "../../axum" }
 axum-extra = { path = "../../axum-extra", features = ["typed-header"] }
-http = "1.0.0"
-oauth2 = "4.1"
+http = "1.3.1"
+oauth2 = { version = "5.0" }
 # Use Rustls because it makes it easier to cross-compile on CI
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
+reqwest = { version = "0.12", default-features = false, features = [
+    "rustls-tls",
+    "json",
+] }
 serde = { version = "1.0", features = ["derive"] }
-tokio = { version = "1.0", features = ["full"] }
+tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/parse-body-based-on-content-type/Cargo.toml
+++ b/examples/parse-body-based-on-content-type/Cargo.toml
@@ -7,6 +7,6 @@ publish = false
 [dependencies]
 axum = { path = "../../axum" }
 serde = { version = "1.0", features = ["derive"] }
-tokio = { version = "1.0", features = ["full"] }
+tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/print-request-response/Cargo.toml
+++ b/examples/print-request-response/Cargo.toml
@@ -7,6 +7,6 @@ publish = false
 [dependencies]
 axum = { path = "../../axum" }
 http-body-util = "0.1.0"
-tokio = { version = "1.0", features = ["full"] }
+tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/prometheus-metrics/Cargo.toml
+++ b/examples/prometheus-metrics/Cargo.toml
@@ -8,6 +8,6 @@ publish = false
 axum = { path = "../../axum" }
 metrics = { version = "0.23", default-features = false }
 metrics-exporter-prometheus = { version = "0.15", default-features = false }
-tokio = { version = "1.0", features = ["full"] }
+tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/query-params-with-empty-strings/Cargo.toml
+++ b/examples/query-params-with-empty-strings/Cargo.toml
@@ -8,5 +8,5 @@ publish = false
 axum = { path = "../../axum" }
 http-body-util = "0.1.0"
 serde = { version = "1.0", features = ["derive"] }
-tokio = { version = "1.0", features = ["full"] }
+tokio = { version = "1", features = ["full"] }
 tower = { version = "0.5.2", features = ["util"] }

--- a/examples/readme/Cargo.toml
+++ b/examples/readme/Cargo.toml
@@ -7,6 +7,6 @@ publish = false
 [dependencies]
 axum = { path = "../../axum" }
 serde = { version = "1.0", features = ["derive"] }
-tokio = { version = "1.0", features = ["full"] }
+tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/readme/src/main.rs
+++ b/examples/readme/src/main.rs
@@ -11,11 +11,18 @@ use axum::{
     Json, Router,
 };
 use serde::{Deserialize, Serialize};
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 #[tokio::main]
 async fn main() {
     // initialize tracing
-    tracing_subscriber::fmt::init();
+    tracing_subscriber::registry()
+        .with(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| format!("{}=debug", env!("CARGO_CRATE_NAME")).into()),
+        )
+        .with(tracing_subscriber::fmt::layer())
+        .init();
 
     // build our application with a route
     let app = Router::new()

--- a/examples/request-id/Cargo.toml
+++ b/examples/request-id/Cargo.toml
@@ -6,8 +6,8 @@ publish = false
 
 [dependencies]
 axum = { path = "../../axum" }
-tokio = { version = "1.0", features = ["full"] }
+tokio = { version = "1", features = ["full"] }
 tower = "0.5.2"
-tower-http = { version = "0.5", features = ["request-id", "trace"] }
+tower-http = { version = "0.6.6", features = ["request-id", "trace"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/request-id/src/main.rs
+++ b/examples/request-id/src/main.rs
@@ -15,7 +15,6 @@ use tower_http::{
     request_id::{MakeRequestUuid, PropagateRequestIdLayer, SetRequestIdLayer},
     trace::TraceLayer,
 };
-use tracing::{error, info, info_span};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 const REQUEST_ID_HEADER: &str = "x-request-id";
@@ -50,13 +49,13 @@ async fn main() {
                 let request_id = request.headers().get(REQUEST_ID_HEADER);
 
                 match request_id {
-                    Some(request_id) => info_span!(
+                    Some(request_id) => tracing::info_span!(
                         "http_request",
                         request_id = ?request_id,
                     ),
                     None => {
-                        error!("could not extract request_id");
-                        info_span!("http_request")
+                        tracing::error!("could not extract request_id");
+                        tracing::info_span!("http_request")
                     }
                 }
             }),
@@ -76,6 +75,6 @@ async fn main() {
 }
 
 async fn handler() -> Html<&'static str> {
-    info!("Hello world!");
+    tracing::info!("Hello world!");
     Html("<h1>Hello, World!</h1>")
 }

--- a/examples/reqwest-response/Cargo.toml
+++ b/examples/reqwest-response/Cargo.toml
@@ -7,8 +7,8 @@ publish = false
 [dependencies]
 axum = { path = "../../axum" }
 reqwest = { version = "0.12", features = ["stream"] }
-tokio = { version = "1.0", features = ["full"] }
+tokio = { version = "1", features = ["full"] }
 tokio-stream = "0.1"
-tower-http = { version = "0.6.1", features = ["trace"] }
+tower-http = { version = "0.6.6", features = ["trace"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/reqwest-response/src/main.rs
+++ b/examples/reqwest-response/src/main.rs
@@ -16,7 +16,6 @@ use reqwest::Client;
 use std::{convert::Infallible, time::Duration};
 use tokio_stream::StreamExt;
 use tower_http::trace::TraceLayer;
-use tracing::Span;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 #[tokio::main]
@@ -37,7 +36,7 @@ async fn main() {
         .route("/stream", get(stream_some_data))
         // Add some logging so we can see the streams going through
         .layer(TraceLayer::new_for_http().on_body_chunk(
-            |chunk: &Bytes, _latency: Duration, _span: &Span| {
+            |chunk: &Bytes, _latency: Duration, _span: &tracing::Span| {
                 tracing::debug!("streaming {} bytes", chunk.len());
             },
         ))

--- a/examples/reverse-proxy/Cargo.toml
+++ b/examples/reverse-proxy/Cargo.toml
@@ -5,6 +5,6 @@ edition = "2021"
 
 [dependencies]
 axum = { path = "../../axum" }
-hyper = { version = "1.0.0", features = ["full"] }
-hyper-util = { version = "0.1.1", features = ["client-legacy"] }
+hyper = { version = "1", features = ["full"] }
+hyper-util = { version = "0.1", features = ["client-legacy"] }
 tokio = { version = "1", features = ["full"] }

--- a/examples/routes-and-handlers-close-together/Cargo.toml
+++ b/examples/routes-and-handlers-close-together/Cargo.toml
@@ -6,4 +6,4 @@ publish = false
 
 [dependencies]
 axum = { path = "../../axum" }
-tokio = { version = "1.0", features = ["full"] }
+tokio = { version = "1", features = ["full"] }

--- a/examples/serve-with-hyper/Cargo.toml
+++ b/examples/serve-with-hyper/Cargo.toml
@@ -8,5 +8,5 @@ publish = false
 axum = { path = "../../axum" }
 hyper = { version = "1.0", features = [] }
 hyper-util = { version = "0.1", features = ["tokio", "server-auto", "http1"] }
-tokio = { version = "1.0", features = ["full"] }
+tokio = { version = "1", features = ["full"] }
 tower = { version = "0.5.2", features = ["util"] }

--- a/examples/sqlx-postgres/Cargo.toml
+++ b/examples/sqlx-postgres/Cargo.toml
@@ -6,8 +6,12 @@ publish = false
 
 [dependencies]
 axum = { path = "../../axum" }
-tokio = { version = "1.0", features = ["full"] }
+tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
-sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "any", "postgres"] }
+sqlx = { version = "0.8", features = [
+    "runtime-tokio-rustls",
+    "any",
+    "postgres",
+] }

--- a/examples/sse/Cargo.toml
+++ b/examples/sse/Cargo.toml
@@ -7,11 +7,14 @@ publish = false
 [dependencies]
 axum = { path = "../../axum" }
 axum-extra = { path = "../../axum-extra", features = ["typed-header"] }
-futures-util = { version = "0.3", default-features = false, features = ["sink", "std"] }
+futures-util = { version = "0.3", default-features = false, features = [
+    "sink",
+    "std",
+] }
 headers = "0.4"
-tokio = { version = "1.0", features = ["full"] }
+tokio = { version = "1", features = ["full"] }
 tokio-stream = "0.1"
-tower-http = { version = "0.6.1", features = ["fs", "trace"] }
+tower-http = { version = "0.6.6", features = ["fs", "trace"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 

--- a/examples/sse/assets/index.html
+++ b/examples/sse/assets/index.html
@@ -1,1 +1,1 @@
-<script src='script.js'></script>
+<script src="script.js"></script>

--- a/examples/sse/assets/script.js
+++ b/examples/sse/assets/script.js
@@ -1,5 +1,5 @@
-var eventSource = new EventSource('sse');
+var eventSource = new EventSource("sse");
 
-eventSource.onmessage = function(event) {
-    console.log('Message from server ', event.data);
-}
+eventSource.onmessage = (event) => {
+  console.log("Message from server ", event.data);
+};

--- a/examples/static-file-server/Cargo.toml
+++ b/examples/static-file-server/Cargo.toml
@@ -6,8 +6,8 @@ publish = false
 
 [dependencies]
 axum = { path = "../../axum" }
-tokio = { version = "1.0", features = ["full"] }
+tokio = { version = "1", features = ["full"] }
 tower = { version = "0.5.2", features = ["util"] }
-tower-http = { version = "0.6.1", features = ["fs", "trace"] }
+tower-http = { version = "0.6.6", features = ["fs", "trace"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/stream-to-file/Cargo.toml
+++ b/examples/stream-to-file/Cargo.toml
@@ -6,8 +6,11 @@ publish = false
 
 [dependencies]
 axum = { path = "../../axum", features = ["multipart"] }
-futures-util = { version = "0.3", default-features = false, features = ["sink", "std"] }
-tokio = { version = "1.0", features = ["full"] }
+futures-util = { version = "0.3", default-features = false, features = [
+    "sink",
+    "std",
+] }
+tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "0.7", features = ["io"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/templates-minijinja/Cargo.toml
+++ b/examples/templates-minijinja/Cargo.toml
@@ -6,5 +6,5 @@ publish = false
 
 [dependencies]
 axum = { path = "../../axum" }
-minijinja = "2.3.1"
-tokio = { version = "1.0", features = ["full"] }
+minijinja = "2.11.0"
+tokio = { version = "1", features = ["full"] }

--- a/examples/templates/Cargo.toml
+++ b/examples/templates/Cargo.toml
@@ -5,12 +5,12 @@ edition = "2021"
 publish = false
 
 [dependencies]
-askama = "0.12"
+askama = "0.14"
 axum = { path = "../../axum" }
-tokio = { version = "1.0", features = ["full"] }
+tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]
-http-body-util = "0.1.0"
+http-body-util = "0.1.3"
 tower = { version = "0.5.2", features = ["util"] }

--- a/examples/testing-websockets/Cargo.toml
+++ b/examples/testing-websockets/Cargo.toml
@@ -7,6 +7,9 @@ publish = false
 [dependencies]
 axum = { path = "../../axum", features = ["ws"] }
 futures-channel = "0.3"
-futures-util = { version = "0.3", default-features = false, features = ["sink", "std"] }
-tokio = { version = "1.0", features = ["full"] }
+futures-util = { version = "0.3", default-features = false, features = [
+    "sink",
+    "std",
+] }
+tokio = { version = "1", features = ["full"] }
 tokio-tungstenite = "0.27"

--- a/examples/testing/Cargo.toml
+++ b/examples/testing/Cargo.toml
@@ -7,11 +7,15 @@ publish = false
 [dependencies]
 axum = { path = "../../axum" }
 http-body-util = "0.1.0"
-hyper-util = { version = "0.1", features = ["client", "http1", "client-legacy"] }
+hyper-util = { version = "0.1", features = [
+    "client",
+    "http1",
+    "client-legacy",
+] }
 mime = "0.3"
 serde_json = "1.0"
-tokio = { version = "1.0", features = ["full"] }
-tower-http = { version = "0.6.1", features = ["trace"] }
+tokio = { version = "1", features = ["full"] }
+tower-http = { version = "0.6.6", features = ["trace"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 

--- a/examples/todos/Cargo.toml
+++ b/examples/todos/Cargo.toml
@@ -7,9 +7,9 @@ publish = false
 [dependencies]
 axum = { path = "../../axum" }
 serde = { version = "1.0", features = ["derive"] }
-tokio = { version = "1.0", features = ["full"] }
+tokio = { version = "1", features = ["full"] }
 tower = { version = "0.5.2", features = ["util", "timeout"] }
-tower-http = { version = "0.6.1", features = ["add-extension", "trace"] }
+tower-http = { version = "0.6.6", features = ["add-extension", "trace"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-uuid = { version = "1.0", features = ["serde", "v4"] }
+uuid = { version = "1.18", features = ["serde", "v4"] }

--- a/examples/tokio-postgres/Cargo.toml
+++ b/examples/tokio-postgres/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 axum = { path = "../../axum" }
 bb8 = "0.9.0"
 bb8-postgres = "0.9.0"
-tokio = { version = "1.0", features = ["full"] }
+tokio = { version = "1", features = ["full"] }
 tokio-postgres = "0.7.2"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/tokio-redis/Cargo.toml
+++ b/examples/tokio-redis/Cargo.toml
@@ -9,6 +9,6 @@ axum = { path = "../../axum" }
 bb8 = "0.8.5"
 bb8-redis = "0.17.0"
 redis = "0.27.2"
-tokio = { version = "1.0", features = ["full"] }
+tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/tracing-aka-logging/Cargo.toml
+++ b/examples/tracing-aka-logging/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [dependencies]
 axum = { path = "../../axum", features = ["tracing"] }
-tokio = { version = "1.0", features = ["full"] }
-tower-http = { version = "0.6.1", features = ["trace"] }
+tokio = { version = "1", features = ["full"] }
+tower-http = { version = "0.6.6", features = ["trace"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/tracing-aka-logging/src/main.rs
+++ b/examples/tracing-aka-logging/src/main.rs
@@ -15,7 +15,6 @@ use axum::{
 use std::time::Duration;
 use tokio::net::TcpListener;
 use tower_http::{classify::ServerErrorsFailureClass, trace::TraceLayer};
-use tracing::{info_span, Span};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 #[tokio::main]
@@ -54,31 +53,39 @@ async fn main() {
                         .get::<MatchedPath>()
                         .map(MatchedPath::as_str);
 
-                    info_span!(
+                    tracing::info_span!(
                         "http_request",
                         method = ?request.method(),
                         matched_path,
                         some_other_field = tracing::field::Empty,
                     )
                 })
-                .on_request(|_request: &Request<_>, _span: &Span| {
+                .on_request(|_request: &Request<_>, _span: &tracing::Span| {
                     // You can use `_span.record("some_other_field", value)` in one of these
                     // closures to attach a value to the initially empty field in the info_span
                     // created above.
                 })
-                .on_response(|_response: &Response, _latency: Duration, _span: &Span| {
-                    // ...
-                })
-                .on_body_chunk(|_chunk: &Bytes, _latency: Duration, _span: &Span| {
-                    // ...
-                })
+                .on_response(
+                    |_response: &Response, _latency: Duration, _span: &tracing::Span| {
+                        // ...
+                    },
+                )
+                .on_body_chunk(
+                    |_chunk: &Bytes, _latency: Duration, _span: &tracing::Span| {
+                        // ...
+                    },
+                )
                 .on_eos(
-                    |_trailers: Option<&HeaderMap>, _stream_duration: Duration, _span: &Span| {
+                    |_trailers: Option<&HeaderMap>,
+                     _stream_duration: Duration,
+                     _span: &tracing::Span| {
                         // ...
                     },
                 )
                 .on_failure(
-                    |_error: ServerErrorsFailureClass, _latency: Duration, _span: &Span| {
+                    |_error: ServerErrorsFailureClass,
+                     _latency: Duration,
+                     _span: &tracing::Span| {
                         // ...
                     },
                 ),

--- a/examples/unix-domain-socket/Cargo.toml
+++ b/examples/unix-domain-socket/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 axum = { path = "../../axum" }
 http-body-util = "0.1"
-hyper = { version = "1.0.0", features = ["full"] }
+hyper = { version = "1", features = ["full"] }
 hyper-util = { version = "0.1", features = ["tokio", "server-auto", "http1"] }
-tokio = { version = "1.0", features = ["full"] }
+tokio = { version = "1", features = ["full"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/validator/Cargo.toml
+++ b/examples/validator/Cargo.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 axum = { path = "../../axum" }
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0.29"
-tokio = { version = "1.0", features = ["full"] }
+tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 validator = { version = "0.20.0", features = ["derive"] }

--- a/examples/versioning/Cargo.toml
+++ b/examples/versioning/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [dependencies]
 axum = { path = "../../axum" }
-tokio = { version = "1.0", features = ["full"] }
+tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 

--- a/examples/websockets-http2/Cargo.toml
+++ b/examples/websockets-http2/Cargo.toml
@@ -6,8 +6,8 @@ publish = false
 
 [dependencies]
 axum = { path = "../../axum", features = ["ws", "http2"] }
-axum-server = { version = "0.6", features = ["tls-rustls"] }
+axum-server = { version = "0.7.2", features = ["tls-rustls"] }
 tokio = { version = "1", features = ["full"] }
-tower-http = { version = "0.5.0", features = ["fs"] }
+tower-http = { version = "0.6.6", features = ["fs"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/websockets-http2/assets/index.html
+++ b/examples/websockets-http2/assets/index.html
@@ -1,7 +1,7 @@
 <p>Open this page in two windows and try sending some messages!</p>
 <form action="javascript:void(0)">
-    <input type="text" name="content" required>
-    <button>Send</button>
+  <input type="text" name="content" required />
+  <button>Send</button>
 </form>
 <div id="messages"></div>
-<script src='script.js'></script>
+<script src="script.js"></script>

--- a/examples/websockets-http2/assets/script.js
+++ b/examples/websockets-http2/assets/script.js
@@ -1,11 +1,13 @@
-const socket = new WebSocket('wss://localhost:3000/ws');
+const socket = new WebSocket("wss://localhost:3000/ws");
 
-socket.addEventListener('message', e => {
-    document.getElementById("messages").append(e.data, document.createElement("br"));
+socket.addEventListener("message", (event) => {
+  document
+    .getElementById("messages")
+    .append(event.data, document.createElement("br"));
 });
 
 const form = document.querySelector("form");
 form.addEventListener("submit", () => {
-    socket.send(form.elements.namedItem("content").value);
-    form.elements.namedItem("content").value = "";
+  socket.send(form.elements.namedItem("content").value);
+  form.elements.namedItem("content").value = "";
 });

--- a/examples/websockets/Cargo.toml
+++ b/examples/websockets/Cargo.toml
@@ -15,10 +15,13 @@ path = "src/client.rs"
 [dependencies]
 axum = { path = "../../axum", features = ["ws"] }
 axum-extra = { path = "../../axum-extra", features = ["typed-header"] }
-futures-util = { version = "0.3", default-features = false, features = ["sink", "std"] }
+futures-util = { version = "0.3", default-features = false, features = [
+    "sink",
+    "std",
+] }
 headers = "0.4"
-tokio = { version = "1.0", features = ["full"] }
+tokio = { version = "1", features = ["full"] }
 tokio-tungstenite = "0.27.0"
-tower-http = { version = "0.6.1", features = ["fs", "trace"] }
+tower-http = { version = "0.6.6", features = ["fs", "trace"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/websockets/assets/index.html
+++ b/examples/websockets/assets/index.html
@@ -1,2 +1,2 @@
 <a>Open the console to see stuff, then refresh to initiate exchange.</a>
-<script src='script.js'></script>
+<script src="script.js"></script>

--- a/examples/websockets/assets/script.js
+++ b/examples/websockets/assets/script.js
@@ -1,25 +1,24 @@
-const socket = new WebSocket('ws://localhost:3000/ws');
+const socket = new WebSocket("ws://localhost:3000/ws");
 
-socket.addEventListener('open', function (event) {
-    socket.send('Hello Server!');
+socket.addEventListener("open", (_event) => {
+  socket.send("Hello Server!");
 });
 
-socket.addEventListener('message', function (event) {
-    console.log('Message from server ', event.data);
+socket.addEventListener("message", (event) => {
+  console.log("Message from server ", event.data);
 });
-
 
 setTimeout(() => {
-    const obj = { hello: "world" };
-    const blob = new Blob([JSON.stringify(obj, null, 2)], {
-      type: "application/json",
-    });
-    console.log("Sending blob over websocket");
-    socket.send(blob);
+  const obj = { hello: "world" };
+  const blob = new Blob([JSON.stringify(obj, null, 2)], {
+    type: "application/json",
+  });
+  console.log("Sending blob over websocket");
+  socket.send(blob);
 }, 1000);
 
 setTimeout(() => {
-    socket.send('About done here...');
-    console.log("Sending close over websocket");
-    socket.close(3000, "Crash and Burn!");
+  socket.send("About done here...");
+  console.log("Sending close over websocket");
+  socket.close(3000, "Crash and Burn!");
 }, 3000);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

Update the example projects and fix minor issues discovered during the cleanup.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

- tests(extract/path): fix `captures_match_empty_inner_segments` by using `param.clone()` instead of `param.to_string()` to satisfy clippy
- examples(readme): configure tracing to emit DEBUG-level logs
- examples: lower default tracing level from TRACE to DEBUG; set `axum::rejection=trace` for selected examples to retain useful diagnostics
- examples: standardize tracing macros (`tracing::debug!`, etc.) and format HTML/JS
- examples: rename `auto-reload` to `example-auto-reload` to match example naming conventions
- examples(cors): add `"http://127.0.0.1:3000".parse::<HeaderValue>().unwrap()` to avoid localhost vs 127.0.0.1 CORS mismatch
- deps(examples): bump some example dependencies; set `tokio = "1"` (allow any 1.x) to avoid implying a 1.0.x pin
- examples(oauth): migrate `oauth2` from 4.4.2 to 5.0.0 (**not runtime-verified due to lack of Discord account**)

### Notes

- No behavior change for library code beyond the test fix.