### PR TITLE
examples: remove redundant borrows in form example format args

### DIFF
--- a/examples/form/src/main.rs
+++ b/examples/form/src/main.rs
@@ -68,10 +68,7 @@ struct Input {
 
 async fn accept_form(Form(input): Form<Input>) -> Html<String> {
     dbg!(&input);
-    Html(format!(
-        "email='{}'\nname='{}'\n",
-        &input.email, &input.name
-    ))
+    Html(format!("email='{}'\nname='{}'\n", input.email, input.name))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
The `check (examples)` CI job currently fails on every open PR (and on `main`):

```
error: redundant reference in `format!` argument
  --> form/src/main.rs:73:9
   = note: `-D clippy::useless-borrows-in-formatting` implied by `-D warnings`
```

`&input.email` and `&input.name` are redundant, because `format!` already takes its arguments by reference. This removes the borrows, and rustfmt then collapses the call onto a single line.

Verified locally:

```
cargo clippy --manifest-path examples/Cargo.toml -p example-form --all-targets -- -D warnings   # passes
cargo fmt    --manifest-path examples/Cargo.toml -p example-form -- --check                      # passes
```
