### PR TITLE
ci: Check axum-extra typed-routing feature

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -60,6 +60,8 @@ jobs:
         curl -LsSf https://github.com/taiki-e/cargo-hack/releases/latest/download/cargo-hack-x86_64-unknown-linux-gnu.tar.gz | tar xzf - -C ~/.cargo/bin
     - name: cargo hack check
       run: cargo hack check --each-feature --no-dev-deps --all
+    - name: check axum-extra typed-routing feature
+      run: cargo check --package axum-extra --features routing,typed-routing
 
   cargo-public-api-crates:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
## Motivation

Since `axum-extra`'s `typed-routing` feature requires `routing` feature, both are needed to be enabled to be checked.

## Solution

Adds an check of `axum-extra` with enabling both of `routing` and `typed-routing` features.
