### PR TITLE
axum: Make futures-sink optional dependency

### DIFF
--- a/axum/Cargo.toml
+++ b/axum/Cargo.toml
@@ -70,7 +70,14 @@ tokio = [
 ]
 tower-log = ["tower/log"]
 tracing = ["dep:tracing", "axum-core/tracing"]
-ws = ["dep:hyper", "tokio", "dep:tokio-tungstenite", "dep:sha1", "dep:base64"]
+ws = [
+    "dep:hyper",
+    "dep:futures-sink",
+    "tokio",
+    "dep:tokio-tungstenite",
+    "dep:sha1",
+    "dep:base64",
+]
 
 __private_docs = [
     # We re-export some docs from axum-core via #[doc(inline)],
@@ -90,7 +97,6 @@ __private = ["tokio", "http1", "dep:reqwest"]
 axum-core = { path = "../axum-core", version = "0.5.2" }
 bytes = "1.0"
 futures-core = "0.3"
-futures-sink = "0.3"
 futures-util = { version = "0.3", default-features = false, features = ["alloc"] }
 http = "1.0.0"
 http-body = "1.0.0"
@@ -111,6 +117,7 @@ tower-service = "0.3"
 axum-macros = { path = "../axum-macros", version = "0.5.0", optional = true }
 base64 = { version = "0.22.1", optional = true }
 form_urlencoded = { version = "1.1.0", optional = true }
+futures-sink = { version = "0.3", optional = true }
 hyper = { version = "1.1.0", optional = true }
 hyper-util = { version = "0.1.3", features = ["tokio", "server", "service"], optional = true }
 multer = { version = "3.0.0", optional = true }


### PR DESCRIPTION
## Motivation

`futures-sink` seems to be used only in the `ws` feature.

## Solution

Makes `futures-sink` an optional dependency.