### PR TITLE
axum-extra: Remove unused tower dependency

### DIFF
--- a/axum-extra/Cargo.toml
+++ b/axum-extra/Cargo.toml
@@ -79,7 +79,7 @@ typed-routing = [
 
 # Enabled by docs.rs because it uses all-features
 # Enables upstream things linked to in docs
-__private_docs = ["axum/json", "dep:serde"]
+__private_docs = ["axum/json", "dep:serde", "dep:tower"]
 
 [dependencies]
 axum = { path = "../axum", version = "0.8.4", default-features = false, features = ["original-uri"] }
@@ -94,7 +94,6 @@ mime = "0.3"
 pin-project-lite = "0.2"
 rustversion = "1.0.9"
 serde_core = "1.0.221"
-tower = { version = "0.5.2", default-features = false, features = ["util"] }
 tower-layer = "0.3"
 tower-service = "0.3"
 
@@ -118,6 +117,7 @@ typed-json = { version = "0.1.1", optional = true }
 
 # doc dependencies
 serde = { version = "1.0.221", optional = true }
+tower = { version = "0.5.2", default-features = false, features = ["util"], optional = true }
 
 [dev-dependencies]
 axum = { path = "../axum", features = ["macros", "__private"] }


### PR DESCRIPTION
## Motivation

`tower` crate doesn't seem to be used in `axum-extra`.

## Solution

Removes `tower` dependency from `axum-extra`.