### PR TITLE
Release axum v0.8.8 and axum-extra v0.12.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,7 +109,7 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "axum"
-version = "0.8.7"
+version = "0.8.8"
 dependencies = [
  "anyhow",
  "axum-core",
@@ -181,7 +181,7 @@ dependencies = [
 
 [[package]]
 name = "axum-extra"
-version = "0.12.2"
+version = "0.12.3"
 dependencies = [
  "axum",
  "axum-core",

--- a/axum-extra/CHANGELOG.md
+++ b/axum-extra/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog],
 and this project adheres to [Semantic Versioning].
 
+# 0.12.3
+
+- **changed:** Make the `typed-routing` feature enable the `routing` feature ([#3514])
+- **changed:** Add trailing newline to `ErasedJson::pretty` response bodies ([#3526])
+- **fixed:** Fix integer underflow in `FileStream::try_range_response` for empty files ([#3566])
+
+[#3514]: https://github.com/tokio-rs/axum/pull/3514
+[#3526]: https://github.com/tokio-rs/axum/pull/3526
+[#3566]: https://github.com/tokio-rs/axum/pull/3566
+
 # 0.12.2
 
 - Make it easier to visually scan for default features ([#3550])

--- a/axum-extra/Cargo.toml
+++ b/axum-extra/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 name = "axum-extra"
 readme = "README.md"
 repository = "https://github.com/tokio-rs/axum"
-version = "0.12.2"
+version = "0.12.3"
 
 [package.metadata.docs.rs]
 all-features = true
@@ -113,7 +113,7 @@ tower-layer = "0.3"
 tower-service = "0.3"
 
 # optional dependencies
-axum = { path = "../axum", version = "0.8.7", default-features = false, optional = true }
+axum = { path = "../axum", version = "0.8.8", default-features = false, optional = true }
 axum-macros = { path = "../axum-macros", version = "0.5.0", optional = true }
 cookie = { package = "cookie", version = "0.18.0", features = ["percent-encode"], optional = true }
 fastrand = { version = "2.1.0", optional = true }

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -21,6 +21,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#3478]: https://github.com/tokio-rs/axum/pull/3478
 [#3489]: https://github.com/tokio-rs/axum/pull/3489
 
+# 0.8.8
+
+- Clarify documentation for `Router::route_layer` ([#3567])
+
+[#3567]: https://github.com/tokio-rs/axum/pull/3567
+
 # 0.8.7
 
 - Relax implicit `Send` / `Sync` bounds on `RouterAsService`, `RouterIntoService` ([#3555])

--- a/axum/Cargo.toml
+++ b/axum/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axum"
-version = "0.8.7" # remember to bump the version that axum-extra depends on
+version = "0.8.8" # remember to bump the version that axum-extra depends on
 categories = ["asynchronous", "network-programming", "web-programming::http-server"]
 description = "Web framework that focuses on ergonomics and modularity"
 edition = "2021"


### PR DESCRIPTION
# axum 0.8.8

- Clarify documentation for `Router::route_layer` ([#3567])

[#3567]: https://github.com/tokio-rs/axum/pull/3567

# 0.12.3

- **changed:** Make the `typed-routing` feature enable the `routing` feature ([#3514])
- **changed:** Add trailing newline to `ErasedJson::pretty` response bodies ([#3526])
- **fixed:** Fix integer underflow in `FileStream::try_range_response` for empty files ([#3566])

[#3514]: https://github.com/tokio-rs/axum/pull/3514
[#3526]: https://github.com/tokio-rs/axum/pull/3526
[#3566]: https://github.com/tokio-rs/axum/pull/3566

Full Diff: https://github.com/tokio-rs/axum/compare/axum-v0.8.7...d07863f97d2649c414d2cdd162d1a10750e29a25

Closes #3580.