### PR TITLE
Restrict Mutlipart::next_field's Field lifetime

### DIFF
--- a/axum/src/extract/multipart.rs
+++ b/axum/src/extract/multipart.rs
@@ -105,7 +105,9 @@ where
 
 impl Multipart {
     /// Yields the next [`Field`] if available.
-    pub async fn next_field(&mut self) -> Result<Option<Field<'_>>, MultipartError> {
+    pub async fn next_field<'output, 'multipart: 'output>(
+        &'multipart mut self,
+    ) -> Result<Option<Field<'output>>, MultipartError> {
         let field = self
             .inner
             .next_field()


### PR DESCRIPTION
Restricting it (making it shorter) allows for more operations on the field itself, for example returning the Field from a function which holds a &mut Multipart reference. I don't think this is a breaking change, as it actually enables more legal code to compile.


