### PR TITLE
fix(examples): restore query-params-with-empty-strings example

### DIFF
--- a/axum/src/extract/query.rs
+++ b/axum/src/extract/query.rs
@@ -36,6 +36,16 @@ use serde_core::de::DeserializeOwned;
 ///
 /// If the query string cannot be parsed it will reject the request with a `400
 /// Bad Request` response.
+///
+/// For handling values being empty vs missing see the [query-params-with-empty-strings][example]
+/// example.
+///
+/// [example]: https://github.com/tokio-rs/axum/blob/main/examples/query-params-with-empty-strings/src/main.rs
+///
+/// For handling multiple values for the same query parameter, in a `?foo=1&foo=2&foo=3`
+/// fashion, use [`axum_extra::extract::Query`] instead.
+///
+/// [`axum_extra::extract::Query`]: https://docs.rs/axum-extra/latest/axum_extra/extract/struct.Query.html
 #[cfg_attr(docsrs, doc(cfg(feature = "query")))]
 #[derive(Debug, Clone, Copy, Default)]
 pub struct Query<T>(pub T);

--- a/examples/query-params-with-empty-strings/Cargo.toml
+++ b/examples/query-params-with-empty-strings/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "example-query-params-with-empty-strings"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+axum = { path = "../../axum" }
+http-body-util = "0.1.0"
+serde = { version = "1.0", features = ["derive"] }
+tokio = { version = "1.0", features = ["full"] }
+tower = { version = "0.5.2", features = ["util"] }

--- a/examples/query-params-with-empty-strings/src/main.rs
+++ b/examples/query-params-with-empty-strings/src/main.rs
@@ -1,0 +1,121 @@
+//! Run with
+//!
+//! ```not_rust
+//! cargo run -p example-query-params-with-empty-strings
+//! ```
+
+use axum::{extract::Query, routing::get, Router};
+use serde::{de, Deserialize, Deserializer};
+use std::{fmt, str::FromStr};
+
+#[tokio::main]
+async fn main() {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:3000")
+        .await
+        .unwrap();
+    println!("listening on {}", listener.local_addr().unwrap());
+    axum::serve(listener, app()).await.unwrap();
+}
+
+fn app() -> Router {
+    Router::new().route("/", get(handler))
+}
+
+async fn handler(Query(params): Query<Params>) -> String {
+    format!("{params:?}")
+}
+
+/// See the tests below for which combinations of `foo` and `bar` result in
+/// which deserializations.
+///
+/// This example only shows one possible way to do this. [`serde_with`] provides
+/// another way. Use which ever method works best for you.
+///
+/// [`serde_with`]: https://docs.rs/serde_with/1.11.0/serde_with/rust/string_empty_as_none/index.html
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+struct Params {
+    #[serde(default, deserialize_with = "empty_string_as_none")]
+    foo: Option<i32>,
+    bar: Option<String>,
+}
+
+/// Serde deserialization decorator to map empty Strings to None,
+fn empty_string_as_none<'de, D, T>(de: D) -> Result<Option<T>, D::Error>
+where
+    D: Deserializer<'de>,
+    T: FromStr,
+    T::Err: fmt::Display,
+{
+    let opt = Option::<String>::deserialize(de)?;
+    match opt.as_deref() {
+        None | Some("") => Ok(None),
+        Some(s) => FromStr::from_str(s).map_err(de::Error::custom).map(Some),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{body::Body, http::Request};
+    use http_body_util::BodyExt;
+    use tower::ServiceExt;
+
+    #[tokio::test]
+    async fn test_something() {
+        assert_eq!(
+            send_request_get_body("foo=1&bar=bar").await,
+            r#"Params { foo: Some(1), bar: Some("bar") }"#,
+        );
+
+        assert_eq!(
+            send_request_get_body("foo=&bar=bar").await,
+            r#"Params { foo: None, bar: Some("bar") }"#,
+        );
+
+        assert_eq!(
+            send_request_get_body("foo=&bar=").await,
+            r#"Params { foo: None, bar: Some("") }"#,
+        );
+
+        assert_eq!(
+            send_request_get_body("foo=1").await,
+            r#"Params { foo: Some(1), bar: None }"#,
+        );
+
+        assert_eq!(
+            send_request_get_body("bar=bar").await,
+            r#"Params { foo: None, bar: Some("bar") }"#,
+        );
+
+        assert_eq!(
+            send_request_get_body("foo=").await,
+            r#"Params { foo: None, bar: None }"#,
+        );
+
+        assert_eq!(
+            send_request_get_body("bar=").await,
+            r#"Params { foo: None, bar: Some("") }"#,
+        );
+
+        assert_eq!(
+            send_request_get_body("").await,
+            r#"Params { foo: None, bar: None }"#,
+        );
+    }
+
+    async fn send_request_get_body(query: &str) -> String {
+        let body = app()
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/?{query}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap()
+            .into_body();
+        let bytes = body.collect().await.unwrap().to_bytes();
+        String::from_utf8(bytes.to_vec()).unwrap()
+    }
+}

--- a/examples/query-params-with-empty-strings/src/main.rs
+++ b/examples/query-params-with-empty-strings/src/main.rs
@@ -14,7 +14,7 @@ async fn main() {
         .await
         .unwrap();
     println!("listening on {}", listener.local_addr().unwrap());
-    axum::serve(listener, app()).await.unwrap();
+    axum::serve(listener, app()).await;
 }
 
 fn app() -> Router {


### PR DESCRIPTION
## Summary
- Restores the `query-params-with-empty-strings` example referenced from `Query` docs (present in 0.8.x releases but missing on `main`)
- Re-adds doc links for empty vs missing query values and multi-value params

Fixes #3691

## Test plan
- [ ] `cargo test -p example-query-params-with-empty-strings`
- [ ] Example runs with `cargo run -p example-query-params-with-empty-strings`