### PR TITLE
Release axum-extra 0.12.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -369,7 +369,7 @@ dependencies = [
 
 [[package]]
 name = "axum-extra"
-version = "0.10.3"
+version = "0.12.1"
 dependencies = [
  "axum",
  "axum-core",

--- a/axum-extra/CHANGELOG.md
+++ b/axum-extra/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog],
 and this project adheres to [Semantic Versioning].
 
+# 0.12.1
+
+This release contains no changes in code, only a small `Cargo.toml` fix for
+`docs.rs`.
+
+# 0.12.0
+
 - **breaking:** Remove unused `async-stream` feature, which was accidentally
   introduced as an implicit feature through an optional dependency which was no
   longer being used ([#3298])

--- a/axum-extra/Cargo.toml
+++ b/axum-extra/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 name = "axum-extra"
 readme = "README.md"
 repository = "https://github.com/tokio-rs/axum"
-version = "0.10.3"
+version = "0.12.1"
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
## Motivation

We accidentally removed `package.metadata.docs.rs` from `axum-extra/Cargo.toml`, so the docs for v0.12.0 were very incomplete.

## Solution

Add it back. I already released this, just need to merge back the version + changelog into the main branch.

Making this a draft PR to ensure it doesn't get merged in Web UI, but it is ready for review. Replaces #3541.