### PR TITLE
test(axum-extra): improve `response_not_set_filename` test invariants

### DIFF
--- a/axum-extra/src/response/file_stream.rs
+++ b/axum-extra/src/response/file_stream.rs
@@ -357,7 +357,6 @@ mod tests {
 
         let app = {
             let file_content = file_content.clone();
-            let size = size;
 
             Router::new().route(
                 "/file",

--- a/axum-extra/src/response/file_stream.rs
+++ b/axum-extra/src/response/file_stream.rs
@@ -300,16 +300,15 @@ mod tests {
     use super::*;
     use axum::{extract::Request, routing::get, Router};
     use body::Body;
+    use http::header::CONTENT_LENGTH;
+    use http::header::CONTENT_TYPE;
     use http::HeaderMap;
+    use http::StatusCode;
     use http_body_util::BodyExt;
+    use mime;
     use std::io::Cursor;
     use tokio_util::io::ReaderStream;
     use tower::ServiceExt;
-    use http::header::CONTENT_TYPE;
-    use http::header::CONTENT_LENGTH;
-    use http::StatusCode;
-    use mime;
-
 
     #[tokio::test]
     async fn response() -> Result<(), Box<dyn std::error::Error>> {
@@ -367,9 +366,7 @@ mod tests {
                         let reader = Cursor::new(file_content);
                         let stream = ReaderStream::new(reader);
 
-                        FileStream::new(stream)
-                            .content_size(size)
-                            .into_response()
+                        FileStream::new(stream).content_size(size).into_response()
                     }
                 }),
             )
@@ -400,10 +397,7 @@ mod tests {
 
         // Validate Response Body
         let body: &[u8] = &response.into_body().collect().await?.to_bytes();
-        assert_eq!(
-            std::str::from_utf8(body)?.as_bytes(),
-            file_content
-        );
+        assert_eq!(std::str::from_utf8(body)?.as_bytes(), file_content);
         Ok(())
     }
 


### PR DESCRIPTION
Strengthen test invariants for `file_stream.rs` by deriving values where possible and replacing magic values with constants.

## Motivation

To improve test quality and reduce brittleness when changing test data, this PR updates the `response_not_set_filename` test to derive values (like `content-length`) from the test payload and to use existing constants (like mime types and headers).

## Solution
- Define `file_content` and `size` once at the top of the test to enable reuse for assertions and usage in the `/file` handler
- Replace hard coded header names, with constants from `http::header`
- Replace hard coded MIME string with constant from `mime`
