### PR TITLE
move imports under the feature

### DIFF
--- a/axum-extra/src/routing/typed.rs
+++ b/axum-extra/src/routing/typed.rs
@@ -384,12 +384,7 @@ impl_second_element_is!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, 
 
 #[cfg(test)]
 mod tests {
-    use crate::routing::{RouterExt, TypedPath};
-    use axum::{
-        extract::rejection::PathRejection,
-        response::{IntoResponse, Response},
-        Router,
-    };
+    use crate::routing::TypedPath;
     use serde::{Deserialize, Serialize};
 
     #[derive(TypedPath, Deserialize)]
@@ -441,6 +436,12 @@ mod tests {
     #[cfg(feature = "with-rejection")]
     #[allow(dead_code)] // just needs to compile
     fn supports_with_rejection() {
+        use crate::routing::RouterExt;
+        use axum::{
+            extract::rejection::PathRejection,
+            response::{IntoResponse, Response},
+            Router,
+        };
         async fn handler(_: crate::extract::WithRejection<UsersShow, MyRejection>) {}
 
         struct MyRejection {}


### PR DESCRIPTION
Fix the warnings.
Move the imports under the feature they're being used.
