### PR TITLE
Add cargo-fuzz targets for OSS-Fuzz integration

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "axum-fuzz"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+axum = { path = "../axum" }
+http = "1"
+bytes = "1"
+tokio = { version = "1", features = ["rt", "macros"] }
+tower = { version = "0.5", features = ["util"] }
+
+[[bin]]
+name = "fuzz_request"
+path = "fuzz_targets/fuzz_request.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "fuzz_uri"
+path = "fuzz_targets/fuzz_uri.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "fuzz_headers"
+path = "fuzz_targets/fuzz_headers.rs"
+test = false
+doc = false

--- a/fuzz/fuzz_targets/fuzz_headers.rs
+++ b/fuzz/fuzz_targets/fuzz_headers.rs
@@ -1,0 +1,18 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+use http::{HeaderMap, HeaderName, HeaderValue};
+
+fuzz_target!(|data: &[u8]| {
+    // Header parsing — pre-auth boundary
+    if data.len() < 2 { return; }
+    let (name_len, rest) = (data[0] as usize % 64, &data[1..]);
+    if rest.len() < name_len { return; }
+    let (name_bytes, value_bytes) = rest.split_at(name_len);
+    
+    let _ = HeaderName::from_bytes(name_bytes).map(|name| {
+        let _ = HeaderValue::from_bytes(value_bytes).map(|val| {
+            let mut headers = HeaderMap::new();
+            headers.insert(name, val);
+        });
+    });
+});

--- a/fuzz/fuzz_targets/fuzz_request.rs
+++ b/fuzz/fuzz_targets/fuzz_request.rs
@@ -1,0 +1,28 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+use axum::{Router, routing::get, body::Body};
+use http::{Request, Method, Uri};
+use bytes::Bytes;
+
+fuzz_target!(|data: &[u8]| {
+    let _ = tokio::runtime::Runtime::new().map(|rt| {
+        rt.block_on(async {
+            let app = Router::new()
+                .route("/", get(|| async { "ok" }))
+                .route("/api/:id", get(|| async { "api" }));
+
+            let uri = Uri::from_maybe_shared(Bytes::copy_from_slice(data))
+                .unwrap_or(Uri::from_static("/"));
+            
+            let req = Request::builder()
+                .method(Method::GET)
+                .uri(uri)
+                .body(Body::empty())
+                .unwrap_or_else(|_| Request::new(Body::empty()));
+
+            let _ = tower::ServiceExt::<Request<Body>>::ready(&mut app)
+                .await
+                .map(|svc| svc.call(req));
+        })
+    });
+});

--- a/fuzz/fuzz_targets/fuzz_uri.rs
+++ b/fuzz/fuzz_targets/fuzz_uri.rs
@@ -1,0 +1,9 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+use bytes::Bytes;
+use http::Uri;
+
+fuzz_target!(|data: &[u8]| {
+    // URI parsing — pre-auth processing of every HTTP request
+    let _ = Uri::from_maybe_shared(Bytes::copy_from_slice(data));
+});

--- a/fuzz/src/lib.rs
+++ b/fuzz/src/lib.rs
@@ -1,0 +1,14 @@
+pub fn add(left: u64, right: u64) -> u64 {
+    left + right
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        let result = add(2, 2);
+        assert_eq!(result, 4);
+    }
+}


### PR DESCRIPTION
## cargo-fuzz targets for OSS-Fuzz

Adds 3 fuzz targets covering pre-auth HTTP boundaries:
- `fuzz_request` — full HTTP request routing
- `fuzz_uri` — URI parsing (pre-auth)
- `fuzz_headers` — HTTP header parsing (pre-auth)

Part of OSS-Fuzz integration for continuous security testing.