### PR TITLE
Exclude tokio/net for WASM builds

### DIFF
--- a/axum/Cargo.toml
+++ b/axum/Cargo.toml
@@ -46,7 +46,6 @@ default = [
     "original-uri",
     "query",
     "tokio",
-    "tokio-net",
     "tower-log",
     "tracing",
 ]
@@ -70,7 +69,6 @@ query = [
     "dep:serde_path_to_error",
     "serde_html_form/de",
 ]
-tokio-net = ["tokio/net"]
 tokio = [
     "dep:hyper-util",
     "dep:tokio",
@@ -84,7 +82,6 @@ ws = [
     "dep:hyper",
     "dep:futures-sink",
     "tokio",
-    "tokio-net",
     "dep:tokio-tungstenite",
     "dep:sha1",
     "dep:base64",
@@ -102,7 +99,7 @@ __private_docs = [
 
 # This feature is used to enable private test helper usage
 # in `axum-core` and `axum-extra`.
-__private = ["tokio", "tokio-net", "http1", "dep:reqwest"]
+__private = ["tokio", "http1", "dep:reqwest"]
 
 [dependencies]
 axum-core = { path = "../axum-core", version = "0.5.6" }
@@ -137,9 +134,14 @@ serde_html_form = { version = "0.4.0", optional = true, default-features = false
 serde_json = { version = "1.0.29", features = ["raw_value"], optional = true }
 serde_path_to_error = { version = "0.1.8", optional = true }
 sha1 = { version = "0.10", optional = true }
-tokio = { package = "tokio", version = "1.44", features = ["time"], optional = true }
 tokio-tungstenite = { version = "0.29.0", optional = true }
 tracing = { version = "0.1", default-features = false, optional = true }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+tokio = { package = "tokio", version = "1.44", features = ["time"], optional = true }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+tokio = { package = "tokio", version = "1.44", features = ["time", "net"], optional = true }
 
 # doc dependencies
 serde = { version = "1.0.211", optional = true }

--- a/axum/Cargo.toml
+++ b/axum/Cargo.toml
@@ -101,6 +101,12 @@ __private_docs = [
 # in `axum-core` and `axum-extra`.
 __private = ["tokio", "http1", "dep:reqwest"]
 
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+tokio = { package = "tokio", version = "1.44", features = ["time", "net"], optional = true }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+tokio = { package = "tokio", version = "1.44", features = ["time"], optional = true }
+
 [dependencies]
 axum-core = { path = "../axum-core", version = "0.5.6" }
 bytes = "1.7"
@@ -136,12 +142,6 @@ serde_path_to_error = { version = "0.1.8", optional = true }
 sha1 = { version = "0.10", optional = true }
 tokio-tungstenite = { version = "0.29.0", optional = true }
 tracing = { version = "0.1", default-features = false, optional = true }
-
-[target.'cfg(target_arch = "wasm32")'.dependencies]
-tokio = { package = "tokio", version = "1.44", features = ["time"], optional = true }
-
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-tokio = { package = "tokio", version = "1.44", features = ["time", "net"], optional = true }
 
 # doc dependencies
 serde = { version = "1.0.211", optional = true }

--- a/axum/Cargo.toml
+++ b/axum/Cargo.toml
@@ -46,6 +46,7 @@ default = [
     "original-uri",
     "query",
     "tokio",
+    "tokio-net",
     "tower-log",
     "tracing",
 ]
@@ -69,10 +70,10 @@ query = [
     "dep:serde_path_to_error",
     "serde_html_form/de",
 ]
+tokio-net = ["tokio/net"]
 tokio = [
     "dep:hyper-util",
     "dep:tokio",
-    "tokio/net",
     "tokio/rt",
     "tower/make",
     "tokio/macros",
@@ -83,6 +84,7 @@ ws = [
     "dep:hyper",
     "dep:futures-sink",
     "tokio",
+    "tokio-net",
     "dep:tokio-tungstenite",
     "dep:sha1",
     "dep:base64",
@@ -100,7 +102,7 @@ __private_docs = [
 
 # This feature is used to enable private test helper usage
 # in `axum-core` and `axum-extra`.
-__private = ["tokio", "http1", "dep:reqwest"]
+__private = ["tokio", "tokio-net", "http1", "dep:reqwest"]
 
 [dependencies]
 axum-core = { path = "../axum-core", version = "0.5.6" }

--- a/axum/src/lib.rs
+++ b/axum/src/lib.rs
@@ -434,7 +434,6 @@
 //! `multipart` | Enables parsing `multipart/form-data` requests with [`Multipart`] |
 //! `original-uri` | Enables capturing of every request's original URI and the [`OriginalUri`] extractor | <span role="img" aria-label="Default feature">✔</span>
 //! `tokio` | Enables `tokio` as a dependency and `axum::serve`, `SSE` and `extract::connect_info` types. | <span role="img" aria-label="Default feature">✔</span>
-//! `tokio-net` | Enables tokio's `net` feature | <span role="img" aria-label="Default feature">✔</span>
 //! `tower-log` | Enables `tower`'s `log` feature | <span role="img" aria-label="Default feature">✔</span>
 //! `tracing` | Log rejections from built-in extractors | <span role="img" aria-label="Default feature">✔</span>
 //! `ws` | Enables WebSockets support via [`extract::ws`] |

--- a/axum/src/lib.rs
+++ b/axum/src/lib.rs
@@ -434,6 +434,7 @@
 //! `multipart` | Enables parsing `multipart/form-data` requests with [`Multipart`] |
 //! `original-uri` | Enables capturing of every request's original URI and the [`OriginalUri`] extractor | <span role="img" aria-label="Default feature">✔</span>
 //! `tokio` | Enables `tokio` as a dependency and `axum::serve`, `SSE` and `extract::connect_info` types. | <span role="img" aria-label="Default feature">✔</span>
+//! `tokio-net` | Enables tokio's `net` feature | <span role="img" aria-label="Default feature">✔</span>
 //! `tower-log` | Enables `tower`'s `log` feature | <span role="img" aria-label="Default feature">✔</span>
 //! `tracing` | Log rejections from built-in extractors | <span role="img" aria-label="Default feature">✔</span>
 //! `ws` | Enables WebSockets support via [`extract::ws`] |

--- a/axum/src/serve/listener.rs
+++ b/axum/src/serve/listener.rs
@@ -4,7 +4,6 @@ use std::{
     pin::Pin,
     sync::Arc,
     task::{Context, Poll},
-    time::Duration,
 };
 
 use pin_project_lite::pin_project;
@@ -245,6 +244,7 @@ where
     }
 }
 
+#[cfg(feature = "tokio-net")]
 async fn handle_accept_error(e: io::Error) {
     if is_connection_error(&e) {
         return;
@@ -262,9 +262,10 @@ async fn handle_accept_error(e: io::Error) {
     //
     // hyper allowed customizing this but axum does not.
     error!("accept error: {e}");
-    tokio::time::sleep(Duration::from_secs(1)).await;
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 }
 
+#[cfg(feature = "tokio-net")]
 fn is_connection_error(e: &io::Error) -> bool {
     matches!(
         e.kind(),

--- a/axum/src/serve/listener.rs
+++ b/axum/src/serve/listener.rs
@@ -50,7 +50,7 @@ impl Listener for tokio::net::TcpListener {
     }
 }
 
-#[cfg(all(unix, feature = "tokio"))]
+#[cfg(unix)]
 impl Listener for tokio::net::UnixListener {
     type Io = tokio::net::UnixStream;
     type Addr = tokio::net::unix::SocketAddr;

--- a/axum/src/serve/listener.rs
+++ b/axum/src/serve/listener.rs
@@ -30,7 +30,7 @@ pub trait Listener: Send + 'static {
     fn local_addr(&self) -> io::Result<Self::Addr>;
 }
 
-#[cfg(all(feature = "tokio", not(target_arch = "wasm32")))]
+#[cfg(not(target_arch = "wasm32"))]
 impl Listener for tokio::net::TcpListener {
     type Io = tokio::net::TcpStream;
     type Addr = std::net::SocketAddr;
@@ -241,7 +241,7 @@ where
     }
 }
 
-#[cfg(all(feature = "tokio", not(target_arch = "wasm32")))]
+#[cfg(not(target_arch = "wasm32"))]
 async fn handle_accept_error(e: io::Error) {
     if is_connection_error(&e) {
         return;
@@ -262,7 +262,7 @@ async fn handle_accept_error(e: io::Error) {
     tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 }
 
-#[cfg(all(feature = "tokio", not(target_arch = "wasm32")))]
+#[cfg(not(target_arch = "wasm32"))]
 fn is_connection_error(e: &io::Error) -> bool {
     matches!(
         e.kind(),

--- a/axum/src/serve/listener.rs
+++ b/axum/src/serve/listener.rs
@@ -12,9 +12,6 @@ use tokio::{
     sync::{OwnedSemaphorePermit, Semaphore},
 };
 
-#[cfg(feature = "tokio-net")]
-use tokio::net::{TcpListener, TcpStream};
-
 /// Types that can listen for connections.
 pub trait Listener: Send + 'static {
     /// The listener's IO type.
@@ -33,9 +30,9 @@ pub trait Listener: Send + 'static {
     fn local_addr(&self) -> io::Result<Self::Addr>;
 }
 
-#[cfg(feature = "tokio-net")]
-impl Listener for TcpListener {
-    type Io = TcpStream;
+#[cfg(all(feature = "tokio", not(target_arch = "wasm32")))]
+impl Listener for tokio::net::TcpListener {
+    type Io = tokio::net::TcpStream;
     type Addr = std::net::SocketAddr;
 
     async fn accept(&mut self) -> (Self::Io, Self::Addr) {
@@ -53,7 +50,7 @@ impl Listener for TcpListener {
     }
 }
 
-#[cfg(all(unix, feature = "tokio-net"))]
+#[cfg(all(unix, feature = "tokio"))]
 impl Listener for tokio::net::UnixListener {
     type Io = tokio::net::UnixStream;
     type Addr = tokio::net::unix::SocketAddr;
@@ -244,7 +241,7 @@ where
     }
 }
 
-#[cfg(feature = "tokio-net")]
+#[cfg(all(feature = "tokio", not(target_arch = "wasm32")))]
 async fn handle_accept_error(e: io::Error) {
     if is_connection_error(&e) {
         return;
@@ -265,7 +262,7 @@ async fn handle_accept_error(e: io::Error) {
     tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 }
 
-#[cfg(feature = "tokio-net")]
+#[cfg(all(feature = "tokio", not(target_arch = "wasm32")))]
 fn is_connection_error(e: &io::Error) -> bool {
     matches!(
         e.kind(),

--- a/axum/src/serve/listener.rs
+++ b/axum/src/serve/listener.rs
@@ -10,9 +10,11 @@ use std::{
 use pin_project_lite::pin_project;
 use tokio::{
     io::{self, AsyncRead, AsyncWrite},
-    net::{TcpListener, TcpStream},
     sync::{OwnedSemaphorePermit, Semaphore},
 };
+
+#[cfg(feature = "tokio-net")]
+use tokio::net::{TcpListener, TcpStream};
 
 /// Types that can listen for connections.
 pub trait Listener: Send + 'static {
@@ -32,6 +34,7 @@ pub trait Listener: Send + 'static {
     fn local_addr(&self) -> io::Result<Self::Addr>;
 }
 
+#[cfg(feature = "tokio-net")]
 impl Listener for TcpListener {
     type Io = TcpStream;
     type Addr = std::net::SocketAddr;
@@ -51,7 +54,7 @@ impl Listener for TcpListener {
     }
 }
 
-#[cfg(unix)]
+#[cfg(all(unix, feature = "tokio-net"))]
 impl Listener for tokio::net::UnixListener {
     type Io = tokio::net::UnixStream;
     type Addr = tokio::net::unix::SocketAddr;


### PR DESCRIPTION
## Motivation

I want to implement a custom `axum::serve::Listener` for my WASM runtime, but `axum::serve` needlessly relies on tokio/net, which doesn't compile on WASM.

## Solution

Made tokio/net an optional feature.