### PR TITLE
Release axum v0.8.7 and axum-extra v0.12.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -297,7 +297,7 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "anyhow",
  "axum-core",
@@ -369,7 +369,7 @@ dependencies = [
 
 [[package]]
 name = "axum-extra"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "axum",
  "axum-core",

--- a/axum-extra/CHANGELOG.md
+++ b/axum-extra/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog],
 and this project adheres to [Semantic Versioning].
 
+# 0.12.2
+
+- Make it easier to visually scan for default features ([#3550])
+
+[#3550]: https://github.com/tokio-rs/axum/pull/3550
+
 # 0.12.1
 
 This release contains no changes in code, only a small `Cargo.toml` fix for

--- a/axum-extra/Cargo.toml
+++ b/axum-extra/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 name = "axum-extra"
 readme = "README.md"
 repository = "https://github.com/tokio-rs/axum"
-version = "0.12.1"
+version = "0.12.2"
 
 [package.metadata.docs.rs]
 all-features = true
@@ -115,7 +115,7 @@ tower-layer = "0.3"
 tower-service = "0.3"
 
 # optional dependencies
-axum = { path = "../axum", version = "0.8.6", default-features = false, optional = true }
+axum = { path = "../axum", version = "0.8.7", default-features = false, optional = true }
 axum-macros = { path = "../axum-macros", version = "0.5.0", optional = true }
 cookie = { package = "cookie", version = "0.18.0", features = ["percent-encode"], optional = true }
 fastrand = { version = "2.1.0", optional = true }

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -21,6 +21,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#3478]: https://github.com/tokio-rs/axum/pull/3478
 [#3489]: https://github.com/tokio-rs/axum/pull/3489
 
+# 0.8.7
+
+- Relax implicit `Send` / `Sync` bounds on `RouterAsService`, `RouterIntoService` ([#3555])
+- Make it easier to visually scan for default features ([#3550])
+- Fix some documentation typos
+
+[#3550]: https://github.com/tokio-rs/axum/pull/3550
+[#3555]: https://github.com/tokio-rs/axum/pull/3555
+
 # 0.8.6
 
 Released without changes to fix docs.rs build.

--- a/axum/Cargo.toml
+++ b/axum/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axum"
-version = "0.8.6" # remember to bump the version that axum-extra depends on
+version = "0.8.7" # remember to bump the version that axum-extra depends on
 categories = ["asynchronous", "network-programming", "web-programming::http-server"]
 description = "Web framework that focuses on ergonomics and modularity"
 edition = "2021"


### PR DESCRIPTION
Backport recently-merged changes to `v0.8.x`.

Release diff: https://github.com/tokio-rs/axum/compare/f9ce3e5b42c462411bcec2969841b1a3dcad68ac...4404f27cea206b0dca63637b1c76dff23772a5cc

**DO NOT MERGE VIA WEB UI**