### PR TITLE
axum-extra: Make rustversion and serde_core optional dependency

### DIFF
--- a/axum-extra/Cargo.toml
+++ b/axum-extra/Cargo.toml
@@ -54,16 +54,18 @@ cookie = ["dep:cookie"]
 cookie-private = ["cookie", "cookie?/private"]
 cookie-signed = ["cookie", "cookie?/signed"]
 cookie-key-expansion = ["cookie", "cookie?/key-expansion"]
-erased-json = ["dep:serde_json", "dep:typed-json"]
+erased-json = ["dep:serde_core", "dep:serde_json", "dep:typed-json"]
 form = [
     "dep:axum",
     "dep:form_urlencoded",
+    "dep:serde_core",
     "dep:serde_html_form",
     "dep:serde_path_to_error",
 ]
 handler = ["dep:axum"]
-json-deserializer = ["dep:serde_json", "dep:serde_path_to_error"]
+json-deserializer = ["dep:serde_core", "dep:serde_json", "dep:serde_path_to_error"]
 json-lines = [
+    "dep:serde_core",
     "dep:serde_json",
     "dep:tokio-util",
     "dep:tokio-stream",
@@ -73,16 +75,22 @@ json-lines = [
 ]
 middleware = ["dep:axum"]
 multipart = ["dep:multer", "dep:fastrand"]
-optional-path = ["dep:axum"]
+optional-path = ["dep:axum", "dep:serde_core"]
 protobuf = ["dep:prost"]
-routing = ["axum/original-uri"]
+routing = ["axum/original-uri", "dep:rustversion"]
 scheme = []
-query = ["dep:form_urlencoded", "dep:serde_html_form", "dep:serde_path_to_error"]
+query = [
+    "dep:form_urlencoded",
+    "dep:serde_core",
+    "dep:serde_html_form",
+    "dep:serde_path_to_error",
+]
 tracing = ["axum-core/tracing", "axum/tracing", "dep:tracing"]
 typed-header = ["dep:headers"]
 typed-routing = [
     "dep:axum-macros",
     "dep:percent-encoding",
+    "dep:serde_core",
     "dep:serde_html_form",
     "dep:form_urlencoded",
 ]
@@ -102,8 +110,6 @@ http-body = "1.0.0"
 http-body-util = "0.1.0"
 mime = "0.3"
 pin-project-lite = "0.2"
-rustversion = "1.0.9"
-serde_core = "1.0.221"
 tower-layer = "0.3"
 tower-service = "0.3"
 
@@ -117,6 +123,8 @@ headers = { version = "0.4.0", optional = true }
 multer = { version = "3.0.0", optional = true }
 percent-encoding = { version = "2.1", optional = true }
 prost = { version = "0.13", optional = true }
+rustversion = { version = "1.0.9", optional = true }
+serde_core = { version = "1.0.221", optional = true }
 serde_html_form = { version = "0.2.0", optional = true }
 serde_json = { version = "1.0.71", optional = true }
 serde_path_to_error = { version = "0.1.8", optional = true }


### PR DESCRIPTION
## Motivation

`rustversion` and `serde_core` crates seem to be used in a part of `axum-extra`.

## Solution

Makes `rustversion` and `serde_core` optional dependency.
