### PR TITLE
axum: correct typo in append_allow_header

### DIFF
--- a/axum/src/routing/method_routing.rs
+++ b/axum/src/routing/method_routing.rs
@@ -1188,7 +1188,7 @@ fn append_allow_header(allow_header: &mut AllowHeader, method: &'static str) {
                 }
             } else {
                 #[cfg(debug_assertions)]
-                panic!("`allow_header` contained invalid uft-8. This should never happen")
+                panic!("`allow_header` contained invalid utf-8. This should never happen")
             }
         }
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation
I assumed uft-8 was a typo for utf-8, so I corrected it.


<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
