### PR TITLE
SecondElementIs: Correct a small inconsistency

### DIFF
--- a/axum-extra/src/routing/typed.rs
+++ b/axum-extra/src/routing/typed.rs
@@ -320,7 +320,7 @@ where
 /// Utility trait used with [`RouterExt`] to ensure the second element of a tuple type is a
 /// given type.
 ///
-/// If you see it in type errors it's most likely because the second argument to your handler doesn't
+/// If you see it in type errors it's most likely because the first argument to your handler doesn't
 /// implement [`TypedPath`].
 ///
 /// You normally shouldn't have to use this trait directly.


### PR DESCRIPTION
This trait checks for the second element of a tuple, but the second element of the tuple is the first argument to a handler because the first element is the type parameter `M` from `FromRequest<S, M>`.
