### PR TITLE
Remove usage of the `doc_auto_cfg` feature

### DIFF
--- a/axum-extra/src/lib.rs
+++ b/axum-extra/src/lib.rs
@@ -36,7 +36,7 @@
 //!
 //! [`axum`]: https://crates.io/crates/axum
 
-#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(test, allow(clippy::float_cmp))]
 #![cfg_attr(not(test), warn(clippy::print_stdout, clippy::dbg_macro))]
 

--- a/axum/src/lib.rs
+++ b/axum/src/lib.rs
@@ -427,7 +427,7 @@
 //! [`axum-core`]: http://crates.io/crates/axum-core
 //! [`State`]: crate::extract::State
 
-#![cfg_attr(docsrs, feature(doc_auto_cfg, doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(test, allow(clippy::float_cmp))]
 #![cfg_attr(not(test), warn(clippy::print_stdout, clippy::dbg_macro))]
 


### PR DESCRIPTION
## Motivation

Fixes #3504

The docs feature has been removed and merged into `doc_cfg` so we can use just that.

Log of failure of the last build can be found [here](https://docs.rs/crate/axum/0.8.5/builds/2544074/x86_64-unknown-linux-gnu.txt).

## Solution

Remove the usage.