### PR TITLE
Release axum 0.8.6 and related crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -297,7 +297,7 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "anyhow",
  "axum-core",
@@ -346,7 +346,7 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "axum",
  "axum-extra",
@@ -369,7 +369,7 @@ dependencies = [
 
 [[package]]
 name = "axum-extra"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "axum",
  "axum-core",

--- a/axum-core/CHANGELOG.md
+++ b/axum-core/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# 0.5.5
+
+Released without changes to fix docs.rs build.
+
 # 0.5.4
 
 - **fixed:** Removed unused `rustversion` dependency ([#3502])

--- a/axum-core/Cargo.toml
+++ b/axum-core/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 name = "axum-core"
 readme = "README.md"
 repository = "https://github.com/tokio-rs/axum"
-version = "0.5.4" # remember to bump the version that axum and axum-extra depend on
+version = "0.5.5" # remember to bump the version that axum and axum-extra depend on
 
 [package.metadata.cargo-public-api-crates]
 allowed = [

--- a/axum-extra/CHANGELOG.md
+++ b/axum-extra/CHANGELOG.md
@@ -27,6 +27,10 @@ Yanked from crates.io due to unforeseen breaking change, see [#3190] for details
 
 [#3190]: https://github.com/tokio-rs/axum/pull/3190
 
+# 0.10.3
+
+Released without changes to fix docs.rs build.
+
 # 0.10.2
 
 - **added:** Implement `OptionalFromRequest` for `Host` ([#3177])

--- a/axum-extra/Cargo.toml
+++ b/axum-extra/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 name = "axum-extra"
 readme = "README.md"
 repository = "https://github.com/tokio-rs/axum"
-version = "0.10.2"
+version = "0.10.3"
 
 [package.metadata.docs.rs]
 all-features = true
@@ -101,7 +101,7 @@ with-rejection = ["dep:axum"]
 __private_docs = ["axum/json", "dep:serde", "dep:tower"]
 
 [dependencies]
-axum-core = { path = "../axum-core", version = "0.5.2" }
+axum-core = { path = "../axum-core", version = "0.5.5" }
 bytes = "1.1.0"
 futures-core = "0.3"
 futures-util = { version = "0.3", default-features = false, features = ["alloc"] }
@@ -114,7 +114,7 @@ tower-layer = "0.3"
 tower-service = "0.3"
 
 # optional dependencies
-axum = { path = "../axum", version = "0.8.4", default-features = false, optional = true }
+axum = { path = "../axum", version = "0.8.6", default-features = false, optional = true }
 axum-macros = { path = "../axum-macros", version = "0.5.0", optional = true }
 cookie = { package = "cookie", version = "0.18.0", features = ["percent-encode"], optional = true }
 fastrand = { version = "2.1.0", optional = true }

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#3478]: https://github.com/tokio-rs/axum/pull/3478
 [#3489]: https://github.com/tokio-rs/axum/pull/3489
 
+# 0.8.6
+
+Released without changes to fix docs.rs build.
+
 # 0.8.5
 
 - **fixed:** Reject JSON request bodies with trailing characters after the JSON document ([#3453])

--- a/axum/Cargo.toml
+++ b/axum/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axum"
-version = "0.8.5" # remember to bump the version that axum-extra depends on
+version = "0.8.6" # remember to bump the version that axum-extra depends on
 categories = ["asynchronous", "network-programming", "web-programming::http-server"]
 description = "Web framework that focuses on ergonomics and modularity"
 edition = "2021"
@@ -94,7 +94,7 @@ __private_docs = [
 __private = ["tokio", "http1", "dep:reqwest"]
 
 [dependencies]
-axum-core = { path = "../axum-core", version = "0.5.3" }
+axum-core = { path = "../axum-core", version = "0.5.5" }
 bytes = "1.0"
 futures-core = "0.3"
 futures-util = { version = "0.3", default-features = false, features = ["alloc"] }


### PR DESCRIPTION
This is practically empty release just to fix docs.rs build.