### PR TITLE
Add recommended settings for VSCode

### DIFF
--- a/contrib/ide/vscode/settings.json
+++ b/contrib/ide/vscode/settings.json
@@ -1,0 +1,9 @@
+// Recommended settings for VSCode.
+//
+// Copy to `.vscode/settings.json` at the crate root too use.
+{
+    "rust-analyzer.linkedProjects": [
+        "Cargo.toml",
+        "examples/Cargo.toml"
+    ]
+}


### PR DESCRIPTION
With the new dual-workspace setup, VSCode no longer checks examples by default, which can be very annoying for local development. This adds a recommended settings file that fixes this issue.