### PR TITLE
refac(axum-extra): improve test invariants for `protobuf.rs` extractor

### DIFF
--- a/axum-extra/src/protobuf.rs
+++ b/axum-extra/src/protobuf.rs
@@ -161,7 +161,7 @@ mod tests {
     use super::*;
     use crate::test_helpers::*;
     use axum::{routing::post, Router};
-    use http::header::{CONTENT_TYPE};
+    use http::header::CONTENT_TYPE;
     use http::StatusCode;
 
     #[tokio::test]
@@ -253,7 +253,10 @@ mod tests {
             .get(CONTENT_TYPE)
             .expect("missing expected header");
 
-        assert_eq!(content_type_header_value, mime::APPLICATION_OCTET_STREAM.as_ref());
+        assert_eq!(
+            content_type_header_value,
+            mime::APPLICATION_OCTET_STREAM.as_ref()
+        );
 
         let body = res.bytes().await;
 


### PR DESCRIPTION
## Motivation
Some of the existing tests for the `Protobuf` extractor can benefit from using available input values directly, and from adding a couple of small assertions to make the tested behavior a bit more explicit.

This PR aims to strengthen the existing tests slightly, without changing any
behavior or structure. It’s a small polish to make the intent of the tests a
little clearer.

## Solution
* Where possible, we utilize the value in the input struct for asserting on the response body
* Where missing, we also assert on the expected HTTP response status code
* In `prost_decode_error`, verify that the rejection body contains the expected prefix from the `ProtobufDecodeError` definition.
* Replace the hardcoded "content-type" string with the `CONTENT_TYPE` constant.

