### PR TITLE
Add WebSocketUpgrade::manually_close

### DIFF
--- a/axum/src/extract/ws.rs
+++ b/axum/src/extract/ws.rs
@@ -206,6 +206,12 @@ impl<F> WebSocketUpgrade<F> {
         self
     }
 
+    /// Require manually sending the close frame (defaults to false)
+    pub fn manually_close(mut self, manually_close: bool) -> Self {
+        self.config.manually_close = manually_close;
+        self
+    }
+
     /// Set the known protocols.
     ///
     /// If the protocol name specified by `Sec-WebSocket-Protocol` header


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation

When making an API using WebSockets, I decided I wanted to delay replying to close frames until all tasks being processed are done.

I have provided a [pull request to Tungstenite](https://github.com/snapview/tungstenite-rs/pull/527) and am submitting this one to prepare for if and when that gets accepted and released.

## Solution

Adds a method  `WebSocketUpgrade::manually_close` to set `WebSocketConfig::manually_close` as added in the Tungstenite PR.
