### PR TITLE
axum: bump 'bytes' dependency to 1.7

### DIFF
--- a/axum/Cargo.toml
+++ b/axum/Cargo.toml
@@ -95,7 +95,7 @@ __private = ["tokio", "http1", "dep:reqwest"]
 
 [dependencies]
 axum-core = { path = "../axum-core", version = "0.5.5" }
-bytes = "1.0"
+bytes = "1.7"
 futures-core = "0.3"
 futures-util = { version = "0.3", default-features = false, features = ["alloc"] }
 http = "1.0.0"


### PR DESCRIPTION
Axum relies on `From<Bytes>` implemented for `BytesMut` in SSE response
implementation. The conversion was added in `bytes` 1.7
(https://github.com/tokio-rs/bytes/releases/tag/v1.7.0). So bump the
minimum required version.
