### PR TITLE
Release axum 0.8.5 and related crates

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -7,7 +7,8 @@ env:
 on:
   push:
     branches:
-    - main
+      - main
+      - v0.*
   pull_request: {}
 
 jobs:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -297,7 +297,7 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.8.4"
+version = "0.8.5"
 dependencies = [
  "anyhow",
  "axum-core",
@@ -346,7 +346,7 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "axum",
  "axum-extra",
@@ -370,7 +370,7 @@ dependencies = [
 
 [[package]]
 name = "axum-extra"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "axum",
  "axum-core",

--- a/axum-core/CHANGELOG.md
+++ b/axum-core/CHANGELOG.md
@@ -5,10 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-# Unreleased
+# 0.5.3
 
 - **added:** `DefaultBodyLimit::apply` for changing the `DefaultBodyLimit` inside extractors.
   ([#3368])
+- **changed:** Update minimum rust version to 1.78 ([#3412])
 
 [#3368]: https://github.com/tokio-rs/axum/pull/3366
 

--- a/axum-core/Cargo.toml
+++ b/axum-core/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 name = "axum-core"
 readme = "README.md"
 repository = "https://github.com/tokio-rs/axum"
-version = "0.5.2" # remember to bump the version that axum and axum-extra depend on
+version = "0.5.3" # remember to bump the version that axum and axum-extra depend on
 
 [package.metadata.cargo-public-api-crates]
 allowed = [

--- a/axum-extra/CHANGELOG.md
+++ b/axum-extra/CHANGELOG.md
@@ -27,6 +27,12 @@ Yanked from crates.io due to unforeseen breaking change, see [#3190] for details
 
 [#3190]: https://github.com/tokio-rs/axum/pull/3190
 
+# 0.10.2
+
+- **added:** Implement `OptionalFromRequest` for `Host` ([#3177])
+
+[#3177]: https://github.com/tokio-rs/axum/pull/3177
+
 # 0.10.1
 
 - **fixed:** Fix a broken link in the documentation of `ErasedJson` ([#3186])

--- a/axum-extra/Cargo.toml
+++ b/axum-extra/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 name = "axum-extra"
 readme = "README.md"
 repository = "https://github.com/tokio-rs/axum"
-version = "0.10.1"
+version = "0.10.2"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -11,19 +11,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **breaking:** `#[from_request(via(Extractor))]` now uses the extractor's
   rejection type instead of `axum::response::Response` ([#3261])
 - **breaking:** `axum::serve` now applies hyper's default `header_read_timeout` ([#3478])
-- **added:** Implement `OptionalFromRequest` for `Multipart` ([#3220])
 - **added:** New `ListenerExt::limit_connections` allows limiting concurrent `axum::serve` connections ([#3489])
 - **changed:** `serve` has an additional generic argument and can now work with any response body
   type, not just `axum::body::Body` ([#3205])
-- **change:** Update minimum rust version to 1.78 ([#3412])
 
 [#3158]: https://github.com/tokio-rs/axum/pull/3158
 [#3261]: https://github.com/tokio-rs/axum/pull/3261
 [#3205]: https://github.com/tokio-rs/axum/pull/3205
-[#3220]: https://github.com/tokio-rs/axum/pull/3220
-[#3412]: https://github.com/tokio-rs/axum/pull/3412
 [#3478]: https://github.com/tokio-rs/axum/pull/3478
 [#3489]: https://github.com/tokio-rs/axum/pull/3489
+
+# 0.8.5
+
+- **fixed:** Reject JSON request bodies with trailing characters after the JSON document ([#3453])
+- **added:** Implement `OptionalFromRequest` for `Multipart` ([#3220])
+- **added:** Getter methods `Location::{status_code, location}`
+- **added:** Support for writing arbitrary binary data into server-sent events ([#3425])]
+- **added:** `middleware::ResponseAxumBodyLayer` for mapping response body to `axum::body::Body` ([#3469])
+- **added:** `impl FusedStream for WebSocket` ([#3443])
+- **changed:** The `sse` module and `Sse` type no longer depend on the `tokio` feature ([#3154])
+- **changed:** If the location given to one of `Redirect`s constructors is not a valid
+  header value, instead of panicking on construction, the `IntoResponse` impl now returns
+  an HTTP 500, just like `Json` does when serialization fails ([#3377])
+- **changed:** Update minimum rust version to 1.78 ([#3412])
+
+[#3154]: https://github.com/tokio-rs/axum/pull/3154
+[#3220]: https://github.com/tokio-rs/axum/pull/3220
+[#3377]: https://github.com/tokio-rs/axum/pull/3377
+[#3412]: https://github.com/tokio-rs/axum/pull/3412
+[#3425]: https://github.com/tokio-rs/axum/pull/3425
+[#3443]: https://github.com/tokio-rs/axum/pull/3443
+[#3453]: https://github.com/tokio-rs/axum/pull/3453
+[#3469]: https://github.com/tokio-rs/axum/pull/3469
 
 # 0.8.4
 

--- a/axum/Cargo.toml
+++ b/axum/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axum"
-version = "0.8.4" # remember to bump the version that axum-extra depends on
+version = "0.8.5" # remember to bump the version that axum-extra depends on
 categories = ["asynchronous", "network-programming", "web-programming::http-server"]
 description = "Web framework that focuses on ergonomics and modularity"
 edition = "2021"
@@ -94,7 +94,7 @@ __private_docs = [
 __private = ["tokio", "http1", "dep:reqwest"]
 
 [dependencies]
-axum-core = { path = "../axum-core", version = "0.5.2" }
+axum-core = { path = "../axum-core", version = "0.5.3" }
 bytes = "1.0"
 futures-core = "0.3"
 futures-util = { version = "0.3", default-features = false, features = ["alloc"] }

--- a/deny.toml
+++ b/deny.toml
@@ -23,6 +23,23 @@ skip-tree = [
     { name = "base64" },
     # parking_lot pulls in old versions of windows-sys
     { name = "windows-sys" },
+    # old version pulled in by rustls via ring
+    { name = "spin" },
+    # lots still pulls in syn 1.x
+    { name = "syn" },
+    # until 1.0 is out we're pulling in both 0.14 and 1.0-rc.x
+    { name = "hyper" },
+    # pulled in by tracing-subscriber
+    { name = "regex-syntax" },
+    # pulled in by tracing-subscriber
+    { name = "regex-automata" },
+    # pulled in by hyper
+    { name = "socket2" },
+    # hyper-util hasn't upgraded to 0.5 yet, but it's the same service / layer
+    # crates beneath
+    { name = "tower" },
+    # tower hasn't upgraded to 1.0 yet
+    { name = "sync_wrapper" },
     # pulled in by quickcheck and cookie
     { name = "rand" },
 ]


### PR DESCRIPTION
Release log:

- [x] Backport relevant non-breaking changes to release branch
- [x] Update changelogs on release branch
- [x] Make merge-back-to-main PR (this), wait for approval
- [x] Run cargo publish on release branch, in the right order
- [x] Create git tags
- [x] Create GitHub releases
- [x] Merge this PR

Some CI jobs fail on the `v0.8.x` branch (for previous releases off of separate branches, we just didn't run CI), but they'd be rather annoying to fix, and I think we can ignore them:

- The `axum-macros` nightly CI job fails due to the old toolchain used for that, I could cherry-pick #3500 but that seems to cause new problems
- The `cargo-sort` CI job fails because I didn't cherry-pick some related changes, I think I shouldn't because that's purely about `Cargo.toml` formatting and I don't want to make this harder than it needs to be
- The `cargo-hack` CI job fails because of a dependency of an example being a bit broken; I don't think this is worth updating the example on the release branch for