### PR TITLE
fix: add tracing calls to tracing-aka-logging example closures

### DIFF
--- a/examples/tracing-aka-logging/src/main.rs
+++ b/examples/tracing-aka-logging/src/main.rs
@@ -65,21 +65,22 @@ async fn main() {
                     // You can use `_span.record("some_other_field", value)` in one of these
                     // closures to attach a value to the initially empty field in the info_span
                     // created above.
+                    tracing::debug!("started processing request")
                 })
                 .on_response(|_response: &Response, _latency: Duration, _span: &Span| {
-                    // ...
+                    tracing::debug!("finished processing request")
                 })
                 .on_body_chunk(|_chunk: &Bytes, _latency: Duration, _span: &Span| {
-                    // ...
+                    tracing::debug!("sending body chunk")
                 })
                 .on_eos(
                     |_trailers: Option<&HeaderMap>, _stream_duration: Duration, _span: &Span| {
-                        // ...
+                        tracing::debug!("stream closed")
                     },
                 )
                 .on_failure(
                     |_error: ServerErrorsFailureClass, _latency: Duration, _span: &Span| {
-                        // ...
+                        tracing::error!("something went wrong")
                     },
                 ),
         );


### PR DESCRIPTION
## Motivation

The `tracing-aka-logging` example's `on_request`, `on_response`, `on_body_chunk`, `on_eos`, and `on_failure` closures were empty no-ops. Since providing custom closures to `TraceLayer` **replaces** the default `DefaultOnRequest`, `DefaultOnResponse`, etc. behavior, the example produced zero request logs when run — making it confusing for users trying to learn request tracing with axum.

Closes #3592

## Solution

Add actual `tracing::debug!` / `tracing::error!` calls inside each closure to demonstrate how to customize logging behavior while still producing visible output.

This keeps the example's purpose (showing *how* to customize each callback) while making it actually functional out of the box.