### PR TITLE
examples: Reuse reqwest client in oauth example

### DIFF
--- a/examples/oauth/src/main.rs
+++ b/examples/oauth/src/main.rs
@@ -270,15 +270,16 @@ async fn login_authorized(
 ) -> Result<impl IntoResponse, AppError> {
     csrf_token_validation_workflow(&query, &cookies, &store).await?;
 
+    let client = reqwest::Client::new();
+
     // Get an auth token
     let token = oauth_client
         .exchange_code(AuthorizationCode::new(query.code.clone()))
-        .request_async(&reqwest::Client::new())
+        .request_async(&client)
         .await
         .context("failed in sending request request to authorization server")?;
 
     // Fetch user data from discord
-    let client = reqwest::Client::new();
     let user_data: User = client
         // https://discord.com/developers/docs/resources/user#get-current-user
         .get("https://discordapp.com/api/users/@me")


### PR DESCRIPTION
The `reqwest`'s client could be reused in the `oauth` example.