### PR TITLE
Add trailing newline to pretty JSON response

### DIFF
--- a/axum-extra/src/response/erased_json.rs
+++ b/axum-extra/src/response/erased_json.rs
@@ -57,7 +57,10 @@ impl ErasedJson {
     pub fn pretty<T: Serialize>(val: T) -> Self {
         let mut bytes = BytesMut::with_capacity(128);
         let result = match serde_json::to_writer_pretty((&mut bytes).writer(), &val) {
-            Ok(()) => Ok(bytes.freeze()),
+            Ok(()) => {
+                bytes.put_u8(b'\n');
+                Ok(bytes.freeze())
+            }
             Err(e) => Err(Arc::new(e)),
         };
         Self(result)


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

Normally human-readable JSON HTTP response bodies have a trailing newline, so that the body is a valid "text file" and nicer for viewing in the terminal with something like `curl`.

I think it would make sense that `ErasedJson::pretty` also had a trailing newline.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Append a newline to the output of `serde_json::to_writer_pretty`.