### PR TITLE
docs: WebSocket cancel safety and route_service example updates

### DIFF
--- a/axum/src/docs/routing/route_service.md
+++ b/axum/src/docs/routing/route_service.md
@@ -20,9 +20,9 @@ let app = Router::new()
     .route(
         // Any request to `/` goes to a service
         "/",
-        // Services whose response body is not `axum::body::BoxBody`
-        // can be wrapped in `axum::routing::any_service` (or one of the other routing filters)
-        // to have the response body mapped
+        // Services whose responses implement `axum::response::IntoResponse` can
+        // be wrapped in `axum::routing::any_service` (or one of the other routing filters)
+        // to turn them into routes.
         any_service(service_fn(|_: Request| async {
             let res = Response::new(Body::from("Hi from `GET /`"));
             Ok::<_, Infallible>(res)
@@ -30,8 +30,8 @@ let app = Router::new()
     )
     .route_service(
         "/foo",
-        // This service's response body is `axum::body::BoxBody` so
-        // it can be routed to directly.
+        // This service's request body is `axum::body::Body`, and its response
+        // can be any type that implements `axum::response::IntoResponse`.
         service_fn(|req: Request| async move {
             let body = Body::from(format!("Hi from `{} /foo`", req.method()));
             let res = Response::new(body);

--- a/axum/src/extract/ws.rs
+++ b/axum/src/extract/ws.rs
@@ -89,6 +89,24 @@
 //! ```
 //!
 //! [`StreamExt::split`]: https://docs.rs/futures/0.3.17/futures/stream/trait.StreamExt.html#method.split
+//!
+//! # Cancellation safety
+//!
+//! [`WebSocket::recv`] is cancel-safe: it forwards to [`StreamExt::next`], which only
+//! holds a reference to the stream, so dropping the future before it completes does not
+//! discard a received message. This makes it suitable for use in
+//! [`tokio::select!`](https://docs.rs/tokio/latest/tokio/macro.select.html) alongside
+//! other cancel-safe futures (for example [`broadcast::Receiver::recv`]).
+//!
+//! When using [`StreamExt::split`], the read half is a [`SplitStream`] that implements
+//! [`Stream`]; use [`StreamExt::next`] on it for the same cancel-safety guarantees.
+//!
+//! [`WebSocket::send`] uses the [`Sink`] implementation. See [`SinkExt::send`] for its
+//! cancellation semantics when used in `select!`.
+//!
+//! [`broadcast::Receiver::recv`]: https://docs.rs/tokio/latest/tokio/sync/broadcast/struct.Receiver.html#method.recv
+//! [`SplitStream`]: https://docs.rs/futures-util/latest/futures_util/stream/struct.SplitStream.html
+//! [`SinkExt::send`]: https://docs.rs/futures-util/latest/futures_util/sink/trait.SinkExt.html#method.send
 
 use self::rejection::*;
 use super::FromRequestParts;
@@ -549,6 +567,10 @@ impl WebSocket {
     /// Receive another message.
     ///
     /// Returns `None` if the stream has closed.
+    ///
+    /// # Cancel safety
+    ///
+    /// This method is cancel-safe (see [the module-level documentation](self#cancellation-safety)).
     pub async fn recv(&mut self) -> Option<Result<Message, Error>> {
         self.next().await
     }


### PR DESCRIPTION
Combines two small documentation fixes for easier review:

1. **WebSocket cancellation safety** (`axum/src/extract/ws.rs`) — documents that `WebSocket::recv` is cancel-safe via `StreamExt::next`, with guidance for split streams and `tokio::select!`. Fixes #3282.

2. **route_service example** (`axum/src/docs/routing/route_service.md`) — removes obsolete `BoxBody` references; uses current `Body` / `IntoResponse` types for axum 0.7+. Fixes #2536.

Supersedes #3765 and #3766 (will close those if this is preferred).