### PR TITLE
axum::serve: Enable Hyper request header timeout

### DIFF
--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **breaking:** Router fallbacks are now properly merged for nested routers ([#3158])
 - **breaking:** `#[from_request(via(Extractor))]` now uses the extractor's
   rejection type instead of `axum::response::Response` ([#3261])
+- **breaking:** `axum::serve` now applies hyper's default `header_read_timeout` ([#3478])
 - **added:** Implement `OptionalFromRequest` for `Multipart` ([#3220])
 - **changed:** `serve` has an additional generic argument and can now work with any response body
   type, not just `axum::body::Body` ([#3205])
@@ -20,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#3205]: https://github.com/tokio-rs/axum/pull/3205
 [#3220]: https://github.com/tokio-rs/axum/pull/3220
 [#3412]: https://github.com/tokio-rs/axum/pull/3412
+[#3478]: https://github.com/tokio-rs/axum/pull/3478
 
 # 0.8.4
 

--- a/axum/src/serve/mod.rs
+++ b/axum/src/serve/mod.rs
@@ -28,7 +28,8 @@ pub use self::listener::{Listener, ListenerExt, TapIo};
 /// Serve the service with the supplied listener.
 ///
 /// This method of running a service is intentionally simple and doesn't support any configuration.
-/// Use hyper or hyper-util if you need configuration.
+/// hyper's default configuration applies (including [timeouts]); use hyper or hyper-util if you
+/// need configuration.
 ///
 /// It supports both HTTP/1 as well as HTTP/2.
 ///
@@ -88,6 +89,7 @@ pub use self::listener::{Listener, ListenerExt, TapIo};
 /// error. Errors on the TCP socket will be handled by sleeping for a short while (currently, one
 /// second).
 ///
+/// [timeouts]: hyper::server::conn::http1::Builder::header_read_timeout
 /// [`Router`]: crate::Router
 /// [`Router::into_make_service_with_connect_info`]: crate::Router::into_make_service_with_connect_info
 /// [`MethodRouter`]: crate::routing::MethodRouter


### PR DESCRIPTION
## Motivation

It's possible for an HTTP request to get stuck (due to network issues or malicious clients) halfway through the request line or header, in which case no amount of timeouts configured by an application using axum/tower will help, since Hyper hasn't yet handed off the request to the service.

This has two consequences:

- Wasted memory: Up to ~1 MB per connection in the worst case, compared to the ~2.5 kB used by a regular idle connection.

- A `with_graceful_shutdown` signal will cause the server to stop accepting new requests, but then hang instead of actually stopping.

## Solution

This changes axum::serve to configure a Timer for HTTP/1 connections, which activates Hyper's default timeout (currently 30 seconds).

The timeout applies only to the request line and request header, not the request body or subsequent response (where axum applications can instead simply configure a timeout using `tower_http::timeout::TimeoutLayer`).

The timeout does not currently apply to newly opened connections, even though Hyper's `header_read_timeout` _should_ apply here too since 1.4.0; discussion on #2741 suggests a possible `TokioIo` issue. However, the graceful shutdown still works as expected for such connections.

The timer is only enabled for HTTP/1 here since similar functionality does not currently appear to exist for HTTP/2 connections in Hyper.

**This is a breaking change** for any axum::serve users who currently rely on being able to begin sending a HTTP/1 request, and then take more than 30 seconds to finish the request line and headers, or rely on keeping connections idle for 30+ seconds between requests.