### PR TITLE
feat(axum): add `ConnectionLimits` for bounding connection lifetime

### DIFF
--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **added:** `IntoResponseParts` impl for `Redirect`, allowing it to be combined
   with a body in a response tuple ([#3721])
 - **added:** Add `RawPathParams::from_request_extensions` ([#3757])
+- **added:** `serve::ConnectionLimits` and `Serve::connection_limits` for bounding the lifetime of
+  individual connections (`max_connection_age`, `max_connection_age_jitter`,
+  `max_connection_age_grace`), forcing clients to rotate connections ([#3779])
 - **changed:** `serve` has an additional generic argument and can now work with any response body
   type, not just `axum::body::Body` ([#3205])
 - **changed:** `Redirect` constructors now accept any `impl Into<String>` ([#3635])
@@ -44,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#3836]: https://github.com/tokio-rs/axum/pull/3836
 [#3757]: https://github.com/tokio-rs/axum/pull/3757
 [#3801]: https://github.com/tokio-rs/axum/pull/3801
+[#3779]: https://github.com/tokio-rs/axum/pull/3779
 
 # 0.8.9
 

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -22,9 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   with a body in a response tuple ([#3721])
 - **added:** Add `RawPathParams::from_request_extensions` ([#3757])
 - **added:** `sse::Event::raw` for events with fully custom payloads ([#3829])
-- **added:** `serve::ConnectionLifetimeLimits` and `Serve::connection_lifetime_limits` for bounding the lifetime of
-  individual connections (`max_connection_age`, `max_connection_age_jitter`,
-  `max_connection_age_grace`), forcing clients to rotate connections ([#3779])
+- **added:** `serve::ConnectionLifetimeLimits` and `Serve::connection_lifetime_limits` for bounding the
+  lifetime of individual connections via `serve::MaxConnectionAge` (with `jitter` and `grace`),
+  forcing clients to rotate connections ([#3779])
 - **changed:** `serve` has an additional generic argument and can now work with any response body
   type, not just `axum::body::Body` ([#3205])
 - **changed:** Reduced contention in `axum::serve` shutdown notification with many

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   with a body in a response tuple ([#3721])
 - **added:** Add `RawPathParams::from_request_extensions` ([#3757])
 - **added:** `sse::Event::raw` for events with fully custom payloads ([#3829])
+- **added:** `serve::ConnectionLimits` and `Serve::connection_limits` for bounding the lifetime of
+  individual connections (`max_connection_age`, `max_connection_age_jitter`,
+  `max_connection_age_grace`), forcing clients to rotate connections ([#3779])
 - **changed:** `serve` has an additional generic argument and can now work with any response body
   type, not just `axum::body::Body` ([#3205])
 - **changed:** Reduced contention in `axum::serve` shutdown notification with many
@@ -49,6 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#3829]: https://github.com/tokio-rs/axum/pull/3829
 [#3801]: https://github.com/tokio-rs/axum/pull/3801
 [#3867]: https://github.com/tokio-rs/axum/pull/3867
+[#3779]: https://github.com/tokio-rs/axum/pull/3779
 
 # 0.8.9
 

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   with a body in a response tuple ([#3721])
 - **added:** Add `RawPathParams::from_request_extensions` ([#3757])
 - **added:** `sse::Event::raw` for events with fully custom payloads ([#3829])
-- **added:** `serve::ConnectionLimits` and `Serve::connection_limits` for bounding the lifetime of
+- **added:** `serve::ConnectionLifetimeLimits` and `Serve::connection_lifetime_limits` for bounding the lifetime of
   individual connections (`max_connection_age`, `max_connection_age_jitter`,
   `max_connection_age_grace`), forcing clients to rotate connections ([#3779])
 - **changed:** `serve` has an additional generic argument and can now work with any response body

--- a/axum/src/serve/mod.rs
+++ b/axum/src/serve/mod.rs
@@ -137,51 +137,40 @@ where
 /// It also bounds the worst case when a client's connection pool has no
 /// rotation of its own.
 ///
-/// The mechanism differs by protocol but the knobs are the same:
-///
-/// - **HTTP/1**: the next response gets a `Connection: close` header and the
-///   connection is closed once the in-flight request finishes.
-/// - **HTTP/2**: a `GOAWAY` is sent, so new streams are refused
-///   while in-flight streams are allowed to finish.
-///
-/// In both cases in-flight work is waited on for as long as it takes, unless
-/// [`max_connection_age_grace`] is set: once the grace period elapses the
-/// connection is closed even if a request is still in flight. See
-/// [`max_connection_age_grace`] for the trade-off.
+/// Each limit is configured with its own value type, so a limit's modifiers
+/// cannot be set without the limit itself. Currently the only limit is
+/// [`MaxConnectionAge`].
 ///
 /// # Example
 ///
 /// ```
 /// use std::time::Duration;
-/// use axum::{Router, routing::get, serve::ConnectionLifetimeLimits};
+/// use axum::{Router, routing::get, serve::{ConnectionLifetimeLimits, MaxConnectionAge}};
 ///
 /// # async {
 /// let router = Router::new().route("/", get(|| async { "Hello, World!" }));
 /// let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await.unwrap();
 ///
-/// let limits = ConnectionLifetimeLimits::new()
-///     // Stop accepting new requests on a connection after this long.
-///     .max_connection_age(Duration::from_secs(10 * 60))
-///     // Random per-connection jitter added to the age, to avoid synchronized
-///     // reconnect storms when many connections were established at once.
-///     .max_connection_age_jitter(Duration::from_secs(60))
-///     // Hard cap on how long to wait for in-flight work after the age limit
-///     // fires before forcibly closing.
-///     .max_connection_age_grace(Duration::from_secs(30));
+/// let limits = ConnectionLifetimeLimits::new().max_connection_age(
+///     MaxConnectionAge::new(Duration::from_secs(10 * 60))
+///         // Random per-connection jitter added to the age, to avoid
+///         // synchronized reconnect storms when many connections were
+///         // established at once.
+///         .jitter(Duration::from_secs(60))
+///         // Hard cap on how long to wait for in-flight work after the age
+///         // limit fires before forcibly closing.
+///         .grace(Duration::from_secs(30)),
+/// );
 ///
 /// axum::serve(listener, router)
 ///     .connection_lifetime_limits(limits)
 ///     .await;
 /// # };
 /// ```
-///
-/// [`max_connection_age_grace`]: ConnectionLifetimeLimits::max_connection_age_grace
 #[derive(Clone, Debug, Default)]
 #[must_use]
 pub struct ConnectionLifetimeLimits {
-    max_connection_age: Option<Duration>,
-    max_connection_age_jitter: Duration,
-    max_connection_age_grace: Option<Duration>,
+    max_connection_age: Option<MaxConnectionAge>,
 }
 
 impl ConnectionLifetimeLimits {
@@ -190,29 +179,66 @@ impl ConnectionLifetimeLimits {
         Self::default()
     }
 
-    /// Set a cap on how long a connection keeps accepting new requests.
+    /// Cap how long a connection keeps accepting new requests.
     ///
-    /// Once a connection has been open for this long, a graceful shutdown of
-    /// that connection is started: HTTP/1 connections close after the in-flight
-    /// request completes (sending `Connection: close`), and HTTP/2 connections
-    /// send a `GOAWAY`, refusing new streams while letting in-flight ones finish
-    /// (bounded by [`max_connection_age_grace`] if set).
+    /// See [`MaxConnectionAge`] for what the limit does and how to configure
+    /// its jitter and grace period.
     ///
-    /// Consider also setting [`max_connection_age_jitter`] to avoid all
-    /// connections opened around the same time tearing down simultaneously.
-    ///
-    /// The clock starts when the connection task is spawned, which happens
-    /// after the connection has been accepted and the service for it has been
-    /// created, rather than at accept time.
-    ///
-    /// [`max_connection_age_grace`]: ConnectionLifetimeLimits::max_connection_age_grace
-    /// [`max_connection_age_jitter`]: ConnectionLifetimeLimits::max_connection_age_jitter
-    pub fn max_connection_age(mut self, age: Duration) -> Self {
-        self.max_connection_age = Some(age);
+    /// Accepts a [`MaxConnectionAge`] or an `Option<MaxConnectionAge>`, so an
+    /// optional value derived from configuration can be passed straight
+    /// through. `None` leaves connection age unbounded, which is the default.
+    pub fn max_connection_age(mut self, age: impl Into<Option<MaxConnectionAge>>) -> Self {
+        self.max_connection_age = age.into();
         self
     }
+}
 
-    /// Set the maximum random jitter added to [`max_connection_age`].
+/// A cap on how long a connection keeps accepting new requests, applied by
+/// [`serve`] via [`ConnectionLifetimeLimits::max_connection_age`].
+///
+/// Once a connection has been open for [`new`]'s duration (plus [`jitter`]), a
+/// graceful shutdown of that connection is started. The clock starts when the
+/// connection task is spawned, which happens after the connection has been
+/// accepted and the service for it has been created, rather than at accept
+/// time. The mechanism differs by protocol:
+///
+/// - **HTTP/1**: the next response gets a `Connection: close` header and the
+///   connection is closed once the in-flight request finishes.
+/// - **HTTP/2**: a `GOAWAY` is sent, so new streams are refused while in-flight
+///   streams are allowed to finish.
+///
+/// In both cases in-flight work is waited on for as long as it takes, unless
+/// [`grace`] is set: once the grace period elapses the connection is closed even
+/// if a request is still in flight. See [`grace`] for the trade-off.
+///
+/// [`new`]: MaxConnectionAge::new
+/// [`jitter`]: MaxConnectionAge::jitter
+/// [`grace`]: MaxConnectionAge::grace
+#[derive(Clone, Debug)]
+#[must_use]
+pub struct MaxConnectionAge {
+    age: Duration,
+    jitter: Duration,
+    grace: Option<Duration>,
+}
+
+impl MaxConnectionAge {
+    /// Create a new `MaxConnectionAge` that stops a connection from accepting
+    /// new requests once it has been open for `age`.
+    ///
+    /// Consider also setting [`jitter`] to avoid all connections opened around
+    /// the same time tearing down simultaneously.
+    ///
+    /// [`jitter`]: MaxConnectionAge::jitter
+    pub fn new(age: Duration) -> Self {
+        Self {
+            age,
+            jitter: Duration::ZERO,
+            grace: None,
+        }
+    }
+
+    /// Set the maximum random jitter added to the age.
     ///
     /// Each connection adds a random duration in `[0, jitter]` to its age limit.
     /// This is important for avoiding synchronized reconnect storms when many
@@ -220,34 +246,29 @@ impl ConnectionLifetimeLimits {
     /// deploy): without it, every connection opened in the same instant tears
     /// down in the same instant once the age limit elapses.
     ///
-    /// Defaults to `Duration::ZERO`, i.e. no jitter. Has no effect unless
-    /// [`max_connection_age`] is also set.
-    ///
-    /// [`max_connection_age`]: ConnectionLifetimeLimits::max_connection_age
-    pub fn max_connection_age_jitter(mut self, jitter: Duration) -> Self {
-        self.max_connection_age_jitter = jitter;
+    /// Defaults to `Duration::ZERO`, i.e. no jitter.
+    pub fn jitter(mut self, jitter: Duration) -> Self {
+        self.jitter = jitter;
         self
     }
 
-    /// Set a hard cap on how long to wait for in-flight work after
-    /// [`max_connection_age`] fires before forcibly closing the connection.
+    /// Set a hard cap on how long to wait for in-flight work after the age
+    /// limit fires before forcibly closing the connection.
     ///
-    /// Without a grace period, [`max_connection_age`] only stops new requests:
-    /// the server waits however long it takes for in-flight work to finish
-    /// before closing the connection. Setting a grace period turns
-    /// `max_connection_age` (+ jitter) + grace into a hard deadline: when it
-    /// elapses the connection is closed *even if a request is still in flight*,
-    /// and the client never receives a response for it. This applies to HTTP/1
-    /// requests as well as HTTP/2 streams, so a handler that runs longer than
-    /// the age limit plus the grace period will never complete successfully.
-    /// Only set a grace period if bounding connection lifetime matters more
-    /// than letting slow requests finish.
+    /// Without a grace period the age limit only stops new requests: the server
+    /// waits however long it takes for in-flight work to finish before closing
+    /// the connection. Setting a grace period turns age (+ jitter) + grace into
+    /// a hard deadline: when it elapses the connection is closed *even if a
+    /// request is still in flight*, and the client never receives a response for
+    /// it. This applies to HTTP/1 requests as well as HTTP/2 streams, so a
+    /// handler that runs longer than the age limit plus the grace period will
+    /// never complete successfully. Only set a grace period if bounding
+    /// connection lifetime matters more than letting slow requests finish.
     ///
-    /// This has no effect unless [`max_connection_age`] is also set.
-    ///
-    /// [`max_connection_age`]: ConnectionLifetimeLimits::max_connection_age
-    pub fn max_connection_age_grace(mut self, grace: Duration) -> Self {
-        self.max_connection_age_grace = Some(grace);
+    /// Accepts a `Duration` or an `Option<Duration>`. `None` waits for in-flight
+    /// work for as long as it takes, which is the default.
+    pub fn grace(mut self, grace: impl Into<Option<Duration>>) -> Self {
+        self.grace = grace.into();
         self
     }
 }
@@ -822,10 +843,11 @@ async fn handle_connection<L, M, S, B, E>(
         // elapses we start a graceful shutdown of this connection and re-arm the
         // timer with the grace period (if any), which then bounds how long we
         // wait before forcibly closing.
-        let max_age = connection_lifetime_limits.max_connection_age.map(|age| {
-            let jitter = random_duration(connection_lifetime_limits.max_connection_age_jitter);
-            age.saturating_add(jitter)
-        });
+        let max_connection_age = connection_lifetime_limits.max_connection_age;
+        let max_age = max_connection_age
+            .as_ref()
+            .map(|limit| limit.age.saturating_add(random_duration(limit.jitter)));
+        let grace = max_connection_age.and_then(|limit| limit.grace);
         let mut timer = pin!(sleep_or_pending(max_age));
         let mut age_fired = false;
 
@@ -853,9 +875,7 @@ async fn handle_connection<L, M, S, B, E>(
                     age_fired = true;
                     trace!("max connection age reached, starting graceful shutdown");
                     conn.as_mut().graceful_shutdown();
-                    timer.set(sleep_or_pending(
-                        connection_lifetime_limits.max_connection_age_grace,
-                    ));
+                    timer.set(sleep_or_pending(grace));
                 }
                 Either::Right((Either::Right(_), _)) => {
                     trace!("max connection age grace period elapsed, closing connection");
@@ -947,7 +967,7 @@ mod tests {
 
     #[cfg(unix)]
     use super::IncomingStream;
-    use super::{serve, ConnectionLifetimeLimits, Listener};
+    use super::{serve, ConnectionLifetimeLimits, Listener, MaxConnectionAge};
     #[cfg(unix)]
     use crate::extract::connect_info::Connected;
     use crate::{
@@ -1132,10 +1152,14 @@ mod tests {
         .with_executor(exec);
 
         // connection_lifetime_limits, composable with the other builder methods in any order
+        let optional_age: Option<MaxConnectionAge> = None;
         let limits = ConnectionLifetimeLimits::new()
-            .max_connection_age(Duration::from_secs(60))
-            .max_connection_age_jitter(Duration::from_secs(10))
-            .max_connection_age_grace(Duration::from_secs(5));
+            .max_connection_age(optional_age)
+            .max_connection_age(
+                MaxConnectionAge::new(Duration::from_secs(60))
+                    .jitter(Duration::from_secs(10))
+                    .grace(Duration::from_secs(5)),
+            );
         serve(TcpListener::bind(addr).await.unwrap(), router.clone())
             .connection_lifetime_limits(limits.clone());
         serve(TcpListener::bind(addr).await.unwrap(), router.clone())
@@ -1546,7 +1570,8 @@ mod tests {
         tokio::spawn(
             serve(listener, app)
                 .connection_lifetime_limits(
-                    ConnectionLifetimeLimits::new().max_connection_age(Duration::from_secs(10)),
+                    ConnectionLifetimeLimits::new()
+                        .max_connection_age(MaxConnectionAge::new(Duration::from_secs(10))),
                 )
                 .into_future(),
         );
@@ -1599,11 +1624,9 @@ mod tests {
 
         tokio::spawn(
             serve(listener, app)
-                .connection_lifetime_limits(
-                    ConnectionLifetimeLimits::new()
-                        .max_connection_age(Duration::from_secs(10))
-                        .max_connection_age_grace(Duration::from_secs(5)),
-                )
+                .connection_lifetime_limits(ConnectionLifetimeLimits::new().max_connection_age(
+                    MaxConnectionAge::new(Duration::from_secs(10)).grace(Duration::from_secs(5)),
+                ))
                 .into_future(),
         );
 
@@ -1662,7 +1685,8 @@ mod tests {
         tokio::spawn(
             serve(listener, app)
                 .connection_lifetime_limits(
-                    ConnectionLifetimeLimits::new().max_connection_age(Duration::from_secs(10)),
+                    ConnectionLifetimeLimits::new()
+                        .max_connection_age(MaxConnectionAge::new(Duration::from_secs(10))),
                 )
                 .into_future(),
         );
@@ -1705,7 +1729,8 @@ mod tests {
         tokio::spawn(
             serve(listener, app)
                 .connection_lifetime_limits(
-                    ConnectionLifetimeLimits::new().max_connection_age(Duration::from_secs(10)),
+                    ConnectionLifetimeLimits::new()
+                        .max_connection_age(MaxConnectionAge::new(Duration::from_secs(10))),
                 )
                 .into_future(),
         );
@@ -1762,11 +1787,9 @@ mod tests {
 
         tokio::spawn(
             serve(listener, app)
-                .connection_lifetime_limits(
-                    ConnectionLifetimeLimits::new()
-                        .max_connection_age(Duration::from_secs(10))
-                        .max_connection_age_grace(Duration::from_secs(5)),
-                )
+                .connection_lifetime_limits(ConnectionLifetimeLimits::new().max_connection_age(
+                    MaxConnectionAge::new(Duration::from_secs(10)).grace(Duration::from_secs(5)),
+                ))
                 .into_future(),
         );
 
@@ -1815,11 +1838,9 @@ mod tests {
 
         tokio::spawn(
             serve(listener, app)
-                .connection_lifetime_limits(
-                    ConnectionLifetimeLimits::new()
-                        .max_connection_age(Duration::from_secs(10))
-                        .max_connection_age_grace(Duration::from_secs(5)),
-                )
+                .connection_lifetime_limits(ConnectionLifetimeLimits::new().max_connection_age(
+                    MaxConnectionAge::new(Duration::from_secs(10)).grace(Duration::from_secs(5)),
+                ))
                 .into_future(),
         );
 
@@ -1868,8 +1889,7 @@ mod tests {
                 serve(ReadyListener(Some(server)), app)
                     .connection_lifetime_limits(
                         ConnectionLifetimeLimits::new()
-                            .max_connection_age(age)
-                            .max_connection_age_jitter(jitter),
+                            .max_connection_age(MaxConnectionAge::new(age).jitter(jitter)),
                     )
                     .into_future(),
             );
@@ -1946,11 +1966,9 @@ mod tests {
         let (signal_tx, signal_rx) = oneshot::channel::<()>();
         let server_handle = tokio::spawn(
             serve(listener, app)
-                .connection_lifetime_limits(
-                    ConnectionLifetimeLimits::new()
-                        .max_connection_age(Duration::from_secs(10))
-                        .max_connection_age_grace(Duration::from_secs(5)),
-                )
+                .connection_lifetime_limits(ConnectionLifetimeLimits::new().max_connection_age(
+                    MaxConnectionAge::new(Duration::from_secs(10)).grace(Duration::from_secs(5)),
+                ))
                 .with_graceful_shutdown(async move {
                     signal_rx.await.ok();
                 })

--- a/axum/src/serve/mod.rs
+++ b/axum/src/serve/mod.rs
@@ -5,6 +5,7 @@ use std::{
     error::Error as StdError,
     fmt::Debug,
     future::{Future, IntoFuture, Pending},
+    hash::{BuildHasher, Hasher},
     io,
     marker::PhantomData,
     pin::pin,
@@ -256,7 +257,6 @@ fn random_duration(max: Duration) -> Duration {
         return Duration::ZERO;
     }
 
-    use std::hash::{BuildHasher, Hasher};
     let rand = std::collections::hash_map::RandomState::new()
         .build_hasher()
         .finish();

--- a/axum/src/serve/mod.rs
+++ b/axum/src/serve/mod.rs
@@ -137,9 +137,7 @@ where
 /// It also bounds the worst case when a client's connection pool has no
 /// rotation of its own.
 ///
-/// Each limit is configured with its own value type, so a limit's modifiers
-/// cannot be set without the limit itself. Currently the only limit is
-/// [`MaxConnectionAge`].
+/// The only limit currently available is [`MaxConnectionAge`].
 ///
 /// # Example
 ///

--- a/axum/src/serve/mod.rs
+++ b/axum/src/serve/mod.rs
@@ -143,8 +143,12 @@ where
 /// - **HTTP/1**: the next response gets a `Connection: close` header and the
 ///   connection is closed once the in-flight request finishes.
 /// - **HTTP/2** (including gRPC): a `GOAWAY` is sent, so new streams are refused
-///   while in-flight streams are given up to [`max_connection_age_grace`] to
-///   finish.
+///   while in-flight streams are allowed to finish.
+///
+/// In both cases in-flight work is waited on for as long as it takes, unless
+/// [`max_connection_age_grace`] is set: once the grace period elapses the
+/// connection is closed even if a request is still in flight. See
+/// [`max_connection_age_grace`] for the trade-off.
 ///
 /// Note that this is distinct from [`ListenerExt::limit_connections`], which
 /// bounds the *number* of concurrent connections rather than their lifetime.
@@ -230,9 +234,16 @@ impl ConnectionLimits {
     /// Set a hard cap on how long to wait for in-flight work after
     /// [`max_connection_age`] fires before forcibly closing the connection.
     ///
-    /// This primarily matters for HTTP/2, where in-flight streams are allowed to
-    /// finish after the `GOAWAY` is sent; once this grace period elapses the
-    /// connection is closed regardless. Mirrors `tonic`'s
+    /// Without a grace period, [`max_connection_age`] is purely a soft cap: the
+    /// server waits however long it takes for in-flight work to finish before
+    /// closing the connection. Setting a grace period turns
+    /// `max_connection_age` (+ jitter) + grace into a hard deadline: when it
+    /// elapses the connection is closed *even if a request is still in flight*,
+    /// and the client never receives a response for it. This applies to HTTP/1
+    /// requests as well as HTTP/2 streams, so a handler that runs longer than
+    /// the age limit plus the grace period will never complete successfully.
+    /// Only set a grace period if bounding connection lifetime matters more
+    /// than letting slow requests finish. Mirrors `tonic`'s
     /// `max_connection_age_grace`.
     ///
     /// This has no effect unless [`max_connection_age`] is also set.
@@ -819,13 +830,13 @@ async fn handle_connection<L, M, S, B, E>(
         // elapses we start a graceful shutdown of this connection and re-arm the
         // timer with the grace period (if any), which then bounds how long we
         // wait before forcibly closing.
-        let mut timer = pin!(sleep_or_pending(connection_limits.max_connection_age.map(
-            |age| {
-                age + connection_limits
-                    .max_connection_age_jitter
-                    .map_or(Duration::ZERO, random_duration)
-            }
-        )));
+        let max_age = connection_limits.max_connection_age.map(|age| {
+            let jitter = connection_limits
+                .max_connection_age_jitter
+                .map_or(Duration::ZERO, random_duration);
+            age.saturating_add(jitter)
+        });
+        let mut timer = pin!(sleep_or_pending(max_age));
         let mut age_fired = false;
 
         loop {
@@ -1620,6 +1631,67 @@ mod tests {
             result.is_err(),
             "expected the in-flight request to fail when the connection is force-closed",
         );
+    }
+
+    // Without a grace period, `max_connection_age` is a soft cap: a request
+    // that is still in flight when the age limit fires keeps the connection
+    // alive for as long as it needs and still completes successfully. Only
+    // `max_connection_age_grace` opts into force-closing in-flight work.
+    #[tokio::test(start_paused = true)]
+    async fn max_connection_age_without_grace_lets_inflight_request_finish() {
+        use std::sync::Arc;
+
+        use tokio::sync::Notify;
+
+        let started = Arc::new(Notify::new());
+        let released = Arc::new(Notify::new());
+
+        let app = Router::new().route("/", {
+            let started = started.clone();
+            let released = released.clone();
+            get(move || {
+                let started = started.clone();
+                let released = released.clone();
+                async move {
+                    started.notify_one();
+                    released.notified().await;
+                    "done"
+                }
+            })
+        });
+
+        let (client, server) = io::duplex(1024);
+        let listener = ReadyListener(Some(server));
+
+        tokio::spawn(
+            serve(listener, app)
+                .connection_limits(
+                    ConnectionLimits::new().max_connection_age(Duration::from_secs(10)),
+                )
+                .into_future(),
+        );
+
+        let stream = TokioIo::new(client);
+        let (mut sender, conn) = hyper::client::conn::http1::handshake(stream).await.unwrap();
+        tokio::spawn(conn);
+
+        let request = Request::builder().uri("/").body(Body::empty()).unwrap();
+        let send = tokio::spawn(async move { sender.send_request(request).await });
+
+        // Wait until the handler is actually running, then advance (paused)
+        // time well past the age limit while the request is still in flight.
+        started.notified().await;
+        tokio::time::sleep(Duration::from_secs(60)).await;
+
+        // Release the handler; the response must still arrive because the age
+        // limit alone never cuts in-flight requests.
+        released.notify_one();
+        let response = tokio::time::timeout(Duration::from_secs(5), send)
+            .await
+            .expect("in-flight request did not resolve after the age limit fired")
+            .unwrap()
+            .expect("in-flight request failed: the age limit must not cut in-flight requests");
+        assert_eq!(response.status(), StatusCode::OK);
     }
 
     // The HTTP/2 equivalent of `max_connection_age_closes_idle_connection`: the

--- a/axum/src/serve/mod.rs
+++ b/axum/src/serve/mod.rs
@@ -143,8 +143,12 @@ where
 /// - **HTTP/1**: the next response gets a `Connection: close` header and the
 ///   connection is closed once the in-flight request finishes.
 /// - **HTTP/2** (including gRPC): a `GOAWAY` is sent, so new streams are refused
-///   while in-flight streams are given up to [`max_connection_age_grace`] to
-///   finish.
+///   while in-flight streams are allowed to finish.
+///
+/// In both cases in-flight work is waited on for as long as it takes, unless
+/// [`max_connection_age_grace`] is set: once the grace period elapses the
+/// connection is closed even if a request is still in flight. See
+/// [`max_connection_age_grace`] for the trade-off.
 ///
 /// Note that this is distinct from [`ListenerExt::limit_connections`], which
 /// bounds the *number* of concurrent connections rather than their lifetime.
@@ -230,9 +234,16 @@ impl ConnectionLimits {
     /// Set a hard cap on how long to wait for in-flight work after
     /// [`max_connection_age`] fires before forcibly closing the connection.
     ///
-    /// This primarily matters for HTTP/2, where in-flight streams are allowed to
-    /// finish after the `GOAWAY` is sent; once this grace period elapses the
-    /// connection is closed regardless. Mirrors `tonic`'s
+    /// Without a grace period, [`max_connection_age`] is purely a soft cap: the
+    /// server waits however long it takes for in-flight work to finish before
+    /// closing the connection. Setting a grace period turns
+    /// `max_connection_age` (+ jitter) + grace into a hard deadline: when it
+    /// elapses the connection is closed *even if a request is still in flight*,
+    /// and the client never receives a response for it. This applies to HTTP/1
+    /// requests as well as HTTP/2 streams, so a handler that runs longer than
+    /// the age limit plus the grace period will never complete successfully.
+    /// Only set a grace period if bounding connection lifetime matters more
+    /// than letting slow requests finish. Mirrors `tonic`'s
     /// `max_connection_age_grace`.
     ///
     /// This has no effect unless [`max_connection_age`] is also set.
@@ -822,13 +833,13 @@ async fn handle_connection<L, M, S, B, E>(
         // elapses we start a graceful shutdown of this connection and re-arm the
         // timer with the grace period (if any), which then bounds how long we
         // wait before forcibly closing.
-        let mut timer = pin!(sleep_or_pending(connection_limits.max_connection_age.map(
-            |age| {
-                age + connection_limits
-                    .max_connection_age_jitter
-                    .map_or(Duration::ZERO, random_duration)
-            }
-        )));
+        let max_age = connection_limits.max_connection_age.map(|age| {
+            let jitter = connection_limits
+                .max_connection_age_jitter
+                .map_or(Duration::ZERO, random_duration);
+            age.saturating_add(jitter)
+        });
+        let mut timer = pin!(sleep_or_pending(max_age));
         let mut age_fired = false;
 
         loop {
@@ -1626,6 +1637,67 @@ mod tests {
             result.is_err(),
             "expected the in-flight request to fail when the connection is force-closed",
         );
+    }
+
+    // Without a grace period, `max_connection_age` is a soft cap: a request
+    // that is still in flight when the age limit fires keeps the connection
+    // alive for as long as it needs and still completes successfully. Only
+    // `max_connection_age_grace` opts into force-closing in-flight work.
+    #[tokio::test(start_paused = true)]
+    async fn max_connection_age_without_grace_lets_inflight_request_finish() {
+        use std::sync::Arc;
+
+        use tokio::sync::Notify;
+
+        let started = Arc::new(Notify::new());
+        let released = Arc::new(Notify::new());
+
+        let app = Router::new().route("/", {
+            let started = started.clone();
+            let released = released.clone();
+            get(move || {
+                let started = started.clone();
+                let released = released.clone();
+                async move {
+                    started.notify_one();
+                    released.notified().await;
+                    "done"
+                }
+            })
+        });
+
+        let (client, server) = io::duplex(1024);
+        let listener = ReadyListener(Some(server));
+
+        tokio::spawn(
+            serve(listener, app)
+                .connection_limits(
+                    ConnectionLimits::new().max_connection_age(Duration::from_secs(10)),
+                )
+                .into_future(),
+        );
+
+        let stream = TokioIo::new(client);
+        let (mut sender, conn) = hyper::client::conn::http1::handshake(stream).await.unwrap();
+        tokio::spawn(conn);
+
+        let request = Request::builder().uri("/").body(Body::empty()).unwrap();
+        let send = tokio::spawn(async move { sender.send_request(request).await });
+
+        // Wait until the handler is actually running, then advance (paused)
+        // time well past the age limit while the request is still in flight.
+        started.notified().await;
+        tokio::time::sleep(Duration::from_secs(60)).await;
+
+        // Release the handler; the response must still arrive because the age
+        // limit alone never cuts in-flight requests.
+        released.notify_one();
+        let response = tokio::time::timeout(Duration::from_secs(5), send)
+            .await
+            .expect("in-flight request did not resolve after the age limit fired")
+            .unwrap()
+            .expect("in-flight request failed: the age limit must not cut in-flight requests");
+        assert_eq!(response.status(), StatusCode::OK);
     }
 
     // The HTTP/2 equivalent of `max_connection_age_closes_idle_connection`: the

--- a/axum/src/serve/mod.rs
+++ b/axum/src/serve/mod.rs
@@ -253,17 +253,13 @@ impl ConnectionLimits {
 }
 
 /// Returns a pseudo-random [`Duration`] in `[Duration::ZERO, max]`.
-///
-/// Uses [`RandomState`], whose keys are seeded by the OS and bumped on each
-/// construction, to get cheap per-connection randomness without pulling in a
-/// dedicated RNG dependency.
-///
-/// [`RandomState`]: std::collections::hash_map::RandomState
 fn random_duration(max: Duration) -> Duration {
     if max.is_zero() {
         return Duration::ZERO;
     }
 
+    // `RandomState` keys are seeded by the OS and vary per construction, giving
+    // cheap randomness without a dedicated RNG dependency.
     let rand = std::collections::hash_map::RandomState::new()
         .build_hasher()
         .finish();

--- a/axum/src/serve/mod.rs
+++ b/axum/src/serve/mod.rs
@@ -184,11 +184,9 @@ impl ConnectionLifetimeLimits {
     /// See [`MaxConnectionAge`] for what the limit does and how to configure
     /// its jitter and grace period.
     ///
-    /// Accepts a [`MaxConnectionAge`] or an `Option<MaxConnectionAge>`, so an
-    /// optional value derived from configuration can be passed straight
-    /// through. `None` leaves connection age unbounded, which is the default.
-    pub fn max_connection_age(mut self, age: impl Into<Option<MaxConnectionAge>>) -> Self {
-        self.max_connection_age = age.into();
+    /// Connection age is unbounded by default.
+    pub fn max_connection_age(mut self, age: MaxConnectionAge) -> Self {
+        self.max_connection_age = Some(age);
         self
     }
 }
@@ -265,8 +263,8 @@ impl MaxConnectionAge {
     /// never complete successfully. Only set a grace period if bounding
     /// connection lifetime matters more than letting slow requests finish.
     ///
-    /// Accepts a `Duration` or an `Option<Duration>`. `None` waits for in-flight
-    /// work for as long as it takes, which is the default.
+    /// `None` waits for in-flight work for as long as it takes, which is the
+    /// default.
     pub fn grace(mut self, grace: impl Into<Option<Duration>>) -> Self {
         self.grace = grace.into();
         self
@@ -1152,14 +1150,11 @@ mod tests {
         .with_executor(exec);
 
         // connection_lifetime_limits, composable with the other builder methods in any order
-        let optional_age: Option<MaxConnectionAge> = None;
-        let limits = ConnectionLifetimeLimits::new()
-            .max_connection_age(optional_age)
-            .max_connection_age(
-                MaxConnectionAge::new(Duration::from_secs(60))
-                    .jitter(Duration::from_secs(10))
-                    .grace(Duration::from_secs(5)),
-            );
+        let limits = ConnectionLifetimeLimits::new().max_connection_age(
+            MaxConnectionAge::new(Duration::from_secs(60))
+                .jitter(Duration::from_secs(10))
+                .grace(Duration::from_secs(5)),
+        );
         serve(TcpListener::bind(addr).await.unwrap(), router.clone())
             .connection_lifetime_limits(limits.clone());
         serve(TcpListener::bind(addr).await.unwrap(), router.clone())

--- a/axum/src/serve/mod.rs
+++ b/axum/src/serve/mod.rs
@@ -35,10 +35,10 @@ pub use self::listener::{ConnLimiter, ConnLimiterIo, Listener, ListenerExt, TapI
 
 /// Serve the service with the supplied listener.
 ///
-/// This method of running a service is intentionally simple and doesn't support much configuration.
-/// hyper's default configuration applies (including [timeouts]); use hyper or hyper-util if you
-/// need more control. You can supply a custom [`Executor`] via [`Serve::with_executor`] to
-/// control how connection tasks are spawned.
+/// This method of running a service exposes only some configuration knobs: how connection
+/// tasks are spawned (via [`Serve::with_executor`]) and how long connections live (via
+/// [`Serve::connection_lifetime_limits`]). Everything else uses hyper's default configuration
+/// (including [timeouts]); use hyper or hyper-util if you need more control.
 ///
 /// It supports both HTTP/1 as well as HTTP/2.
 ///
@@ -200,6 +200,10 @@ impl ConnectionLifetimeLimits {
     ///
     /// Consider also setting [`max_connection_age_jitter`] to avoid all
     /// connections opened around the same time tearing down simultaneously.
+    ///
+    /// The clock starts when the connection task is spawned, which happens
+    /// after the connection has been accepted and the service for it has been
+    /// created, rather than at accept time.
     ///
     /// [`max_connection_age_grace`]: ConnectionLifetimeLimits::max_connection_age_grace
     /// [`max_connection_age_jitter`]: ConnectionLifetimeLimits::max_connection_age_jitter
@@ -1726,5 +1730,260 @@ mod tests {
             .expect("HTTP/2 connection was not closed after max_connection_age elapsed")
             .unwrap()
             .ok();
+    }
+
+    // The HTTP/2 equivalent of
+    // `max_connection_age_grace_force_closes_stuck_connection`: once the grace
+    // period elapses the connection is closed even though an HTTP/2 stream is
+    // still open, so the in-flight request fails.
+    #[cfg(feature = "http2")]
+    #[tokio::test(start_paused = true)]
+    async fn max_connection_age_grace_force_closes_stuck_connection_http2() {
+        use std::{future::pending, sync::Arc};
+
+        use hyper_util::rt::TokioExecutor;
+        use tokio::sync::Notify;
+
+        let started = Arc::new(Notify::new());
+        let app = Router::new().route("/", {
+            let started = started.clone();
+            get(move || {
+                let started = started.clone();
+                async move {
+                    started.notify_one();
+                    pending::<()>().await;
+                    "unreachable"
+                }
+            })
+        });
+
+        let (client, server) = io::duplex(1024);
+        let listener = ReadyListener(Some(server));
+
+        tokio::spawn(
+            serve(listener, app)
+                .connection_lifetime_limits(
+                    ConnectionLifetimeLimits::new()
+                        .max_connection_age(Duration::from_secs(10))
+                        .max_connection_age_grace(Duration::from_secs(5)),
+                )
+                .into_future(),
+        );
+
+        let io = TokioIo::new(client);
+        let (mut sender, conn) = hyper::client::conn::http2::Builder::new(TokioExecutor::new())
+            .handshake(io)
+            .await
+            .unwrap();
+        tokio::spawn(conn);
+
+        let request = Request::builder().uri("/").body(Body::empty()).unwrap();
+        let send = tokio::spawn(async move { sender.send_request(request).await });
+
+        // Wait until the (never-completing) handler is actually running.
+        started.notified().await;
+
+        // age (10s) + grace (5s) later, the connection is force-closed despite
+        // the still-open stream, so the in-flight request resolves with an error.
+        let result = tokio::time::timeout(Duration::from_secs(60), send)
+            .await
+            .expect("request was not aborted within the grace period")
+            .unwrap();
+        assert!(
+            result.is_err(),
+            "expected the in-flight HTTP/2 request to fail when the connection is force-closed",
+        );
+    }
+
+    // The grace period is an upper bound, not a deadline that requests are cut
+    // at: a request that finishes after the age limit fires but before the
+    // grace period elapses still gets its response.
+    #[tokio::test(start_paused = true)]
+    async fn max_connection_age_grace_lets_request_finish_in_time() {
+        // The age limit fires at 10s and the grace period force-closes at 15s,
+        // so a handler that takes 12s completes in between the two.
+        let app = Router::new().route(
+            "/",
+            get(|| async {
+                tokio::time::sleep(Duration::from_secs(12)).await;
+                "done"
+            }),
+        );
+
+        let (client, server) = io::duplex(1024);
+        let listener = ReadyListener(Some(server));
+
+        tokio::spawn(
+            serve(listener, app)
+                .connection_lifetime_limits(
+                    ConnectionLifetimeLimits::new()
+                        .max_connection_age(Duration::from_secs(10))
+                        .max_connection_age_grace(Duration::from_secs(5)),
+                )
+                .into_future(),
+        );
+
+        let stream = TokioIo::new(client);
+        let (mut sender, conn) = hyper::client::conn::http1::handshake(stream).await.unwrap();
+        tokio::spawn(conn);
+
+        let request = Request::builder().uri("/").body(Body::empty()).unwrap();
+        let response = tokio::time::timeout(Duration::from_secs(60), sender.send_request(request))
+            .await
+            .expect("in-flight request did not resolve")
+            .expect("in-flight request failed even though it finished within the grace period");
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = to_bytes(Body::new(response.into_body()), usize::MAX)
+            .await
+            .unwrap();
+        assert_eq!(&body[..], b"done");
+    }
+
+    // Jitter is added to the age limit of each individual connection, so
+    // connections opened at the same instant close at different times spread
+    // over `[age, age + jitter]` rather than all closing exactly at `age`.
+    #[tokio::test(start_paused = true)]
+    async fn max_connection_age_jitter_extends_deadline() {
+        const CONNECTIONS: usize = 8;
+
+        let age = Duration::from_secs(1);
+        // Kept comfortably below hyper's 30s header read timeout, which would
+        // otherwise close these never-used connections before their deadline.
+        let jitter = Duration::from_secs(20);
+
+        let start = tokio::time::Instant::now();
+
+        // The senders are held for the duration of the test: dropping one would
+        // close its connection from the client side.
+        let mut senders: Vec<hyper::client::conn::http1::SendRequest<Body>> =
+            Vec::with_capacity(CONNECTIONS);
+        let mut closed_at = Vec::with_capacity(CONNECTIONS);
+
+        for _ in 0..CONNECTIONS {
+            let app = Router::new().route("/", get(|| async { "ok" }));
+            let (client, server) = io::duplex(1024);
+
+            tokio::spawn(
+                serve(ReadyListener(Some(server)), app)
+                    .connection_lifetime_limits(
+                        ConnectionLifetimeLimits::new()
+                            .max_connection_age(age)
+                            .max_connection_age_jitter(jitter),
+                    )
+                    .into_future(),
+            );
+
+            let stream = TokioIo::new(client);
+            let (sender, conn) = hyper::client::conn::http1::handshake(stream).await.unwrap();
+            senders.push(sender);
+            // Each connection records when it was closed from its own task, so
+            // the deadlines don't collapse onto whichever one is awaited first.
+            closed_at.push(tokio::spawn(async move {
+                conn.await.ok();
+                tokio::time::Instant::now()
+            }));
+        }
+
+        let mut deadlines = Vec::with_capacity(CONNECTIONS);
+        for handle in closed_at {
+            let closed = tokio::time::timeout(Duration::from_secs(60), handle)
+                .await
+                .expect("connection was not closed after max_connection_age elapsed")
+                .unwrap();
+            deadlines.push(closed - start);
+        }
+
+        for deadline in &deadlines {
+            assert!(
+                *deadline >= age,
+                "connection closed after {deadline:?}, before the age limit {age:?}",
+            );
+            assert!(
+                *deadline <= age + jitter,
+                "connection closed after {deadline:?}, past the jittered bound {:?}",
+                age + jitter,
+            );
+        }
+
+        // Every connection would close at exactly `age` if jitter were ignored.
+        // Each draw is uniform over `[0, jitter]`, so all of them landing within
+        // a second of zero is vanishingly unlikely.
+        assert!(
+            deadlines
+                .iter()
+                .any(|deadline| *deadline > age + Duration::from_secs(1)),
+            "no connection had jitter added to its age limit: {deadlines:?}",
+        );
+    }
+
+    // A shutdown signal only asks connections to stop accepting new requests, so
+    // on its own it waits forever on a stuck handler. The age and grace limits
+    // still apply, force-closing the connection and letting the `serve` future
+    // resolve.
+    #[tokio::test(start_paused = true)]
+    async fn max_connection_age_grace_unblocks_graceful_shutdown() {
+        use std::{future::pending, sync::Arc};
+
+        use tokio::sync::{oneshot, Notify};
+
+        let started = Arc::new(Notify::new());
+        let app = Router::new().route("/", {
+            let started = started.clone();
+            get(move || {
+                let started = started.clone();
+                async move {
+                    started.notify_one();
+                    pending::<()>().await;
+                    "unreachable"
+                }
+            })
+        });
+
+        let (client, server) = io::duplex(1024);
+        let listener = ReadyListener(Some(server));
+
+        let (signal_tx, signal_rx) = oneshot::channel::<()>();
+        let server_handle = tokio::spawn(
+            serve(listener, app)
+                .connection_lifetime_limits(
+                    ConnectionLifetimeLimits::new()
+                        .max_connection_age(Duration::from_secs(10))
+                        .max_connection_age_grace(Duration::from_secs(5)),
+                )
+                .with_graceful_shutdown(async move {
+                    signal_rx.await.ok();
+                })
+                .into_future(),
+        );
+
+        let stream = TokioIo::new(client);
+        let (mut sender, conn) = hyper::client::conn::http1::handshake(stream).await.unwrap();
+        tokio::spawn(conn);
+
+        let request = Request::builder().uri("/").body(Body::empty()).unwrap();
+        let send = tokio::spawn(async move { sender.send_request(request).await });
+
+        // Wait until the (never-completing) handler is actually running, then
+        // signal shutdown well before the age limit fires.
+        started.notified().await;
+        tokio::time::sleep(Duration::from_secs(1)).await;
+        signal_tx.send(()).unwrap();
+
+        // The age limit still fires at 10s and the grace period force-closes at
+        // 15s, so the in-flight request resolves with an error.
+        let result = tokio::time::timeout(Duration::from_secs(60), send)
+            .await
+            .expect("request was not aborted within the grace period")
+            .unwrap();
+        assert!(
+            result.is_err(),
+            "expected the in-flight request to fail when the connection is force-closed",
+        );
+
+        tokio::time::timeout(Duration::from_secs(60), server_handle)
+            .await
+            .expect("serve future did not resolve after the connection was force-closed")
+            .unwrap();
     }
 }

--- a/axum/src/serve/mod.rs
+++ b/axum/src/serve/mod.rs
@@ -4,11 +4,12 @@ use std::{
     convert::Infallible,
     error::Error as StdError,
     fmt::Debug,
-    future::{Future, IntoFuture},
+    future::{Future, IntoFuture, Pending},
     io,
     marker::PhantomData,
     pin::pin,
     sync::Arc,
+    time::Duration,
 };
 
 use axum_core::{body::Body, extract::Request, response::Response};
@@ -117,7 +118,163 @@ where
         listener,
         make_service,
         executor: TokioExecutor,
+        connection_limits: ConnectionLimits::default(),
         _marker: PhantomData,
+    }
+}
+
+/// Per-connection limits applied by [`serve`], used to bound the lifetime of
+/// individual connections.
+///
+/// Closing connections after a bounded lifetime pressures clients to establish
+/// *new* connections, which is useful behind a load balancer (e.g. a Kubernetes
+/// `Service`) that round-robins new connections across the current set of
+/// backends: without rotation, a client's connection pool keeps sending work to
+/// whichever backends it first connected to, even after the pool has scaled up.
+/// It also bounds the worst case when a client's connection pool has no
+/// rotation of its own. This mirrors `tonic`'s `max_connection_age` and Envoy's
+/// `max_connection_duration`.
+///
+/// The mechanism differs by protocol but the knobs are the same:
+///
+/// - **HTTP/1**: the next response gets a `Connection: close` header and the
+///   connection is closed once the in-flight request finishes.
+/// - **HTTP/2** (including gRPC): a `GOAWAY` is sent, so new streams are refused
+///   while in-flight streams are given up to [`max_connection_age_grace`] to
+///   finish.
+///
+/// Note that this is distinct from [`ListenerExt::limit_connections`], which
+/// bounds the *number* of concurrent connections rather than their lifetime.
+///
+/// # Example
+///
+/// ```
+/// use std::time::Duration;
+/// use axum::{Router, routing::get, serve::ConnectionLimits};
+///
+/// # async {
+/// let router = Router::new().route("/", get(|| async { "Hello, World!" }));
+/// let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await.unwrap();
+///
+/// let limits = ConnectionLimits::new()
+///     // Soft cap on total connection lifetime.
+///     .max_connection_age(Duration::from_secs(10 * 60))
+///     // Random per-connection jitter added to the age, to avoid synchronized
+///     // reconnect storms when many connections were established at once.
+///     .max_connection_age_jitter(Duration::from_secs(60))
+///     // Hard cap on how long to wait for in-flight work after the age limit
+///     // fires before forcibly closing.
+///     .max_connection_age_grace(Duration::from_secs(30));
+///
+/// axum::serve(listener, router)
+///     .connection_limits(limits)
+///     .await;
+/// # };
+/// ```
+///
+/// [`max_connection_age_grace`]: ConnectionLimits::max_connection_age_grace
+/// [`ListenerExt::limit_connections`]: crate::serve::ListenerExt::limit_connections
+#[cfg(all(feature = "tokio", any(feature = "http1", feature = "http2")))]
+#[derive(Clone, Copy, Debug, Default)]
+#[must_use]
+pub struct ConnectionLimits {
+    max_connection_age: Option<Duration>,
+    max_connection_age_jitter: Option<Duration>,
+    max_connection_age_grace: Option<Duration>,
+}
+
+#[cfg(all(feature = "tokio", any(feature = "http1", feature = "http2")))]
+impl ConnectionLimits {
+    /// Create a new [`ConnectionLimits`] with no limits set.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set a soft cap on the total lifetime of a connection.
+    ///
+    /// Once a connection has been open for this long, a graceful shutdown of
+    /// that connection is started: HTTP/1 connections close after the in-flight
+    /// request completes (sending `Connection: close`), and HTTP/2 connections
+    /// send a `GOAWAY`, refusing new streams while letting in-flight ones finish
+    /// (bounded by [`max_connection_age_grace`] if set).
+    ///
+    /// Consider also setting [`max_connection_age_jitter`] to avoid all
+    /// connections opened around the same time tearing down simultaneously.
+    ///
+    /// [`max_connection_age_grace`]: ConnectionLimits::max_connection_age_grace
+    /// [`max_connection_age_jitter`]: ConnectionLimits::max_connection_age_jitter
+    pub fn max_connection_age(mut self, age: Duration) -> Self {
+        self.max_connection_age = Some(age);
+        self
+    }
+
+    /// Set the maximum random jitter added to [`max_connection_age`].
+    ///
+    /// Each connection adds a random duration in `[0, jitter]` to its age limit.
+    /// This is important for avoiding synchronized reconnect storms when many
+    /// connections were established at the same time (e.g. right after a
+    /// deploy): without it, every connection opened in the same instant tears
+    /// down in the same instant once the age limit elapses.
+    ///
+    /// This has no effect unless [`max_connection_age`] is also set.
+    ///
+    /// [`max_connection_age`]: ConnectionLimits::max_connection_age
+    pub fn max_connection_age_jitter(mut self, jitter: Duration) -> Self {
+        self.max_connection_age_jitter = Some(jitter);
+        self
+    }
+
+    /// Set a hard cap on how long to wait for in-flight work after
+    /// [`max_connection_age`] fires before forcibly closing the connection.
+    ///
+    /// This primarily matters for HTTP/2, where in-flight streams are allowed to
+    /// finish after the `GOAWAY` is sent; once this grace period elapses the
+    /// connection is closed regardless. Mirrors `tonic`'s
+    /// `max_connection_age_grace`.
+    ///
+    /// This has no effect unless [`max_connection_age`] is also set.
+    ///
+    /// [`max_connection_age`]: ConnectionLimits::max_connection_age
+    pub fn max_connection_age_grace(mut self, grace: Duration) -> Self {
+        self.max_connection_age_grace = Some(grace);
+        self
+    }
+}
+
+/// Returns a pseudo-random [`Duration`] in `[Duration::ZERO, max]`.
+///
+/// Uses [`RandomState`], whose keys are seeded by the OS and bumped on each
+/// construction, to get cheap per-connection randomness without pulling in a
+/// dedicated RNG dependency.
+///
+/// [`RandomState`]: std::collections::hash_map::RandomState
+#[cfg(all(feature = "tokio", any(feature = "http1", feature = "http2")))]
+fn random_duration(max: Duration) -> Duration {
+    if max.is_zero() {
+        return Duration::ZERO;
+    }
+
+    use std::hash::{BuildHasher, Hasher};
+    let rand = std::collections::hash_map::RandomState::new()
+        .build_hasher()
+        .finish();
+
+    let max_nanos = max.as_nanos();
+    let nanos = u128::from(rand) % (max_nanos + 1);
+    // `nanos <= max_nanos` and realistic jitter fits comfortably in `u64`;
+    // saturate in the absurd case rather than truncating.
+    Duration::from_nanos(u64::try_from(nanos).unwrap_or(u64::MAX))
+}
+
+/// Sleeps for `duration`, or never completes if it's `None`.
+///
+/// Used to model an unset timer without having to poll a future that would
+/// otherwise complete immediately.
+#[cfg(all(feature = "tokio", any(feature = "http1", feature = "http2")))]
+fn sleep_or_pending(duration: Option<Duration>) -> Either<tokio::time::Sleep, Pending<()>> {
+    match duration {
+        Some(duration) => Either::Left(tokio::time::sleep(duration)),
+        None => Either::Right(std::future::pending()),
     }
 }
 
@@ -204,6 +361,7 @@ pub struct Serve<L, M, S, B, E = TokioExecutor> {
     listener: L,
     make_service: M,
     executor: E,
+    connection_limits: ConnectionLimits,
     _marker: PhantomData<fn(B) -> S>,
 }
 
@@ -245,6 +403,7 @@ where
             listener: self.listener,
             make_service: self.make_service,
             executor: self.executor,
+            connection_limits: self.connection_limits,
             signal,
             _marker: PhantomData,
         }
@@ -253,6 +412,22 @@ where
     /// Returns the local address this server is bound to.
     pub fn local_addr(&self) -> io::Result<L::Addr> {
         self.listener.local_addr()
+    }
+
+    /// Apply per-connection [`ConnectionLimits`], bounding the lifetime of
+    /// individual connections.
+    ///
+    /// This is useful for forcing clients to rotate connections — see
+    /// [`ConnectionLimits`] for details and an example.
+    ///
+    /// This method can be called before or after [`with_graceful_shutdown`] and
+    /// [`with_executor`].
+    ///
+    /// [`with_graceful_shutdown`]: Serve::with_graceful_shutdown
+    /// [`with_executor`]: Serve::with_executor
+    pub fn connection_limits(mut self, limits: ConnectionLimits) -> Self {
+        self.connection_limits = limits;
+        self
     }
 
     /// Provide a custom [`Executor`] to use for spawning connection tasks and
@@ -302,6 +477,7 @@ where
             listener: self.listener,
             make_service: self.make_service,
             executor,
+            connection_limits: self.connection_limits,
             _marker: PhantomData,
         }
     }
@@ -326,6 +502,7 @@ where
             mut listener,
             mut make_service,
             executor,
+            connection_limits,
             _marker,
         } = self;
 
@@ -341,6 +518,7 @@ where
                 io,
                 remote_addr,
                 &executor,
+                connection_limits,
             )
             .await;
         }
@@ -359,13 +537,15 @@ where
             listener,
             make_service,
             executor,
+            connection_limits,
             _marker: _,
         } = self;
 
         let mut s = f.debug_struct("Serve");
         s.field("listener", listener)
             .field("make_service", make_service)
-            .field("executor", executor);
+            .field("executor", executor)
+            .field("connection_limits", connection_limits);
 
         s.finish()
     }
@@ -400,6 +580,7 @@ pub struct WithGracefulShutdown<L, M, S, F, B, E = TokioExecutor> {
     listener: L,
     make_service: M,
     executor: E,
+    connection_limits: ConnectionLimits,
     signal: F,
     _marker: PhantomData<fn(B) -> S>,
 }
@@ -426,9 +607,19 @@ where
             listener: self.listener,
             make_service: self.make_service,
             executor,
+            connection_limits: self.connection_limits,
             signal: self.signal,
             _marker: PhantomData,
         }
+    }
+
+    /// Apply per-connection [`ConnectionLimits`], bounding the lifetime of
+    /// individual connections.
+    ///
+    /// See [`Serve::connection_limits`] and [`ConnectionLimits`] for details.
+    pub fn connection_limits(mut self, limits: ConnectionLimits) -> Self {
+        self.connection_limits = limits;
+        self
     }
 }
 
@@ -452,6 +643,7 @@ where
             mut listener,
             mut make_service,
             executor,
+            connection_limits,
             signal,
             _marker,
         } = self;
@@ -485,6 +677,7 @@ where
                 io,
                 remote_addr,
                 &executor,
+                connection_limits,
             )
             .await;
         }
@@ -514,6 +707,7 @@ where
             listener,
             make_service,
             executor: _,
+            connection_limits,
             signal,
             _marker: _,
         } = self;
@@ -521,6 +715,7 @@ where
         f.debug_struct("WithGracefulShutdown")
             .field("listener", listener)
             .field("make_service", make_service)
+            .field("connection_limits", connection_limits)
             .field("signal", signal)
             .finish()
     }
@@ -570,6 +765,7 @@ async fn handle_connection<L, M, S, B, E>(
     io: <L as Listener>::Io,
     remote_addr: <L as Listener>::Addr,
     executor: &E,
+    connection_limits: ConnectionLimits,
 ) where
     L: Listener,
     L::Addr: Debug,
@@ -620,20 +816,48 @@ async fn handle_connection<L, M, S, B, E>(
         let mut conn = pin!(builder.serve_connection_with_upgrades(io, hyper_service));
         let mut signal_closed = pin!(signal_rx.changed().fuse());
 
+        // Soft cap on the connection's lifetime (with optional jitter). When it
+        // elapses we start a graceful shutdown of this connection and re-arm the
+        // timer with the grace period (if any), which then bounds how long we
+        // wait before forcibly closing.
+        let mut timer = pin!(sleep_or_pending(connection_limits.max_connection_age.map(
+            |age| {
+                age + connection_limits
+                    .max_connection_age_jitter
+                    .map_or(Duration::ZERO, random_duration)
+            }
+        )));
+        let mut age_fired = false;
+
         loop {
-            match select(conn.as_mut(), &mut signal_closed).await {
+            match select(
+                conn.as_mut(),
+                select(signal_closed.as_mut(), timer.as_mut()),
+            )
+            .await
+            {
                 Either::Left((result, _)) => {
                     if let Err(_err) = result {
                         trace!("failed to serve connection: {_err:#}");
                     }
                     break;
                 }
-                Either::Right((Err(_), _)) => {
+                Either::Right((Either::Left((Err(_), _)), _)) => {
                     trace!("signal received in task, starting graceful shutdown");
                     conn.as_mut().graceful_shutdown();
                 }
-                Either::Right((Ok(()), _)) => {
+                Either::Right((Either::Left((Ok(()), _)), _)) => {
                     unreachable!("shutdown channel never sends values")
+                }
+                Either::Right((Either::Right(_), _)) if !age_fired => {
+                    age_fired = true;
+                    trace!("max connection age reached, starting graceful shutdown");
+                    conn.as_mut().graceful_shutdown();
+                    timer.set(sleep_or_pending(connection_limits.max_connection_age_grace));
+                }
+                Either::Right((Either::Right(_), _)) => {
+                    trace!("max connection age grace period elapsed, closing connection");
+                    break;
                 }
             }
         }
@@ -721,7 +945,7 @@ mod tests {
 
     #[cfg(unix)]
     use super::IncomingStream;
-    use super::{serve, Listener};
+    use super::{serve, ConnectionLimits, Listener};
     #[cfg(unix)]
     use crate::extract::connect_info::Connected;
     use crate::{
@@ -904,6 +1128,22 @@ mod tests {
             handler.into_make_service(),
         )
         .with_executor(exec);
+
+        // connection_limits, composable with the other builder methods in any order
+        let limits = ConnectionLimits::new()
+            .max_connection_age(Duration::from_secs(60))
+            .max_connection_age_jitter(Duration::from_secs(10))
+            .max_connection_age_grace(Duration::from_secs(5));
+        serve(TcpListener::bind(addr).await.unwrap(), router.clone()).connection_limits(limits);
+        serve(TcpListener::bind(addr).await.unwrap(), router.clone())
+            .connection_limits(limits)
+            .with_graceful_shutdown(std::future::pending());
+        serve(TcpListener::bind(addr).await.unwrap(), router.clone())
+            .with_graceful_shutdown(std::future::pending())
+            .connection_limits(limits);
+        serve(TcpListener::bind(addr).await.unwrap(), router.clone())
+            .connection_limits(limits)
+            .with_executor(TestExecutor::new());
     }
 
     async fn handler() {}
@@ -1270,5 +1510,161 @@ mod tests {
             TcpListener::bind(addr).await.unwrap(),
             app.into_make_service(),
         );
+    }
+
+    #[test]
+    fn random_duration_is_bounded_and_varies() {
+        use std::collections::HashSet;
+
+        assert_eq!(super::random_duration(Duration::ZERO), Duration::ZERO);
+
+        let max = Duration::from_secs(60);
+        let mut seen = HashSet::new();
+        for _ in 0..256 {
+            let d = super::random_duration(max);
+            assert!(d <= max, "{d:?} exceeds the requested bound {max:?}");
+            seen.insert(d);
+        }
+
+        // It would be astronomically unlikely for 256 draws to all collide if
+        // the source is actually random.
+        assert!(seen.len() > 1, "random_duration produced a constant value");
+    }
+
+    // After `max_connection_age` elapses, an idle keep-alive connection is
+    // gracefully shut down by the server, which the client observes as its
+    // connection task completing.
+    #[tokio::test(start_paused = true)]
+    async fn max_connection_age_closes_idle_connection() {
+        let app = Router::new().route("/", get(|| async { "ok" }));
+        let (client, server) = io::duplex(1024);
+        let listener = ReadyListener(Some(server));
+
+        tokio::spawn(
+            serve(listener, app)
+                .connection_limits(
+                    ConnectionLimits::new().max_connection_age(Duration::from_secs(10)),
+                )
+                .into_future(),
+        );
+
+        let stream = TokioIo::new(client);
+        let (mut sender, conn) = hyper::client::conn::http1::handshake(stream).await.unwrap();
+        let conn_handle = tokio::spawn(conn);
+
+        // A first request succeeds normally before the age limit elapses.
+        let request = Request::builder().uri("/").body(Body::empty()).unwrap();
+        let response = sender.send_request(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let _ = to_bytes(Body::new(response.into_body()), usize::MAX)
+            .await
+            .unwrap();
+
+        // With (paused) time auto-advancing, the age timer fires and the server
+        // closes the now-idle connection, completing the client's conn task.
+        tokio::time::timeout(Duration::from_secs(30), conn_handle)
+            .await
+            .expect("connection was not closed after max_connection_age elapsed")
+            .unwrap()
+            .ok();
+    }
+
+    // When `max_connection_age` fires while a request is in flight and the
+    // handler never completes, the grace period bounds how long the server
+    // waits before forcibly closing, so the in-flight request fails.
+    #[tokio::test(start_paused = true)]
+    async fn max_connection_age_grace_force_closes_stuck_connection() {
+        use std::{future::pending, sync::Arc};
+
+        use tokio::sync::Notify;
+
+        let started = Arc::new(Notify::new());
+        let app = Router::new().route("/", {
+            let started = started.clone();
+            get(move || {
+                let started = started.clone();
+                async move {
+                    started.notify_one();
+                    pending::<()>().await;
+                    "unreachable"
+                }
+            })
+        });
+
+        let (client, server) = io::duplex(1024);
+        let listener = ReadyListener(Some(server));
+
+        tokio::spawn(
+            serve(listener, app)
+                .connection_limits(
+                    ConnectionLimits::new()
+                        .max_connection_age(Duration::from_secs(10))
+                        .max_connection_age_grace(Duration::from_secs(5)),
+                )
+                .into_future(),
+        );
+
+        let stream = TokioIo::new(client);
+        let (mut sender, conn) = hyper::client::conn::http1::handshake(stream).await.unwrap();
+        tokio::spawn(conn);
+
+        let request = Request::builder().uri("/").body(Body::empty()).unwrap();
+        let send = tokio::spawn(async move { sender.send_request(request).await });
+
+        // Wait until the (never-completing) handler is actually running.
+        started.notified().await;
+
+        // age (10s) + grace (5s) later, the connection is force-closed despite
+        // the stuck handler, so the in-flight request resolves with an error.
+        let result = tokio::time::timeout(Duration::from_secs(60), send)
+            .await
+            .expect("request was not aborted within the grace period")
+            .unwrap();
+        assert!(
+            result.is_err(),
+            "expected the in-flight request to fail when the connection is force-closed",
+        );
+    }
+
+    // The HTTP/2 equivalent of `max_connection_age_closes_idle_connection`: the
+    // server sends GOAWAY once the age limit elapses, completing the client's
+    // connection task.
+    #[cfg(feature = "http2")]
+    #[tokio::test(start_paused = true)]
+    async fn max_connection_age_closes_idle_connection_http2() {
+        use hyper_util::rt::TokioExecutor;
+
+        let app = Router::new().route("/", get(|| async { "ok" }));
+        let (client, server) = io::duplex(1024);
+        let listener = ReadyListener(Some(server));
+
+        tokio::spawn(
+            serve(listener, app)
+                .connection_limits(
+                    ConnectionLimits::new().max_connection_age(Duration::from_secs(10)),
+                )
+                .into_future(),
+        );
+
+        let io = TokioIo::new(client);
+        let (mut sender, conn) = hyper::client::conn::http2::Builder::new(TokioExecutor::new())
+            .handshake(io)
+            .await
+            .unwrap();
+        let conn_handle = tokio::spawn(conn);
+
+        let request = Request::builder().uri("/").body(Body::empty()).unwrap();
+        let response = sender.send_request(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let _ = to_bytes(Body::new(response.into_body()), usize::MAX)
+            .await
+            .unwrap();
+
+        // GOAWAY after the age limit closes the connection from the server side.
+        tokio::time::timeout(Duration::from_secs(30), conn_handle)
+            .await
+            .expect("HTTP/2 connection was not closed after max_connection_age elapsed")
+            .unwrap()
+            .ok();
     }
 }

--- a/axum/src/serve/mod.rs
+++ b/axum/src/serve/mod.rs
@@ -181,7 +181,6 @@ where
 ///
 /// [`max_connection_age_grace`]: ConnectionLimits::max_connection_age_grace
 /// [`ListenerExt::limit_connections`]: crate::serve::ListenerExt::limit_connections
-#[cfg(all(feature = "tokio", any(feature = "http1", feature = "http2")))]
 #[derive(Clone, Copy, Debug, Default)]
 #[must_use]
 pub struct ConnectionLimits {
@@ -190,7 +189,6 @@ pub struct ConnectionLimits {
     max_connection_age_grace: Option<Duration>,
 }
 
-#[cfg(all(feature = "tokio", any(feature = "http1", feature = "http2")))]
 impl ConnectionLimits {
     /// Create a new [`ConnectionLimits`] with no limits set.
     pub fn new() -> Self {
@@ -262,7 +260,6 @@ impl ConnectionLimits {
 /// dedicated RNG dependency.
 ///
 /// [`RandomState`]: std::collections::hash_map::RandomState
-#[cfg(all(feature = "tokio", any(feature = "http1", feature = "http2")))]
 fn random_duration(max: Duration) -> Duration {
     if max.is_zero() {
         return Duration::ZERO;
@@ -283,7 +280,6 @@ fn random_duration(max: Duration) -> Duration {
 ///
 /// Used to model an unset timer without having to poll a future that would
 /// otherwise complete immediately.
-#[cfg(all(feature = "tokio", any(feature = "http1", feature = "http2")))]
 fn sleep_or_pending(duration: Option<Duration>) -> Either<tokio::time::Sleep, Pending<()>> {
     match duration {
         Some(duration) => Either::Left(tokio::time::sleep(duration)),

--- a/axum/src/serve/mod.rs
+++ b/axum/src/serve/mod.rs
@@ -163,7 +163,7 @@ where
 /// let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await.unwrap();
 ///
 /// let limits = ConnectionLimits::new()
-///     // Soft cap on total connection lifetime.
+///     // Stop accepting new requests on a connection after this long.
 ///     .max_connection_age(Duration::from_secs(10 * 60))
 ///     // Random per-connection jitter added to the age, to avoid synchronized
 ///     // reconnect storms when many connections were established at once.
@@ -194,7 +194,7 @@ impl ConnectionLimits {
         Self::default()
     }
 
-    /// Set a soft cap on the total lifetime of a connection.
+    /// Set a cap on how long a connection keeps accepting new requests.
     ///
     /// Once a connection has been open for this long, a graceful shutdown of
     /// that connection is started: HTTP/1 connections close after the in-flight
@@ -231,9 +231,9 @@ impl ConnectionLimits {
     /// Set a hard cap on how long to wait for in-flight work after
     /// [`max_connection_age`] fires before forcibly closing the connection.
     ///
-    /// Without a grace period, [`max_connection_age`] is purely a soft cap: the
-    /// server waits however long it takes for in-flight work to finish before
-    /// closing the connection. Setting a grace period turns
+    /// Without a grace period, [`max_connection_age`] only stops new requests:
+    /// the server waits however long it takes for in-flight work to finish
+    /// before closing the connection. Setting a grace period turns
     /// `max_connection_age` (+ jitter) + grace into a hard deadline: when it
     /// elapses the connection is closed *even if a request is still in flight*,
     /// and the client never receives a response for it. This applies to HTTP/1
@@ -823,7 +823,7 @@ async fn handle_connection<L, M, S, B, E>(
         let mut conn = pin!(builder.serve_connection_with_upgrades(io, hyper_service));
         let mut signal_closed = pin!(signal_rx.changed().fuse());
 
-        // Soft cap on the connection's lifetime (with optional jitter). When it
+        // Age limit for the connection (with optional jitter). When it
         // elapses we start a graceful shutdown of this connection and re-arm the
         // timer with the grace period (if any), which then bounds how long we
         // wait before forcibly closing.
@@ -1633,7 +1633,7 @@ mod tests {
         );
     }
 
-    // Without a grace period, `max_connection_age` is a soft cap: a request
+    // Without a grace period, `max_connection_age` only stops new requests: one
     // that is still in flight when the age limit fires keeps the connection
     // alive for as long as it needs and still completes successfully. Only
     // `max_connection_age_grace` opts into force-closing in-flight work.

--- a/axum/src/serve/mod.rs
+++ b/axum/src/serve/mod.rs
@@ -848,7 +848,9 @@ async fn handle_connection<L, M, S, B, E>(
                     age_fired = true;
                     trace!("max connection age reached, starting graceful shutdown");
                     conn.as_mut().graceful_shutdown();
-                    timer.set(sleep_or_pending(connection_lifetime_limits.max_connection_age_grace));
+                    timer.set(sleep_or_pending(
+                        connection_lifetime_limits.max_connection_age_grace,
+                    ));
                 }
                 Either::Right((Either::Right(_), _)) => {
                     trace!("max connection age grace period elapsed, closing connection");
@@ -1129,7 +1131,8 @@ mod tests {
             .max_connection_age(Duration::from_secs(60))
             .max_connection_age_jitter(Duration::from_secs(10))
             .max_connection_age_grace(Duration::from_secs(5));
-        serve(TcpListener::bind(addr).await.unwrap(), router.clone()).connection_lifetime_limits(limits);
+        serve(TcpListener::bind(addr).await.unwrap(), router.clone())
+            .connection_lifetime_limits(limits);
         serve(TcpListener::bind(addr).await.unwrap(), router.clone())
             .connection_lifetime_limits(limits)
             .with_graceful_shutdown(std::future::pending());

--- a/axum/src/serve/mod.rs
+++ b/axum/src/serve/mod.rs
@@ -4,11 +4,12 @@ use std::{
     convert::Infallible,
     error::Error as StdError,
     fmt::Debug,
-    future::{Future, IntoFuture},
+    future::{Future, IntoFuture, Pending},
     io,
     marker::PhantomData,
     pin::pin,
     sync::Arc,
+    time::Duration,
 };
 
 use axum_core::{body::Body, extract::Request, response::Response};
@@ -117,7 +118,163 @@ where
         listener,
         make_service,
         executor: TokioExecutor,
+        connection_limits: ConnectionLimits::default(),
         _marker: PhantomData,
+    }
+}
+
+/// Per-connection limits applied by [`serve`], used to bound the lifetime of
+/// individual connections.
+///
+/// Closing connections after a bounded lifetime pressures clients to establish
+/// *new* connections, which is useful behind a load balancer (e.g. a Kubernetes
+/// `Service`) that round-robins new connections across the current set of
+/// backends: without rotation, a client's connection pool keeps sending work to
+/// whichever backends it first connected to, even after the pool has scaled up.
+/// It also bounds the worst case when a client's connection pool has no
+/// rotation of its own. This mirrors `tonic`'s `max_connection_age` and Envoy's
+/// `max_connection_duration`.
+///
+/// The mechanism differs by protocol but the knobs are the same:
+///
+/// - **HTTP/1**: the next response gets a `Connection: close` header and the
+///   connection is closed once the in-flight request finishes.
+/// - **HTTP/2** (including gRPC): a `GOAWAY` is sent, so new streams are refused
+///   while in-flight streams are given up to [`max_connection_age_grace`] to
+///   finish.
+///
+/// Note that this is distinct from [`ListenerExt::limit_connections`], which
+/// bounds the *number* of concurrent connections rather than their lifetime.
+///
+/// # Example
+///
+/// ```
+/// use std::time::Duration;
+/// use axum::{Router, routing::get, serve::ConnectionLimits};
+///
+/// # async {
+/// let router = Router::new().route("/", get(|| async { "Hello, World!" }));
+/// let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await.unwrap();
+///
+/// let limits = ConnectionLimits::new()
+///     // Soft cap on total connection lifetime.
+///     .max_connection_age(Duration::from_secs(10 * 60))
+///     // Random per-connection jitter added to the age, to avoid synchronized
+///     // reconnect storms when many connections were established at once.
+///     .max_connection_age_jitter(Duration::from_secs(60))
+///     // Hard cap on how long to wait for in-flight work after the age limit
+///     // fires before forcibly closing.
+///     .max_connection_age_grace(Duration::from_secs(30));
+///
+/// axum::serve(listener, router)
+///     .connection_limits(limits)
+///     .await;
+/// # };
+/// ```
+///
+/// [`max_connection_age_grace`]: ConnectionLimits::max_connection_age_grace
+/// [`ListenerExt::limit_connections`]: crate::serve::ListenerExt::limit_connections
+#[cfg(all(feature = "tokio", any(feature = "http1", feature = "http2")))]
+#[derive(Clone, Copy, Debug, Default)]
+#[must_use]
+pub struct ConnectionLimits {
+    max_connection_age: Option<Duration>,
+    max_connection_age_jitter: Option<Duration>,
+    max_connection_age_grace: Option<Duration>,
+}
+
+#[cfg(all(feature = "tokio", any(feature = "http1", feature = "http2")))]
+impl ConnectionLimits {
+    /// Create a new [`ConnectionLimits`] with no limits set.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set a soft cap on the total lifetime of a connection.
+    ///
+    /// Once a connection has been open for this long, a graceful shutdown of
+    /// that connection is started: HTTP/1 connections close after the in-flight
+    /// request completes (sending `Connection: close`), and HTTP/2 connections
+    /// send a `GOAWAY`, refusing new streams while letting in-flight ones finish
+    /// (bounded by [`max_connection_age_grace`] if set).
+    ///
+    /// Consider also setting [`max_connection_age_jitter`] to avoid all
+    /// connections opened around the same time tearing down simultaneously.
+    ///
+    /// [`max_connection_age_grace`]: ConnectionLimits::max_connection_age_grace
+    /// [`max_connection_age_jitter`]: ConnectionLimits::max_connection_age_jitter
+    pub fn max_connection_age(mut self, age: Duration) -> Self {
+        self.max_connection_age = Some(age);
+        self
+    }
+
+    /// Set the maximum random jitter added to [`max_connection_age`].
+    ///
+    /// Each connection adds a random duration in `[0, jitter]` to its age limit.
+    /// This is important for avoiding synchronized reconnect storms when many
+    /// connections were established at the same time (e.g. right after a
+    /// deploy): without it, every connection opened in the same instant tears
+    /// down in the same instant once the age limit elapses.
+    ///
+    /// This has no effect unless [`max_connection_age`] is also set.
+    ///
+    /// [`max_connection_age`]: ConnectionLimits::max_connection_age
+    pub fn max_connection_age_jitter(mut self, jitter: Duration) -> Self {
+        self.max_connection_age_jitter = Some(jitter);
+        self
+    }
+
+    /// Set a hard cap on how long to wait for in-flight work after
+    /// [`max_connection_age`] fires before forcibly closing the connection.
+    ///
+    /// This primarily matters for HTTP/2, where in-flight streams are allowed to
+    /// finish after the `GOAWAY` is sent; once this grace period elapses the
+    /// connection is closed regardless. Mirrors `tonic`'s
+    /// `max_connection_age_grace`.
+    ///
+    /// This has no effect unless [`max_connection_age`] is also set.
+    ///
+    /// [`max_connection_age`]: ConnectionLimits::max_connection_age
+    pub fn max_connection_age_grace(mut self, grace: Duration) -> Self {
+        self.max_connection_age_grace = Some(grace);
+        self
+    }
+}
+
+/// Returns a pseudo-random [`Duration`] in `[Duration::ZERO, max]`.
+///
+/// Uses [`RandomState`], whose keys are seeded by the OS and bumped on each
+/// construction, to get cheap per-connection randomness without pulling in a
+/// dedicated RNG dependency.
+///
+/// [`RandomState`]: std::collections::hash_map::RandomState
+#[cfg(all(feature = "tokio", any(feature = "http1", feature = "http2")))]
+fn random_duration(max: Duration) -> Duration {
+    if max.is_zero() {
+        return Duration::ZERO;
+    }
+
+    use std::hash::{BuildHasher, Hasher};
+    let rand = std::collections::hash_map::RandomState::new()
+        .build_hasher()
+        .finish();
+
+    let max_nanos = max.as_nanos();
+    let nanos = u128::from(rand) % (max_nanos + 1);
+    // `nanos <= max_nanos` and realistic jitter fits comfortably in `u64`;
+    // saturate in the absurd case rather than truncating.
+    Duration::from_nanos(u64::try_from(nanos).unwrap_or(u64::MAX))
+}
+
+/// Sleeps for `duration`, or never completes if it's `None`.
+///
+/// Used to model an unset timer without having to poll a future that would
+/// otherwise complete immediately.
+#[cfg(all(feature = "tokio", any(feature = "http1", feature = "http2")))]
+fn sleep_or_pending(duration: Option<Duration>) -> Either<tokio::time::Sleep, Pending<()>> {
+    match duration {
+        Some(duration) => Either::Left(tokio::time::sleep(duration)),
+        None => Either::Right(std::future::pending()),
     }
 }
 
@@ -204,6 +361,7 @@ pub struct Serve<L, M, S, B, E = TokioExecutor> {
     listener: L,
     make_service: M,
     executor: E,
+    connection_limits: ConnectionLimits,
     _marker: PhantomData<fn(B) -> S>,
 }
 
@@ -245,6 +403,7 @@ where
             listener: self.listener,
             make_service: self.make_service,
             executor: self.executor,
+            connection_limits: self.connection_limits,
             signal,
             _marker: PhantomData,
         }
@@ -253,6 +412,22 @@ where
     /// Returns the local address this server is bound to.
     pub fn local_addr(&self) -> io::Result<L::Addr> {
         self.listener.local_addr()
+    }
+
+    /// Apply per-connection [`ConnectionLimits`], bounding the lifetime of
+    /// individual connections.
+    ///
+    /// This is useful for forcing clients to rotate connections — see
+    /// [`ConnectionLimits`] for details and an example.
+    ///
+    /// This method can be called before or after [`with_graceful_shutdown`] and
+    /// [`with_executor`].
+    ///
+    /// [`with_graceful_shutdown`]: Serve::with_graceful_shutdown
+    /// [`with_executor`]: Serve::with_executor
+    pub fn connection_limits(mut self, limits: ConnectionLimits) -> Self {
+        self.connection_limits = limits;
+        self
     }
 
     /// Provide a custom [`Executor`] to use for spawning connection tasks and
@@ -302,6 +477,7 @@ where
             listener: self.listener,
             make_service: self.make_service,
             executor,
+            connection_limits: self.connection_limits,
             _marker: PhantomData,
         }
     }
@@ -326,6 +502,7 @@ where
             mut listener,
             mut make_service,
             executor,
+            connection_limits,
             _marker,
         } = self;
 
@@ -341,6 +518,7 @@ where
                 io,
                 remote_addr,
                 &executor,
+                connection_limits,
             )
             .await;
         }
@@ -359,13 +537,15 @@ where
             listener,
             make_service,
             executor,
+            connection_limits,
             _marker: _,
         } = self;
 
         let mut s = f.debug_struct("Serve");
         s.field("listener", listener)
             .field("make_service", make_service)
-            .field("executor", executor);
+            .field("executor", executor)
+            .field("connection_limits", connection_limits);
 
         s.finish()
     }
@@ -400,6 +580,7 @@ pub struct WithGracefulShutdown<L, M, S, F, B, E = TokioExecutor> {
     listener: L,
     make_service: M,
     executor: E,
+    connection_limits: ConnectionLimits,
     signal: F,
     _marker: PhantomData<fn(B) -> S>,
 }
@@ -426,9 +607,19 @@ where
             listener: self.listener,
             make_service: self.make_service,
             executor,
+            connection_limits: self.connection_limits,
             signal: self.signal,
             _marker: PhantomData,
         }
+    }
+
+    /// Apply per-connection [`ConnectionLimits`], bounding the lifetime of
+    /// individual connections.
+    ///
+    /// See [`Serve::connection_limits`] and [`ConnectionLimits`] for details.
+    pub fn connection_limits(mut self, limits: ConnectionLimits) -> Self {
+        self.connection_limits = limits;
+        self
     }
 }
 
@@ -452,6 +643,7 @@ where
             mut listener,
             mut make_service,
             executor,
+            connection_limits,
             signal,
             _marker,
         } = self;
@@ -482,6 +674,7 @@ where
                 io,
                 remote_addr,
                 &executor,
+                connection_limits,
             )
             .await;
         }
@@ -511,6 +704,7 @@ where
             listener,
             make_service,
             executor: _,
+            connection_limits,
             signal,
             _marker: _,
         } = self;
@@ -518,6 +712,7 @@ where
         f.debug_struct("WithGracefulShutdown")
             .field("listener", listener)
             .field("make_service", make_service)
+            .field("connection_limits", connection_limits)
             .field("signal", signal)
             .finish()
     }
@@ -567,6 +762,7 @@ async fn handle_connection<L, M, S, B, E>(
     io: <L as Listener>::Io,
     remote_addr: <L as Listener>::Addr,
     executor: &E,
+    connection_limits: ConnectionLimits,
 ) where
     L: Listener,
     L::Addr: Debug,
@@ -617,17 +813,45 @@ async fn handle_connection<L, M, S, B, E>(
         let mut conn = pin!(builder.serve_connection_with_upgrades(io, hyper_service));
         let mut signal_closed = pin!(signal_tx.closed().fuse());
 
+        // Soft cap on the connection's lifetime (with optional jitter). When it
+        // elapses we start a graceful shutdown of this connection and re-arm the
+        // timer with the grace period (if any), which then bounds how long we
+        // wait before forcibly closing.
+        let mut timer = pin!(sleep_or_pending(connection_limits.max_connection_age.map(
+            |age| {
+                age + connection_limits
+                    .max_connection_age_jitter
+                    .map_or(Duration::ZERO, random_duration)
+            }
+        )));
+        let mut age_fired = false;
+
         loop {
-            match select(conn.as_mut(), &mut signal_closed).await {
+            match select(
+                conn.as_mut(),
+                select(signal_closed.as_mut(), timer.as_mut()),
+            )
+            .await
+            {
                 Either::Left((result, _)) => {
                     if let Err(_err) = result {
                         trace!("failed to serve connection: {_err:#}");
                     }
                     break;
                 }
-                Either::Right(_) => {
+                Either::Right((Either::Left(_), _)) => {
                     trace!("signal received in task, starting graceful shutdown");
                     conn.as_mut().graceful_shutdown();
+                }
+                Either::Right((Either::Right(_), _)) if !age_fired => {
+                    age_fired = true;
+                    trace!("max connection age reached, starting graceful shutdown");
+                    conn.as_mut().graceful_shutdown();
+                    timer.set(sleep_or_pending(connection_limits.max_connection_age_grace));
+                }
+                Either::Right((Either::Right(_), _)) => {
+                    trace!("max connection age grace period elapsed, closing connection");
+                    break;
                 }
             }
         }
@@ -715,7 +939,7 @@ mod tests {
 
     #[cfg(unix)]
     use super::IncomingStream;
-    use super::{serve, Listener};
+    use super::{serve, ConnectionLimits, Listener};
     #[cfg(unix)]
     use crate::extract::connect_info::Connected;
     use crate::{
@@ -898,6 +1122,22 @@ mod tests {
             handler.into_make_service(),
         )
         .with_executor(exec);
+
+        // connection_limits, composable with the other builder methods in any order
+        let limits = ConnectionLimits::new()
+            .max_connection_age(Duration::from_secs(60))
+            .max_connection_age_jitter(Duration::from_secs(10))
+            .max_connection_age_grace(Duration::from_secs(5));
+        serve(TcpListener::bind(addr).await.unwrap(), router.clone()).connection_limits(limits);
+        serve(TcpListener::bind(addr).await.unwrap(), router.clone())
+            .connection_limits(limits)
+            .with_graceful_shutdown(std::future::pending());
+        serve(TcpListener::bind(addr).await.unwrap(), router.clone())
+            .with_graceful_shutdown(std::future::pending())
+            .connection_limits(limits);
+        serve(TcpListener::bind(addr).await.unwrap(), router.clone())
+            .connection_limits(limits)
+            .with_executor(TestExecutor::new());
     }
 
     async fn handler() {}
@@ -1264,5 +1504,161 @@ mod tests {
             TcpListener::bind(addr).await.unwrap(),
             app.into_make_service(),
         );
+    }
+
+    #[test]
+    fn random_duration_is_bounded_and_varies() {
+        use std::collections::HashSet;
+
+        assert_eq!(super::random_duration(Duration::ZERO), Duration::ZERO);
+
+        let max = Duration::from_secs(60);
+        let mut seen = HashSet::new();
+        for _ in 0..256 {
+            let d = super::random_duration(max);
+            assert!(d <= max, "{d:?} exceeds the requested bound {max:?}");
+            seen.insert(d);
+        }
+
+        // It would be astronomically unlikely for 256 draws to all collide if
+        // the source is actually random.
+        assert!(seen.len() > 1, "random_duration produced a constant value");
+    }
+
+    // After `max_connection_age` elapses, an idle keep-alive connection is
+    // gracefully shut down by the server, which the client observes as its
+    // connection task completing.
+    #[tokio::test(start_paused = true)]
+    async fn max_connection_age_closes_idle_connection() {
+        let app = Router::new().route("/", get(|| async { "ok" }));
+        let (client, server) = io::duplex(1024);
+        let listener = ReadyListener(Some(server));
+
+        tokio::spawn(
+            serve(listener, app)
+                .connection_limits(
+                    ConnectionLimits::new().max_connection_age(Duration::from_secs(10)),
+                )
+                .into_future(),
+        );
+
+        let stream = TokioIo::new(client);
+        let (mut sender, conn) = hyper::client::conn::http1::handshake(stream).await.unwrap();
+        let conn_handle = tokio::spawn(conn);
+
+        // A first request succeeds normally before the age limit elapses.
+        let request = Request::builder().uri("/").body(Body::empty()).unwrap();
+        let response = sender.send_request(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let _ = to_bytes(Body::new(response.into_body()), usize::MAX)
+            .await
+            .unwrap();
+
+        // With (paused) time auto-advancing, the age timer fires and the server
+        // closes the now-idle connection, completing the client's conn task.
+        tokio::time::timeout(Duration::from_secs(30), conn_handle)
+            .await
+            .expect("connection was not closed after max_connection_age elapsed")
+            .unwrap()
+            .ok();
+    }
+
+    // When `max_connection_age` fires while a request is in flight and the
+    // handler never completes, the grace period bounds how long the server
+    // waits before forcibly closing, so the in-flight request fails.
+    #[tokio::test(start_paused = true)]
+    async fn max_connection_age_grace_force_closes_stuck_connection() {
+        use std::{future::pending, sync::Arc};
+
+        use tokio::sync::Notify;
+
+        let started = Arc::new(Notify::new());
+        let app = Router::new().route("/", {
+            let started = started.clone();
+            get(move || {
+                let started = started.clone();
+                async move {
+                    started.notify_one();
+                    pending::<()>().await;
+                    "unreachable"
+                }
+            })
+        });
+
+        let (client, server) = io::duplex(1024);
+        let listener = ReadyListener(Some(server));
+
+        tokio::spawn(
+            serve(listener, app)
+                .connection_limits(
+                    ConnectionLimits::new()
+                        .max_connection_age(Duration::from_secs(10))
+                        .max_connection_age_grace(Duration::from_secs(5)),
+                )
+                .into_future(),
+        );
+
+        let stream = TokioIo::new(client);
+        let (mut sender, conn) = hyper::client::conn::http1::handshake(stream).await.unwrap();
+        tokio::spawn(conn);
+
+        let request = Request::builder().uri("/").body(Body::empty()).unwrap();
+        let send = tokio::spawn(async move { sender.send_request(request).await });
+
+        // Wait until the (never-completing) handler is actually running.
+        started.notified().await;
+
+        // age (10s) + grace (5s) later, the connection is force-closed despite
+        // the stuck handler, so the in-flight request resolves with an error.
+        let result = tokio::time::timeout(Duration::from_secs(60), send)
+            .await
+            .expect("request was not aborted within the grace period")
+            .unwrap();
+        assert!(
+            result.is_err(),
+            "expected the in-flight request to fail when the connection is force-closed",
+        );
+    }
+
+    // The HTTP/2 equivalent of `max_connection_age_closes_idle_connection`: the
+    // server sends GOAWAY once the age limit elapses, completing the client's
+    // connection task.
+    #[cfg(feature = "http2")]
+    #[tokio::test(start_paused = true)]
+    async fn max_connection_age_closes_idle_connection_http2() {
+        use hyper_util::rt::TokioExecutor;
+
+        let app = Router::new().route("/", get(|| async { "ok" }));
+        let (client, server) = io::duplex(1024);
+        let listener = ReadyListener(Some(server));
+
+        tokio::spawn(
+            serve(listener, app)
+                .connection_limits(
+                    ConnectionLimits::new().max_connection_age(Duration::from_secs(10)),
+                )
+                .into_future(),
+        );
+
+        let io = TokioIo::new(client);
+        let (mut sender, conn) = hyper::client::conn::http2::Builder::new(TokioExecutor::new())
+            .handshake(io)
+            .await
+            .unwrap();
+        let conn_handle = tokio::spawn(conn);
+
+        let request = Request::builder().uri("/").body(Body::empty()).unwrap();
+        let response = sender.send_request(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let _ = to_bytes(Body::new(response.into_body()), usize::MAX)
+            .await
+            .unwrap();
+
+        // GOAWAY after the age limit closes the connection from the server side.
+        tokio::time::timeout(Duration::from_secs(30), conn_handle)
+            .await
+            .expect("HTTP/2 connection was not closed after max_connection_age elapsed")
+            .unwrap()
+            .ok();
     }
 }

--- a/axum/src/serve/mod.rs
+++ b/axum/src/serve/mod.rs
@@ -264,11 +264,8 @@ fn random_duration(max: Duration) -> Duration {
         .build_hasher()
         .finish();
 
-    let max_nanos = max.as_nanos();
-    let nanos = u128::from(rand) % (max_nanos + 1);
-    // `nanos <= max_nanos` and realistic jitter fits comfortably in `u64`;
-    // saturate in the absurd case rather than truncating.
-    Duration::from_nanos(u64::try_from(nanos).unwrap_or(u64::MAX))
+    let max_nanos = u64::try_from(max.as_nanos()).unwrap_or(u64::MAX);
+    Duration::from_nanos(rand % max_nanos.saturating_add(1))
 }
 
 /// Sleeps for `duration`, or never completes if it's `None`.

--- a/axum/src/serve/mod.rs
+++ b/axum/src/serve/mod.rs
@@ -19,7 +19,9 @@ use futures_util::{
 };
 use http_body::Body as HttpBody;
 use hyper::body::Incoming;
-use hyper_util::rt::{TokioIo, TokioTimer};
+use hyper_util::rt::TokioIo;
+#[cfg(feature = "http1")]
+use hyper_util::rt::TokioTimer;
 #[cfg(any(feature = "http1", feature = "http2"))]
 use hyper_util::{server::conn::auto::Builder, service::TowerToHyperService};
 use tokio::{sync::watch, task::JoinHandle};

--- a/axum/src/serve/mod.rs
+++ b/axum/src/serve/mod.rs
@@ -135,8 +135,7 @@ where
 /// backends: without rotation, a client's connection pool keeps sending work to
 /// whichever backends it first connected to, even after the pool has scaled up.
 /// It also bounds the worst case when a client's connection pool has no
-/// rotation of its own. This mirrors `tonic`'s `max_connection_age` and Envoy's
-/// `max_connection_duration`.
+/// rotation of its own.
 ///
 /// The mechanism differs by protocol but the knobs are the same:
 ///
@@ -241,8 +240,7 @@ impl ConnectionLimits {
     /// requests as well as HTTP/2 streams, so a handler that runs longer than
     /// the age limit plus the grace period will never complete successfully.
     /// Only set a grace period if bounding connection lifetime matters more
-    /// than letting slow requests finish. Mirrors `tonic`'s
-    /// `max_connection_age_grace`.
+    /// than letting slow requests finish.
     ///
     /// This has no effect unless [`max_connection_age`] is also set.
     ///

--- a/axum/src/serve/mod.rs
+++ b/axum/src/serve/mod.rs
@@ -258,8 +258,8 @@ fn random_duration(max: Duration) -> Duration {
         return Duration::ZERO;
     }
 
-    // `RandomState` keys are seeded by the OS and vary per construction, giving
-    // cheap randomness without a dedicated RNG dependency.
+    // Each `RandomState` is seeded with fresh random keys, so hashing empty
+    // input still yields a different value per call.
     let rand = std::collections::hash_map::RandomState::new()
         .build_hasher()
         .finish();

--- a/axum/src/serve/mod.rs
+++ b/axum/src/serve/mod.rs
@@ -184,7 +184,7 @@ where
 #[must_use]
 pub struct ConnectionLimits {
     max_connection_age: Option<Duration>,
-    max_connection_age_jitter: Option<Duration>,
+    max_connection_age_jitter: Duration,
     max_connection_age_grace: Option<Duration>,
 }
 
@@ -220,11 +220,12 @@ impl ConnectionLimits {
     /// deploy): without it, every connection opened in the same instant tears
     /// down in the same instant once the age limit elapses.
     ///
-    /// This has no effect unless [`max_connection_age`] is also set.
+    /// Defaults to `Duration::ZERO`, i.e. no jitter. Has no effect unless
+    /// [`max_connection_age`] is also set.
     ///
     /// [`max_connection_age`]: ConnectionLimits::max_connection_age
     pub fn max_connection_age_jitter(mut self, jitter: Duration) -> Self {
-        self.max_connection_age_jitter = Some(jitter);
+        self.max_connection_age_jitter = jitter;
         self
     }
 
@@ -828,9 +829,7 @@ async fn handle_connection<L, M, S, B, E>(
         // timer with the grace period (if any), which then bounds how long we
         // wait before forcibly closing.
         let max_age = connection_limits.max_connection_age.map(|age| {
-            let jitter = connection_limits
-                .max_connection_age_jitter
-                .map_or(Duration::ZERO, random_duration);
+            let jitter = random_duration(connection_limits.max_connection_age_jitter);
             age.saturating_add(jitter)
         });
         let mut timer = pin!(sleep_or_pending(max_age));

--- a/axum/src/serve/mod.rs
+++ b/axum/src/serve/mod.rs
@@ -176,7 +176,7 @@ where
 /// ```
 ///
 /// [`max_connection_age_grace`]: ConnectionLifetimeLimits::max_connection_age_grace
-#[derive(Clone, Copy, Debug, Default)]
+#[derive(Clone, Debug, Default)]
 #[must_use]
 pub struct ConnectionLifetimeLimits {
     max_connection_age: Option<Duration>,
@@ -515,7 +515,7 @@ where
                 io,
                 remote_addr,
                 &executor,
-                connection_lifetime_limits,
+                &connection_lifetime_limits,
             )
             .await;
         }
@@ -674,7 +674,7 @@ where
                 io,
                 remote_addr,
                 &executor,
-                connection_lifetime_limits,
+                &connection_lifetime_limits,
             )
             .await;
         }
@@ -762,7 +762,7 @@ async fn handle_connection<L, M, S, B, E>(
     io: <L as Listener>::Io,
     remote_addr: <L as Listener>::Addr,
     executor: &E,
-    connection_lifetime_limits: ConnectionLifetimeLimits,
+    connection_lifetime_limits: &ConnectionLifetimeLimits,
 ) where
     L: Listener,
     L::Addr: Debug,
@@ -776,6 +776,7 @@ async fn handle_connection<L, M, S, B, E>(
     E: Executor,
 {
     let mut signal_rx = signal_rx.clone();
+    let connection_lifetime_limits = connection_lifetime_limits.clone();
     let io = TokioIo::new(io);
 
     trace!("connection {remote_addr:?} accepted");
@@ -1132,15 +1133,15 @@ mod tests {
             .max_connection_age_jitter(Duration::from_secs(10))
             .max_connection_age_grace(Duration::from_secs(5));
         serve(TcpListener::bind(addr).await.unwrap(), router.clone())
-            .connection_lifetime_limits(limits);
+            .connection_lifetime_limits(limits.clone());
         serve(TcpListener::bind(addr).await.unwrap(), router.clone())
-            .connection_lifetime_limits(limits)
+            .connection_lifetime_limits(limits.clone())
             .with_graceful_shutdown(std::future::pending());
         serve(TcpListener::bind(addr).await.unwrap(), router.clone())
             .with_graceful_shutdown(std::future::pending())
-            .connection_lifetime_limits(limits);
+            .connection_lifetime_limits(limits.clone());
         serve(TcpListener::bind(addr).await.unwrap(), router.clone())
-            .connection_lifetime_limits(limits)
+            .connection_lifetime_limits(limits.clone())
             .with_executor(TestExecutor::new());
     }
 

--- a/axum/src/serve/mod.rs
+++ b/axum/src/serve/mod.rs
@@ -141,7 +141,7 @@ where
 ///
 /// - **HTTP/1**: the next response gets a `Connection: close` header and the
 ///   connection is closed once the in-flight request finishes.
-/// - **HTTP/2** (including gRPC): a `GOAWAY` is sent, so new streams are refused
+/// - **HTTP/2**: a `GOAWAY` is sent, so new streams are refused
 ///   while in-flight streams are allowed to finish.
 ///
 /// In both cases in-flight work is waited on for as long as it takes, unless

--- a/axum/src/serve/mod.rs
+++ b/axum/src/serve/mod.rs
@@ -121,7 +121,7 @@ where
         listener,
         make_service,
         executor: TokioExecutor,
-        connection_limits: ConnectionLimits::default(),
+        connection_lifetime_limits: ConnectionLifetimeLimits::default(),
         _marker: PhantomData,
     }
 }
@@ -149,20 +149,17 @@ where
 /// connection is closed even if a request is still in flight. See
 /// [`max_connection_age_grace`] for the trade-off.
 ///
-/// Note that this is distinct from [`ListenerExt::limit_connections`], which
-/// bounds the *number* of concurrent connections rather than their lifetime.
-///
 /// # Example
 ///
 /// ```
 /// use std::time::Duration;
-/// use axum::{Router, routing::get, serve::ConnectionLimits};
+/// use axum::{Router, routing::get, serve::ConnectionLifetimeLimits};
 ///
 /// # async {
 /// let router = Router::new().route("/", get(|| async { "Hello, World!" }));
 /// let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await.unwrap();
 ///
-/// let limits = ConnectionLimits::new()
+/// let limits = ConnectionLifetimeLimits::new()
 ///     // Stop accepting new requests on a connection after this long.
 ///     .max_connection_age(Duration::from_secs(10 * 60))
 ///     // Random per-connection jitter added to the age, to avoid synchronized
@@ -173,23 +170,22 @@ where
 ///     .max_connection_age_grace(Duration::from_secs(30));
 ///
 /// axum::serve(listener, router)
-///     .connection_limits(limits)
+///     .connection_lifetime_limits(limits)
 ///     .await;
 /// # };
 /// ```
 ///
-/// [`max_connection_age_grace`]: ConnectionLimits::max_connection_age_grace
-/// [`ListenerExt::limit_connections`]: crate::serve::ListenerExt::limit_connections
+/// [`max_connection_age_grace`]: ConnectionLifetimeLimits::max_connection_age_grace
 #[derive(Clone, Copy, Debug, Default)]
 #[must_use]
-pub struct ConnectionLimits {
+pub struct ConnectionLifetimeLimits {
     max_connection_age: Option<Duration>,
     max_connection_age_jitter: Duration,
     max_connection_age_grace: Option<Duration>,
 }
 
-impl ConnectionLimits {
-    /// Create a new [`ConnectionLimits`] with no limits set.
+impl ConnectionLifetimeLimits {
+    /// Create a new [`ConnectionLifetimeLimits`] with no limits set.
     pub fn new() -> Self {
         Self::default()
     }
@@ -205,8 +201,8 @@ impl ConnectionLimits {
     /// Consider also setting [`max_connection_age_jitter`] to avoid all
     /// connections opened around the same time tearing down simultaneously.
     ///
-    /// [`max_connection_age_grace`]: ConnectionLimits::max_connection_age_grace
-    /// [`max_connection_age_jitter`]: ConnectionLimits::max_connection_age_jitter
+    /// [`max_connection_age_grace`]: ConnectionLifetimeLimits::max_connection_age_grace
+    /// [`max_connection_age_jitter`]: ConnectionLifetimeLimits::max_connection_age_jitter
     pub fn max_connection_age(mut self, age: Duration) -> Self {
         self.max_connection_age = Some(age);
         self
@@ -223,7 +219,7 @@ impl ConnectionLimits {
     /// Defaults to `Duration::ZERO`, i.e. no jitter. Has no effect unless
     /// [`max_connection_age`] is also set.
     ///
-    /// [`max_connection_age`]: ConnectionLimits::max_connection_age
+    /// [`max_connection_age`]: ConnectionLifetimeLimits::max_connection_age
     pub fn max_connection_age_jitter(mut self, jitter: Duration) -> Self {
         self.max_connection_age_jitter = jitter;
         self
@@ -245,7 +241,7 @@ impl ConnectionLimits {
     ///
     /// This has no effect unless [`max_connection_age`] is also set.
     ///
-    /// [`max_connection_age`]: ConnectionLimits::max_connection_age
+    /// [`max_connection_age`]: ConnectionLifetimeLimits::max_connection_age
     pub fn max_connection_age_grace(mut self, grace: Duration) -> Self {
         self.max_connection_age_grace = Some(grace);
         self
@@ -362,7 +358,7 @@ pub struct Serve<L, M, S, B, E = TokioExecutor> {
     listener: L,
     make_service: M,
     executor: E,
-    connection_limits: ConnectionLimits,
+    connection_lifetime_limits: ConnectionLifetimeLimits,
     _marker: PhantomData<fn(B) -> S>,
 }
 
@@ -404,7 +400,7 @@ where
             listener: self.listener,
             make_service: self.make_service,
             executor: self.executor,
-            connection_limits: self.connection_limits,
+            connection_lifetime_limits: self.connection_lifetime_limits,
             signal,
             _marker: PhantomData,
         }
@@ -415,19 +411,19 @@ where
         self.listener.local_addr()
     }
 
-    /// Apply per-connection [`ConnectionLimits`], bounding the lifetime of
+    /// Apply per-connection [`ConnectionLifetimeLimits`], bounding the lifetime of
     /// individual connections.
     ///
     /// This is useful for forcing clients to rotate connections — see
-    /// [`ConnectionLimits`] for details and an example.
+    /// [`ConnectionLifetimeLimits`] for details and an example.
     ///
     /// This method can be called before or after [`with_graceful_shutdown`] and
     /// [`with_executor`].
     ///
     /// [`with_graceful_shutdown`]: Serve::with_graceful_shutdown
     /// [`with_executor`]: Serve::with_executor
-    pub fn connection_limits(mut self, limits: ConnectionLimits) -> Self {
-        self.connection_limits = limits;
+    pub fn connection_lifetime_limits(mut self, limits: ConnectionLifetimeLimits) -> Self {
+        self.connection_lifetime_limits = limits;
         self
     }
 
@@ -478,7 +474,7 @@ where
             listener: self.listener,
             make_service: self.make_service,
             executor,
-            connection_limits: self.connection_limits,
+            connection_lifetime_limits: self.connection_lifetime_limits,
             _marker: PhantomData,
         }
     }
@@ -503,7 +499,7 @@ where
             mut listener,
             mut make_service,
             executor,
-            connection_limits,
+            connection_lifetime_limits,
             _marker,
         } = self;
 
@@ -519,7 +515,7 @@ where
                 io,
                 remote_addr,
                 &executor,
-                connection_limits,
+                connection_lifetime_limits,
             )
             .await;
         }
@@ -538,7 +534,7 @@ where
             listener,
             make_service,
             executor,
-            connection_limits,
+            connection_lifetime_limits,
             _marker: _,
         } = self;
 
@@ -546,7 +542,7 @@ where
         s.field("listener", listener)
             .field("make_service", make_service)
             .field("executor", executor)
-            .field("connection_limits", connection_limits);
+            .field("connection_lifetime_limits", connection_lifetime_limits);
 
         s.finish()
     }
@@ -581,7 +577,7 @@ pub struct WithGracefulShutdown<L, M, S, F, B, E = TokioExecutor> {
     listener: L,
     make_service: M,
     executor: E,
-    connection_limits: ConnectionLimits,
+    connection_lifetime_limits: ConnectionLifetimeLimits,
     signal: F,
     _marker: PhantomData<fn(B) -> S>,
 }
@@ -608,18 +604,18 @@ where
             listener: self.listener,
             make_service: self.make_service,
             executor,
-            connection_limits: self.connection_limits,
+            connection_lifetime_limits: self.connection_lifetime_limits,
             signal: self.signal,
             _marker: PhantomData,
         }
     }
 
-    /// Apply per-connection [`ConnectionLimits`], bounding the lifetime of
+    /// Apply per-connection [`ConnectionLifetimeLimits`], bounding the lifetime of
     /// individual connections.
     ///
-    /// See [`Serve::connection_limits`] and [`ConnectionLimits`] for details.
-    pub fn connection_limits(mut self, limits: ConnectionLimits) -> Self {
-        self.connection_limits = limits;
+    /// See [`Serve::connection_lifetime_limits`] and [`ConnectionLifetimeLimits`] for details.
+    pub fn connection_lifetime_limits(mut self, limits: ConnectionLifetimeLimits) -> Self {
+        self.connection_lifetime_limits = limits;
         self
     }
 }
@@ -644,7 +640,7 @@ where
             mut listener,
             mut make_service,
             executor,
-            connection_limits,
+            connection_lifetime_limits,
             signal,
             _marker,
         } = self;
@@ -678,7 +674,7 @@ where
                 io,
                 remote_addr,
                 &executor,
-                connection_limits,
+                connection_lifetime_limits,
             )
             .await;
         }
@@ -708,7 +704,7 @@ where
             listener,
             make_service,
             executor: _,
-            connection_limits,
+            connection_lifetime_limits,
             signal,
             _marker: _,
         } = self;
@@ -716,7 +712,7 @@ where
         f.debug_struct("WithGracefulShutdown")
             .field("listener", listener)
             .field("make_service", make_service)
-            .field("connection_limits", connection_limits)
+            .field("connection_lifetime_limits", connection_lifetime_limits)
             .field("signal", signal)
             .finish()
     }
@@ -766,7 +762,7 @@ async fn handle_connection<L, M, S, B, E>(
     io: <L as Listener>::Io,
     remote_addr: <L as Listener>::Addr,
     executor: &E,
-    connection_limits: ConnectionLimits,
+    connection_lifetime_limits: ConnectionLifetimeLimits,
 ) where
     L: Listener,
     L::Addr: Debug,
@@ -821,8 +817,8 @@ async fn handle_connection<L, M, S, B, E>(
         // elapses we start a graceful shutdown of this connection and re-arm the
         // timer with the grace period (if any), which then bounds how long we
         // wait before forcibly closing.
-        let max_age = connection_limits.max_connection_age.map(|age| {
-            let jitter = random_duration(connection_limits.max_connection_age_jitter);
+        let max_age = connection_lifetime_limits.max_connection_age.map(|age| {
+            let jitter = random_duration(connection_lifetime_limits.max_connection_age_jitter);
             age.saturating_add(jitter)
         });
         let mut timer = pin!(sleep_or_pending(max_age));
@@ -852,7 +848,7 @@ async fn handle_connection<L, M, S, B, E>(
                     age_fired = true;
                     trace!("max connection age reached, starting graceful shutdown");
                     conn.as_mut().graceful_shutdown();
-                    timer.set(sleep_or_pending(connection_limits.max_connection_age_grace));
+                    timer.set(sleep_or_pending(connection_lifetime_limits.max_connection_age_grace));
                 }
                 Either::Right((Either::Right(_), _)) => {
                     trace!("max connection age grace period elapsed, closing connection");
@@ -944,7 +940,7 @@ mod tests {
 
     #[cfg(unix)]
     use super::IncomingStream;
-    use super::{serve, ConnectionLimits, Listener};
+    use super::{serve, ConnectionLifetimeLimits, Listener};
     #[cfg(unix)]
     use crate::extract::connect_info::Connected;
     use crate::{
@@ -1128,20 +1124,20 @@ mod tests {
         )
         .with_executor(exec);
 
-        // connection_limits, composable with the other builder methods in any order
-        let limits = ConnectionLimits::new()
+        // connection_lifetime_limits, composable with the other builder methods in any order
+        let limits = ConnectionLifetimeLimits::new()
             .max_connection_age(Duration::from_secs(60))
             .max_connection_age_jitter(Duration::from_secs(10))
             .max_connection_age_grace(Duration::from_secs(5));
-        serve(TcpListener::bind(addr).await.unwrap(), router.clone()).connection_limits(limits);
+        serve(TcpListener::bind(addr).await.unwrap(), router.clone()).connection_lifetime_limits(limits);
         serve(TcpListener::bind(addr).await.unwrap(), router.clone())
-            .connection_limits(limits)
+            .connection_lifetime_limits(limits)
             .with_graceful_shutdown(std::future::pending());
         serve(TcpListener::bind(addr).await.unwrap(), router.clone())
             .with_graceful_shutdown(std::future::pending())
-            .connection_limits(limits);
+            .connection_lifetime_limits(limits);
         serve(TcpListener::bind(addr).await.unwrap(), router.clone())
-            .connection_limits(limits)
+            .connection_lifetime_limits(limits)
             .with_executor(TestExecutor::new());
     }
 
@@ -1541,8 +1537,8 @@ mod tests {
 
         tokio::spawn(
             serve(listener, app)
-                .connection_limits(
-                    ConnectionLimits::new().max_connection_age(Duration::from_secs(10)),
+                .connection_lifetime_limits(
+                    ConnectionLifetimeLimits::new().max_connection_age(Duration::from_secs(10)),
                 )
                 .into_future(),
         );
@@ -1595,8 +1591,8 @@ mod tests {
 
         tokio::spawn(
             serve(listener, app)
-                .connection_limits(
-                    ConnectionLimits::new()
+                .connection_lifetime_limits(
+                    ConnectionLifetimeLimits::new()
                         .max_connection_age(Duration::from_secs(10))
                         .max_connection_age_grace(Duration::from_secs(5)),
                 )
@@ -1657,8 +1653,8 @@ mod tests {
 
         tokio::spawn(
             serve(listener, app)
-                .connection_limits(
-                    ConnectionLimits::new().max_connection_age(Duration::from_secs(10)),
+                .connection_lifetime_limits(
+                    ConnectionLifetimeLimits::new().max_connection_age(Duration::from_secs(10)),
                 )
                 .into_future(),
         );
@@ -1700,8 +1696,8 @@ mod tests {
 
         tokio::spawn(
             serve(listener, app)
-                .connection_limits(
-                    ConnectionLimits::new().max_connection_age(Duration::from_secs(10)),
+                .connection_lifetime_limits(
+                    ConnectionLifetimeLimits::new().max_connection_age(Duration::from_secs(10)),
                 )
                 .into_future(),
         );

--- a/axum/src/serve/mod.rs
+++ b/axum/src/serve/mod.rs
@@ -183,6 +183,15 @@ impl ConnectionLifetimeLimits {
     /// its jitter and grace period.
     ///
     /// Connection age is unbounded by default.
+    ///
+    /// # Upgraded connections
+    ///
+    /// This limit does not apply to connections that have been upgraded, e.g.
+    /// to a WebSocket or via `CONNECT`. Once an HTTP/1 connection is upgraded,
+    /// hyper hands the socket off to the upgrade handler and [`serve`] stops
+    /// tracking it, so neither the age limit nor the grace period affect it.
+    /// An HTTP/2 upgrade stays a stream on the tracked connection and is
+    /// treated like any other in-flight stream.
     pub fn max_connection_age(mut self, age: MaxConnectionAge) -> Self {
         self.max_connection_age = Some(age);
         self


### PR DESCRIPTION
Implements #3753.

Adds `axum::serve::ConnectionLimits`, applied via `Serve::connection_limits` (and the `WithGracefulShutdown` equivalent), to bound the lifetime of individual connections and force clients to rotate connections.

## Motivation

Behind a load balancer that round-robins *new* connections across backends (e.g. a Kubernetes `Service`), a client's connection pool keeps sending work to the backends it first connected to, even after the pool scales up — most HTTP clients don't rotate connections on their own. Servers can pressure clients to rotate by closing connections after a bounded lifetime. This mirrors [`tonic::transport::Server::max_connection_age`](https://docs.rs/tonic/latest/tonic/transport/struct.Server.html#method.max_connection_age) and Envoy's `max_connection_duration`.

## API

```rust
use std::time::Duration;
use axum::serve::ConnectionLimits;

let limits = ConnectionLimits::new()
    .max_connection_age(Duration::from_secs(10 * 60))
    .max_connection_age_jitter(Duration::from_secs(60))
    .max_connection_age_grace(Duration::from_secs(30));

axum::serve(listener, app)
    .connection_limits(limits)
    .await;
```

- **`max_connection_age`** — soft cap on total connection lifetime. When it elapses the connection is gracefully shut down: HTTP/1 sends `Connection: close` after the in-flight request finishes; HTTP/2 (incl. gRPC) sends `GOAWAY`, refusing new streams while in-flight ones finish.
- **`max_connection_age_jitter`** — random per-connection jitter in `[0, jitter]` added to the age limit, to avoid synchronized reconnect storms when many connections were established at once.
- **`max_connection_age_grace`** — hard cap on how long to wait for in-flight work after the age limit fires before forcibly closing.

## Implementation notes

- The mechanism reuses hyper's per-connection `graceful_shutdown` — the same primitive `with_graceful_shutdown` already calls per connection. The per-connection `select!` loop gains an age timer (which triggers `graceful_shutdown`) and a grace timer (which force-closes).
- Jitter uses `std::collections::hash_map::RandomState` for cheap per-connection randomness, avoiding a new RNG dependency.
- `connection_limits` composes with `with_graceful_shutdown` and `with_executor` in any order.

## Scope

Per discussion in #3753, this is age-based rotation only. Deliberately left out (possible follow-ups):

- `max_connection_idle` (needs per-connection IO activity tracking).
- On-demand / "lame-duck" rotation that rotates live connections while still accepting new ones. Note that terminal `with_graceful_shutdown` *already* signals idle connections (`GOAWAY` / `Connection: close`) today.

## Tests

- `random_duration_is_bounded_and_varies`
- `max_connection_age_closes_idle_connection` (HTTP/1) and `_http2` (`GOAWAY`)
- `max_connection_age_grace_force_closes_stuck_connection`
- Extended `if_it_compiles_it_works` type-level coverage

Changelog entry will follow once this PR has a number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)