### PR TITLE
chore: rename clippy empty_enums lint to empty_enum

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ type_complexity = "allow"
 
 await_holding_lock = "warn"
 dbg_macro = "warn"
-empty_enums = "warn"
+empty_enum = "warn"
 enum_glob_use = "warn"
 equatable_if_let = "warn"
 exit = "warn"


### PR DESCRIPTION
Fixes https://github.com/tokio-rs/axum/issues/3658

I did change into 

- empty_enum = "warn" in Cargo.toml

So now 

cargo clippy -p axum --lib --tests -- -D warnings complete with no warning of unknown lint

like this

warning[E0602]: unknown lint: clippy::empty_enums

