### PR TITLE
feat(axum-extra): add QueryList and OptionalQueryList with optional cap

### DIFF
--- a/axum-extra/Cargo.toml
+++ b/axum-extra/Cargo.toml
@@ -80,6 +80,7 @@ query = [
     "dep:serde_core",
     "dep:serde_html_form",
     "dep:serde_path_to_error",
+    "dep:serde_json",
 ]
 tracing = ["axum-core/tracing", "axum/tracing", "dep:tracing"]
 typed-header = ["dep:headers"]

--- a/axum-extra/Cargo.toml
+++ b/axum-extra/Cargo.toml
@@ -77,6 +77,7 @@ protobuf = ["dep:prost"]
 routing = ["axum/original-uri", "dep:rustversion"]
 query = [
     "dep:form_urlencoded",
+    "dep:serde",
     "dep:serde_core",
     "dep:serde_html_form",
     "dep:serde_path_to_error",

--- a/axum-extra/src/extract/mod.rs
+++ b/axum-extra/src/extract/mod.rs
@@ -18,6 +18,9 @@ mod json_deserializer;
 #[cfg(feature = "query")]
 mod query;
 
+#[cfg(feature = "query")]
+mod query_list;
+
 #[cfg(feature = "multipart")]
 pub mod multipart;
 
@@ -45,6 +48,10 @@ pub use self::query::OptionalQuery;
 #[cfg(feature = "query")]
 #[allow(deprecated)]
 pub use self::query::{OptionalQueryRejection, Query, QueryRejection};
+#[cfg(feature = "query")]
+pub use self::query_list::QueryList;
+#[cfg(feature = "query")]
+pub use self::query_list::OptionalQueryList;
 
 #[cfg(feature = "multipart")]
 pub use self::multipart::Multipart;

--- a/axum-extra/src/extract/mod.rs
+++ b/axum-extra/src/extract/mod.rs
@@ -49,9 +49,9 @@ pub use self::query::OptionalQuery;
 #[allow(deprecated)]
 pub use self::query::{OptionalQueryRejection, Query, QueryRejection};
 #[cfg(feature = "query")]
-pub use self::query_list::QueryList;
-#[cfg(feature = "query")]
 pub use self::query_list::OptionalQueryList;
+#[cfg(feature = "query")]
+pub use self::query_list::QueryList;
 
 #[cfg(feature = "multipart")]
 pub use self::multipart::Multipart;

--- a/axum-extra/src/extract/query_list.rs
+++ b/axum-extra/src/extract/query_list.rs
@@ -137,7 +137,6 @@ mod tests {
             .into_parts()
             .0;
         let result = QueryList::<List>::from_request_parts(&mut parts, &()).await;
-        dbg!(&result);
         assert!(result.is_ok());
     }
 

--- a/axum-extra/src/extract/query_list.rs
+++ b/axum-extra/src/extract/query_list.rs
@@ -57,8 +57,7 @@ where
 
         if result.len() > MAX {
             return Err(FailedToDeserializeQueryString::from_err(format!(
-                "too many query parameters, max allowed is {}",
-                MAX
+                "too many query parameters, max allowed is {MAX}"
             ))
             .into());
         }
@@ -94,8 +93,7 @@ where
 
         if result.len() > MAX {
             return Err(FailedToDeserializeQueryString::from_err(format!(
-                "too many query parameters, max allowed is {}",
-                MAX
+                "too many query parameters, max allowed is {MAX}"
             ))
             .into());
         }

--- a/axum-extra/src/extract/query_list.rs
+++ b/axum-extra/src/extract/query_list.rs
@@ -1,0 +1,225 @@
+use axum_core::__composite_rejection as composite_rejection;
+use axum_core::__define_rejection as define_rejection;
+use axum_core::extract::FromRequestParts;
+use http::request::Parts;
+use serde::de::DeserializeOwned;
+
+fn deserialize_pair<T: DeserializeOwned>(key: &str, value: &str) -> Result<T, serde_json::Error> {
+    if let Ok(n) = value.parse::<i64>() {
+        serde_json::from_value(serde_json::json!({ key: n }))
+    } else if let Ok(b) = value.parse::<bool>() {
+        serde_json::from_value(serde_json::json!({ key: b }))
+    } else {
+        serde_json::from_value(serde_json::json!({ key: value }))
+    }
+}
+
+/// Extractor that deserializes query string into `Vec<T>`.
+/// Each key-value pair is deserialized into one `T`.
+///
+/// `MAX` limits the total number of items. Defaults to unlimited.
+///
+/// # Example
+/// ```rust,no_run
+/// use axum_extra::extract::QueryList;
+/// use serde::Deserialize;
+///
+/// #[derive(Deserialize)]
+/// #[serde(rename_all = "lowercase")]
+/// enum Filter {
+///     Id(u32),
+///     Username(String),
+/// }
+///
+/// async fn handler(QueryList(filters): QueryList<Filter>) { }
+/// async fn handler_capped(QueryList(filters): QueryList<Filter, 10>) { }
+/// ```
+#[cfg_attr(docsrs, doc(cfg(feature = "query")))]
+#[derive(Debug, Clone, Default)]
+pub struct QueryList<T, const MAX: usize = { usize::MAX }>(pub Vec<T>);
+
+impl<T, S, const MAX: usize> FromRequestParts<S> for QueryList<T, MAX>
+where
+    T: DeserializeOwned,
+    S: Send + Sync,
+{
+    type Rejection = QueryListRejection;
+
+    async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
+        let query = parts.uri.query().unwrap_or_default();
+
+        let result = form_urlencoded::parse(query.as_bytes())
+            .map(|(k, v)| {
+                deserialize_pair::<T>(k.as_ref(), v.as_ref())
+                    .map_err(FailedToDeserializeQueryString::from_err)
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        if result.len() > MAX {
+            return Err(FailedToDeserializeQueryString::from_err(format!(
+                "too many query parameters, max allowed is {}",
+                MAX
+            ))
+            .into());
+        }
+
+        Ok(Self(result))
+    }
+}
+
+/// Extractor that deserializes query string into `Vec<T>`.
+/// Returns empty `Vec` if no query parameters are present.
+///
+/// `MAX` limits the total number of items. Defaults to unlimited.
+#[cfg_attr(docsrs, doc(cfg(feature = "query")))]
+#[derive(Debug, Clone, Default)]
+pub struct OptionalQueryList<T, const MAX: usize = { usize::MAX }>(pub Vec<T>);
+
+impl<T, S, const MAX: usize> FromRequestParts<S> for OptionalQueryList<T, MAX>
+where
+    T: DeserializeOwned,
+    S: Send + Sync,
+{
+    type Rejection = QueryListRejection;
+
+    async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
+        let query = parts.uri.query().unwrap_or_default();
+
+        let result = form_urlencoded::parse(query.as_bytes())
+            .map(|(k, v)| {
+                deserialize_pair::<T>(k.as_ref(), v.as_ref())
+                    .map_err(FailedToDeserializeQueryString::from_err)
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        if result.len() > MAX {
+            return Err(FailedToDeserializeQueryString::from_err(format!(
+                "too many query parameters, max allowed is {}",
+                MAX
+            ))
+            .into());
+        }
+
+        Ok(Self(result))
+    }
+}
+
+define_rejection! {
+    #[status = BAD_REQUEST]
+    #[body = "Failed to deserialize query string"]
+    pub struct FailedToDeserializeQueryString(Error);
+}
+
+composite_rejection! {
+    pub enum QueryListRejection {
+        FailedToDeserializeQueryString,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::Deserialize;
+
+    #[derive(Debug, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    #[allow(dead_code)]
+    enum List {
+        Id(u32),
+        Username(String),
+    }
+
+    #[tokio::test]
+    async fn test_query_list_enum() {
+        let uri: http::Uri = "/?id=123&username=abc&id=345&username=def".parse().unwrap();
+        let mut parts = http::Request::builder()
+            .uri(uri)
+            .body(())
+            .unwrap()
+            .into_parts()
+            .0;
+        let result = QueryList::<List>::from_request_parts(&mut parts, &()).await;
+        dbg!(&result);
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_same_variant_repeated() {
+        let uri: http::Uri = "/?id=1&id=2&id=3".parse().unwrap();
+        let mut parts = http::Request::builder()
+            .uri(uri)
+            .body(())
+            .unwrap()
+            .into_parts()
+            .0;
+        let result = QueryList::<List>::from_request_parts(&mut parts, &()).await;
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().0.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn test_empty_query_string() {
+        let uri: http::Uri = "/".parse().unwrap();
+        let mut parts = http::Request::builder()
+            .uri(uri)
+            .body(())
+            .unwrap()
+            .into_parts()
+            .0;
+        let result = OptionalQueryList::<List>::from_request_parts(&mut parts, &()).await;
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().0.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_unknown_variant_returns_error() {
+        let uri: http::Uri = "/?unknown=123".parse().unwrap();
+        let mut parts = http::Request::builder()
+            .uri(uri)
+            .body(())
+            .unwrap()
+            .into_parts()
+            .0;
+        let result = QueryList::<List>::from_request_parts(&mut parts, &()).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_invalid_value_returns_error() {
+        let uri: http::Uri = "/?id=abc".parse().unwrap();
+        let mut parts = http::Request::builder()
+            .uri(uri)
+            .body(())
+            .unwrap()
+            .into_parts()
+            .0;
+        let result = QueryList::<List>::from_request_parts(&mut parts, &()).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_special_characters() {
+        let uri: http::Uri = "/?username=hello%20world".parse().unwrap();
+        let mut parts = http::Request::builder()
+            .uri(uri)
+            .body(())
+            .unwrap()
+            .into_parts()
+            .0;
+        let result = QueryList::<List>::from_request_parts(&mut parts, &()).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_cap_limit() {
+        let uri: http::Uri = "/?id=1&id=2&id=3".parse().unwrap();
+        let mut parts = http::Request::builder()
+            .uri(uri)
+            .body(())
+            .unwrap()
+            .into_parts()
+            .0;
+        let result = QueryList::<List, 2>::from_request_parts(&mut parts, &()).await;
+        assert!(result.is_err());
+    }
+}


### PR DESCRIPTION
## Motivation

Fixes #3696

axum's Query extractor doesn't support deserializing `Vec<Enum>` 
from query strings. The original issue also requested a cap on 
total items (`CappedVec<List, 10>`), which existing PR #3751 
doesn't implement.

## Solution

Two new extractors in `axum-extra`:

- `QueryList<T>` — deserializes repeated query params into `Vec<T>`
- `QueryList<T, 10>` — same but with a compile-time cap on total items
- `OptionalQueryList<T>` — returns empty `Vec` if no params present

Implementation avoids intermediate Vec allocation by chaining 
directly into `collect::<Result<Vec<_>, _>>()`.

7 tests added covering:
- Mixed enum variants in order
- Same variant repeated
- Empty query string
- Unknown variant (400 error)
- Invalid value (400 error)  
- Special characters
- Cap limit enforcement