### PR TITLE
document ws cancellation & delegation

### DIFF
--- a/axum/src/extract/ws.rs
+++ b/axum/src/extract/ws.rs
@@ -549,6 +549,13 @@ impl WebSocket {
     /// Receive another message.
     ///
     /// Returns `None` if the stream has closed.
+    ///
+    /// # Cancel safety
+    ///
+    /// This method is cancel safe. If used as a branch in [`tokio::select!`] and
+    /// another branch completes first, then no message is received.
+    ///
+    /// [`tokio::select!`]: https://docs.rs/tokio/latest/tokio/macro.select.html
     pub async fn recv(&mut self) -> Option<Result<Message, Error>> {
         self.next().await
     }

--- a/axum/src/extract/ws.rs
+++ b/axum/src/extract/ws.rs
@@ -550,6 +550,8 @@ impl WebSocket {
     ///
     /// Returns `None` if the stream has closed.
     ///
+    /// This method delegates to [`Stream`].
+    ///
     /// # Cancel safety
     ///
     /// This method is cancel safe. If used as a branch in [`tokio::select!`] and
@@ -561,6 +563,8 @@ impl WebSocket {
     }
 
     /// Send a message.
+    ///
+    /// This method delegates to [`Sink`].
     pub async fn send(&mut self, msg: Message) -> Result<(), Error> {
         self.inner
             .send(msg.into_tungstenite())


### PR DESCRIPTION
Documents `recv` as cancel safe as well as the difference between `StreamExt::next`/`recv` and `SinkExt::send`/`send` (there is no difference).

Ref: #3780, #3282