### PR TITLE
Fix typo in extractors guide

### DIFF
--- a/axum/src/docs/extract.md
+++ b/axum/src/docs/extract.md
@@ -606,8 +606,8 @@ For more details, including how to disable this limit, see [`DefaultBodyLimit`].
 
 # Wrapping extractors
 
-If you want write an extractor that generically wraps another extractor (that
-may or may not consume the request body) you should implement both
+If you want to write an extractor that generically wraps another extractor
+(that may or may not consume the request body) you should implement both
 [`FromRequest`] and [`FromRequestParts`]:
 
 ```rust


### PR DESCRIPTION
This fixes a minor typo in extractors guide, specifically in "Wrapping extractors" section.

## Motivation

Came across it, thought I'd fix it.

## Solution

Add `to` between `want` and `write`.