### PR TITLE
Fix return types of serve futures

### DIFF
--- a/axum-macros/src/lib.rs
+++ b/axum-macros/src/lib.rs
@@ -438,7 +438,7 @@ pub fn derive_from_request_parts(item: TokenStream) -> TokenStream {
 ///     let app = Router::new().route("/", get(handler));
 ///
 ///     let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await.unwrap();
-///     axum::serve(listener, app).await.unwrap();
+///     axum::serve(listener, app).await;
 /// }
 ///
 /// fn handler() -> &'static str {
@@ -458,7 +458,7 @@ pub fn derive_from_request_parts(item: TokenStream) -> TokenStream {
 /// #     let app = Router::new().route("/", get(handler));
 /// #
 /// #     let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await.unwrap();
-/// #     axum::serve(listener, app).await.unwrap();
+/// #     axum::serve(listener, app).await;
 /// # }
 /// #
 /// #[debug_handler]
@@ -485,7 +485,7 @@ pub fn derive_from_request_parts(item: TokenStream) -> TokenStream {
 ///     let app = Router::new().route("/", get(handler));
 ///
 ///     let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await.unwrap();
-///     axum::serve(listener, app).await.unwrap();
+///     axum::serve(listener, app).await;
 /// }
 ///
 /// #[debug_handler]
@@ -607,7 +607,7 @@ pub fn debug_handler(_attr: TokenStream, input: TokenStream) -> TokenStream {
 ///         .layer(middleware::from_fn(my_middleware));
 ///
 ///     let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await.unwrap();
-///     axum::serve(listener, app).await.unwrap();
+///     axum::serve(listener, app).await;
 /// }
 ///
 /// // if this wasn't a valid middleware function #[debug_middleware] would

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **breaking:** `#[from_request(via(Extractor))]` now uses the extractor's
   rejection type instead of `axum::response::Response` ([#3261])
 - **breaking:** `axum::serve` now applies hyper's default `header_read_timeout` ([#3478])
+- **breaking:** `axum::serve` future output type has been adjusted to remove `io::Result`
+  (never returned `Err`) and be an uninhabited type if `with_graceful_shutdown` is not used
+  (because it was already never terminating if that method wasn't used) ([#3601])
 - **added:** New `ListenerExt::limit_connections` allows limiting concurrent `axum::serve` connections ([#3489])
 - **changed:** `serve` has an additional generic argument and can now work with any response body
   type, not just `axum::body::Body` ([#3205])
@@ -19,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#3261]: https://github.com/tokio-rs/axum/pull/3261
 [#3205]: https://github.com/tokio-rs/axum/pull/3205
 [#3478]: https://github.com/tokio-rs/axum/pull/3478
+[#3601]: https://github.com/tokio-rs/axum/pull/3601
 [#3489]: https://github.com/tokio-rs/axum/pull/3489
 
 # 0.8.8

--- a/axum/README.md
+++ b/axum/README.md
@@ -54,7 +54,7 @@ async fn main() {
 
     // run our app with hyper, listening globally on port 3000
     let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await.unwrap();
-    axum::serve(listener, app).await.unwrap();
+    axum::serve(listener, app).await;
 }
 
 // basic handler that responds with a static string

--- a/axum/benches/benches.rs
+++ b/axum/benches/benches.rs
@@ -163,9 +163,9 @@ impl BenchmarkBuilder {
             .unwrap();
         let addr = listener.local_addr().unwrap();
 
+        #[allow(unreachable_code)] // buggy lint, fixed in nightly
         std::thread::spawn(move || {
-            rt.block_on(axum::serve(listener, app).into_future())
-                .unwrap();
+            rt.block_on(axum::serve(listener, app).into_future());
         });
 
         let mut cmd = Command::new("rewrk");

--- a/axum/src/docs/middleware.md
+++ b/axum/src/docs/middleware.md
@@ -557,7 +557,7 @@ let app_with_middleware = middleware.layer(app);
 
 # async {
 let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await.unwrap();
-axum::serve(listener, app_with_middleware.into_make_service()).await.unwrap();
+axum::serve(listener, app_with_middleware.into_make_service()).await;
 # };
 ```
 

--- a/axum/src/docs/routing/fallback.md
+++ b/axum/src/docs/routing/fallback.md
@@ -43,7 +43,7 @@ let app = Router::new().fallback(handler);
 
 # async {
 let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await.unwrap();
-axum::serve(listener, app).await.unwrap();
+axum::serve(listener, app).await;
 # };
 ```
 
@@ -56,6 +56,6 @@ async fn handler() {}
 
 # async {
 let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await.unwrap();
-axum::serve(listener, handler.into_make_service()).await.unwrap();
+axum::serve(listener, handler.into_make_service()).await;
 # };
 ```

--- a/axum/src/docs/routing/into_make_service_with_connect_info.md
+++ b/axum/src/docs/routing/into_make_service_with_connect_info.md
@@ -22,7 +22,7 @@ async fn handler(ConnectInfo(addr): ConnectInfo<SocketAddr>) -> String {
 
 # async {
 let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await.unwrap();
-axum::serve(listener, app.into_make_service_with_connect_info::<SocketAddr>()).await.unwrap();
+axum::serve(listener, app.into_make_service_with_connect_info::<SocketAddr>()).await;
 # };
 ```
 
@@ -60,7 +60,7 @@ impl Connected<IncomingStream<'_, TcpListener>> for MyConnectInfo {
 
 # async {
 let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await.unwrap();
-axum::serve(listener, app.into_make_service_with_connect_info::<MyConnectInfo>()).await.unwrap();
+axum::serve(listener, app.into_make_service_with_connect_info::<MyConnectInfo>()).await;
 # };
 ```
 

--- a/axum/src/docs/routing/method_not_allowed_fallback.md
+++ b/axum/src/docs/routing/method_not_allowed_fallback.md
@@ -27,7 +27,7 @@ async fn main() {
 
     let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await.unwrap();
 
-    axum::serve(listener, router).await.unwrap();
+    axum::serve(listener, router).await;
 }
 ```
 

--- a/axum/src/docs/routing/with_state.md
+++ b/axum/src/docs/routing/with_state.md
@@ -15,7 +15,7 @@ let routes = Router::new()
 
 # async {
 let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await.unwrap();
-axum::serve(listener, routes).await.unwrap();
+axum::serve(listener, routes).await;
 # };
 ```
 
@@ -41,7 +41,7 @@ let routes = routes().with_state(AppState {});
 
 # async {
 let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await.unwrap();
-axum::serve(listener, routes).await.unwrap();
+axum::serve(listener, routes).await;
 # };
 ```
 
@@ -64,7 +64,7 @@ let routes = routes(AppState {});
 
 # async {
 let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await.unwrap();
-axum::serve(listener, routes).await.unwrap();
+axum::serve(listener, routes).await;
 # };
 ```
 
@@ -91,7 +91,7 @@ let routes = Router::new().nest("/api", routes(AppState {}));
 
 # async {
 let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await.unwrap();
-axum::serve(listener, routes).await.unwrap();
+axum::serve(listener, routes).await;
 # };
 ```
 
@@ -124,7 +124,7 @@ let router: Router<()> = router.with_state(AppState {});
 // because it is still missing an `AppState`.
 # async {
 let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await.unwrap();
-axum::serve(listener, router).await.unwrap();
+axum::serve(listener, router).await;
 # };
 ```
 
@@ -153,7 +153,7 @@ let final_router: Router<()> = string_router.with_state("foo".to_owned());
 // Since we have a `Router<()>` we can run it.
 # async {
 let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await.unwrap();
-axum::serve(listener, final_router).await.unwrap();
+axum::serve(listener, final_router).await;
 # };
 ```
 
@@ -179,7 +179,7 @@ let app = routes(AppState {});
 // but `app` is a `Router<AppState>`
 # async {
 let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await.unwrap();
-axum::serve(listener, app).await.unwrap();
+axum::serve(listener, app).await;
 # };
 ```
 
@@ -202,7 +202,7 @@ let app = routes(AppState {});
 // We can now call `Router::into_make_service`
 # async {
 let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await.unwrap();
-axum::serve(listener, app).await.unwrap();
+axum::serve(listener, app).await;
 # };
 ```
 

--- a/axum/src/extract/connect_info.rs
+++ b/axum/src/extract/connect_info.rs
@@ -321,8 +321,7 @@ mod tests {
                 listener,
                 app.into_make_service_with_connect_info::<SocketAddr>(),
             )
-            .await
-            .unwrap();
+            .await;
         });
         rx.await.unwrap();
 
@@ -363,8 +362,7 @@ mod tests {
                 listener,
                 app.into_make_service_with_connect_info::<MyConnectInfo>(),
             )
-            .await
-            .unwrap();
+            .await;
         });
         rx.await.unwrap();
 
@@ -410,8 +408,7 @@ mod tests {
                 listener,
                 app.into_make_service_with_connect_info::<SocketAddr>(),
             )
-            .await
-            .unwrap();
+            .await;
         });
 
         let client = reqwest::Client::new();

--- a/axum/src/extract/state.rs
+++ b/axum/src/extract/state.rs
@@ -157,7 +157,7 @@ use std::{
 ///
 /// # async {
 /// let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await.unwrap();
-/// axum::serve(listener, handler_with_state.into_make_service()).await.unwrap();
+/// axum::serve(listener, handler_with_state.into_make_service()).await;
 /// # };
 /// ```
 ///

--- a/axum/src/handler/service.rs
+++ b/axum/src/handler/service.rs
@@ -55,7 +55,7 @@ impl<H, T, S> HandlerService<H, T, S> {
     ///
     /// # async {
     /// let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await.unwrap();
-    /// axum::serve(listener, app.into_make_service()).await.unwrap();
+    /// axum::serve(listener, app.into_make_service()).await;
     /// # };
     /// ```
     ///
@@ -94,7 +94,7 @@ impl<H, T, S> HandlerService<H, T, S> {
     /// axum::serve(
     ///     listener,
     ///     app.into_make_service_with_connect_info::<SocketAddr>(),
-    /// ).await.unwrap();
+    /// ).await;
     /// # };
     /// ```
     ///

--- a/axum/src/lib.rs
+++ b/axum/src/lib.rs
@@ -37,7 +37,7 @@
 //!
 //!     // run our app with hyper, listening globally on port 3000
 //!     let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await.unwrap();
-//!     axum::serve(listener, app).await.unwrap();
+//!     axum::serve(listener, app).await;
 //! }
 //! ```
 //!

--- a/axum/src/routing/method_routing.rs
+++ b/axum/src/routing/method_routing.rs
@@ -697,7 +697,7 @@ impl MethodRouter<(), Infallible> {
     ///
     /// # async {
     /// let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await.unwrap();
-    /// axum::serve(listener, router.into_make_service()).await.unwrap();
+    /// axum::serve(listener, router.into_make_service()).await;
     /// # };
     /// ```
     ///
@@ -729,7 +729,7 @@ impl MethodRouter<(), Infallible> {
     ///
     /// # async {
     /// let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await.unwrap();
-    /// axum::serve(listener, router.into_make_service()).await.unwrap();
+    /// axum::serve(listener, router.into_make_service()).await;
     /// # };
     /// ```
     ///
@@ -1451,7 +1451,7 @@ mod tests {
         );
 
         let listener = tokio::net::TcpListener::bind("0.0.0.0:0").await.unwrap();
-        crate::serve(listener, app).await.unwrap();
+        crate::serve(listener, app).await;
     }
 
     #[crate::test]

--- a/axum/src/routing/mod.rs
+++ b/axum/src/routing/mod.rs
@@ -532,7 +532,7 @@ impl Router {
     ///
     /// # async {
     /// let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await.unwrap();
-    /// axum::serve(listener, app).await.unwrap();
+    /// axum::serve(listener, app).await;
     /// # };
     /// ```
     ///

--- a/axum/src/serve/listener.rs
+++ b/axum/src/serve/listener.rs
@@ -110,7 +110,7 @@ pub trait ListenerExt: Listener + Sized {
     ///             trace!("failed to set TCP_NODELAY on incoming connection: {err:#}");
     ///         }
     ///     });
-    /// axum::serve(listener, router).await.unwrap();
+    /// axum::serve(listener, router).await;
     /// # };
     /// ```
     fn tap_io<F>(self, tap_fn: F) -> TapIo<Self, F>

--- a/axum/src/test_helpers/test_client.rs
+++ b/axum/src/test_helpers/test_client.rs
@@ -21,9 +21,7 @@ where
     println!("Listening on {addr}");
 
     tokio::spawn(async move {
-        serve(listener, Shared::new(svc))
-            .await
-            .expect("server error")
+        serve(listener, Shared::new(svc)).await;
     });
 
     addr

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -313,7 +313,7 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "bytes",
  "futures-core",
@@ -330,7 +330,7 @@ dependencies = [
 
 [[package]]
 name = "axum-extra"
-version = "0.12.3"
+version = "0.12.5"
 dependencies = [
  "axum",
  "axum-core",
@@ -4059,9 +4059,9 @@ dependencies = [
 
 [[package]]
 name = "serde_html_form"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a055051604d997ae4ddff53663d390c15e96adc3720f54d43d18a7fd944cc79"
+checksum = "2acf96b1d9364968fce46ebb548f1c0e1d7eceae27bdff73865d42e6c7369d94"
 dependencies = [
  "form_urlencoded",
  "indexmap",

--- a/examples/anyhow-error-response/src/main.rs
+++ b/examples/anyhow-error-response/src/main.rs
@@ -19,7 +19,7 @@ async fn main() {
         .await
         .unwrap();
     println!("listening on {}", listener.local_addr().unwrap());
-    axum::serve(listener, app).await.unwrap();
+    axum::serve(listener, app).await;
 }
 
 async fn handler() -> Result<(), AppError> {

--- a/examples/auto-reload/src/main.rs
+++ b/examples/auto-reload/src/main.rs
@@ -26,7 +26,7 @@ async fn main() {
 
     // run it
     println!("listening on {}", listener.local_addr().unwrap());
-    axum::serve(listener, app).await.unwrap();
+    axum::serve(listener, app).await;
 }
 
 async fn handler() -> Html<&'static str> {

--- a/examples/chat/src/main.rs
+++ b/examples/chat/src/main.rs
@@ -56,7 +56,7 @@ async fn main() {
         .await
         .unwrap();
     tracing::debug!("listening on {}", listener.local_addr().unwrap());
-    axum::serve(listener, app).await.unwrap();
+    axum::serve(listener, app).await;
 }
 
 async fn websocket_handler(

--- a/examples/compression/src/main.rs
+++ b/examples/compression/src/main.rs
@@ -23,7 +23,7 @@ async fn main() {
         .await
         .unwrap();
     tracing::debug!("listening on {}", listener.local_addr().unwrap());
-    axum::serve(listener, app).await.unwrap();
+    axum::serve(listener, app).await;
 }
 
 fn app() -> Router {

--- a/examples/consume-body-in-extractor-or-middleware/src/main.rs
+++ b/examples/consume-body-in-extractor-or-middleware/src/main.rs
@@ -34,7 +34,7 @@ async fn main() {
         .await
         .unwrap();
     tracing::debug!("listening on {}", listener.local_addr().unwrap());
-    axum::serve(listener, app).await.unwrap();
+    axum::serve(listener, app).await;
 }
 
 // middleware that shows how to consume the request body upfront

--- a/examples/cors/src/main.rs
+++ b/examples/cors/src/main.rs
@@ -41,7 +41,7 @@ async fn main() {
 async fn serve(app: Router, port: u16) {
     let addr = SocketAddr::from(([127, 0, 0, 1], port));
     let listener = tokio::net::TcpListener::bind(addr).await.unwrap();
-    axum::serve(listener, app).await.unwrap();
+    axum::serve(listener, app).await;
 }
 
 async fn html() -> impl IntoResponse {

--- a/examples/customize-extractor-error/src/main.rs
+++ b/examples/customize-extractor-error/src/main.rs
@@ -32,5 +32,5 @@ async fn main() {
         .await
         .unwrap();
     tracing::debug!("listening on {}", listener.local_addr().unwrap());
-    axum::serve(listener, app).await.unwrap();
+    axum::serve(listener, app).await;
 }

--- a/examples/customize-path-rejection/src/main.rs
+++ b/examples/customize-path-rejection/src/main.rs
@@ -32,7 +32,7 @@ async fn main() {
         .await
         .unwrap();
     tracing::debug!("listening on {}", listener.local_addr().unwrap());
-    axum::serve(listener, app).await.unwrap();
+    axum::serve(listener, app).await;
 }
 
 async fn handler(Path(params): Path<Params>) -> impl IntoResponse {

--- a/examples/dependency-injection/src/main.rs
+++ b/examples/dependency-injection/src/main.rs
@@ -69,7 +69,7 @@ async fn main() {
 
     let listener = TcpListener::bind("127.0.0.1:3000").await.unwrap();
     tracing::debug!("listening on {}", listener.local_addr().unwrap());
-    axum::serve(listener, app).await.unwrap();
+    axum::serve(listener, app).await;
 }
 
 #[derive(Clone)]

--- a/examples/diesel-async-postgres/src/main.rs
+++ b/examples/diesel-async-postgres/src/main.rs
@@ -83,7 +83,7 @@ async fn main() {
     let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
     tracing::debug!("listening on {addr}");
     let listener = tokio::net::TcpListener::bind(addr).await.unwrap();
-    axum::serve(listener, app).await.unwrap();
+    axum::serve(listener, app).await;
 }
 
 async fn create_user(

--- a/examples/diesel-postgres/src/main.rs
+++ b/examples/diesel-postgres/src/main.rs
@@ -86,7 +86,7 @@ async fn main() {
     let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
     tracing::debug!("listening on {addr}");
     let listener = tokio::net::TcpListener::bind(addr).await.unwrap();
-    axum::serve(listener, app).await.unwrap();
+    axum::serve(listener, app).await;
 }
 
 async fn create_user(

--- a/examples/error-handling/src/main.rs
+++ b/examples/error-handling/src/main.rs
@@ -85,7 +85,7 @@ async fn main() {
         .await
         .unwrap();
     tracing::debug!("listening on {}", listener.local_addr().unwrap());
-    axum::serve(listener, app).await.unwrap();
+    axum::serve(listener, app).await;
 }
 
 #[derive(Default, Clone)]

--- a/examples/form/src/main.rs
+++ b/examples/form/src/main.rs
@@ -26,7 +26,7 @@ async fn main() {
         .await
         .unwrap();
     tracing::debug!("listening on {}", listener.local_addr().unwrap());
-    axum::serve(listener, app).await.unwrap();
+    axum::serve(listener, app).await;
 }
 
 fn app() -> Router {

--- a/examples/global-404-handler/src/main.rs
+++ b/examples/global-404-handler/src/main.rs
@@ -33,7 +33,7 @@ async fn main() {
         .await
         .unwrap();
     tracing::debug!("listening on {}", listener.local_addr().unwrap());
-    axum::serve(listener, app).await.unwrap();
+    axum::serve(listener, app).await;
 }
 
 async fn handler() -> Html<&'static str> {

--- a/examples/graceful-shutdown/src/main.rs
+++ b/examples/graceful-shutdown/src/main.rs
@@ -48,8 +48,7 @@ async fn main() {
     // Run the server with graceful shutdown
     axum::serve(listener, app)
         .with_graceful_shutdown(shutdown_signal())
-        .await
-        .unwrap();
+        .await;
 }
 
 async fn shutdown_signal() {

--- a/examples/handle-head-request/src/main.rs
+++ b/examples/handle-head-request/src/main.rs
@@ -17,7 +17,7 @@ async fn main() {
         .await
         .unwrap();
     println!("listening on {}", listener.local_addr().unwrap());
-    axum::serve(listener, app()).await.unwrap();
+    axum::serve(listener, app()).await;
 }
 
 // GET routes will also be called for HEAD requests but will have the response body removed.

--- a/examples/hello-world/src/main.rs
+++ b/examples/hello-world/src/main.rs
@@ -16,7 +16,7 @@ async fn main() {
         .await
         .unwrap();
     println!("listening on {}", listener.local_addr().unwrap());
-    axum::serve(listener, app).await.unwrap();
+    axum::serve(listener, app).await;
 }
 
 async fn handler() -> Html<&'static str> {

--- a/examples/jwt/src/main.rs
+++ b/examples/jwt/src/main.rs
@@ -73,7 +73,7 @@ async fn main() {
         .await
         .unwrap();
     tracing::debug!("listening on {}", listener.local_addr().unwrap());
-    axum::serve(listener, app).await.unwrap();
+    axum::serve(listener, app).await;
 }
 
 async fn protected(claims: Claims) -> Result<String, AuthError> {

--- a/examples/key-value-store/src/main.rs
+++ b/examples/key-value-store/src/main.rs
@@ -78,7 +78,7 @@ async fn main() {
         .await
         .unwrap();
     tracing::debug!("listening on {}", listener.local_addr().unwrap());
-    axum::serve(listener, app).await.unwrap();
+    axum::serve(listener, app).await;
 }
 
 type SharedState = Arc<RwLock<AppState>>;

--- a/examples/mongodb/src/main.rs
+++ b/examples/mongodb/src/main.rs
@@ -50,7 +50,7 @@ async fn main() {
         .await
         .unwrap();
     tracing::debug!("Listening on {}", listener.local_addr().unwrap());
-    axum::serve(listener, app(client)).await.unwrap();
+    axum::serve(listener, app(client)).await;
 }
 
 // defining routes and state

--- a/examples/multipart-form/src/main.rs
+++ b/examples/multipart-form/src/main.rs
@@ -38,7 +38,7 @@ async fn main() {
         .await
         .unwrap();
     tracing::debug!("listening on {}", listener.local_addr().unwrap());
-    axum::serve(listener, app).await.unwrap();
+    axum::serve(listener, app).await;
 }
 
 async fn show_form() -> Html<&'static str> {

--- a/examples/oauth/src/main.rs
+++ b/examples/oauth/src/main.rs
@@ -77,7 +77,7 @@ async fn main() {
             .unwrap()
     );
 
-    axum::serve(listener, app).await.unwrap();
+    axum::serve(listener, app).await;
 }
 
 #[derive(Clone)]

--- a/examples/parse-body-based-on-content-type/src/main.rs
+++ b/examples/parse-body-based-on-content-type/src/main.rs
@@ -33,7 +33,7 @@ async fn main() {
         .await
         .unwrap();
     tracing::debug!("listening on {}", listener.local_addr().unwrap());
-    axum::serve(listener, app).await.unwrap();
+    axum::serve(listener, app).await;
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/examples/print-request-response/src/main.rs
+++ b/examples/print-request-response/src/main.rs
@@ -35,7 +35,7 @@ async fn main() {
         .await
         .unwrap();
     tracing::debug!("listening on {}", listener.local_addr().unwrap());
-    axum::serve(listener, app).await.unwrap();
+    axum::serve(listener, app).await;
 }
 
 async fn print_request_response(

--- a/examples/prometheus-metrics/src/main.rs
+++ b/examples/prometheus-metrics/src/main.rs
@@ -45,7 +45,7 @@ async fn start_main_server() {
         .await
         .unwrap();
     tracing::debug!("listening on {}", listener.local_addr().unwrap());
-    axum::serve(listener, app).await.unwrap();
+    axum::serve(listener, app).await;
 }
 
 async fn start_metrics_server() {
@@ -56,7 +56,7 @@ async fn start_metrics_server() {
         .await
         .unwrap();
     tracing::debug!("listening on {}", listener.local_addr().unwrap());
-    axum::serve(listener, app).await.unwrap();
+    axum::serve(listener, app).await;
 }
 
 #[tokio::main]

--- a/examples/readme/src/main.rs
+++ b/examples/readme/src/main.rs
@@ -29,7 +29,7 @@ async fn main() {
         .await
         .unwrap();
     tracing::debug!("listening on {}", listener.local_addr().unwrap());
-    axum::serve(listener, app).await.unwrap();
+    axum::serve(listener, app).await;
 }
 
 // basic handler that responds with a static string

--- a/examples/request-id/src/main.rs
+++ b/examples/request-id/src/main.rs
@@ -72,7 +72,7 @@ async fn main() {
         .await
         .unwrap();
     println!("listening on {}", listener.local_addr().unwrap());
-    axum::serve(listener, app).await.unwrap();
+    axum::serve(listener, app).await;
 }
 
 async fn handler() -> Html<&'static str> {

--- a/examples/reqwest-response/src/main.rs
+++ b/examples/reqwest-response/src/main.rs
@@ -47,7 +47,7 @@ async fn main() {
         .await
         .unwrap();
     tracing::debug!("listening on {}", listener.local_addr().unwrap());
-    axum::serve(listener, app).await.unwrap();
+    axum::serve(listener, app).await;
 }
 
 async fn stream_reqwest_response(State(client): State<Client>) -> Response {

--- a/examples/reverse-proxy/src/main.rs
+++ b/examples/reverse-proxy/src/main.rs
@@ -34,7 +34,7 @@ async fn main() {
         .await
         .unwrap();
     println!("listening on {}", listener.local_addr().unwrap());
-    axum::serve(listener, app).await.unwrap();
+    axum::serve(listener, app).await;
 }
 
 async fn handler(State(client): State<Client>, mut req: Request) -> Result<Response, StatusCode> {
@@ -63,5 +63,5 @@ async fn server() {
         .await
         .unwrap();
     println!("listening on {}", listener.local_addr().unwrap());
-    axum::serve(listener, app).await.unwrap();
+    axum::serve(listener, app).await;
 }

--- a/examples/routes-and-handlers-close-together/src/main.rs
+++ b/examples/routes-and-handlers-close-together/src/main.rs
@@ -20,7 +20,7 @@ async fn main() {
         .await
         .unwrap();
     println!("listening on {}", listener.local_addr().unwrap());
-    axum::serve(listener, app).await.unwrap();
+    axum::serve(listener, app).await;
 }
 
 fn root() -> Router {

--- a/examples/sqlx-postgres/src/main.rs
+++ b/examples/sqlx-postgres/src/main.rs
@@ -57,7 +57,7 @@ async fn main() {
     // run it with hyper
     let listener = TcpListener::bind("127.0.0.1:3000").await.unwrap();
     tracing::debug!("listening on {}", listener.local_addr().unwrap());
-    axum::serve(listener, app).await.unwrap();
+    axum::serve(listener, app).await;
 }
 
 // we can extract the connection pool with `State`

--- a/examples/sse/src/main.rs
+++ b/examples/sse/src/main.rs
@@ -39,7 +39,7 @@ async fn main() {
         .await
         .unwrap();
     tracing::debug!("listening on {}", listener.local_addr().unwrap());
-    axum::serve(listener, app).await.unwrap();
+    axum::serve(listener, app).await;
 }
 
 fn app() -> Router {
@@ -89,7 +89,7 @@ mod tests {
             // Retrieve the port assigned to us by the OS
             let port = listener.local_addr().unwrap().port();
             tokio::spawn(async {
-                axum::serve(listener, app()).await.unwrap();
+                axum::serve(listener, app()).await;
             });
             // Returns address (e.g. http://127.0.0.1{random_port})
             format!("http://{host}:{port}")

--- a/examples/static-file-server/src/main.rs
+++ b/examples/static-file-server/src/main.rs
@@ -111,7 +111,5 @@ async fn serve(app: Router, port: u16) {
     let addr = SocketAddr::from(([127, 0, 0, 1], port));
     let listener = tokio::net::TcpListener::bind(addr).await.unwrap();
     tracing::debug!("listening on {}", listener.local_addr().unwrap());
-    axum::serve(listener, app.layer(TraceLayer::new_for_http()))
-        .await
-        .unwrap();
+    axum::serve(listener, app.layer(TraceLayer::new_for_http())).await;
 }

--- a/examples/stream-to-file/src/main.rs
+++ b/examples/stream-to-file/src/main.rs
@@ -43,7 +43,7 @@ async fn main() {
         .await
         .unwrap();
     tracing::debug!("listening on {}", listener.local_addr().unwrap());
-    axum::serve(listener, app).await.unwrap();
+    axum::serve(listener, app).await;
 }
 
 // Handler that streams the request body to a file.

--- a/examples/templates-minijinja/src/main.rs
+++ b/examples/templates-minijinja/src/main.rs
@@ -44,7 +44,7 @@ async fn main() {
         .await
         .unwrap();
     println!("listening on {}", listener.local_addr().unwrap());
-    axum::serve(listener, app).await.unwrap();
+    axum::serve(listener, app).await;
 }
 
 async fn handler_home(State(state): State<Arc<AppState>>) -> Result<Html<String>, StatusCode> {

--- a/examples/templates/src/main.rs
+++ b/examples/templates/src/main.rs
@@ -32,7 +32,7 @@ async fn main() {
         .await
         .unwrap();
     tracing::debug!("listening on {}", listener.local_addr().unwrap());
-    axum::serve(listener, app).await.unwrap();
+    axum::serve(listener, app).await;
 }
 
 fn app() -> Router {

--- a/examples/testing-websockets/src/main.rs
+++ b/examples/testing-websockets/src/main.rs
@@ -21,7 +21,7 @@ async fn main() {
         .await
         .unwrap();
     println!("listening on {}", listener.local_addr().unwrap());
-    axum::serve(listener, app()).await.unwrap();
+    axum::serve(listener, app()).await;
 }
 
 fn app() -> Router {

--- a/examples/testing/src/main.rs
+++ b/examples/testing/src/main.rs
@@ -29,7 +29,7 @@ async fn main() {
         .await
         .unwrap();
     tracing::debug!("listening on {}", listener.local_addr().unwrap());
-    axum::serve(listener, app()).await.unwrap();
+    axum::serve(listener, app()).await;
 }
 
 /// Having a function that produces our app makes it easy to call it from tests
@@ -132,7 +132,7 @@ mod tests {
         let addr = listener.local_addr().unwrap();
 
         tokio::spawn(async move {
-            axum::serve(listener, app()).await.unwrap();
+            axum::serve(listener, app()).await;
         });
 
         let client =

--- a/examples/tls-graceful-shutdown/src/main.rs
+++ b/examples/tls-graceful-shutdown/src/main.rs
@@ -133,6 +133,5 @@ where
     tracing::debug!("listening on {addr}");
     axum::serve(listener, redirect.into_make_service())
         .with_graceful_shutdown(signal)
-        .await
-        .unwrap();
+        .await;
 }

--- a/examples/tls-rustls/src/main.rs
+++ b/examples/tls-rustls/src/main.rs
@@ -97,7 +97,5 @@ async fn redirect_http_to_https(ports: Ports) {
     let addr = SocketAddr::from(([127, 0, 0, 1], ports.http));
     let listener = tokio::net::TcpListener::bind(addr).await.unwrap();
     tracing::debug!("listening on {}", listener.local_addr().unwrap());
-    axum::serve(listener, redirect.into_make_service())
-        .await
-        .unwrap();
+    axum::serve(listener, redirect.into_make_service()).await;
 }

--- a/examples/todos/src/main.rs
+++ b/examples/todos/src/main.rs
@@ -72,7 +72,7 @@ async fn main() {
         .await
         .unwrap();
     tracing::debug!("listening on {}", listener.local_addr().unwrap());
-    axum::serve(listener, app).await.unwrap();
+    axum::serve(listener, app).await;
 }
 
 // The query parameters for todos index

--- a/examples/tokio-postgres/src/main.rs
+++ b/examples/tokio-postgres/src/main.rs
@@ -44,7 +44,7 @@ async fn main() {
         .await
         .unwrap();
     tracing::debug!("listening on {}", listener.local_addr().unwrap());
-    axum::serve(listener, app).await.unwrap();
+    axum::serve(listener, app).await;
 }
 
 type ConnectionPool = Pool<PostgresConnectionManager<NoTls>>;

--- a/examples/tokio-redis/src/main.rs
+++ b/examples/tokio-redis/src/main.rs
@@ -49,7 +49,7 @@ async fn main() {
         .await
         .unwrap();
     tracing::debug!("listening on {}", listener.local_addr().unwrap());
-    axum::serve(listener, app).await.unwrap();
+    axum::serve(listener, app).await;
 }
 
 type ConnectionPool = bb8::Pool<redis::Client>;

--- a/examples/tracing-aka-logging/src/main.rs
+++ b/examples/tracing-aka-logging/src/main.rs
@@ -87,7 +87,7 @@ async fn main() {
     // run it
     let listener = TcpListener::bind("127.0.0.1:3000").await.unwrap();
     tracing::debug!("listening on {}", listener.local_addr().unwrap());
-    axum::serve(listener, app).await.unwrap();
+    axum::serve(listener, app).await;
 }
 
 async fn handler() -> Html<&'static str> {

--- a/examples/unix-domain-socket/src/main.rs
+++ b/examples/unix-domain-socket/src/main.rs
@@ -52,7 +52,7 @@ mod unix {
                 .route("/", get(handler))
                 .into_make_service_with_connect_info::<UdsConnectInfo>();
 
-            axum::serve(uds, app).await.unwrap();
+            axum::serve(uds, app).await;
         });
 
         let stream = TokioIo::new(UnixStream::connect(path).await.unwrap());

--- a/examples/validator/src/main.rs
+++ b/examples/validator/src/main.rs
@@ -39,7 +39,7 @@ async fn main() {
     // run it
     let listener = TcpListener::bind("127.0.0.1:3000").await.unwrap();
     tracing::debug!("listening on {}", listener.local_addr().unwrap());
-    axum::serve(listener, app).await.unwrap();
+    axum::serve(listener, app).await;
 }
 
 fn app() -> Router {

--- a/examples/versioning/src/main.rs
+++ b/examples/versioning/src/main.rs
@@ -32,7 +32,7 @@ async fn main() {
         .await
         .unwrap();
     tracing::debug!("listening on {}", listener.local_addr().unwrap());
-    axum::serve(listener, app).await.unwrap();
+    axum::serve(listener, app).await;
 }
 
 fn app() -> Router {

--- a/examples/websockets/src/main.rs
+++ b/examples/websockets/src/main.rs
@@ -73,8 +73,7 @@ async fn main() {
         listener,
         app.into_make_service_with_connect_info::<SocketAddr>(),
     )
-    .await
-    .unwrap();
+    .await;
 }
 
 /// The handler for the HTTP request (this gets called when the HTTP request lands at the start


### PR DESCRIPTION
Closes #3164.

I used `Infallible` for the output type of `Serve` (instead of a custom never type or hacks to name the real `!`). It should become equivalent to `!` down the line.