### PR TITLE
Release axum-core v0.5.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,7 +158,7 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "axum",
  "axum-extra",

--- a/axum-core/CHANGELOG.md
+++ b/axum-core/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# 0.5.6
+
+Improve error messages with `#[diagnostic::do_not_recommend]`.
+
 # 0.5.5
 
 Released without changes to fix docs.rs build.

--- a/axum-core/Cargo.toml
+++ b/axum-core/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 name = "axum-core"
 readme = "README.md"
 repository = "https://github.com/tokio-rs/axum"
-version = "0.5.5" # remember to bump the version that axum and axum-extra depend on
+version = "0.5.6" # remember to bump the version that axum and axum-extra depend on
 
 [package.metadata.cargo_check_external_types]
 allowed_external_types = [

--- a/axum-extra/Cargo.toml
+++ b/axum-extra/Cargo.toml
@@ -100,7 +100,7 @@ with-rejection = ["dep:axum"]
 __private_docs = ["axum/json", "axum/query", "dep:serde", "dep:tower"]
 
 [dependencies]
-axum-core = { path = "../axum-core", version = "0.5.5" }
+axum-core = { path = "../axum-core", version = "0.5.6" }
 bytes = "1.1.0"
 futures-core = "0.3"
 futures-util = { version = "0.3", default-features = false, features = ["alloc"] }

--- a/axum/Cargo.toml
+++ b/axum/Cargo.toml
@@ -92,7 +92,7 @@ __private_docs = [
 __private = ["tokio", "http1", "dep:reqwest"]
 
 [dependencies]
-axum-core = { path = "../axum-core", version = "0.5.5" }
+axum-core = { path = "../axum-core", version = "0.5.6" }
 bytes = "1.7"
 futures-core = "0.3"
 futures-util = { version = "0.3", default-features = false, features = ["alloc"] }


### PR DESCRIPTION
There's been a small diagnostics improvement. Because `axum-core` hasn't had any breaking changes, this is not part of the `v0.8.x` branch like other recent releases.

The improved error messages were also part of one of the other crates, but that one I'll release separately (probably after #3595).