### PR TITLE
add: sigterm crate to ecosystem

### DIFF
--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -61,6 +61,7 @@ If your project isn't listed here and you would like it to be, please feel free 
 - [datastar](https://crates.io/crates/datastar): Rust implementation of the Datastar SDK specification with Axum support
 - [axum-governor](https://crates.io/crates/axum-governor): An independent Axum middleware for rate limiting, powered by [lazy-limit](https://github.com/canmi21/lazy-limit) (not related to tower-governor).
 - [axum-conditional-requests](https://crates.io/crates/axum-conditional-requests): A library for handling client-side caching HTTP headers
+- [sigterm](https://github.com/canmi21/sigterm): Signal-aware async control and cancellation primitives for Tokio.
 
 ## Project showcase
 


### PR DESCRIPTION
I just wrote a relatively simple but very commonly used crate. Its simplest application is to handle the binding of shutdown signals, but it can do much more than that and provides a [simple example](https://github.com/canmi21/sigterm/blob/main/examples/shutdown_signal.rs) for long services like axum