### PR TITLE
fix typo in file_stream error message

### DIFF
--- a/axum-extra/src/response/file_stream.rs
+++ b/axum-extra/src/response/file_stream.rs
@@ -284,7 +284,7 @@ where
             .unwrap_or_else(|e| {
                 (
                     StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("build FileStream responsec error: {e}"),
+                    format!("build FileStream response error: {e}"),
                 )
                     .into_response()
             })


### PR DESCRIPTION
## Motivation

Fixed type in error message:
`"build FileStream responsec error: {e}"` should be `"build FileStream response error: {e}"`

## Solution

Fixed the typo
