### PR TITLE
examples: Update to metrics-exporter-prometheus 0.18

### DIFF
--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -2863,9 +2863,9 @@ dependencies = [
 
 [[package]]
 name = "metrics-exporter-prometheus"
-version = "0.17.2"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b166dea96003ee2531cf14833efedced545751d800f03535801d833313f8c15"
+checksum = "3589659543c04c7dc5526ec858591015b87cd8746583b51b48ef4353f99dbcda"
 dependencies = [
  "base64 0.22.1",
  "indexmap",

--- a/examples/prometheus-metrics/Cargo.toml
+++ b/examples/prometheus-metrics/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 axum = { path = "../../axum" }
 metrics = { version = "0.24", default-features = false }
-metrics-exporter-prometheus = { version = "0.17", default-features = false }
+metrics-exporter-prometheus = { version = "0.18", default-features = false }
 tokio = { version = "1.0", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }


### PR DESCRIPTION
Updates to `metrics-exporter-prometheus` 0.18.