### PR TITLE
add: seamjs in axum ecosystem

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ type_complexity = "allow"
 
 await_holding_lock = "warn"
 dbg_macro = "warn"
-empty_enum = "warn"
+empty_enums = "warn"
 enum_glob_use = "warn"
 equatable_if_let = "warn"
 exit = "warn"

--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -63,6 +63,7 @@ If your project isn't listed here and you would like it to be, please feel free 
 - [axum-conditional-requests](https://crates.io/crates/axum-conditional-requests): A library for handling client-side caching HTTP headers
 - [sigterm](https://github.com/canmi21/sigterm): Signal-aware async control and cancellation primitives for Tokio.
 - [tower-resilience](https://github.com/joshrotenberg/tower-resilience): Resilience middleware for tower: circuit breaker, bulkhead, retry, rate limiter, and more.
+- [seamjs](https://github.com/canmi21/seam): Compile-time rendering framework where UI Stack (e.g. React...) pages are pre-rendered at build time and Axum serves them via Rust-native HTML slot injection (~1ms/page), with typed RPC procedures codegen'd from a shared manifest.   
 
 ## Project showcase
 


### PR DESCRIPTION
## Motivation

I have created something that enables Rust developers to write React just like Next.js, but not limited to React. The core-server system is well adapted to Axum in Rust exmaple.