### PR TITLE
ci: Use taiki-e/install-action to setup cargo-hack

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -55,9 +55,7 @@ jobs:
     - uses: Swatinem/rust-cache@v2
       with:
         save-if: ${{ github.ref == 'refs/heads/main' }}
-    - name: Install cargo-hack
-      run: |
-        curl -LsSf https://github.com/taiki-e/cargo-hack/releases/latest/download/cargo-hack-x86_64-unknown-linux-gnu.tar.gz | tar xzf - -C ~/.cargo/bin
+    - uses: taiki-e/install-action@cargo-hack
     - name: cargo hack check
       run: cargo hack check --each-feature --no-dev-deps --all
 


### PR DESCRIPTION
## Motivation

Simplifies the setup process to install `cargo-hack` in the CI.

## Solution

Uses `taiki-e/install-action` to setup cargo-hack.