### PR TITLE
Stop calling axum a 'framework'

### DIFF
--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -24,7 +24,7 @@ If your project isn't listed here and you would like it to be, please feel free 
 - [axum-template](https://github.com/Altair-Bueno/axum-template): Layers, extractors and template engine wrappers for axum based Web MVC applications
 - [axum-template](https://github.com/janos-r/axum-template): GraphQL and REST API, SurrealDb, JWT auth, direct error handling, request logs
 - [axum-guard-logic](https://github.com/sjud/axum_guard_logic): Use AND/OR logic to extract types and check their values against `Service` inputs.
-- [axum-casbin-auth](https://github.com/casbin-rs/axum-casbin-auth): Casbin access control middleware for axum framework
+- [axum-casbin-auth](https://github.com/casbin-rs/axum-casbin-auth): Casbin access control middleware for axum
 - [aide](https://docs.rs/aide): Code-first Open API documentation generator with [axum integration](https://docs.rs/aide/latest/aide/axum/index.html).
 - [axum-typed-routing](https://docs.rs/axum-typed-routing/latest/axum_typed_routing/): Statically typed routing macros with OpenAPI generation using aide.
 - [axum-jsonschema](https://docs.rs/axum-jsonschema/): A `Json<T>` extractor that does JSON schema validation of requests.
@@ -115,7 +115,7 @@ If your project isn't listed here and you would like it to be, please feel free 
 
 - [Rust on Nails](https://rust-on-nails.com/): A full stack architecture for Rust web applications
 - [axum-tutorial] ([website][axum-tutorial-website]): axum tutorial for beginners
-- [demo-rust-axum]: Demo of Rust and axum web framework
+- [demo-rust-axum]: Demo of Rust and axum
 - [Introduction to axum (talk)]: Talk about axum from the Copenhagen Rust Meetup
 - [Getting Started with Axum]: axum tutorial, GET, POST endpoints and serving files
 - [Using Rust, Axum, PostgreSQL, and Tokio to build a Blog]

--- a/axum-core/Cargo.toml
+++ b/axum-core/Cargo.toml
@@ -4,7 +4,7 @@ description = "Core types and traits for axum"
 edition = "2021"
 rust-version = { workspace = true }
 homepage = "https://github.com/tokio-rs/axum"
-keywords = ["http", "web", "framework"]
+keywords = ["http", "web", "routing"]
 license = "MIT"
 name = "axum-core"
 readme = "README.md"

--- a/axum-extra/Cargo.toml
+++ b/axum-extra/Cargo.toml
@@ -4,7 +4,7 @@ description = "Extra utilities for axum"
 edition = "2021"
 rust-version = { workspace = true }
 homepage = "https://github.com/tokio-rs/axum"
-keywords = ["http", "web", "framework"]
+keywords = ["http", "web", "routing"]
 license = "MIT"
 name = "axum-extra"
 readme = "README.md"

--- a/axum/Cargo.toml
+++ b/axum/Cargo.toml
@@ -2,11 +2,11 @@
 name = "axum"
 version = "0.8.8" # remember to bump the version that axum-extra depends on
 categories = ["asynchronous", "network-programming", "web-programming::http-server"]
-description = "Web framework that focuses on ergonomics and modularity"
+description = "HTTP routing and request handling library that focuses on ergonomics and modularity"
 edition = "2021"
 rust-version = { workspace = true }
 homepage = "https://github.com/tokio-rs/axum"
-keywords = ["http", "web", "framework"]
+keywords = ["http", "web", "routing"]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/tokio-rs/axum"

--- a/axum/README.md
+++ b/axum/README.md
@@ -1,6 +1,6 @@
 # axum
 
-`axum` is a web application framework that focuses on ergonomics and modularity.
+`axum` is an HTTP routing and request-handling library that focuses on ergonomics and modularity.
 
 [![Build status](https://github.com/tokio-rs/axum/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/tokio-rs/axum/actions/workflows/CI.yml)
 [![Crates.io](https://img.shields.io/crates/v/axum)](https://crates.io/crates/axum)
@@ -17,7 +17,7 @@ More information about this crate can be found in the [crate documentation][docs
 - Take full advantage of the [`tower`] and [`tower-http`] ecosystem of
   middleware, services, and utilities.
 
-In particular the last point is what sets `axum` apart from other frameworks.
+In particular the last point is what sets `axum` apart from other libraries / frameworks.
 `axum` doesn't have its own middleware system but instead uses
 [`tower::Service`]. This means `axum` gets timeouts, tracing, compression,
 authorization, and more, for free. It also enables you to share middleware with

--- a/axum/src/lib.rs
+++ b/axum/src/lib.rs
@@ -1,4 +1,4 @@
-//! axum is a web application framework that focuses on ergonomics and modularity.
+//! axum is an HTTP routing and request-handling library that focuses on ergonomics and modularity.
 //!
 //! # High-level features
 //!
@@ -9,7 +9,7 @@
 //! - Take full advantage of the [`tower`] and [`tower-http`] ecosystem of
 //!   middleware, services, and utilities.
 //!
-//! In particular, the last point is what sets `axum` apart from other frameworks.
+//! In particular, the last point is what sets `axum` apart from other libraries / frameworks.
 //! `axum` doesn't have its own middleware system but instead uses
 //! [`tower::Service`]. This means `axum` gets timeouts, tracing, compression,
 //! authorization, and more, for free. It also enables you to share middleware with

--- a/axum/src/routing/mod.rs
+++ b/axum/src/routing/mod.rs
@@ -200,7 +200,7 @@ where
     }
 
     #[doc = include_str!("../docs/routing/nest.md")]
-    #[doc(alias = "scope")] // Some web frameworks like actix-web use this term
+    #[doc(alias = "scope")] // Some other libs like actix-web use this term
     #[track_caller]
     pub fn nest(self, path: &str, router: Self) -> Self {
         if path.is_empty() || path == "/" {


### PR DESCRIPTION
It's not very opinionated or batteries-included like Ruby on Rails, Django or Spring, nor does it intend to be. Because of that, I think the term 'framework' is not fitting.

Inspired by <https://status.pointless.one/@pointlessone/115804828862541092>.