### PR TITLE
examples: Remove unused reqwest-eventsource dependency

### DIFF
--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -1627,7 +1627,6 @@ dependencies = [
  "futures-util",
  "headers",
  "reqwest",
- "reqwest-eventsource",
  "tokio",
  "tokio-stream",
  "tower-http",
@@ -2017,12 +2016,6 @@ name = "futures-task"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
-
-[[package]]
-name = "futures-timer"
-version = "3.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 
 [[package]]
 name = "futures-util"
@@ -3653,22 +3646,6 @@ dependencies = [
  "wasm-streams",
  "web-sys",
  "webpki-roots 1.0.6",
-]
-
-[[package]]
-name = "reqwest-eventsource"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "632c55746dbb44275691640e7b40c907c16a2dc1a5842aa98aaec90da6ec6bde"
-dependencies = [
- "eventsource-stream",
- "futures-core",
- "futures-timer",
- "mime",
- "nom",
- "pin-project-lite",
- "reqwest",
- "thiserror 1.0.69",
 ]
 
 [[package]]

--- a/examples/sse/Cargo.toml
+++ b/examples/sse/Cargo.toml
@@ -18,4 +18,3 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 [dev-dependencies]
 eventsource-stream = "0.2"
 reqwest = { version = "0.12", default-features = false, features = ["stream"] }
-reqwest-eventsource = "0.6"


### PR DESCRIPTION
Removes unused `reqwest-eventsource` dependency.