### PR TITLE
 fix(macros): support prefix and suffix captures in TypedPath segments

### DIFF
--- a/axum-macros/src/typed_path.rs
+++ b/axum-macros/src/typed_path.rs
@@ -362,8 +362,7 @@ fn format_str_from_path(segments: &[Segment]) -> String {
             Segment::Capture(capture, _) => format!("{{{capture}}}"),
             Segment::Static(segment) => segment.to_owned(),
         })
-        .collect::<Vec<_>>()
-        .join("/")
+        .collect()
 }
 
 fn captures_from_path(segments: &[Segment]) -> Vec<syn::Ident> {
@@ -383,27 +382,47 @@ fn parse_path(path: &LitStr) -> syn::Result<Vec<Segment>> {
             path,
             "paths must start with a `/`. Use \"/\" for root routes",
         ));
-    } else if !path.value().starts_with('/') {
+    } else if !value.starts_with('/') {
         return Err(syn::Error::new_spanned(path, "paths must start with a `/`"));
     }
 
-    path.value()
-        .split('/')
-        .map(|segment| {
-            if let Some(capture) = segment
-                .strip_prefix('{')
-                .and_then(|segment| segment.strip_suffix('}'))
-                .and_then(|segment| {
-                    (!segment.starts_with('{') && !segment.ends_with('}')).then_some(segment)
-                })
-                .map(|capture| capture.strip_prefix('*').unwrap_or(capture))
+    let mut segments = Vec::new();
+    let mut rest = value.as_str();
+
+    while let Some(start) = rest.find('{') {
+        if start > 0 {
+            segments.push(Segment::Static(rest[..start].to_owned()));
+        }
+
+        rest = &rest[start + 1..];
+
+        if let Some(end) = rest.find('}') {
+            let capture = &rest[..end];
+            if capture.is_empty()
+                || capture.starts_with('{')
+                || capture.ends_with('}')
+                || capture.contains('{')
             {
-                Ok(Segment::Capture(capture.to_owned(), path.span()))
-            } else {
-                Ok(Segment::Static(segment.to_owned()))
+                return Err(syn::Error::new_spanned(path, "invalid capture in path"));
             }
-        })
-        .collect()
+
+            segments.push(Segment::Capture(
+                capture.strip_prefix('*').unwrap_or(capture).to_owned(),
+                path.span(),
+            ));
+
+            rest = &rest[end + 1..];
+        } else {
+            segments.push(Segment::Static(format!("{{{rest}")));
+            rest = "";
+        }
+    }
+
+    if !rest.is_empty() {
+        segments.push(Segment::Static(rest.to_owned()));
+    }
+
+    Ok(segments)
 }
 
 enum Segment {

--- a/axum-macros/tests/typed_path/pass/prefixed_segments.rs
+++ b/axum-macros/tests/typed_path/pass/prefixed_segments.rs
@@ -1,0 +1,69 @@
+use axum_extra::routing::{RouterExt, TypedPath};
+use serde::Deserialize;
+
+#[derive(TypedPath, Deserialize)]
+#[typed_path("/@{username}")]
+struct PrefixedCapture {
+    username: String,
+}
+
+#[derive(TypedPath, Deserialize)]
+#[typed_path("/files/{name}.json")]
+struct SuffixedCapture {
+    name: String,
+}
+
+#[derive(TypedPath, Deserialize)]
+#[typed_path("/users/{user_id}/teams/team-{team_id}")]
+struct MixedCaptures {
+    user_id: u32,
+    team_id: u32,
+}
+
+#[derive(TypedPath, Deserialize)]
+#[typed_path("/@{username}")]
+struct UnnamedPrefixedCapture(String);
+
+fn main() {
+    _ = axum::Router::<()>::new().typed_get(|_: PrefixedCapture| async {});
+    _ = axum::Router::<()>::new().typed_get(|_: SuffixedCapture| async {});
+    _ = axum::Router::<()>::new().typed_get(|_: MixedCaptures| async {});
+
+    assert_eq!(PrefixedCapture::PATH, "/@{username}");
+    assert_eq!(
+        format!(
+            "{}",
+            PrefixedCapture {
+                username: "alice".to_owned(),
+            }
+        ),
+        "/@alice"
+    );
+
+    assert_eq!(SuffixedCapture::PATH, "/files/{name}.json");
+    assert_eq!(
+        format!(
+            "{}",
+            SuffixedCapture {
+                name: "report final".to_owned(),
+            }
+        ),
+        "/files/report%20final.json"
+    );
+
+    assert_eq!(
+        format!(
+            "{}",
+            MixedCaptures {
+                user_id: 1,
+                team_id: 2,
+            }
+        ),
+        "/users/1/teams/team-2"
+    );
+
+    assert_eq!(
+        format!("{}", UnnamedPrefixedCapture("bob".to_owned())),
+        "/@bob"
+    );
+}


### PR DESCRIPTION
## Motivation
Resolves #3681. Currently, the `TypedPath` derive macro fails to handle path segments with prefixes or suffixes (e.g. `/@{username}`, `/files/{name}.json`), silently treating them as static segments. This forces users to implement `TypedPath` manually for such routes.

## Solution
Instead of splitting path segments by `/` and parsing them, this PR updates the parser (`parse_path`) to scan the path linearly using `.find('{')` and `.find('}')`. This yields alternating `Segment::Static` and `Segment::Capture` segments. 

This approach is highly elegant because:
1. It does not introduce any new variants to the `Segment` enum.
2. It requires zero modifications to the existing code generator logic (`expand_named_fields`, `expand_unnamed_fields`, `expand_unit_fields`, etc.).
3. It naturally supports multiple captures in a single segment (e.g. `/{first}-{last}`).

Added new trybuild pass tests in `axum-macros/tests/typed_path/pass/prefixed_segments.rs` covering all the prefix/suffix scenarios.
