### PR TITLE
docs(axum): document cancellation safety for WebSocket::recv

### DIFF
--- a/axum/src/extract/ws.rs
+++ b/axum/src/extract/ws.rs
@@ -549,6 +549,15 @@ impl WebSocket {
     /// Receive another message.
     ///
     /// Returns `None` if the stream has closed.
+    ///
+    /// # Cancel safety
+    ///
+    /// This method is cancel-safe. `recv` is `self.next().await` over the inner
+    /// [`WebSocketStream`], whose `Stream` impl gained a `# Cancel safety`
+    /// section in [snapview/tokio-tungstenite#378].
+    ///
+    /// [`WebSocketStream`]: https://docs.rs/tokio-tungstenite/latest/tokio_tungstenite/struct.WebSocketStream.html
+    /// [snapview/tokio-tungstenite#378]: https://github.com/snapview/tokio-tungstenite/pull/378
     pub async fn recv(&mut self) -> Option<Result<Message, Error>> {
         self.next().await
     }


### PR DESCRIPTION
Closes #3282.

Adds a `# Cancel safety` note to `WebSocket::recv`. The citation routes through the inner [`WebSocketStream`](https://docs.rs/tokio-tungstenite/latest/tokio_tungstenite/struct.WebSocketStream.html)'s `# Cancel safety` section, which landed via [snapview/tokio-tungstenite#378](https://github.com/snapview/tokio-tungstenite/pull/378) (merged 2026-05-27).
