### PR TITLE
docs: fix outdated BoxBody comments in route_service example

### DIFF
--- a/axum/src/docs/routing/route_service.md
+++ b/axum/src/docs/routing/route_service.md
@@ -18,20 +18,18 @@ use tower::service_fn;
 
 let app = Router::new()
     .route(
-        // Any request to `/` goes to a service
+        // Any request to `/` goes to a service.
+        // `route` requires a `MethodRouter`, so `any_service` is used to
+        // accept all HTTP methods.
         "/",
-        // Services whose response body is not `axum::body::BoxBody`
-        // can be wrapped in `axum::routing::any_service` (or one of the other routing filters)
-        // to have the response body mapped
         any_service(service_fn(|_: Request| async {
             let res = Response::new(Body::from("Hi from `GET /`"));
             Ok::<_, Infallible>(res)
         }))
     )
     .route_service(
+        // `route_service` accepts a `Service` directly, so no wrapping is needed.
         "/foo",
-        // This service's response body is `axum::body::BoxBody` so
-        // it can be routed to directly.
         service_fn(|req: Request| async move {
             let body = Body::from(format!("Hi from `{} /foo`", req.method()));
             let res = Response::new(body);


### PR DESCRIPTION
Fixes #2536

The example in the `route_service` documentation contained comments referring to `axum::body::BoxBody`, which was removed in axum 0.7. All request and response bodies are now `axum::body::Body`, so the old comments explaining why wrapping with `any_service` was needed (for body type mapping) were incorrect and potentially confusing.

**Changes:**
- Remove stale comments about `axum::body::BoxBody`
- Add accurate explanation: `any_service` is needed when using `route()` because `route()` expects a `MethodRouter`, and `any_service` adapts a `Service` to accept all HTTP methods
- Add accurate explanation: `route_service()` accepts a `Service` directly, so no wrapping is needed