### PR TITLE
feat(macros): add compile-time validations to TypedPath macro

### DIFF
--- a/axum-macros/src/typed_path.rs
+++ b/axum-macros/src/typed_path.rs
@@ -404,14 +404,6 @@ fn parse_path(path: &LitStr) -> syn::Result<Vec<Segment>> {
                 return Err(syn::Error::new_spanned(path, "invalid capture in path"));
             }
 
-            let is_catch_all = capture.starts_with('*');
-            if is_catch_all && !rest[end + 1..].is_empty() {
-                return Err(syn::Error::new_spanned(
-                    path,
-                    "Wildcards/catch-alls must be at the end of the path",
-                ));
-            }
-
             segments.push(Segment::Capture(
                 capture.strip_prefix('*').unwrap_or(capture).to_owned(),
                 path.span(),
@@ -433,19 +425,35 @@ fn parse_path(path: &LitStr) -> syn::Result<Vec<Segment>> {
 
 fn validate_path_segments(value: &str, path: &LitStr) -> syn::Result<()> {
     for segment in value.split('/') {
-        let mut count = 0;
+        let mut capture_count = 0;
         let mut rest = segment;
         while let Some(start) = find_first_not_double(b'{', rest.as_bytes()) {
-            count += 1;
+            capture_count += 1;
             rest = &rest[start + 1..];
         }
-        if count > 1 {
+        if capture_count > 1 {
             return Err(syn::Error::new_spanned(
                 path,
                 "Cannot have multiple path parameters in a single segment",
             ));
         }
     }
+
+    let mut rest = value;
+    while let Some(start) = find_first_not_double(b'{', rest.as_bytes()) {
+        rest = &rest[start + 1..];
+        let Some(end) = rest.find('}') else {
+            break;
+        };
+        if rest[..end].starts_with('*') && rest.len() != end + 1 {
+            return Err(syn::Error::new_spanned(
+                path,
+                "Wildcards must be at the end of the path",
+            ));
+        }
+        rest = &rest[end + 1..];
+    }
+
     Ok(())
 }
 

--- a/axum-macros/src/typed_path.rs
+++ b/axum-macros/src/typed_path.rs
@@ -424,34 +424,40 @@ fn parse_path(path: &LitStr) -> syn::Result<Vec<Segment>> {
 }
 
 fn validate_path_segments(value: &str, path: &LitStr) -> syn::Result<()> {
+    let mut wildcard_seen = false;
+
     for segment in value.split('/') {
+        if wildcard_seen {
+            return Err(syn::Error::new_spanned(
+                path,
+                "Wildcards must be at the end of the path",
+            ));
+        }
+
         let mut capture_count = 0;
         let mut rest = segment;
         while let Some(start) = find_first_not_double(b'{', rest.as_bytes()) {
             capture_count += 1;
             rest = &rest[start + 1..];
+
+            if rest.starts_with('*') {
+                wildcard_seen = true;
+                // a wildcard capture must cover its entire segment
+                if start != 0 || rest.find('}') != Some(rest.len() - 1) {
+                    return Err(syn::Error::new_spanned(
+                        path,
+                        "Wildcards must be at the end of the path",
+                    ));
+                }
+            }
         }
+
         if capture_count > 1 {
             return Err(syn::Error::new_spanned(
                 path,
                 "Cannot have multiple path parameters in a single segment",
             ));
         }
-    }
-
-    let mut rest = value;
-    while let Some(start) = find_first_not_double(b'{', rest.as_bytes()) {
-        rest = &rest[start + 1..];
-        let Some(end) = rest.find('}') else {
-            break;
-        };
-        if rest[..end].starts_with('*') && rest.len() != end + 1 {
-            return Err(syn::Error::new_spanned(
-                path,
-                "Wildcards must be at the end of the path",
-            ));
-        }
-        rest = &rest[end + 1..];
     }
 
     Ok(())

--- a/axum-macros/src/typed_path.rs
+++ b/axum-macros/src/typed_path.rs
@@ -386,6 +386,8 @@ fn parse_path(path: &LitStr) -> syn::Result<Vec<Segment>> {
         return Err(syn::Error::new_spanned(path, "paths must start with a `/`"));
     }
 
+    validate_path_segments(&value, path)?;
+
     let mut segments = Vec::new();
     let mut rest = value.as_str();
 
@@ -400,6 +402,14 @@ fn parse_path(path: &LitStr) -> syn::Result<Vec<Segment>> {
             let capture = &rest[..end];
             if capture.is_empty() || capture.contains('{') {
                 return Err(syn::Error::new_spanned(path, "invalid capture in path"));
+            }
+
+            let is_catch_all = capture.starts_with('*');
+            if is_catch_all && !rest[end + 1..].is_empty() {
+                return Err(syn::Error::new_spanned(
+                    path,
+                    "Wildcards/catch-alls must be at the end of the path",
+                ));
             }
 
             segments.push(Segment::Capture(
@@ -419,6 +429,24 @@ fn parse_path(path: &LitStr) -> syn::Result<Vec<Segment>> {
     }
 
     Ok(segments)
+}
+
+fn validate_path_segments(value: &str, path: &LitStr) -> syn::Result<()> {
+    for segment in value.split('/') {
+        let mut count = 0;
+        let mut rest = segment;
+        while let Some(start) = find_first_not_double(b'{', rest.as_bytes()) {
+            count += 1;
+            rest = &rest[start + 1..];
+        }
+        if count > 1 {
+            return Err(syn::Error::new_spanned(
+                path,
+                "Cannot have multiple path parameters in a single segment",
+            ));
+        }
+    }
+    Ok(())
 }
 
 fn find_first_not_double(needle: u8, haystack: &[u8]) -> Option<usize> {

--- a/axum-macros/tests/typed_path/fail/catch_all_not_at_end.rs
+++ b/axum-macros/tests/typed_path/fail/catch_all_not_at_end.rs
@@ -1,0 +1,10 @@
+use axum_macros::TypedPath;
+use serde::Deserialize;
+
+#[derive(TypedPath, Deserialize)]
+#[typed_path("/{*rest}/foo")]
+struct MyPath {
+    rest: String,
+}
+
+fn main() {}

--- a/axum-macros/tests/typed_path/fail/catch_all_not_at_end.stderr
+++ b/axum-macros/tests/typed_path/fail/catch_all_not_at_end.stderr
@@ -1,0 +1,5 @@
+error: Wildcards/catch-alls must be at the end of the path
+ --> tests/typed_path/fail/catch_all_not_at_end.rs:5:14
+  |
+5 | #[typed_path("/{*rest}/foo")]
+  |              ^^^^^^^^^^^^^^

--- a/axum-macros/tests/typed_path/fail/catch_all_not_at_end.stderr
+++ b/axum-macros/tests/typed_path/fail/catch_all_not_at_end.stderr
@@ -1,4 +1,4 @@
-error: Wildcards/catch-alls must be at the end of the path
+error: Wildcards must be at the end of the path
  --> tests/typed_path/fail/catch_all_not_at_end.rs:5:14
   |
 5 | #[typed_path("/{*rest}/foo")]

--- a/axum-macros/tests/typed_path/fail/catch_all_not_whole_segment.rs
+++ b/axum-macros/tests/typed_path/fail/catch_all_not_whole_segment.rs
@@ -1,0 +1,10 @@
+use axum_macros::TypedPath;
+use serde::Deserialize;
+
+#[derive(TypedPath, Deserialize)]
+#[typed_path("/files/{*rest}.txt")]
+struct MyPath {
+    rest: String,
+}
+
+fn main() {}

--- a/axum-macros/tests/typed_path/fail/catch_all_not_whole_segment.stderr
+++ b/axum-macros/tests/typed_path/fail/catch_all_not_whole_segment.stderr
@@ -1,0 +1,5 @@
+error: Wildcards must be at the end of the path
+ --> tests/typed_path/fail/catch_all_not_whole_segment.rs:5:14
+  |
+5 | #[typed_path("/files/{*rest}.txt")]
+  |              ^^^^^^^^^^^^^^^^^^^^

--- a/axum-macros/tests/typed_path/fail/multiple_params_in_segment.rs
+++ b/axum-macros/tests/typed_path/fail/multiple_params_in_segment.rs
@@ -1,0 +1,11 @@
+use axum_macros::TypedPath;
+use serde::Deserialize;
+
+#[derive(TypedPath, Deserialize)]
+#[typed_path("/user-{first}-{last}")]
+struct MyPath {
+    first: String,
+    last: String,
+}
+
+fn main() {}

--- a/axum-macros/tests/typed_path/fail/multiple_params_in_segment.stderr
+++ b/axum-macros/tests/typed_path/fail/multiple_params_in_segment.stderr
@@ -1,0 +1,5 @@
+error: Cannot have multiple path parameters in a single segment
+ --> tests/typed_path/fail/multiple_params_in_segment.rs:5:14
+  |
+5 | #[typed_path("/user-{first}-{last}")]
+  |              ^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Currently, the `TypedPath` derive macro compiles successfully but causes runtime panics during router setup in two cases:
1. Multiple captures in a single segment - (e.g. `/user-{first}-{last}`): Panics with `Only one parameter is allowed per path segment`.
2. Misplaced catch-all parameters - (e.g. `/{*rest}/foo`): Panics with `catch-all parameters are only allowed at the end of a path`.

This PR introduces compile-time validation checks for both of these cases directly inside `parse_path` using the macro's native brace-escaped scanner (`find_first_not_double`), raising compile errors instead of runtime crashes.

Includes:
- Compile-time segment capture limit check.
- Compile-time catch-all placement check.
- UI trybuild tests for both failure modes.
