### PR TITLE
fix(examples): add missing `sink` feature for futures-channel in `example-testing-websockets`

### DIFF
--- a/examples/testing-websockets/Cargo.toml
+++ b/examples/testing-websockets/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [dependencies]
 axum = { path = "../../axum", features = ["ws"] }
-futures-channel = "0.3"
+futures-channel = { version = "0.3", features = ["sink"] }
 futures-util = { version = "0.3", default-features = false, features = ["sink", "std"] }
 tokio = { version = "1.0", features = ["full"] }
 tokio-tungstenite = "0.29"


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation
The official testing-websockets example fails to compile when running cargo test due to a missing feature flag on futures-channel.
The unit test uses futures_channel::mpsc::Sender and passes it to unit_testable_handle_socket, which requires the type to implement the Sink trait. However, the Sink implementation for Sender is only available when the sink feature of futures-channel is enabled, which was not declared in the example's dependencies.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution
Add features = ["sink"] to the futures-channel dependency in the example's Cargo.toml to enable the necessary trait implementation.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
