### PR TITLE
Support skipping the `Allow` header in method routing

### DIFF
--- a/axum/src/docs/method_routing/skip_allow_header.md
+++ b/axum/src/docs/method_routing/skip_allow_header.md
@@ -1,0 +1,12 @@
+Skip `Allow` Header for not implemented method
+
+```rust
+use axum::routing::get;
+use axum::Router;
+
+let app = Router::new().route("/", get(|| async {}).skip_allow_header());
+
+// Our app now accepts
+// - GET /
+# let _: Router = app;
+```

--- a/axum/src/routing/method_routing.rs
+++ b/axum/src/routing/method_routing.rs
@@ -1111,6 +1111,7 @@ where
         self.layer(HandleErrorLayer::new(f))
     }
 
+    #[doc = include_str!("../docs/method_routing/skip_allow_header.md")]
     pub fn skip_allow_header(mut self) -> Self {
         self.allow_header = AllowHeader::Skip;
         self
@@ -1467,6 +1468,14 @@ mod tests {
         let (status, headers, _) = call(Method::PUT, &mut svc).await;
         assert_eq!(status, StatusCode::METHOD_NOT_ALLOWED);
         assert_eq!(headers[ALLOW], "GET,HEAD");
+    }
+
+    #[crate::test]
+    async fn skips_allow_header() {
+        let mut svc = MethodRouter::new().get(ok).skip_allow_header();
+        let (status, headers, _) = call(Method::POST, &mut svc).await;
+        assert_eq!(status, StatusCode::METHOD_NOT_ALLOWED);
+        assert_eq!(headers.get(ALLOW), None);
     }
 
     #[crate::test]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation
There is no way to remove the added 'Allow' Header from Method Router. It is not possible to operate in middleware, and even if possible, it is a code that causes overhead.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Add public access to skip_allow_header.