### PR TITLE
fix: silence `clippy::implicit_clone` in `TypedPath` macro expansions

### DIFF
--- a/axum-macros/src/typed_path.rs
+++ b/axum-macros/src/typed_path.rs
@@ -118,6 +118,7 @@ fn expand_named_fields(
         #[automatically_derived]
         impl ::std::fmt::Display for #ident {
             #[allow(clippy::unnecessary_to_owned)]
+            #[allow(clippy::implicit_clone)]
             fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
                 let Self { #(#captures,)* } = self;
                 write!(
@@ -223,6 +224,7 @@ fn expand_unnamed_fields(
         #[automatically_derived]
         impl ::std::fmt::Display for #ident {
             #[allow(clippy::unnecessary_to_owned)]
+            #[allow(clippy::implicit_clone)]
             fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
                 let Self { #(#destructure_self)* } = self;
                 write!(


### PR DESCRIPTION
## Motivation

PR https://github.com/tokio-rs/axum/pull/1117 silenced the `clippy::unnecessary_to_owned` lint in `TypedPath` macro expansions. However, when the opt-in [`clippy::implicit_clone` lint](https://rust-lang.github.io/rust-clippy/master/index.html#implicit_clone) is enabled, converting a `String` path capture into another `String` using the `.to_string()` method in the expanded macro code can still trigger a Clippy warning, since this expression effectively performs an implicit clone. ([Clippy source code reference.](https://github.com/rust-lang/rust-clippy/blob/87c404e08f797e27e7d927c26fe9a6408655cbdf/clippy_lints/src/methods/implicit_clone.rs#L49))

## Solution

Following the approach taken in PR https://github.com/tokio-rs/axum/pull/1117, I've added the corresponding Clippy lint allowance attribute to suppress this non-actionable warning properly.