### PR TITLE
Fix `IntoResponse` for tuples overriding error response codes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,6 +171,7 @@ dependencies = [
  "hyper",
  "mime",
  "pin-project-lite",
+ "serde",
  "sync_wrapper",
  "tokio",
  "tower-http",

--- a/axum-core/Cargo.toml
+++ b/axum-core/Cargo.toml
@@ -55,6 +55,7 @@ axum = { path = "../axum", features = ["__private"] }
 axum-extra = { path = "../axum-extra", features = ["typed-header"] }
 axum-macros = { path = "../axum-macros", features = ["__private"] }
 hyper = "1.0.0"
+serde = { version = "1.0.200", features = ["derive"] }
 tokio = { version = "1.25.0", features = ["macros"] }
 tower-http = { version = "0.6.0", features = ["limit"] }
 

--- a/axum-core/src/response/into_response.rs
+++ b/axum-core/src/response/into_response.rs
@@ -1,4 +1,4 @@
-use super::{IntoResponseParts, Response, ResponseParts};
+use super::{ForceStatusCode, IntoResponseFailed, IntoResponseParts, Response, ResponseParts};
 use crate::{body::Body, BoxError};
 use bytes::{buf::Chain, Buf, Bytes, BytesMut};
 use http::{
@@ -329,7 +329,9 @@ where
 {
     fn into_response(self) -> Response {
         let mut res = self.1.into_response();
-        *res.status_mut() = self.0;
+        if res.extensions().get::<IntoResponseFailed>().is_none() {
+            *res.status_mut() = self.0;
+        }
         res
     }
 }
@@ -405,18 +407,16 @@ macro_rules! impl_into_response {
                 let ($($ty),*, res) = self;
 
                 let res = res.into_response();
-                let parts = ResponseParts { res };
-
-                $(
-                    let parts = match $ty.into_response_parts(parts) {
+                if res.extensions().get::<IntoResponseFailed>().is_none() {
+                    let parts = ResponseParts { res };
+                    let parts = match ($($ty,)*).into_response_parts(parts) {
                         Ok(parts) => parts,
-                        Err(err) => {
-                            return err.into_response();
-                        }
+                        Err(err) => return err.into_response(),
                     };
-                )*
-
-                parts.res
+                    parts.res
+                } else {
+                    res
+                }
             }
         }
 
@@ -430,16 +430,40 @@ macro_rules! impl_into_response {
                 let (status, $($ty),*, res) = self;
 
                 let res = res.into_response();
-                let parts = ResponseParts { res };
-
-                $(
-                    let parts = match $ty.into_response_parts(parts) {
+                if res.extensions().get::<IntoResponseFailed>().is_none() {
+                    let parts = ResponseParts { res };
+                    let mut parts = match ($($ty,)*).into_response_parts(parts) {
                         Ok(parts) => parts,
-                        Err(err) => {
-                            return err.into_response();
-                        }
+                        Err(err) => return err.into_response(),
                     };
-                )*
+
+                    // Don't call `(status, parts.res).into_response()` since that checks for
+                    // `IntoResponseFailed` and skips setting the status. We've already done that
+                    // check here so overriding the status is required if returning
+                    // `(IntoResponseFailed, StatusCode::INTERNAL_SERVER_ERROR)`
+                    *parts.res.status_mut() = status;
+                    parts.res
+                } else {
+                    res
+                }
+            }
+        }
+
+        #[allow(non_snake_case)]
+        impl<R, $($ty,)*> IntoResponse for (ForceStatusCode, $($ty),*, R)
+        where
+            $( $ty: IntoResponseParts, )*
+            R: IntoResponse,
+        {
+            fn into_response(self) -> Response {
+                let (status, $($ty),*, res) = self;
+
+                let res = res.into_response();
+                let parts = ResponseParts { res };
+                let parts = match ($($ty,)*).into_response_parts(parts) {
+                    Ok(parts) => parts,
+                    Err(err) => return err.into_response(),
+                };
 
                 (status, parts.res).into_response()
             }
@@ -455,17 +479,22 @@ macro_rules! impl_into_response {
                 let (outer_parts, $($ty),*, res) = self;
 
                 let res = res.into_response();
-                let parts = ResponseParts { res };
-                $(
-                    let parts = match $ty.into_response_parts(parts) {
+                if res.extensions().get::<IntoResponseFailed>().is_none() {
+                    let parts = ResponseParts { res };
+                    let mut parts = match ($($ty,)*).into_response_parts(parts) {
                         Ok(parts) => parts,
-                        Err(err) => {
-                            return err.into_response();
-                        }
+                        Err(err) => return err.into_response(),
                     };
-                )*
 
-                (outer_parts, parts.res).into_response()
+                    // Don't call `(outer_parts, parts.res).into_response()` for the same reason we
+                    // don't call `(status, parts.res).into_response()` in the above impl.
+                    *parts.res.status_mut() = outer_parts.status;
+                    parts.res.headers_mut().extend(outer_parts.headers);
+                    parts.res.extensions_mut().extend(outer_parts.extensions);
+                    parts.res
+                } else {
+                    res
+                }
             }
         }
 

--- a/axum-extra/src/protobuf.rs
+++ b/axum-extra/src/protobuf.rs
@@ -4,7 +4,7 @@ use axum_core::__composite_rejection as composite_rejection;
 use axum_core::__define_rejection as define_rejection;
 use axum_core::{
     extract::{rejection::BytesRejection, FromRequest, Request},
-    response::{IntoResponse, Response},
+    response::{IntoResponse, IntoResponseFailed, Response},
     RequestExt,
 };
 use bytes::BytesMut;
@@ -131,7 +131,12 @@ where
         let mut buf = BytesMut::with_capacity(self.0.encoded_len());
         match &self.0.encode(&mut buf) {
             Ok(()) => buf.into_response(),
-            Err(err) => (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()).into_response(),
+            Err(err) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                IntoResponseFailed,
+                err.to_string(),
+            )
+                .into_response(),
         }
     }
 }

--- a/axum-extra/src/response/erased_json.rs
+++ b/axum-extra/src/response/erased_json.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use axum_core::response::{IntoResponse, Response};
+use axum_core::response::{IntoResponse, IntoResponseFailed, Response};
 use bytes::{BufMut, Bytes, BytesMut};
 use http::{header, HeaderValue, StatusCode};
 use serde_core::Serialize;
@@ -78,7 +78,12 @@ impl IntoResponse for ErasedJson {
                 bytes,
             )
                 .into_response(),
-            Err(err) => (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()).into_response(),
+            Err(err) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                IntoResponseFailed,
+                err.to_string(),
+            )
+                .into_response(),
         }
     }
 }

--- a/axum/src/form.rs
+++ b/axum/src/form.rs
@@ -1,6 +1,6 @@
 use crate::extract::Request;
 use crate::extract::{rejection::*, FromRequest, RawForm};
-use axum_core::response::{IntoResponse, Response};
+use axum_core::response::{IntoResponse, IntoResponseFailed, Response};
 use axum_core::RequestExt;
 use http::header::CONTENT_TYPE;
 use http::StatusCode;
@@ -117,7 +117,12 @@ where
                     body,
                 )
                     .into_response(),
-                Err(err) => (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()).into_response(),
+                Err(err) => (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    IntoResponseFailed,
+                    err.to_string(),
+                )
+                    .into_response(),
             }
         }
 

--- a/axum/src/json.rs
+++ b/axum/src/json.rs
@@ -1,7 +1,7 @@
 use crate::extract::Request;
 use crate::extract::{rejection::*, FromRequest};
 use axum_core::extract::OptionalFromRequest;
-use axum_core::response::{IntoResponse, Response};
+use axum_core::response::{IntoResponse, IntoResponseFailed, Response};
 use bytes::{BufMut, Bytes, BytesMut};
 use http::{
     header::{self, HeaderMap, HeaderValue},
@@ -216,6 +216,7 @@ where
                         header::CONTENT_TYPE,
                         HeaderValue::from_static(mime::TEXT_PLAIN_UTF_8.as_ref()),
                     )],
+                    IntoResponseFailed,
                     err.to_string(),
                 )
                     .into_response(),


### PR DESCRIPTION
Closes #2287.
Continuation of #2468.