### PR TITLE
Use Vec for PathRouter

### DIFF
--- a/axum/src/routing/mod.rs
+++ b/axum/src/routing/mod.rs
@@ -58,7 +58,7 @@ macro_rules! panic_on_err {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub(crate) struct RouteId(u32);
+pub(crate) struct RouteId(usize);
 
 /// The router type for composing handlers and services.
 ///


### PR DESCRIPTION
Routes in path seemed to work with linear memory instead of needing the extra hash and tracking of prev_route_id, a Vec should work just fine while having the benefits of cache locality.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation

`Vec` seemed to be able to fulfill routes without needing `HashMap`, as well as better cache locality.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Change `PathRouter` to use `Vec`.