### PR TITLE
axum-extra: gate rejection test behind feature

### DIFF
--- a/axum-extra/src/routing/typed.rs
+++ b/axum-extra/src/routing/typed.rs
@@ -384,10 +384,7 @@ impl_second_element_is!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, 
 
 #[cfg(test)]
 mod tests {
-    use crate::{
-        extract::WithRejection,
-        routing::{RouterExt, TypedPath},
-    };
+    use crate::routing::{RouterExt, TypedPath};
     use axum::{
         extract::rejection::PathRejection,
         response::{IntoResponse, Response},
@@ -441,9 +438,10 @@ mod tests {
         assert_eq!(uri, "/users/1?&foo=foo&bar=123&baz=true&qux=1337");
     }
 
+    #[cfg(feature = "with-rejection")]
     #[allow(dead_code)] // just needs to compile
     fn supports_with_rejection() {
-        async fn handler(_: WithRejection<UsersShow, MyRejection>) {}
+        async fn handler(_: crate::extract::WithRejection<UsersShow, MyRejection>) {}
 
         struct MyRejection {}
 


### PR DESCRIPTION
## Motivation

#3485 moved `WithRejection` behind a feautre gate but this test was not gated.

### Why this wasn't caught in that PR's CI

`cargo hack` checks just lib code, not tests, so the CI did not catch it there. Clippy is run with `--all-targets --all-features` and tests are run with `--all-features` so it wasn't caught there either.

## Solution

Compile the test only when the required feature is enabled.

We might also want to add a check to CI to catch this but I don't see it as necessary as this only prevents compilation of tests without all features, so users are not affected. However, developers may be surprised when they clone this repository and running `cargo test` (as opposed to `cargo test --all-features`) fails.

This does not happen regularly though so I'm not sure if running more stuff in CI is worth it. We could add `--all-targets` to the `cargo hack` invocation but that might be problematic in itself because then I think it will be compiled with dev dependencies features as well as normal features. Or we can just also run `cargo test` and `cargo test --no-default-features` to test these two scenarios on top of what we're already testing. Or the same thing with `cargo check` or `cargo clippy`.