### PR TITLE
Merge branch 'v0.8.x', again

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -181,7 +181,7 @@ dependencies = [
 
 [[package]]
 name = "axum-extra"
-version = "0.12.3"
+version = "0.12.5"
 dependencies = [
  "axum",
  "axum-core",

--- a/axum-extra/CHANGELOG.md
+++ b/axum-extra/CHANGELOG.md
@@ -1,15 +1,15 @@
-# Unreleased
-
-- **fixed:** `JsonLines` now correctly respects the default body limit ([#3591])
-
-[#3591]: https://github.com/tokio-rs/axum/pull/3591
-
 # Changelog
 
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog],
 and this project adheres to [Semantic Versioning].
+
+# 0.12.5
+
+- **fixed:** `JsonLines` now correctly respects the default body limit ([#3591])
+
+[#3591]: https://github.com/tokio-rs/axum/pull/3591
 
 # 0.12.4
 

--- a/axum-extra/Cargo.toml
+++ b/axum-extra/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 name = "axum-extra"
 readme = "README.md"
 repository = "https://github.com/tokio-rs/axum"
-version = "0.12.4"
+version = "0.12.5"
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
I forgot to release https://github.com/tokio-rs/axum/pull/3591 in axum-extra 0.12.4, so I made another release 0.12.5.