### PR TITLE
Add test coverage for hello-world example

### DIFF
--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -1343,7 +1343,9 @@ name = "example-hello-world"
 version = "0.1.0"
 dependencies = [
  "axum",
+ "http-body-util",
  "tokio",
+ "tower",
 ]
 
 [[package]]

--- a/examples/hello-world/Cargo.toml
+++ b/examples/hello-world/Cargo.toml
@@ -7,3 +7,7 @@ publish = false
 [dependencies]
 axum = { path = "../../axum" }
 tokio = { version = "1.0", features = ["full"] }
+
+[dev-dependencies]
+http-body-util = "0.1.3"
+tower = "0.5.2"

--- a/examples/hello-world/src/main.rs
+++ b/examples/hello-world/src/main.rs
@@ -9,7 +9,7 @@ use axum::{response::Html, routing::get, Router};
 #[tokio::main]
 async fn main() {
     // build our application with a route
-    let app = Router::new().route("/", get(handler));
+    let app = app();
 
     // run it
     let listener = tokio::net::TcpListener::bind("127.0.0.1:3000")
@@ -19,6 +19,36 @@ async fn main() {
     axum::serve(listener, app).await;
 }
 
+fn app() -> Router {
+    Router::new().route("/", get(handler))
+}
+
 async fn handler() -> Html<&'static str> {
     Html("<h1>Hello, World!</h1>")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+    };
+    use http_body_util::BodyExt;
+    use tower::ServiceExt;
+
+    #[tokio::test]
+    async fn get_root() {
+        let response = app()
+            .oneshot(Request::get("/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let body = std::str::from_utf8(&body).unwrap();
+
+        assert_eq!(body, "<h1>Hello, World!</h1>");
+    }
 }


### PR DESCRIPTION
#3263

This updates the `hello-world` example to expose an `app()` constructor and adds a focused test for
  `GET /`.

The test verifies that:
- the route responds with `200 OK`
- the response body matches the expected HTML

Tested with:
- cargo fmt --all --check
- cargo test -p example-hello-world