### PR TITLE
examples: Use diesel HasQuery trait

### DIFF
--- a/examples/diesel-async-postgres/src/main.rs
+++ b/examples/diesel-async-postgres/src/main.rs
@@ -38,7 +38,7 @@ table! {
     }
 }
 
-#[derive(serde::Serialize, Selectable, Queryable)]
+#[derive(serde::Serialize, HasQuery)]
 struct User {
     id: i32,
     name: String,
@@ -124,8 +124,7 @@ where
 async fn list_users(
     DatabaseConnection(mut conn): DatabaseConnection,
 ) -> Result<Json<Vec<User>>, (StatusCode, String)> {
-    let res = users::table
-        .select(User::as_select())
+    let res = User::query()
         .load(&mut conn)
         .await
         .map_err(internal_error)?;

--- a/examples/diesel-postgres/src/main.rs
+++ b/examples/diesel-postgres/src/main.rs
@@ -35,7 +35,7 @@ table! {
     }
 }
 
-#[derive(serde::Serialize, Selectable, Queryable)]
+#[derive(serde::Serialize, HasQuery)]
 struct User {
     id: i32,
     name: String,
@@ -112,7 +112,7 @@ async fn list_users(
 ) -> Result<Json<Vec<User>>, (StatusCode, String)> {
     let conn = pool.get().await.map_err(internal_error)?;
     let res = conn
-        .interact(|conn| users::table.select(User::as_select()).load(conn))
+        .interact(|conn| User::query().load(conn))
         .await
         .map_err(internal_error)?
         .map_err(internal_error)?;


### PR DESCRIPTION
## Motivation

`diesel` `2.3` provides a new feature `HasQuery` which can make the examples more simple.

## Solution

Uses the new `HasQuery` trait.
