### PR TITLE
Fix `bytes` dependency incompatibility with v0.8

### DIFF
--- a/axum/Cargo.toml
+++ b/axum/Cargo.toml
@@ -53,7 +53,7 @@ __private = ["tokio", "http1", "dep:reqwest"]
 
 [dependencies]
 axum-core = { path = "../axum-core", version = "0.5.5" }
-bytes = "1.0"
+bytes = "1.7"
 futures-util = { version = "0.3", default-features = false, features = ["alloc"] }
 http = "1.0.0"
 http-body = "1.0.0"


### PR DESCRIPTION
## Motivation

`axum` v0.8 is incompatible with `bytes <1.7`, but the dependency version requirement allows incompatible versions:

https://github.com/tokio-rs/axum/blob/6f01ad2840b62f3fc8848f66ac1607b41c6b1ee7/axum/Cargo.toml#L56

Because of this, I ran into compiler errors during the v0.7.2 -> v0.8.9 upgrade:

```
error[E0277]: the trait bound `BytesMut: From<bytes::Bytes>` is not satisfied
    --> /home/x/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/axum-0.8.9/src/response/sse.rs:160:40
     |
 160 |                 *self = Buffer::Active(BytesMut::from(mem::take(bytes)));
     |                                        ^^^^^^^^ the trait `From<bytes::Bytes>` is not implemented for `BytesMut`
```

I had to manually update `bytes` to a compatible version to solve this problem ([`Cargo.lock` had v1.5.0](https://github.com/solana-playground/solana-playground/blob/3b2d6218c43c5c53b586ebaa98ac2ad4a142c27a/server/Cargo.lock#L297-L298)).

The problem was fixed in `main` (by https://github.com/tokio-rs/axum/pull/3513), but not backported to the `v0.8.x` branch.

## Solution

Cherry-pick https://github.com/tokio-rs/axum/commit/86e4442888b853490cf86cb351e02ad5bdf4a1fb from `main` (https://github.com/tokio-rs/axum/pull/3513) to the `v0.8.x` branch.