### PR TITLE
Make SSE `KeepAliveStream::new` public

### DIFF
--- a/axum/src/response/sse.rs
+++ b/axum/src/response/sse.rs
@@ -587,7 +587,25 @@ pin_project! {
 
 #[cfg(feature = "tokio")]
 impl<S> KeepAliveStream<S> {
-    fn new(keep_alive: KeepAlive, inner: S) -> Self {
+    /// Create a new `KeepAliveStream` from a `KeepAlive` configuration and stream to wrap.
+    ///
+    /// The wrapped stream should yield SSE events as `Result<Event, E>` items. Prefer
+    /// [`Sse::keep_alive`] unless you need to add keep-alive frames without going through [`Sse`].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use axum::response::sse::{Event, KeepAlive, KeepAliveStream};
+    /// use std::convert::Infallible;
+    /// use futures_util::stream;
+    ///
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let events = stream::iter(vec![Ok::<_, Infallible>(Event::default().data("hi"))]);
+    /// let stream = KeepAliveStream::new(KeepAlive::default(), events);
+    /// # }
+    /// ```
+    pub fn new(keep_alive: KeepAlive, inner: S) -> Self {
         Self {
             alive_timer: tokio::time::sleep(keep_alive.max_interval),
             inner,


### PR DESCRIPTION
## Motivation

I have a route that returns updates for a job that is being executed by the service. If the job has already finished I want to return a `futures::stream::once` with the final state of the job. To make this possible I need to box the stream that is returned.

The current issue is that I can not box the `KeepAliveStream` because the only way to construct it is to call `keep_alive` on `Sse` which returns a `Sse<KeepAliveStream<S>>`.

## Solution

Just make the `KeepAliveStream::new` public.

Wrapping the `futures::stream::once` in a `KeepAliveStream` would probably also work, but just by chance.