### PR TITLE
docs: clarify `route_layer` does not apply middleware to the fallback handler

### DIFF
--- a/axum/src/docs/method_routing/route_layer.md
+++ b/axum/src/docs/method_routing/route_layer.md
@@ -1,8 +1,7 @@
 Apply a [`tower::Layer`] to the router that will only run if the request matches
 a route.
 
-Note that the middleware is only applied to existing routes. So you have to
-first add your routes (and / or fallback) and then call `route_layer`
+Note that the middleware is only applied to existing routes. First add your routes and then call `route_layer`
 afterwards. Additional routes added after `route_layer` is called will not have
 the middleware added.
 


### PR DESCRIPTION
## Motivation
The current `route_layer` documentation incorrectly implies that middleware applied via `route_layer` will also run on the fallback route. This is not the case, and this PR clarifies the intent.

Issue #3421 was created, with a PR to correct the bug in the documentation. However, that PR has been stale for multiple weeks.

## Solution
* Remove misleading section `(and / or fallback)` in `route_layer.md`
* No functional changes, the PR updates documentation only.