### PR TITLE
fix(axum-macros): use OptionalFromRequest for Option<T> fields in derive

### DIFF
--- a/axum-macros/CHANGELOG.md
+++ b/axum-macros/CHANGELOG.md
@@ -9,10 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **breaking:** `#[from_request(via(Extractor))]` now uses the extractor's
   rejection type instead of `axum::response::Response` ([#3261])
+- **breaking:** `Option<T>` fields in `#[derive(FromRequest)]` and
+  `#[derive(FromRequestParts)]` now use `OptionalFromRequest` /
+  `OptionalFromRequestParts` instead of calling `.ok()` on the result. This
+  means the extractor decides when to return `None` vs an error, instead of
+  silently converting all rejections to `None`. Extractors used with
+  `Option<T>` must implement `OptionalFromRequest` or
+  `OptionalFromRequestParts`. ([#3623])
 - **fixed:** Fix compilation error when deriving `TypedPath` with
   `OptionalFromRequestParts` being in scope ([#3645])
 
 [#3261]: https://github.com/tokio-rs/axum/pull/3261
+[#3623]: https://github.com/tokio-rs/axum/issues/3623
 [#3645]: https://github.com/tokio-rs/axum/pull/3645
 
 # 0.5.0

--- a/axum-macros/src/lib.rs
+++ b/axum-macros/src/lib.rs
@@ -136,7 +136,7 @@ use from_request::Trait::{FromRequest, FromRequestParts};
 ///
 /// #[derive(FromRequest)]
 /// struct MyExtractor {
-///     // This will extracted via `Option::<TypedHeader<ContentType>>::from_request`
+///     // This will extracted via `<TypedHeader<ContentType> as OptionalFromRequestParts>::from_request_parts`
 ///     #[from_request(via(TypedHeader))]
 ///     content_type: Option<ContentType>,
 ///     // This will extracted via

--- a/axum-macros/tests/from_request/pass/option_via_json.rs
+++ b/axum-macros/tests/from_request/pass/option_via_json.rs
@@ -1,0 +1,51 @@
+use axum::{
+    extract::rejection::{JsonRejection, PathRejection},
+    response::{IntoResponse, Response},
+    routing::get,
+    Json, Router,
+};
+use axum_macros::FromRequest;
+use serde::Deserialize;
+
+fn main() {
+    let _: Router = Router::new().route("/", get(handler));
+}
+
+async fn handler(_: Args) {}
+
+#[derive(Deserialize)]
+struct Payload {
+    value: String,
+}
+
+// Test case from issue #3623:
+// Option<T> with via(Json) should use OptionalFromRequest,
+// not .ok() which silently swallows rejections.
+#[derive(FromRequest)]
+#[from_request(rejection(MyError))]
+struct Args {
+    #[from_request(via(axum::extract::Path))]
+    something: String,
+    #[from_request(via(Json))]
+    request: Option<Payload>,
+}
+
+struct MyError(Response);
+
+impl From<PathRejection> for MyError {
+    fn from(rejection: PathRejection) -> Self {
+        Self(rejection.into_response())
+    }
+}
+
+impl From<JsonRejection> for MyError {
+    fn from(rejection: JsonRejection) -> Self {
+        Self(rejection.into_response())
+    }
+}
+
+impl IntoResponse for MyError {
+    fn into_response(self) -> Response {
+        self.0
+    }
+}

--- a/axum-macros/tests/from_request/pass/option_via_parts.rs
+++ b/axum-macros/tests/from_request/pass/option_via_parts.rs
@@ -1,0 +1,42 @@
+use axum::{
+    extract::FromRequestParts,
+    response::{IntoResponse, Response},
+};
+use axum_extra::{
+    headers,
+    typed_header::TypedHeaderRejection,
+    TypedHeader,
+};
+
+// Option<T> with via() in a FromRequestParts derive should use
+// OptionalFromRequestParts, not .ok().
+#[derive(FromRequestParts)]
+#[from_request(rejection(MyError))]
+struct Extractor {
+    #[from_request(via(TypedHeader))]
+    content_type: Option<headers::ContentType>,
+    #[from_request(via(TypedHeader))]
+    user_agent: headers::UserAgent,
+}
+
+fn assert_from_request()
+where
+    Extractor: FromRequestParts<(), Rejection = MyError>,
+{
+}
+
+struct MyError(Response);
+
+impl From<TypedHeaderRejection> for MyError {
+    fn from(rejection: TypedHeaderRejection) -> Self {
+        Self(rejection.into_response())
+    }
+}
+
+impl IntoResponse for MyError {
+    fn into_response(self) -> Response {
+        self.0
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
**Motivation**

`Option<T>` fields with `#[from_request(via(...))]` were using `.ok()` to convert any rejection into `None`, silently swallowing errors like invalid JSON.

Fixes #3623

**Solution**

Use `OptionalFromRequest` / `OptionalFromRequestParts` traits instead of `.ok()`, letting each extractor decide when to return `None` vs propagate an error.