### PR TITLE
axum: Update to serde_json 1.0.29

### DIFF
--- a/axum/Cargo.toml
+++ b/axum/Cargo.toml
@@ -132,7 +132,7 @@ hyper-util = { version = "0.1.4", features = ["tokio", "server", "service"], opt
 multer = { version = "3.0.0", optional = true }
 reqwest = { version = "0.12", optional = true, default-features = false, features = ["json", "stream", "multipart"] }
 serde_html_form = { version = "0.4.0", optional = true, default-features = false, features = ["std"] }
-serde_json = { version = "1.0", features = ["raw_value"], optional = true }
+serde_json = { version = "1.0.29", features = ["raw_value"], optional = true }
 serde_path_to_error = { version = "0.1.8", optional = true }
 sha1 = { version = "0.10", optional = true }
 tokio = { package = "tokio", version = "1.44", features = ["time"], optional = true }
@@ -186,7 +186,7 @@ quickcheck = "1.0"
 quickcheck_macros = "1.0"
 reqwest = { version = "0.12", default-features = false, features = ["json", "stream", "multipart"] }
 serde = { version = "1.0.221", features = ["derive"] }
-serde_json = { version = "1.0", features = ["raw_value"] }
+serde_json = { version = "1.0.29", features = ["raw_value"] }
 time = { version = "0.3", features = ["serde-human-readable"] }
 tokio = { package = "tokio", version = "1.44.2", features = ["macros", "rt", "rt-multi-thread", "net", "test-util"] }
 tokio-stream = "0.1"


### PR DESCRIPTION
`serde_json`'s `raw_value` feature was introduced at `1.0.29`.

https://github.com/serde-rs/json/releases/tag/v1.0.29