### PR TITLE
Add customizable WebSocket subprotocol selection

### DIFF
--- a/axum/src/extract/ws.rs
+++ b/axum/src/extract/ws.rs
@@ -265,14 +265,16 @@ impl<F> WebSocketUpgrade<F> {
         self
     }
 
-    /// Return the WebSocket subprotocols requested by the client as an iterator of &str.
+    /// Return the WebSocket subprotocols requested by the client.
     ///
     /// # Examples
     ///
     /// If the client sends the following HTTP header in the WebSocket upgrade request:
+    ///
     /// ```txt
     /// Sec-WebSocket-Protocol: soap, wamp
     /// ```
+    ///
     /// this method returns an iterator yielding `"soap"` and `"wamp"`.
     pub fn requested_protocols(&self) -> impl Iterator<Item = &str> {
         self.sec_websocket_protocol


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->
Token-encoded subprotocol is a common practice for authentication in websocket, and though not a standard usage, it is even used by [kubernetes,](https://github.com/kubernetes/kubernetes/commit/714f97d7baf4975ad3aa47735a868a81a984d1f0)

However, current implementation of axum does not support read such ws subprotocol.

## Solution
This adds a getter for the Sec-WebSocket-Protocol requested by the
client and a setter for the chosen subprotocol.

This enables more flexible selection logic (e.g. Token-encoded subprotocols or runtime selection) and avoids unnecessary allocations present in the existing protocols() helper.

And,  in the use case of [k8s](https://github.com/kubernetes/kubernetes/commit/714f97d7baf4975ad3aa47735a868a81a984d1f0), where the client init the ws connection as:

```js
var ws = new WebSocket(
  "wss://<server>/api/v1/namespaces/myns/pods/mypod/logs?follow=true",
  [
    "base64url.bearer.authorization.k8s.io.bXl0b2tlbg",
    "base64.binary.k8s.io"
  ]
);
```

 example usage could be:
```rust
async fn ws_handler(
    mut ws: WebSocketUpgrade,
    ConnectInfo(addr): ConnectInfo<SocketAddr>,
) -> impl IntoResponse {
    let token = ws
        .requested_protocols()
        .find_map(|protocol| protocol.strip_prefix("base64url.bearer.authorization.k8s.io."));

    if token.is_some_and(|token| token == "bXl0b2tl3bg") {
        ws.set_selected_protocol(HeaderValue::from_static("base64.binary.k8s.io"));
        ws.on_upgrade(move |socket| handle_socket(socket, addr))
    } else {
        // Reject the connection
        (axum::http::StatusCode::UNAUTHORIZED, "Unauthorized").into_response()
    }
}
```

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
