### PR TITLE
feat(axum-extra): support deserializing Vec<Enum> from repeated query parameters

### DIFF
--- a/axum-extra/Cargo.toml
+++ b/axum-extra/Cargo.toml
@@ -80,6 +80,7 @@ query = [
     "dep:serde_core",
     "dep:serde_html_form",
     "dep:serde_path_to_error",
+    "dep:serde_json",
 ]
 tracing = ["axum-core/tracing", "axum/tracing", "dep:tracing"]
 typed-header = ["dep:headers"]

--- a/axum-extra/src/extract/mod.rs
+++ b/axum-extra/src/extract/mod.rs
@@ -41,10 +41,12 @@ pub use self::cookie::SignedCookieJar;
 pub use self::form::{Form, FormRejection};
 
 #[cfg(feature = "query")]
-pub use self::query::OptionalQuery;
+pub use self::query::{OptionalQuery, OptionalQueryList, QueryList};
 #[cfg(feature = "query")]
 #[allow(deprecated)]
-pub use self::query::{OptionalQueryRejection, Query, QueryRejection};
+pub use self::query::{
+    OptionalQueryListRejection, OptionalQueryRejection, Query, QueryListRejection, QueryRejection,
+};
 
 #[cfg(feature = "multipart")]
 pub use self::multipart::Multipart;

--- a/axum-extra/src/extract/query.rs
+++ b/axum-extra/src/extract/query.rs
@@ -956,23 +956,23 @@ mod tests {
 
         let app = Router::new().route(
             "/",
-            get(|OptionalQueryList(params): OptionalQueryList<Param>| async move {
-                params
-                    .iter()
-                    .map(|p| match p {
-                        Param::Name(n) => format!("name:{n}"),
-                        Param::Tag(t) => format!("tag:{t}"),
-                    })
-                    .collect::<Vec<_>>()
-                    .join("|")
-            }),
+            get(
+                |OptionalQueryList(params): OptionalQueryList<Param>| async move {
+                    params
+                        .iter()
+                        .map(|p| match p {
+                            Param::Name(n) => format!("name:{n}"),
+                            Param::Tag(t) => format!("tag:{t}"),
+                        })
+                        .collect::<Vec<_>>()
+                        .join("|")
+                },
+            ),
         );
 
         let client = TestClient::new(app);
 
-        let res = client
-            .get("/?name=john%20doe&tag=hello%26world")
-            .await;
+        let res = client.get("/?name=john%20doe&tag=hello%26world").await;
         assert_eq!(res.status(), StatusCode::OK);
         assert_eq!(res.text().await, "name:john doe|tag:hello&world");
     }

--- a/axum-extra/src/extract/query.rs
+++ b/axum-extra/src/extract/query.rs
@@ -175,6 +175,196 @@ composite_rejection! {
     }
 }
 
+fn deserialize_pair<T: DeserializeOwned>(
+    key: String,
+    value: String,
+) -> Result<T, serde_json::Error> {
+    let mut map = serde_json::Map::new();
+    let parsed_value: serde_json::Value = match value.parse::<serde_json::Number>() {
+        Ok(num) => serde_json::Value::Number(num),
+        Err(_) => match value.as_str() {
+            "true" => serde_json::Value::Bool(true),
+            "false" => serde_json::Value::Bool(false),
+            "null" => serde_json::Value::Null,
+            _ => serde_json::Value::String(value),
+        },
+    };
+    map.insert(key, parsed_value);
+    serde_json::from_value(serde_json::Value::Object(map))
+}
+
+/// Extractor that deserializes query strings into `Vec<T>` where each query parameter
+/// becomes an enum variant.
+///
+/// This is useful for deserializing alternating query parameters of different types,
+/// like `?id=123&username=abc&id=456` into `Vec<List>` where `List` is an enum with
+/// `Id(u32)` and `Username(String)` variants.
+///
+/// `T` is expected to be an enum that implements the `Deserialize` trait with externally-tagged
+/// variants where each variant name matches a query parameter name.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use axum::{routing::get, Router};
+/// use axum_extra::extract::QueryList;
+/// use serde::Deserialize;
+///
+/// #[derive(Deserialize)]
+/// #[serde(rename_all = "lowercase")]
+/// enum Param {
+///     Id(u32),
+///     Username(String),
+/// }
+///
+/// async fn handler(QueryList(params): QueryList<Param>) {
+///     for param in params {
+///         match param {
+///             Param::Id(id) => println!("ID: {}", id),
+///             Param::Username(name) => println!("Username: {}", name),
+///         }
+///     }
+/// }
+///
+/// let app = Router::new().route("/", get(handler));
+/// # let _: Router = app;
+/// ```
+#[cfg_attr(docsrs, doc(cfg(feature = "query")))]
+#[derive(Debug, Clone, Default)]
+pub struct QueryList<T>(pub Vec<T>);
+
+impl<T, S> FromRequestParts<S> for QueryList<T>
+where
+    T: DeserializeOwned,
+    S: Send + Sync,
+{
+    type Rejection = QueryListRejection;
+
+    async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
+        let query = parts.uri.query().unwrap_or_default();
+        let pairs: Vec<(String, String)> = form_urlencoded::parse(query.as_bytes())
+            .map(|(k, v)| (k.into_owned(), v.into_owned()))
+            .collect();
+
+        let mut result = Vec::new();
+        for (key, value) in pairs {
+            let item = deserialize_pair::<T>(key, value)
+                .map_err(FailedToDeserializeQueryString::from_err)?;
+            result.push(item);
+        }
+
+        Ok(Self(result))
+    }
+}
+
+impl<T> QueryList<T>
+where
+    T: DeserializeOwned,
+{
+    /// Attempts to construct a [`QueryList`] from a reference to a [`Uri`].
+    pub fn try_from_uri(value: &Uri) -> Result<Self, QueryListRejection> {
+        let query = value.query().unwrap_or_default();
+        let pairs: Vec<(String, String)> = form_urlencoded::parse(query.as_bytes())
+            .map(|(k, v)| (k.into_owned(), v.into_owned()))
+            .collect();
+
+        let mut result = Vec::new();
+        for (key, value) in pairs {
+            let item = deserialize_pair::<T>(key, value)
+                .map_err(FailedToDeserializeQueryString::from_err)?;
+            result.push(item);
+        }
+
+        Ok(Self(result))
+    }
+}
+
+impl<T> std::ops::Deref for QueryList<T> {
+    type Target = Vec<T>;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T> std::ops::DerefMut for QueryList<T> {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+composite_rejection! {
+    /// Rejection used for [`QueryList`].
+    ///
+    /// Contains one variant for each way the [`QueryList`] extractor can fail.
+    pub enum QueryListRejection {
+        FailedToDeserializeQueryString,
+    }
+}
+
+/// Extractor that deserializes query strings into `Vec<T>` when parameters are present,
+/// or an empty `Vec` if no query parameters exist.
+///
+/// Otherwise behaviour is identical to [`QueryList`].
+/// `T` is expected to be an enum that implements the `Deserialize` trait.
+#[cfg_attr(docsrs, doc(cfg(feature = "query")))]
+#[derive(Debug, Clone, Default)]
+pub struct OptionalQueryList<T>(pub Vec<T>);
+
+impl<T, S> FromRequestParts<S> for OptionalQueryList<T>
+where
+    T: DeserializeOwned,
+    S: Send + Sync,
+{
+    type Rejection = OptionalQueryListRejection;
+
+    async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
+        if let Some(query) = parts.uri.query() {
+            let pairs: Vec<(String, String)> = form_urlencoded::parse(query.as_bytes())
+                .map(|(k, v)| (k.into_owned(), v.into_owned()))
+                .collect();
+
+            let mut result = Vec::new();
+            for (key, value) in pairs {
+                let item = deserialize_pair::<T>(key, value)
+                    .map_err(FailedToDeserializeQueryString::from_err)?;
+                result.push(item);
+            }
+
+            Ok(Self(result))
+        } else {
+            Ok(Self(Vec::new()))
+        }
+    }
+}
+
+impl<T> std::ops::Deref for OptionalQueryList<T> {
+    type Target = Vec<T>;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T> std::ops::DerefMut for OptionalQueryList<T> {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+composite_rejection! {
+    /// Rejection used for [`OptionalQueryList`].
+    ///
+    /// Contains one variant for each way the [`OptionalQueryList`] extractor can fail.
+    pub enum OptionalQueryListRejection {
+        FailedToDeserializeQueryString,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -187,6 +377,7 @@ mod tests {
 
     #[tokio::test]
     async fn query_supports_multiple_values() {
+        #[allow(dead_code)]
         #[derive(Deserialize)]
         struct Data {
             #[serde(rename = "value")]
@@ -212,6 +403,7 @@ mod tests {
 
     #[tokio::test]
     async fn correct_rejection_status_code() {
+        #[allow(dead_code)]
         #[derive(Deserialize)]
         #[allow(dead_code)]
         struct Params {
@@ -233,6 +425,7 @@ mod tests {
 
     #[tokio::test]
     async fn optional_query_supports_multiple_values() {
+        #[allow(dead_code)]
         #[derive(Deserialize)]
         struct Data {
             #[serde(rename = "value")]
@@ -261,6 +454,7 @@ mod tests {
 
     #[tokio::test]
     async fn optional_query_deserializes_no_parameters_into_none() {
+        #[allow(dead_code)]
         #[derive(Deserialize)]
         struct Data {
             value: String,
@@ -286,6 +480,7 @@ mod tests {
 
     #[tokio::test]
     async fn optional_query_preserves_parsing_errors() {
+        #[allow(dead_code)]
         #[derive(Deserialize)]
         struct Data {
             value: String,
@@ -314,6 +509,7 @@ mod tests {
 
     #[test]
     fn test_try_from_uri() {
+        #[allow(dead_code)]
         #[derive(Deserialize)]
         struct TestQueryParams {
             foo: Vec<String>,
@@ -329,6 +525,7 @@ mod tests {
 
     #[test]
     fn test_try_from_uri_with_invalid_query() {
+        #[allow(dead_code)]
         #[derive(Deserialize)]
         struct TestQueryParams {
             _foo: String,
@@ -338,6 +535,222 @@ mod tests {
             .parse()
             .unwrap();
         let result: Result<Query<TestQueryParams>, _> = Query::try_from_uri(&uri);
+
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn query_list_deserializes_alternating_enum_variants() {
+        #[allow(dead_code)]
+        #[derive(Debug, Deserialize, PartialEq)]
+        #[serde(rename_all = "lowercase")]
+        enum Param {
+            Id(u32),
+            Username(String),
+        }
+
+        let app = Router::new().route(
+            "/",
+            get(|QueryList(params): QueryList<Param>| async move {
+                format!(
+                    "{}",
+                    params
+                        .iter()
+                        .map(|p| match p {
+                            Param::Id(id) => format!("id:{}", id),
+                            Param::Username(u) => format!("user:{}", u),
+                        })
+                        .collect::<Vec<_>>()
+                        .join("|")
+                )
+            }),
+        );
+
+        let client = TestClient::new(app);
+
+        let res = client.get("/?id=123&username=alice&id=456").await;
+
+        assert_eq!(res.status(), StatusCode::OK);
+        assert_eq!(res.text().await, "id:123|user:alice|id:456");
+    }
+
+    #[tokio::test]
+    async fn query_list_maintains_order_with_repeated_variants() {
+        #[allow(dead_code)]
+        #[derive(Debug, Deserialize)]
+        #[serde(rename_all = "lowercase")]
+        enum Param {
+            Id(u32),
+            Name(String),
+        }
+
+        let app = Router::new().route(
+            "/",
+            get(|QueryList(params): QueryList<Param>| async move { format!("{}", params.len()) }),
+        );
+
+        let client = TestClient::new(app);
+
+        let res = client.get("/?id=1&name=a&id=2&name=b&id=3").await;
+
+        assert_eq!(res.status(), StatusCode::OK);
+        assert_eq!(res.text().await, "5");
+    }
+
+    #[tokio::test]
+    async fn query_list_empty_when_no_params() {
+        #[allow(dead_code)]
+        #[derive(Debug, Deserialize)]
+        enum Param {
+            Id(u32),
+        }
+
+        let app = Router::new().route(
+            "/",
+            get(|QueryList(params): QueryList<Param>| async move { format!("{}", params.len()) }),
+        );
+
+        let client = TestClient::new(app);
+
+        let res = client.get("/").await;
+
+        assert_eq!(res.status(), StatusCode::OK);
+        assert_eq!(res.text().await, "0");
+    }
+
+    #[tokio::test]
+    async fn query_list_rejects_unknown_variant() {
+        #[allow(dead_code)]
+        #[derive(Debug, Deserialize)]
+        #[serde(rename_all = "lowercase")]
+        enum Param {
+            Id(u32),
+        }
+
+        let app = Router::new().route("/", get(|_: QueryList<Param>| async move { "ok" }));
+
+        let client = TestClient::new(app);
+
+        let res = client.get("/?unknown=value").await;
+
+        assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn query_list_rejects_invalid_type_in_variant() {
+        #[allow(dead_code)]
+        #[derive(Debug, Deserialize)]
+        enum Param {
+            Id(u32),
+        }
+
+        let app = Router::new().route("/", get(|_: QueryList<Param>| async move { "ok" }));
+
+        let client = TestClient::new(app);
+
+        let res = client.get("/?id=not_a_number").await;
+
+        assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn optional_query_list_returns_empty_when_no_params() {
+        #[allow(dead_code)]
+        #[derive(Debug, Deserialize)]
+        enum Param {
+            Id(u32),
+        }
+
+        let app = Router::new().route(
+            "/",
+            get(
+                |OptionalQueryList(params): OptionalQueryList<Param>| async move {
+                    format!("{}", params.len())
+                },
+            ),
+        );
+
+        let client = TestClient::new(app);
+
+        let res = client.get("/").await;
+
+        assert_eq!(res.status(), StatusCode::OK);
+        assert_eq!(res.text().await, "0");
+    }
+
+    #[tokio::test]
+    async fn optional_query_list_deserializes_params_when_present() {
+        #[allow(dead_code)]
+        #[derive(Debug, Deserialize)]
+        #[serde(rename_all = "lowercase")]
+        enum Param {
+            Id(u32),
+            Name(String),
+        }
+
+        let app = Router::new().route(
+            "/",
+            get(
+                |OptionalQueryList(params): OptionalQueryList<Param>| async move {
+                    format!("{}", params.len())
+                },
+            ),
+        );
+
+        let client = TestClient::new(app);
+
+        let res = client.get("/?id=1&name=test").await;
+
+        assert_eq!(res.status(), StatusCode::OK);
+        assert_eq!(res.text().await, "2");
+    }
+
+    #[tokio::test]
+    async fn optional_query_list_rejects_invalid_param() {
+        #[allow(dead_code)]
+        #[derive(Debug, Deserialize)]
+        #[serde(rename_all = "lowercase")]
+        enum Param {
+            Id(u32),
+        }
+
+        let app = Router::new().route("/", get(|_: OptionalQueryList<Param>| async move { "ok" }));
+
+        let client = TestClient::new(app);
+
+        let res = client.get("/?id=invalid").await;
+
+        assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn test_query_list_try_from_uri() {
+        #[allow(dead_code)]
+        #[derive(Deserialize)]
+        #[serde(rename_all = "lowercase")]
+        enum Param {
+            Id(u32),
+            Name(String),
+        }
+
+        let uri: Uri = "http://example.com/path?id=123&name=alice&id=456"
+            .parse()
+            .unwrap();
+        let result: QueryList<Param> = QueryList::try_from_uri(&uri).unwrap();
+        assert_eq!(result.len(), 3);
+    }
+
+    #[test]
+    fn test_query_list_try_from_uri_with_invalid_param() {
+        #[allow(dead_code)]
+        #[derive(Deserialize)]
+        #[serde(rename_all = "lowercase")]
+        enum Param {
+            Id(u32),
+        }
+
+        let uri: Uri = "http://example.com/path?id=invalid".parse().unwrap();
+        let result: Result<QueryList<Param>, _> = QueryList::try_from_uri(&uri);
 
         assert!(result.is_err());
     }

--- a/axum-extra/src/extract/query.rs
+++ b/axum-extra/src/extract/query.rs
@@ -991,7 +991,7 @@ mod tests {
             .unwrap();
         let result: QueryList<Param> = QueryList::try_from_uri(&uri).unwrap();
         assert_eq!(result.len(), 2);
-        assert_eq!(result[0], Param::Name("john doe".to_string()));
-        assert_eq!(result[1], Param::Name("jane smith".to_string()));
+        assert_eq!(result[0], Param::Name("john doe".to_owned()));
+        assert_eq!(result[1], Param::Name("jane smith".to_owned()));
     }
 }

--- a/axum-extra/src/extract/query.rs
+++ b/axum-extra/src/extract/query.rs
@@ -405,7 +405,6 @@ mod tests {
     async fn correct_rejection_status_code() {
         #[allow(dead_code)]
         #[derive(Deserialize)]
-        #[allow(dead_code)]
         struct Params {
             n: i32,
         }
@@ -552,17 +551,14 @@ mod tests {
         let app = Router::new().route(
             "/",
             get(|QueryList(params): QueryList<Param>| async move {
-                format!(
-                    "{}",
-                    params
-                        .iter()
-                        .map(|p| match p {
-                            Param::Id(id) => format!("id:{}", id),
-                            Param::Username(u) => format!("user:{}", u),
-                        })
-                        .collect::<Vec<_>>()
-                        .join("|")
-                )
+                params
+                    .iter()
+                    .map(|p| match p {
+                        Param::Id(id) => format!("id:{id}"),
+                        Param::Username(u) => format!("user:{u}"),
+                    })
+                    .collect::<Vec<_>>()
+                    .join("|")
             }),
         );
 

--- a/axum-extra/src/extract/query.rs
+++ b/axum-extra/src/extract/query.rs
@@ -242,16 +242,12 @@ where
 
     async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
         let query = parts.uri.query().unwrap_or_default();
-        let pairs: Vec<(String, String)> = form_urlencoded::parse(query.as_bytes())
-            .map(|(k, v)| (k.into_owned(), v.into_owned()))
-            .collect();
-
-        let mut result = Vec::new();
-        for (key, value) in pairs {
-            let item = deserialize_pair::<T>(key, value)
-                .map_err(FailedToDeserializeQueryString::from_err)?;
-            result.push(item);
-        }
+        let result = form_urlencoded::parse(query.as_bytes())
+            .map(|(k, v)| {
+                deserialize_pair::<T>(k.into_owned(), v.into_owned())
+                    .map_err(FailedToDeserializeQueryString::from_err)
+            })
+            .collect::<Result<Vec<_>, _>>()?;
 
         Ok(Self(result))
     }
@@ -264,16 +260,12 @@ where
     /// Attempts to construct a [`QueryList`] from a reference to a [`Uri`].
     pub fn try_from_uri(value: &Uri) -> Result<Self, QueryListRejection> {
         let query = value.query().unwrap_or_default();
-        let pairs: Vec<(String, String)> = form_urlencoded::parse(query.as_bytes())
-            .map(|(k, v)| (k.into_owned(), v.into_owned()))
-            .collect();
-
-        let mut result = Vec::new();
-        for (key, value) in pairs {
-            let item = deserialize_pair::<T>(key, value)
-                .map_err(FailedToDeserializeQueryString::from_err)?;
-            result.push(item);
-        }
+        let result = form_urlencoded::parse(query.as_bytes())
+            .map(|(k, v)| {
+                deserialize_pair::<T>(k.into_owned(), v.into_owned())
+                    .map_err(FailedToDeserializeQueryString::from_err)
+            })
+            .collect::<Result<Vec<_>, _>>()?;
 
         Ok(Self(result))
     }
@@ -322,16 +314,12 @@ where
 
     async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
         if let Some(query) = parts.uri.query() {
-            let pairs: Vec<(String, String)> = form_urlencoded::parse(query.as_bytes())
-                .map(|(k, v)| (k.into_owned(), v.into_owned()))
-                .collect();
-
-            let mut result = Vec::new();
-            for (key, value) in pairs {
-                let item = deserialize_pair::<T>(key, value)
-                    .map_err(FailedToDeserializeQueryString::from_err)?;
-                result.push(item);
-            }
+            let result = form_urlencoded::parse(query.as_bytes())
+                .map(|(k, v)| {
+                    deserialize_pair::<T>(k.into_owned(), v.into_owned())
+                        .map_err(FailedToDeserializeQueryString::from_err)
+                })
+                .collect::<Result<Vec<_>, _>>()?;
 
             Ok(Self(result))
         } else {

--- a/axum-extra/src/extract/query.rs
+++ b/axum-extra/src/extract/query.rs
@@ -750,4 +750,248 @@ mod tests {
 
         assert!(result.is_err());
     }
+    #[tokio::test]
+    async fn query_list_decodes_url_encoded_whitespace() {
+        #[allow(dead_code)]
+        #[derive(Debug, Deserialize, PartialEq)]
+        #[serde(rename_all = "lowercase")]
+        enum Param {
+            Name(String),
+            Tag(String),
+        }
+
+        let app = Router::new().route(
+            "/",
+            get(|QueryList(params): QueryList<Param>| async move {
+                params
+                    .iter()
+                    .map(|p| match p {
+                        Param::Name(n) => format!("name:{n}"),
+                        Param::Tag(t) => format!("tag:{t}"),
+                    })
+                    .collect::<Vec<_>>()
+                    .join("|")
+            }),
+        );
+
+        let client = TestClient::new(app);
+
+        let res = client.get("/?name=john%20doe&tag=hello%20world").await;
+        assert_eq!(res.status(), StatusCode::OK);
+        assert_eq!(res.text().await, "name:john doe|tag:hello world");
+
+        let res = client.get("/?name=john+doe&tag=hello+world").await;
+        assert_eq!(res.status(), StatusCode::OK);
+        assert_eq!(res.text().await, "name:john doe|tag:hello world");
+    }
+
+    #[tokio::test]
+    async fn query_list_decodes_url_encoded_ampersand() {
+        #[allow(dead_code)]
+        #[derive(Debug, Deserialize, PartialEq)]
+        #[serde(rename_all = "lowercase")]
+        enum Param {
+            Name(String),
+        }
+
+        let app = Router::new().route(
+            "/",
+            get(|QueryList(params): QueryList<Param>| async move {
+                params
+                    .iter()
+                    .map(|p| match p {
+                        Param::Name(n) => format!("name:{n}"),
+                    })
+                    .collect::<Vec<_>>()
+                    .join("|")
+            }),
+        );
+
+        let client = TestClient::new(app);
+
+        let res = client.get("/?name=alice%26bob&name=charlie%26dave").await;
+        assert_eq!(res.status(), StatusCode::OK);
+        assert_eq!(res.text().await, "name:alice&bob|name:charlie&dave");
+    }
+
+    #[tokio::test]
+    async fn query_list_decodes_url_encoded_equals_sign() {
+        #[allow(dead_code)]
+        #[derive(Debug, Deserialize, PartialEq)]
+        #[serde(rename_all = "lowercase")]
+        enum Param {
+            Expression(String),
+        }
+
+        let app = Router::new().route(
+            "/",
+            get(|QueryList(params): QueryList<Param>| async move {
+                params
+                    .iter()
+                    .map(|p| match p {
+                        Param::Expression(e) => format!("expr:{e}"),
+                    })
+                    .collect::<Vec<_>>()
+                    .join("|")
+            }),
+        );
+
+        let client = TestClient::new(app);
+
+        let res = client.get("/?expression=x%3D5&expression=y%3D10").await;
+        assert_eq!(res.status(), StatusCode::OK);
+        assert_eq!(res.text().await, "expr:x=5|expr:y=10");
+    }
+
+    #[tokio::test]
+    async fn query_list_decodes_url_encoded_plus_sign() {
+        #[allow(dead_code)]
+        #[derive(Debug, Deserialize, PartialEq)]
+        #[serde(rename_all = "lowercase")]
+        enum Param {
+            Math(String),
+        }
+
+        let app = Router::new().route(
+            "/",
+            get(|QueryList(params): QueryList<Param>| async move {
+                params
+                    .iter()
+                    .map(|p| match p {
+                        Param::Math(m) => format!("math:{m}"),
+                    })
+                    .collect::<Vec<_>>()
+                    .join("|")
+            }),
+        );
+
+        let client = TestClient::new(app);
+
+        let res = client.get("/?math=1%2B2&math=3%2B4").await;
+        assert_eq!(res.status(), StatusCode::OK);
+        assert_eq!(res.text().await, "math:1+2|math:3+4");
+    }
+
+    #[tokio::test]
+    async fn query_list_decodes_url_encoded_special_characters() {
+        #[allow(dead_code)]
+        #[derive(Debug, Deserialize, PartialEq)]
+        #[serde(rename_all = "lowercase")]
+        enum Param {
+            Url(String),
+            Path(String),
+            Percent(String),
+        }
+
+        let app = Router::new().route(
+            "/",
+            get(|QueryList(params): QueryList<Param>| async move {
+                params
+                    .iter()
+                    .map(|p| match p {
+                        Param::Url(u) => format!("url:{u}"),
+                        Param::Path(p) => format!("path:{p}"),
+                        Param::Percent(p) => format!("pct:{p}"),
+                    })
+                    .collect::<Vec<_>>()
+                    .join("|")
+            }),
+        );
+
+        let client = TestClient::new(app);
+
+        let res = client
+            .get("/?url=https%3A%2F%2Fexample.com&path=foo%2Fbar&percent=100%25")
+            .await;
+        assert_eq!(res.status(), StatusCode::OK);
+        assert_eq!(
+            res.text().await,
+            "url:https://example.com|path:foo/bar|pct:100%"
+        );
+    }
+
+    #[tokio::test]
+    async fn query_list_handles_mixed_encoded_and_plain_text() {
+        #[allow(dead_code)]
+        #[derive(Debug, Deserialize, PartialEq)]
+        #[serde(rename_all = "lowercase")]
+        enum Param {
+            Name(String),
+        }
+
+        let app = Router::new().route(
+            "/",
+            get(|QueryList(params): QueryList<Param>| async move {
+                params
+                    .iter()
+                    .map(|p| match p {
+                        Param::Name(n) => format!("name:{n}"),
+                    })
+                    .collect::<Vec<_>>()
+                    .join("|")
+            }),
+        );
+
+        let client = TestClient::new(app);
+
+        let res = client
+            .get("/?name=simple&name=with%20space&name=with%26ampersand")
+            .await;
+        assert_eq!(res.status(), StatusCode::OK);
+        assert_eq!(
+            res.text().await,
+            "name:simple|name:with space|name:with&ampersand"
+        );
+    }
+
+    #[tokio::test]
+    async fn optional_query_list_decodes_url_encoded_special_characters() {
+        #[allow(dead_code)]
+        #[derive(Debug, Deserialize, PartialEq)]
+        #[serde(rename_all = "lowercase")]
+        enum Param {
+            Name(String),
+            Tag(String),
+        }
+
+        let app = Router::new().route(
+            "/",
+            get(|OptionalQueryList(params): OptionalQueryList<Param>| async move {
+                params
+                    .iter()
+                    .map(|p| match p {
+                        Param::Name(n) => format!("name:{n}"),
+                        Param::Tag(t) => format!("tag:{t}"),
+                    })
+                    .collect::<Vec<_>>()
+                    .join("|")
+            }),
+        );
+
+        let client = TestClient::new(app);
+
+        let res = client
+            .get("/?name=john%20doe&tag=hello%26world")
+            .await;
+        assert_eq!(res.status(), StatusCode::OK);
+        assert_eq!(res.text().await, "name:john doe|tag:hello&world");
+    }
+
+    #[test]
+    fn test_query_list_try_from_uri_with_encoded_special_characters() {
+        #[allow(dead_code)]
+        #[derive(Deserialize, PartialEq, Debug)]
+        #[serde(rename_all = "lowercase")]
+        enum Param {
+            Name(String),
+        }
+
+        let uri: Uri = "http://example.com/path?name=john%20doe&name=jane%20smith"
+            .parse()
+            .unwrap();
+        let result: QueryList<Param> = QueryList::try_from_uri(&uri).unwrap();
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0], Param::Name("john doe".to_string()));
+        assert_eq!(result[1], Param::Name("jane smith".to_string()));
+    }
 }


### PR DESCRIPTION
Fixes #3696

## Summary

This PR adds two new extractors to handle a real pain point: query strings with mixed enum variants. You can now write handlers that accept `?id=123&username=alice&id=456` and get back a properly-typed `Vec<SearchFilter>` with all the variants in order.

## Problem

Axum's query parameter handling works great for flat structs. But if you need to accept different parameter names as different enum variants — like filtering by ID or username in the same request — you're stuck. `serde_html_form` doesn't support this pattern because it doesn't know that the parameter *name* should pick the enum variant.

Your options were: hand-parse the query string, build a custom extractor, or restructure the API. None of them are fun.

## Solution

Two new extractors:
- **`QueryList<T>`** - Deserializes all query parameters into `Vec<T>`, where `T` is an enum. The parameter name becomes the variant discriminator.
- **`OptionalQueryList<T>`** - Same as `QueryList`, but returns an empty vec if there are no parameters (no error on missing data).

### How it works

The trick is simple: for each query parameter pair, create a JSON object `{ variant_name: value }` and let serde's enum deserializer do the work. Serde already knows how to pick the right enum variant from the object key. We just had to bridge the gap between query strings and JSON objects.

The implementation also handles value types correctly: `id=123` deserializes as the number 123 (not the string "123"), and `active=true` becomes a boolean, just like you'd expect from JSON semantics.

## Example

```rust
#[derive(Deserialize)]
#[serde(rename_all = "lowercase")]
enum SearchFilter {
    Id(u32),
    Username(String),
}

async fn search(QueryList(filters): QueryList<SearchFilter>) {
    for filter in filters {
        match filter {
            SearchFilter::Id(id) => println!("Filter by ID: {}", id),
            SearchFilter::Username(name) => println!("Filter by user: {}", name),
        }
    }
}

// GET /search?id=123&username=alice&id=456
// Receives: [Id(123), Username("alice"), Id(456)]
```

## Testing

Nine tests cover the realistic cases:
- Alternating enum variants in any order
- The same variant repeated (e.g., `?id=1&id=2&id=3`)
- Empty query strings
- Unknown variant names (400 Bad Request)
- Invalid values (type errors)
- Both sync and async extraction paths
- `OptionalQueryList` behavior with and without parameters

All existing tests pass. No breakage.

## Changes

- `axum-extra/src/extract/query.rs` — Added `QueryList<T>`, `OptionalQueryList<T>`, the `deserialize_pair` helper, and rejection types
- `axum-extra/src/extract/mod.rs` — Exported the new types
- `axum-extra/Cargo.toml` — Added `serde_json` dependency for the "query" feature

## Notes

- Reuses the existing `FailedToDeserializeQueryString` rejection type for consistency
- Follows the same patterns as `Query`/`OptionalQuery` so the API surface is familiar
- Works with any `DeserializeOwned` enum — full type safety
- Values parse as JSON types: `id=123` is a number, `active=true` is a boolean, `name=alice` is a string

Natural fit for axum-extra's extraction toolkit. The approach is simple and delegates the hard work to serde, which already knows how to deserialize enums correctly.