### PR TITLE
chore: Remove shuttle from docs

### DIFF
--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -43,7 +43,6 @@ If your project isn't listed here and you would like it to be, please feel free 
 - [axum-prometheus](https://github.com/ptrskay3/axum-prometheus): A middleware library to collect HTTP metrics for axum applications, compatible with all [metrics.rs](https://metrics.rs) exporters.
 - [axum-valid](https://github.com/gengteng/axum-valid): Extractors for data validation using validator, garde, and validify.
 - [tower-sessions](https://github.com/maxcountryman/tower-sessions): Sessions as a `tower` and `axum` middleware.
-- [shuttle](https://github.com/shuttle-hq/shuttle): Build & ship backends without writing any infrastructure files. Now with axum support.
 - [socketioxide](https://github.com/totodore/socketioxide): An easy to use socket.io server implementation working as a `tower` layer/service.
 - [axum-serde](https://github.com/gengteng/axum-serde): Provides multiple serde-based extractors / responses, also offers a macro to easily customize serde-based extractors / responses.
 - [loco.rs](https://github.com/loco-rs/loco): A full stack Web and API productivity framework similar to Rails, based on axum.
@@ -122,7 +121,6 @@ If your project isn't listed here and you would like it to be, please feel free 
 - [Using Rust, Axum, PostgreSQL, and Tokio to build a Blog]
 - [Introduction to axum]: YouTube playlist
 - [Rust Axum Full Course]: YouTube video
-- [Deploying Axum projects with Shuttle]
 - [API Development with Rust](https://rust-api.dev/docs/front-matter/preface/): REST APIs based on axum
 - [axum-rest-api-postgres-redis-jwt-docker]: Getting started with REST API Web Services in Rust using Axum, PostgreSQL, Redis, and JWT
 


### PR DESCRIPTION
Hi, unfortunately Shuttle is stopping their deployment platform which means any guides written with a Shuttle deployment in mind are mostly pointless to have now (hence me opening this PR).

Context: https://docs.shuttle.dev/docs/shuttle-shutdown

## Motivation
Motivation is as above. 

## Solution
Just deleting the required links.

I am hoping to salvage most if not all of the articles I wrote for them and re-purpose them somehow, but not really sure where since there are other, better guides now. Probably. People are also using LLMs to get their answers which means that nobody's really reading them anymore.