### PR TITLE
Upgrade serde_html_form to 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,7 +138,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_core",
- "serde_html_form 0.3.2",
+ "serde_html_form 0.4.0",
  "serde_json",
  "serde_path_to_error",
  "sha1",
@@ -1502,9 +1502,9 @@ dependencies = [
 
 [[package]]
 name = "serde_html_form"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2acf96b1d9364968fce46ebb548f1c0e1d7eceae27bdff73865d42e6c7369d94"
+checksum = "0946d52b4b7e28823148aebbeceb901012c595ad737920d504fa8634bb099e6f"
 dependencies = [
  "form_urlencoded",
  "indexmap",

--- a/axum/Cargo.toml
+++ b/axum/Cargo.toml
@@ -49,7 +49,13 @@ default = [
     "tower-log",
     "tracing",
 ]
-form = ["dep:form_urlencoded", "dep:serde_html_form", "dep:serde_path_to_error"]
+form = [
+    "dep:form_urlencoded",
+    "dep:serde_html_form",
+    "dep:serde_path_to_error",
+    "serde_html_form/ser",
+    "serde_html_form/de",
+]
 http1 = ["dep:hyper", "hyper?/http1", "hyper-util?/http1"]
 http2 = ["dep:hyper", "hyper?/http2", "hyper-util?/http2"]
 json = ["dep:serde_json", "dep:serde_path_to_error"]
@@ -57,7 +63,12 @@ macros = ["dep:axum-macros"]
 matched-path = []
 multipart = ["dep:multer"]
 original-uri = []
-query = ["dep:form_urlencoded", "dep:serde_html_form", "dep:serde_path_to_error"]
+query = [
+    "dep:form_urlencoded",
+    "dep:serde_html_form",
+    "dep:serde_path_to_error",
+    "serde_html_form/de",
+]
 tokio = [
     "dep:hyper-util",
     "dep:tokio",
@@ -120,7 +131,7 @@ hyper = { version = "1.4.0", optional = true }
 hyper-util = { version = "0.1.4", features = ["tokio", "server", "service"], optional = true }
 multer = { version = "3.0.0", optional = true }
 reqwest = { version = "0.12", optional = true, default-features = false, features = ["json", "stream", "multipart"] }
-serde_html_form = { version = "0.3.2", optional = true }
+serde_html_form = { version = "0.4.0", optional = true, default-features = false, features = ["std"] }
 serde_json = { version = "1.0", features = ["raw_value"], optional = true }
 serde_path_to_error = { version = "0.1.8", optional = true }
 sha1 = { version = "0.10", optional = true }

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -4052,9 +4052,9 @@ dependencies = [
 
 [[package]]
 name = "serde_html_form"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2acf96b1d9364968fce46ebb548f1c0e1d7eceae27bdff73865d42e6c7369d94"
+checksum = "0946d52b4b7e28823148aebbeceb901012c595ad737920d504fa8634bb099e6f"
 dependencies = [
  "form_urlencoded",
  "indexmap",


### PR DESCRIPTION
… and disable default features, only enabling what's needed.

This release has all the same runtime behavior as before, it's just split up into more Cargo features.

I suppose I could also make separate features for the serialization and deserialization of `Form`, but it doesn't seem terribly interesting to me.