### PR TITLE
fix: Set connect endpoint on correct field in MethodRouter

### DIFF
--- a/axum/src/routing/method_routing.rs
+++ b/axum/src/routing/method_routing.rs
@@ -978,7 +978,7 @@ where
 
         set_endpoint(
             "CONNECT",
-            &mut self.options,
+            &mut self.connect,
             endpoint,
             filter,
             MethodFilter::CONNECT,
@@ -1445,12 +1445,15 @@ mod tests {
 
     #[crate::test]
     async fn merge() {
-        let mut svc = get(ok).merge(post(ok));
+        let mut svc = get(ok).merge(post(ok)).merge(connect(ok));
 
         let (status, _, _) = call(Method::GET, &mut svc).await;
         assert_eq!(status, StatusCode::OK);
 
         let (status, _, _) = call(Method::POST, &mut svc).await;
+        assert_eq!(status, StatusCode::OK);
+
+        let (status, _, _) = call(Method::CONNECT, &mut svc).await;
         assert_eq!(status, StatusCode::OK);
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->
`MethodRouter::on_endpoint` incorrectly stored CONNECT handlers in `self.options` instead of `self.connect`.
This meant `.connect()` and `.connect_service()` silently overwrote the OPTIONS endpoint, and CONNECT requests were never routed to their handler.   

## Solution
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
Fix the `set_endpoint` call for CONNECT to write to `&mut self.connect` instead of `&mut self.options`.