### PR TITLE
ci: Switch cargo-public-api-crates to cargo-check-external-types

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -61,22 +61,22 @@ jobs:
     - name: cargo hack check
       run: cargo hack check --each-feature --no-dev-deps --all
 
-  cargo-public-api-crates:
+  external-types:
     runs-on: ubuntu-24.04
-    strategy:
-      matrix:
-        crate: [axum, axum-core, axum-extra, axum-macros]
     steps:
     - uses: actions/checkout@v6
-    - uses: dtolnay/rust-toolchain@nightly
+    - uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: nightly-2025-08-06
+    - name: Install cargo-check-external-types
+      uses: taiki-e/cache-cargo-install-action@v2
+      with:
+        tool: cargo-check-external-types@0.3.0
+    - uses: taiki-e/install-action@cargo-hack
     - uses: Swatinem/rust-cache@v2
       with:
         save-if: ${{ github.ref == 'refs/heads/main' }}
-    - name: Install cargo-public-api-crates
-      run: |
-        cargo install --git https://github.com/jplatte/cargo-public-api-crates
-    - name: cargo public-api-crates check
-      run: cargo public-api-crates --manifest-path ${{ matrix.crate }}/Cargo.toml check
+    - run: cargo hack --no-private --exclude axum-macros check-external-types --all-features
 
   test-versions:
     needs: check

--- a/axum-core/Cargo.toml
+++ b/axum-core/Cargo.toml
@@ -11,15 +11,15 @@ readme = "README.md"
 repository = "https://github.com/tokio-rs/axum"
 version = "0.5.5" # remember to bump the version that axum and axum-extra depend on
 
-[package.metadata.cargo-public-api-crates]
-allowed = [
+[package.metadata.cargo_check_external_types]
+allowed_external_types = [
     # not 1.0
-    "futures_core",
-    "tower_layer",
+    "futures_core::*",
+    "tower_layer::*",
     # >=1.0
-    "bytes",
-    "http",
-    "http_body",
+    "bytes::*",
+    "http::*",
+    "http_body::*",
 ]
 
 [package.metadata.cargo-machete]

--- a/axum-extra/Cargo.toml
+++ b/axum-extra/Cargo.toml
@@ -14,26 +14,24 @@ version = "0.12.2"
 [package.metadata.docs.rs]
 all-features = true
 
-[package.metadata.cargo-public-api-crates]
-allowed = [
-    "axum",
-    "axum_core",
-    "axum_macros",
-    "bytes",
-    "cookie",
-    "futures_core",
-    "futures_util",
+[package.metadata.cargo_check_external_types]
+allowed_external_types = [
+    "axum::*",
+    "axum_core::*",
+    "axum_macros::*",
+    "bytes::*",
+    "cookie::*",
+    "futures_core::*",
+    "futures_util::*",
     "headers",
-    "headers_core",
-    "http",
-    "http_body",
-    "pin_project_lite",
-    "prost",
-    "serde_core",
-    "tokio",
-    "tokio_util",
-    "tower_layer",
-    "tower_service",
+    "headers_core::*",
+    "http::*",
+    "http_body::*",
+    "prost::*",
+    "serde_core::*",
+    "tokio::*",
+    "tower_layer::*",
+    "tower_service::*",
 ]
 
 [features]

--- a/axum/Cargo.toml
+++ b/axum/Cargo.toml
@@ -17,26 +17,24 @@ all-features = true
 [package.metadata.playground]
 features = ["http1", "http2", "json", "multipart", "ws"]
 
-[package.metadata.cargo-public-api-crates]
-allowed = [
+[package.metadata.cargo_check_external_types]
+allowed_external_types = [
     # our crates
-    "axum_core",
-    "axum_macros",
+    "axum_core::*",
+    "axum_macros::*",
     # not 1.0
-    "futures_core",
-    "futures_sink",
-    "futures_util",
-    "pin_project_lite",
-    "tower_layer",
-    "tower_service",
+    "futures_core::*",
+    "futures_sink::*",
+    "futures_util::*",
+    "tower_layer::*",
+    "tower_service::*",
     # >=1.0
-    "bytes",
+    "bytes::*",
     "http",
-    "http_body",
-    "serde_core",
-    "tokio",
-    # for the `__private` feature
-    "reqwest",
+    "http::*",
+    "http_body::*",
+    "serde_core::*",
+    "tokio::*",
 ]
 
 [features]

--- a/axum/src/lib.rs
+++ b/axum/src/lib.rs
@@ -455,6 +455,7 @@ pub mod serve;
 
 #[cfg(any(test, feature = "__private"))]
 #[allow(missing_docs, missing_debug_implementations, clippy::print_stdout)]
+#[doc(hidden)]
 pub mod test_helpers;
 
 #[doc(no_inline)]


### PR DESCRIPTION
## Motivation

https://github.com/tower-rs/tower-http/pull/613#issuecomment-3605940637

## Solution

Switches `cargo-public-api-crates` to `cargo-check-external-types`.