### PR TITLE
Update to cargo-deny api version 2

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -176,7 +176,7 @@ jobs:
           - bans licenses sources
     steps:
       - uses: actions/checkout@v5
-      - uses: EmbarkStudios/cargo-deny-action@v1
+      - uses: EmbarkStudios/cargo-deny-action@v2
         with:
           command: check ${{ matrix.checks }}
           manifest-path: axum/Cargo.toml

--- a/deny.toml
+++ b/deny.toml
@@ -1,16 +1,18 @@
+[graph]
+exclude-unpublished = true
+
 [advisories]
-vulnerability = "deny"
-unmaintained = "warn"
-notice = "warn"
+unmaintained = "none"
 ignore = []
 
 [licenses]
-unlicensed = "warn"
-allow = []
-deny = []
-copyleft = "warn"
-allow-osi-fsf-free = "either"
 confidence-threshold = 0.8
+allow = [
+    "Apache-2.0",
+    "BSD-3-Clause",
+    "MIT",
+    "Unicode-3.0",
+]
 
 [bans]
 multiple-versions = "deny"
@@ -21,12 +23,6 @@ skip-tree = [
     { name = "base64" },
     # parking_lot pulls in old versions of windows-sys
     { name = "windows-sys" },
-    # old version pulled in by rustls via ring
-    { name = "spin" },
-    # lots still pulls in syn 1.x
-    { name = "syn" },
-    # pulled in by hyper
-    { name = "socket2" },
     # pulled in by quickcheck and cookie
     { name = "rand" },
 ]

--- a/examples/reverse-proxy/Cargo.toml
+++ b/examples/reverse-proxy/Cargo.toml
@@ -2,6 +2,7 @@
 name = "example-reverse-proxy"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 [dependencies]
 axum = { path = "../../axum" }


### PR DESCRIPTION
Updates to cargo-deny API version 2. This allow to use features such as `exclude-unpublished` which could make the config simple.