### PR TITLE
examples: fix `using_serve_dir_with_assets_fallback` to not expose assets at root

### DIFF
--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -1611,6 +1611,7 @@ name = "example-static-file-server"
 version = "0.1.0"
 dependencies = [
  "axum",
+ "http-body-util",
  "tokio",
  "tower",
  "tower-http",

--- a/examples/static-file-server/Cargo.toml
+++ b/examples/static-file-server/Cargo.toml
@@ -11,3 +11,6 @@ tower = { version = "0.5.2", features = ["util"] }
 tower-http = { version = "0.6.1", features = ["fs", "trace"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
+[dev-dependencies]
+http-body-util = "0.1.0"

--- a/examples/static-file-server/Cargo.toml
+++ b/examples/static-file-server/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 axum = { path = "../../axum" }
 tokio = { version = "1.0", features = ["full"] }
 tower = { version = "0.5.2", features = ["util"] }
-tower-http = { version = "0.6.1", features = ["fs", "trace"] }
+tower-http = { version = "0.6.1", features = ["fs", "set-status", "trace"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 

--- a/examples/static-file-server/src/main.rs
+++ b/examples/static-file-server/src/main.rs
@@ -11,6 +11,7 @@ use std::net::SocketAddr;
 use tower::ServiceExt;
 use tower_http::{
     services::{ServeDir, ServeFile},
+    set_status::SetStatus,
     trace::TraceLayer,
 };
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
@@ -47,8 +48,10 @@ fn using_serve_dir_with_assets_fallback() -> Router {
     // so with this `GET /assets/doesnt-exist.jpg` will return `index.html`
     // rather than a 404.
     // The `fallback_service` ensures that all other paths (the standard
-    // SPA pattern) also return `index.html` rather than 404.
-    let index_html = ServeFile::new("assets/index.html");
+    // SPA pattern) also return `index.html`. We wrap it in `SetStatus` so
+    // the response uses 404 instead of 200 -- the path wasn't found, the SPA
+    // just handles routing client-side.
+    let index_html = SetStatus::new(ServeFile::new("assets/index.html"), StatusCode::NOT_FOUND);
     let serve_dir = ServeDir::new("assets").not_found_service(index_html.clone());
 
     Router::new()

--- a/examples/static-file-server/src/main.rs
+++ b/examples/static-file-server/src/main.rs
@@ -46,14 +46,15 @@ fn using_serve_dir_with_assets_fallback() -> Router {
     // `ServeDir` allows setting a fallback if an asset is not found
     // so with this `GET /assets/doesnt-exist.jpg` will return `index.html`
     // rather than a 404.
-    // The `fallback_service` ensures that all other paths (e.g. for a
-    // single-page application) also return `index.html` instead of 404.
-    let serve_dir = ServeDir::new("assets").not_found_service(ServeFile::new("assets/index.html"));
+    // The `fallback_service` ensures that all other paths (the standard
+    // SPA pattern) also return `index.html` rather than 404.
+    let index_html = ServeFile::new("assets/index.html");
+    let serve_dir = ServeDir::new("assets").not_found_service(index_html.clone());
 
     Router::new()
         .route("/foo", get(|| async { "Hi from /foo" }))
         .nest_service("/assets", serve_dir)
-        .fallback_service(ServeFile::new("assets/index.html"))
+        .fallback_service(index_html)
 }
 
 fn using_serve_dir_only_from_root_via_fallback() -> Router {

--- a/examples/static-file-server/src/main.rs
+++ b/examples/static-file-server/src/main.rs
@@ -45,13 +45,15 @@ fn using_serve_dir() -> Router {
 fn using_serve_dir_with_assets_fallback() -> Router {
     // `ServeDir` allows setting a fallback if an asset is not found
     // so with this `GET /assets/doesnt-exist.jpg` will return `index.html`
-    // rather than a 404
+    // rather than a 404.
+    // The `fallback_service` ensures that all other paths (e.g. for a
+    // single-page application) also return `index.html` instead of 404.
     let serve_dir = ServeDir::new("assets").not_found_service(ServeFile::new("assets/index.html"));
 
     Router::new()
         .route("/foo", get(|| async { "Hi from /foo" }))
-        .nest_service("/assets", serve_dir.clone())
-        .fallback_service(serve_dir)
+        .nest_service("/assets", serve_dir)
+        .fallback_service(ServeFile::new("assets/index.html"))
 }
 
 fn using_serve_dir_only_from_root_via_fallback() -> Router {
@@ -106,6 +108,9 @@ fn calling_serve_dir_from_a_handler() -> Router {
 fn using_serve_file_from_a_route() -> Router {
     Router::new().route_service("/foo", ServeFile::new("assets/index.html"))
 }
+
+#[cfg(test)]
+mod tests;
 
 async fn serve(app: Router, port: u16) {
     let addr = SocketAddr::from(([127, 0, 0, 1], port));

--- a/examples/static-file-server/src/tests.rs
+++ b/examples/static-file-server/src/tests.rs
@@ -1,0 +1,29 @@
+use super::using_serve_dir_with_assets_fallback;
+use axum::{body::Body, http::Request, http::StatusCode};
+use http_body_util::BodyExt;
+use tower::ServiceExt;
+
+const INDEX_HTML_CONTENT: &str = include_str!("../assets/index.html");
+
+// Assets nested under `/assets` must not be reachable at the root.
+// Previously, `fallback_service(serve_dir)` served the whole assets directory
+// as a fallback, so `/script.js` would return the actual script.js instead of
+// the SPA fallback (index.html).
+#[tokio::test]
+async fn assets_not_served_at_root() {
+    let app = using_serve_dir_with_assets_fallback();
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/script.js")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let body_str = String::from_utf8(body.to_vec()).unwrap();
+    assert_eq!(body_str, INDEX_HTML_CONTENT);
+}

--- a/examples/static-file-server/src/tests.rs
+++ b/examples/static-file-server/src/tests.rs
@@ -6,9 +6,6 @@ use tower::ServiceExt;
 const INDEX_HTML_CONTENT: &str = include_str!("../assets/index.html");
 
 // Assets nested under `/assets` must not be reachable at the root.
-// Previously, `fallback_service(serve_dir)` served the whole assets directory
-// as a fallback, so `/script.js` would return the actual script.js instead of
-// the SPA fallback (index.html).
 #[tokio::test]
 async fn assets_not_served_at_root() {
     let app = using_serve_dir_with_assets_fallback();

--- a/examples/static-file-server/src/tests.rs
+++ b/examples/static-file-server/src/tests.rs
@@ -5,7 +5,9 @@ use tower::ServiceExt;
 
 const INDEX_HTML_CONTENT: &str = include_str!("../assets/index.html");
 
-// Assets nested under `/assets` must not be reachable at the root.
+// `/script.js` at the root is not an asset under `/assets`, so it falls through to the SPA
+// fallback. The fallback serves `index.html` with a 404 status -- the path wasn't found, but
+// the SPA handles routing client-side.
 #[tokio::test]
 async fn assets_not_served_at_root() {
     let app = using_serve_dir_with_assets_fallback();
@@ -19,7 +21,7 @@ async fn assets_not_served_at_root() {
         .await
         .unwrap();
 
-    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
     let body = response.into_body().collect().await.unwrap().to_bytes();
     let body_str = String::from_utf8(body.to_vec()).unwrap();
     assert_eq!(body_str, INDEX_HTML_CONTENT);


### PR DESCRIPTION
Closes #2809.
Credit to @tobx, who identified the root cause and expected behavior in the issue thread. This is the implementation.

## Motivation

The SPA example in `using_serve_dir_with_assets_fallback` is supposed to serve assets at `/assets/*` and return `index.html` for everything else. In practice, the router fallback pointed at the full `ServeDir`, so `/script.js` served the actual script rather than the index page.

## Solution

Change the fallback from `ServeDir` to a `ServeFile` for `index.html`. The `/assets` route is unchanged. Files still load from there, and missing ones fall back to `index.html`. Only the root-level fallback changes.

`ServeFile: Clone`, so both uses share one binding instead of two identical constructor calls.

Adds a regression test: `GET /script.js` returns `index.html` content, not the script.