### PR TITLE
Relax implicit Send / Sync bounds

### DIFF
--- a/axum/src/routing/mod.rs
+++ b/axum/src/routing/mod.rs
@@ -605,7 +605,7 @@ where
 /// See [`Router::as_service`] for more details.
 pub struct RouterAsService<'a, B, S = ()> {
     router: &'a mut Router<S>,
-    _marker: PhantomData<B>,
+    _marker: PhantomData<fn(B)>,
 }
 
 impl<B> Service<Request<B>> for RouterAsService<'_, B, ()>
@@ -644,7 +644,7 @@ where
 /// See [`Router::into_service`] for more details.
 pub struct RouterIntoService<B, S = ()> {
     router: Router<S>,
-    _marker: PhantomData<B>,
+    _marker: PhantomData<fn(B)>,
 }
 
 impl<B, S> Clone for RouterIntoService<B, S>
@@ -812,4 +812,8 @@ fn traits() {
     use crate::test_helpers::*;
     assert_send::<Router<()>>();
     assert_sync::<Router<()>>();
+    assert_send::<RouterAsService<'static, Body, ()>>();
+    assert_sync::<RouterAsService<'static, Body, ()>>();
+    assert_send::<RouterIntoService<Body, ()>>();
+    assert_sync::<RouterIntoService<Body, ()>>();
 }

--- a/axum/src/serve/mod.rs
+++ b/axum/src/serve/mod.rs
@@ -121,7 +121,7 @@ where
 pub struct Serve<L, M, S, B> {
     listener: L,
     make_service: M,
-    _marker: PhantomData<(S, B)>,
+    _marker: PhantomData<fn(B) -> S>,
 }
 
 #[cfg(all(feature = "tokio", any(feature = "http1", feature = "http2")))]
@@ -252,7 +252,7 @@ pub struct WithGracefulShutdown<L, M, S, F, B> {
     listener: L,
     make_service: M,
     signal: F,
-    _marker: PhantomData<(S, B)>,
+    _marker: PhantomData<fn(B) -> S>,
 }
 
 #[cfg(all(feature = "tokio", any(feature = "http1", feature = "http2")))]


### PR DESCRIPTION
Implicit bounds were unnecessarily restrictive.
Closes #3552.
