### PR TITLE
fix(json-lines): respect default body limit

### DIFF
--- a/axum-extra/CHANGELOG.md
+++ b/axum-extra/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+- **fixed:** `JsonLines` now correctly respects the default body limit ([#3591])
+
+[#3591]: https://github.com/tokio-rs/axum/pull/3591
+
 # Changelog
 
 All notable changes to this project will be documented in this file.

--- a/axum-extra/src/json_lines.rs
+++ b/axum-extra/src/json_lines.rs
@@ -4,7 +4,7 @@ use axum_core::{
     body::Body,
     extract::{FromRequest, Request},
     response::{IntoResponse, Response},
-    BoxError,
+    BoxError, RequestExt,
 };
 use bytes::{BufMut, BytesMut};
 use futures_core::{stream::BoxStream, Stream, TryStream};
@@ -109,7 +109,7 @@ where
     async fn from_request(req: Request, _state: &S) -> Result<Self, Self::Rejection> {
         // `Stream::lines` isn't a thing so we have to convert it into an `AsyncRead`
         // so we can call `AsyncRead::lines` and then convert it back to a `Stream`
-        let body = req.into_body();
+        let body = req.into_limited_body();
         let stream = body.into_data_stream();
         let stream = stream.map_err(io::Error::other);
         let read = StreamReader::new(stream);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation

Fixes #3584 

As mentioned there all the other extractors use the body limit.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

Use `into_limited_body()` instead of `into_body()`

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
