### PR TITLE
examples: Update to diesel-async 0.9

### DIFF
--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -957,9 +957,9 @@ dependencies = [
 
 [[package]]
 name = "diesel"
-version = "2.3.6"
+version = "2.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b6c2fc184a6fb6ebcf5f9a5e3bbfa84d8fd268cdfcce4ed508979a6259494d"
+checksum = "9940fb8467a0a06312218ed384185cb8536aa10d8ec017d0ce7fad2c1bd882d5"
 dependencies = [
  "bitflags",
  "byteorder",
@@ -971,9 +971,9 @@ dependencies = [
 
 [[package]]
 name = "diesel-async"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b95864e58597509106f1fddfe0600de7e589e1fddddd87f54eee0a49fd111bbc"
+checksum = "9c20ddcc6737cecdaef3dfecb2796bdfe3002456521189d30be8e4c5a1bc821d"
 dependencies = [
  "bb8",
  "diesel",
@@ -981,7 +981,6 @@ dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
- "scoped-futures",
  "tokio",
  "tokio-postgres",
 ]
@@ -3669,15 +3668,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
 dependencies = [
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "scoped-futures"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b24aae2d0636530f359e9d5ef0c04669d11c5e756699b27a6a6d845d8329091"
-dependencies = [
- "pin-project-lite",
 ]
 
 [[package]]

--- a/examples/diesel-async-postgres/Cargo.toml
+++ b/examples/diesel-async-postgres/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 axum = { path = "../../axum", features = ["macros"] }
 diesel = "~2.3"
-diesel-async = { version = "0.8", features = ["postgres", "bb8", "migrations"] }
+diesel-async = { version = "0.9", features = ["postgres", "bb8", "migrations"] }
 diesel_migrations = "~2.3"
 serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "1.0", features = ["full"] }


### PR DESCRIPTION
Updates to `diesel-async` 0.9.