### PR TITLE
Make CI docs check closer to docsrs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -42,7 +42,7 @@ jobs:
     - name: cargo doc -p axum-extra
       run: cargo doc --package axum-extra --all-features --no-deps
     env:
-      RUSTDOCFLAGS: "-D rustdoc::all -A rustdoc::private-doc-tests"
+      RUSTDOCFLAGS: "-D rustdoc::all -A rustdoc::private-doc-tests --cfg docsrs"
 
   cargo-hack:
     runs-on: ubuntu-24.04

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v5
-    - uses: dtolnay/rust-toolchain@stable
+    - uses: dtolnay/rust-toolchain@nightly
     - uses: Swatinem/rust-cache@v2
       with:
         save-if: ${{ github.ref == 'refs/heads/main' }}


### PR DESCRIPTION
## Motivation

The failed docs.rs build of 0.8.5 was not caught in CI though it probably should have been.

## Solution

Add `--cfg docsrs` to the rustdoc invocations. This makes the docs build process more like what's going to happen in the docs.rs build and can check for similar kinds of failures that are gated behind this cfg option.