### PR TITLE
keep github actions updated

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    # Check for updates every Monday
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Documentation: https://release-plz.dev/docs/github/update
Given this comment, dependabot should continue using pin dependencies: https://github.com/dependabot/dependabot-core/issues/7913#issuecomment-2748641653
