### PR TITLE
docs(cookie): clarify cookie-key-expansion for Key::derive_from (fixes #2646)

### DIFF
--- a/axum-extra/src/extract/cookie/mod.rs
+++ b/axum-extra/src/extract/cookie/mod.rs
@@ -1,6 +1,12 @@
 //! Cookie parsing and cookie jar management.
 //!
 //! See [`CookieJar`], [`SignedCookieJar`], and [`PrivateCookieJar`] for more details.
+//!
+//! ## `Key::derive_from`
+//!
+//! The [`Key::derive_from`] method is provided by the underlying [`cookie`] crate, whose docs
+//! refer to the `key-expansion` feature. In `axum-extra`, enable **`cookie-key-expansion`**
+//! instead (see the [crate-level feature list](crate#feature-flags)).
 
 use axum_core::{
     extract::FromRequestParts,
@@ -25,7 +31,12 @@ pub use self::signed::SignedCookieJar;
 
 pub use cookie::{Cookie, Expiration, SameSite};
 
+/// Cookie signing and encryption key.
+///
+/// When using [`Key::derive_from`], enable the **`cookie-key-expansion`** feature on
+/// `axum-extra` (not `key-expansion` from the [`cookie`] crate).
 #[cfg(any(feature = "cookie-signed", feature = "cookie-private"))]
+#[doc(inline)]
 pub use cookie::Key;
 
 /// Extractor that grabs cookies from the request and manages the jar.


### PR DESCRIPTION
## Summary
- Document in `extract::cookie` that `Key::derive_from` requires `cookie-key-expansion` on `axum-extra`, not `key-expansion` from the `cookie` crate.
- Add module-level note linking to the crate feature flags table.

## Test plan
- [x] Docs-only change

Fixes #2646