### PR TITLE
axum: Add missing PR link to changelog (#3635)

### DIFF
--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#3601]: https://github.com/tokio-rs/axum/pull/3601
 [#3489]: https://github.com/tokio-rs/axum/pull/3489
 [#3586]: https://github.com/tokio-rs/axum/pull/3586
+[#3635]: https://github.com/tokio-rs/axum/pull/3635
 [#3702]: https://github.com/tokio-rs/axum/pull/3702
 
 # 0.8.9


### PR DESCRIPTION
## Motivation

A changelog entry referes to a PR, but the link is missing

## Solution

Add the missing link