### PR TITLE
Error handling example not displaying the correct behavior

### DIFF
--- a/examples/error-handling/src/main.rs
+++ b/examples/error-handling/src/main.rs
@@ -58,6 +58,11 @@ async fn main() {
     let app = Router::new()
         // A dummy route that accepts some JSON but sometimes fails
         .route("/users", post(users_create))
+        // Layers wraps from the inside out, each new .layer() call becomes the outer one.
+        // Putting TraceLayer outermost means its `request` span is entered before
+        // log_app_errors runs, so our tracing::error! events inherit that span and get
+        // prefixed with `request{method=… uri=… matched_path=…}:`.
+        .layer(from_fn(log_app_errors)) // <- Inner layer
         .layer(
             TraceLayer::new_for_http()
                 // Create our own span for the request and include the matched path. The matched
@@ -77,15 +82,14 @@ async fn main() {
                 // By default `TraceLayer` will log 5xx responses but we're doing our specific
                 // logging of errors so disable that
                 .on_failure(()),
-        )
-        .layer(from_fn(log_app_errors))
+        ) // <- Outer layer
         .with_state(state);
 
     let listener = tokio::net::TcpListener::bind("127.0.0.1:3000")
         .await
         .unwrap();
     tracing::debug!("listening on {}", listener.local_addr().unwrap());
-    axum::serve(listener, app).await;
+    let _ = axum::serve(listener, app).await;
 }
 
 #[derive(Default, Clone)]


### PR DESCRIPTION
## Motivation

This PR targets #3787 which indicates an issue regarding the rust 
documentation of the error-handling example and the actual code's behavior.

The error-handling example added `log_app_errors` as the outer layer and 
TraceLayer as the inner one. Because `.layer()` wraps from the inside out,
this caused `tracing::error!` events from the middleware to be emitted
*outside* the `request` span created by TraceLayer's `make_span_with`,
losing the `request{method=… uri=… matched_path=…}:` prefix and ordering
the ERROR line after `finished processing request` instead of between
`started` and `finished` as the example output documents.

## Solution

Swap the two layers so TraceLayer is outermost, matching the example's
documented log output. Also clarify the intent with inline comments,
and fixing the warning 'unused `Result` that must be used' at line 92.