### PR TITLE
Fix InternalServerError docs to match current behavior

### DIFF
--- a/axum-extra/src/response/error_response.rs
+++ b/axum-extra/src/response/error_response.rs
@@ -9,6 +9,7 @@ use tracing::error;
 /// the `IntoResponse` trait itself. Error details are logged using [`tracing::error!`]
 /// and a generic `500 Internal Server Error` response is returned to the client without
 /// exposing error details.
+///
 /// ```rust
 /// use axum_extra::response::InternalServerError;
 /// use axum_core::response::IntoResponse;


### PR DESCRIPTION
## Motivation

The docs for `InternalServerError` claim it "includes the full error chain with descriptions" and warns about leaking sensitive information. This is no longer accurate.

## Solution

Update the rustdoc for InternalServerError to reflect the current behavior.

Fixes: #3639 