### PR TITLE
impl Sync for RouterIntoService

### DIFF
--- a/axum/src/routing/mod.rs
+++ b/axum/src/routing/mod.rs
@@ -647,6 +647,11 @@ pub struct RouterIntoService<B, S = ()> {
     _marker: PhantomData<B>,
 }
 
+// SAFETY: B is only held onto as PhantomData so does not affect the Sync-ness of
+// RouterIntoService; S passed deep into the type heirarchy but eventually ends up as part of
+// Box<dyn ErasedIntoRoute<S, E>> and ErasedIntoRoute<S, E> as Send + Sync supertrait bounds.
+unsafe impl<B, S> Sync for RouterIntoService<B, S> {}
+
 impl<B, S> Clone for RouterIntoService<B, S>
 where
     Router<S>: Clone,


### PR DESCRIPTION
This PR adds an unsafe impl of Sync for RouterIntoService
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation

Whilst trying to build some testing apparatus for my project, I wanted to pass a reference to something containing `RouterIntoService<Body>` by reference into an async method. Doing so made the `Future` for that method not `Send`, because `RouterIntoService<Body>` was not `Sync`. This was problematic for me, so I looked into your source and found that the body type `B` was only held onto as a`PhantomData`, which to my mind means it shouldn't affect the `Sync`-ness of the data structure. Looking further into the state type `S`, that looks like it's used in a dyn trait bound who's super traits already force `Send` and `Sync`, so I believe there's not a requirement on `S` to be `Sync` here either, but I might be mistaken on that.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

I just added a manual implementation to relax the `!Sync` constraint on the type. This should mean that in the future I don't need to manually annotate the types in my code.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
