### PR TITLE
axum-extra: Add link definition for pull request to changelog

### DIFF
--- a/axum-extra/CHANGELOG.md
+++ b/axum-extra/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning].
   - `WithRejection` extractor requires `with-rejection` feature.
 
 [#3298]: https://github.com/tokio-rs/axum/pull/3298
+[#3469]: https://github.com/tokio-rs/axum/pull/3469
 [#3485]: https://github.com/tokio-rs/axum/pull/3485
 
 # 0.11.0


### PR DESCRIPTION
## Motivation

It doesn't seem there is a definition which corresponds to the link in the changelog.

## Solution

Adds a link definition for the pull request to the changelog.