### PR TITLE
examples: Update to diesel-async 0.8

### DIFF
--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -971,15 +971,16 @@ dependencies = [
 
 [[package]]
 name = "diesel-async"
-version = "0.7.4"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13096fb8dae53f2d411c4b523bec85f45552ed3044a2ab4d85fb2092d9cb4f34"
+checksum = "b95864e58597509106f1fddfe0600de7e589e1fddddd87f54eee0a49fd111bbc"
 dependencies = [
  "bb8",
  "diesel",
  "diesel_migrations",
  "futures-core",
  "futures-util",
+ "pin-project-lite",
  "scoped-futures",
  "tokio",
  "tokio-postgres",
@@ -3122,9 +3123,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pin-utils"

--- a/examples/diesel-async-postgres/Cargo.toml
+++ b/examples/diesel-async-postgres/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 axum = { path = "../../axum", features = ["macros"] }
 diesel = "~2.3"
-diesel-async = { version = "0.7", features = ["postgres", "bb8", "migrations"] }
+diesel-async = { version = "0.8", features = ["postgres", "bb8", "migrations"] }
 diesel_migrations = "~2.3"
 serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "1.0", features = ["full"] }


### PR DESCRIPTION
Updates to `diesel-async` 0.8.