### PR TITLE
Make it easier to visually scan for default features

### DIFF
--- a/axum-extra/src/lib.rs
+++ b/axum-extra/src/lib.rs
@@ -9,30 +9,30 @@
 //!
 //! Name | Description | Default?
 //! ---|---|---
-//! `async-read-body` | Enables the [`AsyncReadBody`](crate::body::AsyncReadBody) body | No
-//! `attachment` | Enables the [`Attachment`](crate::response::Attachment) response | No
-//! `cached` | Enables the [`Cached`](crate::extract::Cached) extractor | No
-//! `cookie` | Enables the [`CookieJar`](crate::extract::CookieJar) extractor | No
-//! `cookie-private` | Enables the [`PrivateCookieJar`](crate::extract::PrivateCookieJar) extractor | No
-//! `cookie-signed` | Enables the [`SignedCookieJar`](crate::extract::SignedCookieJar) extractor | No
-//! `cookie-key-expansion` | Enables the [`Key::derive_from`](crate::extract::cookie::Key::derive_from) method | No
-//! `erased-json` | Enables the [`ErasedJson`](crate::response::ErasedJson) response | No
-//! `error-response` | Enables the [`InternalServerError`](crate::response::InternalServerError) response | No
-//! `form` | Enables the [`Form`](crate::extract::Form) extractor | No
-//! `handler` | Enables the [handler] utilities | No
-//! `json-deserializer` | Enables the [`JsonDeserializer`](crate::extract::JsonDeserializer) extractor | No
-//! `json-lines` | Enables the [`JsonLines`](crate::extract::JsonLines) extractor and response | No
-//! `middleware` | Enables the [middleware] utilities | No
-//! `multipart` | Enables the [`Multipart`](crate::extract::Multipart) extractor | No
-//! `optional-path` | Enables the [`OptionalPath`](crate::extract::OptionalPath) extractor | No
-//! `protobuf` | Enables the [`Protobuf`](crate::protobuf::Protobuf) extractor and response | No
-//! `query` | Enables the [`Query`](crate::extract::Query) extractor | No
-//! `routing` | Enables the [routing] utilities | No
-//! `tracing` | Log rejections from built-in extractors | Yes
-//! `typed-routing` | Enables the [`TypedPath`](crate::routing::TypedPath) routing utilities and the `routing` feature. | No
-//! `typed-header` | Enables the [`TypedHeader`] extractor and response | No
-//! `file-stream` | Enables the [`FileStream`](crate::response::FileStream) response | No
-//! `with-rejection` | Enables the [`WithRejection`](crate::extract::WithRejection) extractor | No
+//! `async-read-body` | Enables the [`AsyncReadBody`](crate::body::AsyncReadBody) body |
+//! `attachment` | Enables the [`Attachment`](crate::response::Attachment) response |
+//! `cached` | Enables the [`Cached`](crate::extract::Cached) extractor |
+//! `cookie` | Enables the [`CookieJar`](crate::extract::CookieJar) extractor |
+//! `cookie-private` | Enables the [`PrivateCookieJar`](crate::extract::PrivateCookieJar) extractor |
+//! `cookie-signed` | Enables the [`SignedCookieJar`](crate::extract::SignedCookieJar) extractor |
+//! `cookie-key-expansion` | Enables the [`Key::derive_from`](crate::extract::cookie::Key::derive_from) method |
+//! `erased-json` | Enables the [`ErasedJson`](crate::response::ErasedJson) response |
+//! `error-response` | Enables the [`InternalServerError`](crate::response::InternalServerError) response |
+//! `form` | Enables the [`Form`](crate::extract::Form) extractor |
+//! `handler` | Enables the [handler] utilities |
+//! `json-deserializer` | Enables the [`JsonDeserializer`](crate::extract::JsonDeserializer) extractor |
+//! `json-lines` | Enables the [`JsonLines`](crate::extract::JsonLines) extractor and response |
+//! `middleware` | Enables the [middleware] utilities |
+//! `multipart` | Enables the [`Multipart`](crate::extract::Multipart) extractor |
+//! `optional-path` | Enables the [`OptionalPath`](crate::extract::OptionalPath) extractor |
+//! `protobuf` | Enables the [`Protobuf`](crate::protobuf::Protobuf) extractor and response |
+//! `query` | Enables the [`Query`](crate::extract::Query) extractor |
+//! `routing` | Enables the [routing] utilities |
+//! `tracing` | Log rejections from built-in extractors | <span role="img" aria-label="Default feature">✔</span>
+//! `typed-routing` | Enables the [`TypedPath`](crate::routing::TypedPath) routing utilities and the `routing` feature. |
+//! `typed-header` | Enables the [`TypedHeader`] extractor and response |
+//! `file-stream` | Enables the [`FileStream`](crate::response::FileStream) response |
+//! `with-rejection` | Enables the [`WithRejection`](crate::extract::WithRejection) extractor |
 //!
 //! [`axum`]: https://crates.io/crates/axum
 

--- a/axum/src/lib.rs
+++ b/axum/src/lib.rs
@@ -381,19 +381,19 @@
 //!
 //! Name | Description | Default?
 //! ---|---|---
-//! `http1` | Enables hyper's `http1` feature | Yes
-//! `http2` | Enables hyper's `http2` feature | No
-//! `json` | Enables the [`Json`] type and some similar convenience functionality | Yes
-//! `macros` | Enables optional utility macros | No
-//! `matched-path` | Enables capturing of every request's router path and the [`MatchedPath`] extractor | Yes
-//! `multipart` | Enables parsing `multipart/form-data` requests with [`Multipart`] | No
-//! `original-uri` | Enables capturing of every request's original URI and the [`OriginalUri`] extractor | Yes
-//! `tokio` | Enables `tokio` as a dependency and `axum::serve`, `SSE` and `extract::connect_info` types. | Yes
-//! `tower-log` | Enables `tower`'s `log` feature | Yes
-//! `tracing` | Log rejections from built-in extractors | Yes
-//! `ws` | Enables WebSockets support via [`extract::ws`] | No
-//! `form` | Enables the `Form` extractor | Yes
-//! `query` | Enables the `Query` extractor | Yes
+//! `http1` | Enables hyper's `http1` feature | <span role="img" aria-label="Default feature">✔</span>
+//! `http2` | Enables hyper's `http2` feature |
+//! `json` | Enables the [`Json`] type and some similar convenience functionality | <span role="img" aria-label="Default feature">✔</span>
+//! `macros` | Enables optional utility macros |
+//! `matched-path` | Enables capturing of every request's router path and the [`MatchedPath`] extractor | <span role="img" aria-label="Default feature">✔</span>
+//! `multipart` | Enables parsing `multipart/form-data` requests with [`Multipart`] |
+//! `original-uri` | Enables capturing of every request's original URI and the [`OriginalUri`] extractor | <span role="img" aria-label="Default feature">✔</span>
+//! `tokio` | Enables `tokio` as a dependency and `axum::serve`, `SSE` and `extract::connect_info` types. | <span role="img" aria-label="Default feature">✔</span>
+//! `tower-log` | Enables `tower`'s `log` feature | <span role="img" aria-label="Default feature">✔</span>
+//! `tracing` | Log rejections from built-in extractors | <span role="img" aria-label="Default feature">✔</span>
+//! `ws` | Enables WebSockets support via [`extract::ws`] |
+//! `form` | Enables the `Form` extractor | <span role="img" aria-label="Default feature">✔</span>
+//! `query` | Enables the `Query` extractor | <span role="img" aria-label="Default feature">✔</span>
 //!
 //! [`MatchedPath`]: crate::extract::MatchedPath
 //! [`Multipart`]: crate::extract::Multipart


### PR DESCRIPTION
## Motivation

Tables with yes–no columns (or other kinds of binary distinctions) can be difficult to 👀 visually scan if the column in each row contains “yes” or “no”. It’s usually easier to spot the “yes” rows if they have a symbol there that the “no” rows do not.

The tables of available features on `axum` and `axum-extra` have this issue on their _Default?_ column where the `default` features are indicated.

## Solution

Before | After
-------|------
<img width="990" height="810" alt="Screenshot 2025-11-09 at 11 43 28 PM" src="https://github.com/user-attachments/assets/3be21ee6-b371-4015-bed7-dafd0cc69ba2" /> | <img width="980" height="820" alt="Screenshot 2025-11-09 at 11 43 55 PM" src="https://github.com/user-attachments/assets/5353f7e8-b15e-4673-b631-ad85420fa3af" />

This PR removes the “No” values, and replaces “Yes” with a checkmark. Scaled down here to fit within the PR description space, the easier readability is (imo!) even more obvious.

For screen readers, I wrapped the checkmark in a `<span>` which sets the `aria-label` to “Default feature”, so this should be clearer even when the table is not being visually read.

I appreciate everyone who’s worked to ship and maintain such a delightful library as Axum! 🙏🏻