### PR TITLE
examples: add rate-limiting example

### DIFF
--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -1503,6 +1503,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "example-rate-limiting"
+version = "0.1.0"
+dependencies = [
+ "axum",
+ "tokio",
+ "tower",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "example-readme"
 version = "0.1.0"
 dependencies = [

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -1508,7 +1508,6 @@ version = "0.1.0"
 dependencies = [
  "axum",
  "tokio",
- "tower",
  "tracing",
  "tracing-subscriber",
 ]

--- a/examples/rate-limiting/Cargo.toml
+++ b/examples/rate-limiting/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "example-rate-limiting"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+axum = { path = "../../axum" }
+tokio = { version = "1.0", features = ["full"] }
+tower = { version = "0.5.2", features = ["limit", "buffer", "load-shed"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/rate-limiting/Cargo.toml
+++ b/examples/rate-limiting/Cargo.toml
@@ -7,6 +7,5 @@ publish = false
 [dependencies]
 axum = { path = "../../axum" }
 tokio = { version = "1.0", features = ["full"] }
-tower = { version = "0.5.2", features = ["limit", "buffer", "load-shed"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/rate-limiting/src/main.rs
+++ b/examples/rate-limiting/src/main.rs
@@ -23,7 +23,9 @@ use axum::{
     Router,
 };
 use std::time::Duration;
-use tower::{buffer::BufferLayer, limit::RateLimitLayer, BoxError, ServiceBuilder};
+use tower::{
+    buffer::BufferLayer, limit::RateLimitLayer, load_shed::LoadShedLayer, BoxError, ServiceBuilder,
+};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 #[tokio::main]
@@ -43,11 +45,14 @@ async fn main() {
         // Apply a global rate limit: 5 requests per second.
         //
         // HandleErrorLayer converts tower errors into HTTP responses.
+        // LoadShedLayer rejects requests immediately when the inner
+        // service is not ready (buffer full) instead of waiting.
         // BufferLayer wraps the non-Clone RateLimit service so that axum
         // can clone it across tasks.
         .layer(
             ServiceBuilder::new()
                 .layer(HandleErrorLayer::new(handle_error))
+                .layer(LoadShedLayer::new())
                 .layer(BufferLayer::new(1024))
                 .layer(RateLimitLayer::new(5, Duration::from_secs(1))),
         );
@@ -65,6 +70,14 @@ async fn slow_handler() -> &'static str {
 }
 
 async fn handle_error(error: BoxError) -> impl IntoResponse {
+    if error.is::<tower::load_shed::error::Overloaded>() {
+        tracing::warn!(%error, "service overloaded");
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "Service overloaded, try again later".to_string(),
+        );
+    }
+
     tracing::error!(%error, "unhandled middleware error");
     (
         StatusCode::INTERNAL_SERVER_ERROR,

--- a/examples/rate-limiting/src/main.rs
+++ b/examples/rate-limiting/src/main.rs
@@ -1,0 +1,73 @@
+//! Rate limiting example using `tower::limit::RateLimitLayer`.
+//!
+//! `RateLimit` does not implement `Clone`, so it must be wrapped with
+//! `BufferLayer` to satisfy axum's `Clone` requirement. `HandleErrorLayer`
+//! converts middleware errors (from `Buffer` / `RateLimit`) into HTTP
+//! responses.
+//!
+//! Run with:
+//!
+//! ```not_rust
+//! cargo run -p example-rate-limiting
+//! ```
+//!
+//! Then try sending requests rapidly:
+//!
+//! ```not_rust
+//! # Send several requests at once — excess requests get 503
+//! for i in $(seq 1 8); do curl -sw '\n' http://127.0.0.1:3000/ & done; wait
+//! ```
+
+use axum::{
+    error_handling::HandleErrorLayer, http::StatusCode, response::IntoResponse, routing::get,
+    Router,
+};
+use std::time::Duration;
+use tower::{buffer::BufferLayer, limit::RateLimitLayer, BoxError, ServiceBuilder};
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::registry()
+        .with(
+            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+                format!("{}=debug,tower=debug", env!("CARGO_CRATE_NAME")).into()
+            }),
+        )
+        .with(tracing_subscriber::fmt::layer())
+        .init();
+
+    let app = Router::new()
+        .route("/", get(|| async { "Hello, World!" }))
+        .route("/slow", get(slow_handler))
+        // Apply a global rate limit: 5 requests per second.
+        //
+        // HandleErrorLayer converts tower errors into HTTP responses.
+        // BufferLayer wraps the non-Clone RateLimit service so that axum
+        // can clone it across tasks.
+        .layer(
+            ServiceBuilder::new()
+                .layer(HandleErrorLayer::new(handle_error))
+                .layer(BufferLayer::new(1024))
+                .layer(RateLimitLayer::new(5, Duration::from_secs(1))),
+        );
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:3000")
+        .await
+        .unwrap();
+    tracing::debug!("listening on {}", listener.local_addr().unwrap());
+    axum::serve(listener, app).await;
+}
+
+async fn slow_handler() -> &'static str {
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    "This was slow!"
+}
+
+async fn handle_error(error: BoxError) -> impl IntoResponse {
+    tracing::error!(%error, "unhandled middleware error");
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        "Something went wrong".to_string(),
+    )
+}

--- a/examples/rate-limiting/src/main.rs
+++ b/examples/rate-limiting/src/main.rs
@@ -1,86 +1,155 @@
-//! Rate limiting example using `tower::limit::RateLimitLayer`.
+//! Rate limiting requests with a custom middleware.
 //!
-//! `RateLimit` does not implement `Clone`, so it must be wrapped with
-//! `BufferLayer` to satisfy axum's `Clone` requirement. `HandleErrorLayer`
-//! converts middleware errors (from `Buffer` / `RateLimit`) into HTTP
-//! responses.
+//! This example implements a per-client (per-IP) token-bucket rate limiter as
+//! an [`axum::middleware::from_fn_with_state`] middleware, backed by nothing
+//! but a shared `Arc<Mutex<..>>`. Each client gets a bucket that holds up to
+//! `BURST` tokens and refills at `REFILL_PER_SECOND`; a request that finds an
+//! empty bucket is rejected with `429 Too Many Requests` and a `Retry-After`
+//! header.
 //!
-//! Run with:
+//! `tower`'s `RateLimitLayer` is deliberately *not* used here. It keeps its
+//! state inside the service, so once the service is cloned — which axum does
+//! per connection — each clone gets an independent limit and the cap is never
+//! actually enforced (see <https://github.com/tokio-rs/axum/issues/2634>).
+//! Keeping the state in an `Arc` shared by every clone is what makes this
+//! middleware work. For production use, a dedicated crate such as
+//! `tower-governor` is recommended.
+//!
+//! Run with
 //!
 //! ```not_rust
 //! cargo run -p example-rate-limiting
 //! ```
 //!
-//! Then try sending requests rapidly:
+//! Then send a burst of requests and watch the excess ones get rejected:
 //!
 //! ```not_rust
-//! # Send several requests at once — excess requests get 503
-//! for i in $(seq 1 8); do curl -sw '\n' http://127.0.0.1:3000/ & done; wait
+//! for i in $(seq 1 10); do curl -s -o /dev/null -w "%{http_code}\n" 127.0.0.1:3000/ & done; wait
 //! ```
 
+use std::{
+    collections::HashMap,
+    net::{IpAddr, SocketAddr},
+    sync::{Arc, Mutex},
+    time::Instant,
+};
+
 use axum::{
-    error_handling::HandleErrorLayer, http::StatusCode, response::IntoResponse, routing::get,
+    extract::{ConnectInfo, Request, State},
+    http::{header, StatusCode},
+    middleware::{self, Next},
+    response::{IntoResponse, Response},
+    routing::get,
     Router,
 };
-use std::time::Duration;
-use tower::{
-    buffer::BufferLayer, limit::RateLimitLayer, load_shed::LoadShedLayer, BoxError, ServiceBuilder,
-};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+
+/// Maximum number of requests a client may burst before being limited.
+const BURST: f64 = 5.0;
+
+/// Steady-state rate, in requests per second, each client is refilled at.
+const REFILL_PER_SECOND: f64 = 1.0;
 
 #[tokio::main]
 async fn main() {
     tracing_subscriber::registry()
         .with(
-            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
-                format!("{}=debug,tower=debug", env!("CARGO_CRATE_NAME")).into()
-            }),
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| format!("{}=debug", env!("CARGO_CRATE_NAME")).into()),
         )
         .with(tracing_subscriber::fmt::layer())
         .init();
 
+    let limiter = RateLimiter::default();
+
     let app = Router::new()
         .route("/", get(|| async { "Hello, World!" }))
-        .route("/slow", get(slow_handler))
-        // Apply a global rate limit: 5 requests per second.
-        //
-        // HandleErrorLayer converts tower errors into HTTP responses.
-        // LoadShedLayer rejects requests immediately when the inner
-        // service is not ready (buffer full) instead of waiting.
-        // BufferLayer wraps the non-Clone RateLimit service so that axum
-        // can clone it across tasks.
-        .layer(
-            ServiceBuilder::new()
-                .layer(HandleErrorLayer::new(handle_error))
-                .layer(LoadShedLayer::new())
-                .layer(BufferLayer::new(1024))
-                .layer(RateLimitLayer::new(5, Duration::from_secs(1))),
-        );
+        .layer(middleware::from_fn_with_state(limiter, rate_limit));
 
     let listener = tokio::net::TcpListener::bind("127.0.0.1:3000")
         .await
         .unwrap();
     tracing::debug!("listening on {}", listener.local_addr().unwrap());
-    axum::serve(listener, app).await;
-}
 
-async fn slow_handler() -> &'static str {
-    tokio::time::sleep(Duration::from_secs(1)).await;
-    "This was slow!"
-}
-
-async fn handle_error(error: BoxError) -> impl IntoResponse {
-    if error.is::<tower::load_shed::error::Overloaded>() {
-        tracing::warn!(%error, "service overloaded");
-        return (
-            StatusCode::SERVICE_UNAVAILABLE,
-            "Service overloaded, try again later".to_string(),
-        );
-    }
-
-    tracing::error!(%error, "unhandled middleware error");
-    (
-        StatusCode::INTERNAL_SERVER_ERROR,
-        "Something went wrong".to_string(),
+    // `into_make_service_with_connect_info` makes the peer address available
+    // to the middleware via the `ConnectInfo` extractor.
+    axum::serve(
+        listener,
+        app.into_make_service_with_connect_info::<SocketAddr>(),
     )
+    .await;
+}
+
+/// Middleware that applies the [`RateLimiter`] to every request, keyed by the
+/// client's IP address.
+async fn rate_limit(
+    State(limiter): State<RateLimiter>,
+    ConnectInfo(addr): ConnectInfo<SocketAddr>,
+    req: Request,
+    next: Next,
+) -> Response {
+    match limiter.check(addr.ip()) {
+        Ok(()) => next.run(req).await,
+        Err(retry_after) => {
+            tracing::debug!(client = %addr.ip(), "rate limited");
+            (
+                StatusCode::TOO_MANY_REQUESTS,
+                [(header::RETRY_AFTER, retry_after.to_string())],
+                "Too many requests, slow down\n",
+            )
+                .into_response()
+        }
+    }
+}
+
+/// A token-bucket rate limiter shared across all requests.
+///
+/// Cloning is cheap and, crucially, every clone points at the *same* shared
+/// state. That is what lets axum clone the middleware per connection without
+/// each clone getting its own independent limit.
+#[derive(Clone, Default)]
+struct RateLimiter {
+    buckets: Arc<Mutex<HashMap<IpAddr, Bucket>>>,
+}
+
+impl RateLimiter {
+    /// Accounts for a request from `client`, returning `Ok` if it is allowed
+    /// or `Err(retry_after)` — seconds to wait — if the client is limited.
+    fn check(&self, client: IpAddr) -> Result<(), u64> {
+        let now = Instant::now();
+
+        // The guard is dropped at the end of this function, so the lock is
+        // never held across the `.await` in `rate_limit`.
+        let mut buckets = self.buckets.lock().unwrap();
+        let bucket = buckets.entry(client).or_insert(Bucket {
+            tokens: BURST,
+            last_refill: now,
+        });
+
+        // Refill the bucket for the time elapsed since the previous request.
+        let elapsed = now.duration_since(bucket.last_refill).as_secs_f64();
+        bucket.tokens = (bucket.tokens + elapsed * REFILL_PER_SECOND).min(BURST);
+        bucket.last_refill = now;
+
+        if bucket.tokens >= 1.0 {
+            bucket.tokens -= 1.0;
+            Ok(())
+        } else {
+            // Seconds until the bucket holds a whole token again.
+            let wait = (1.0 - bucket.tokens) / REFILL_PER_SECOND;
+            Err(wait.ceil() as u64)
+        }
+    }
+}
+
+/// A single client's token bucket.
+///
+/// Note: for brevity this example never evicts entries, so the map grows with
+/// the number of distinct clients. A real deployment would prune buckets that
+/// have been idle (full) for a while.
+struct Bucket {
+    /// Tokens currently available; one is spent per allowed request.
+    tokens: f64,
+    /// When `tokens` was last brought up to date.
+    last_refill: Instant,
 }


### PR DESCRIPTION
Adds a `rate-limiting` example. Rate limiting comes up a lot for axum and there wasn't an example for it, so this fills that gap.

The example is a small per-IP token-bucket limiter implemented as a `from_fn` middleware over a shared `Arc<Mutex<..>>`. Each client gets a burst allowance that refills over time; once it runs out, requests get `429 Too Many Requests` with a `Retry-After` header.

A note on the approach: I first wrote this with tower's `RateLimitLayer` behind a `BufferLayer`, but as #2634 points out that doesn't actually hold a limit under axum — the state lives inside the service, so each per-connection clone gets its own. I confirmed it with the old version: a configured cap of 5 req/s let 1500 concurrent requests all return 200. Keeping the state in a shared `Arc` is what makes the limit real, so the example does that now and stays dependency-free. The doc comment points at `tower-governor` for production use.

Verified locally: 10 concurrent requests return 5x 200 and 5x 429, and a sustained loop settles at the configured rate.
