### PR TITLE
clarify that AddExtension is not the actual `Layer`

### DIFF
--- a/axum/src/extension.rs
+++ b/axum/src/extension.rs
@@ -159,7 +159,7 @@ where
 /// [request extensions]: https://docs.rs/http/latest/http/struct.Extensions.html
 ///
 /// If you need a layer to add an extension to every request,
-/// use the `Layer` implementation of `Extension`.
+/// use the [Layer](tower::Layer) implementation of [Extension].
 #[derive(Clone, Copy, Debug)]
 pub struct AddExtension<S, T> {
     pub(crate) inner: S,


### PR DESCRIPTION
This was a bit of a doozie to find, as the fact that the underlying service can't be publicly created isn't trivial to read from the docs, so I added this tip to the documentation.