### PR TITLE
Add `Redirect::found` and `Redirect::moved_permanently`

### DIFF
--- a/axum/src/response/redirect.rs
+++ b/axum/src/response/redirect.rs
@@ -25,6 +25,20 @@ pub struct Redirect {
 }
 
 impl Redirect {
+    /// Create a new [`Redirect`] that uses a [`301 Moved Permanently`][mdn] status code.
+    ///
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/301
+    pub fn moved_permanently(uri: impl Into<String>) -> Self {
+        Self::with_status_code(StatusCode::MOVED_PERMANENTLY, uri.into())
+    }
+
+    /// Create a new [`Redirect`] that uses a [`302 Found`][mdn] status code.
+    ///
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/302
+    pub fn found(uri: impl Into<String>) -> Self {
+        Self::with_status_code(StatusCode::FOUND, uri.into())
+    }
+
     /// Create a new [`Redirect`] that uses a [`303 See Other`][mdn] status code.
     ///
     /// This redirect instructs the client to change the method to GET for the subsequent request
@@ -156,6 +170,16 @@ mod tests {
     // based on the way it was constructed.
     #[test]
     fn correct_status() {
+        assert_eq!(
+            StatusCode::MOVED_PERMANENTLY,
+            Redirect::moved_permanently(EXAMPLE_URL).status_code()
+        );
+
+        assert_eq!(
+            StatusCode::FOUND,
+            Redirect::found(EXAMPLE_URL).status_code()
+        );
+
         assert_eq!(
             StatusCode::SEE_OTHER,
             Redirect::to(EXAMPLE_URL).status_code()


### PR DESCRIPTION
This PR adds the `Redirect::found` and `Redirect::moved_permanently` constructors.
<sub><sup>Note: No AI has been used in the making of this PR. :)</sup></sub>

## Motivation

I am implementing a web server following a strict spec that among other things specifies the HTTP Status Code I must use on the replies. To comply I must use `302 Found` in some cases, and swapping it to the more modern `307 Temporary Redirect` is sadly not acceptable in this case.

Currently `Redirect` only has constructors for `303 See Other`, `307 Temporary Redirect`, and `307 Permanent Redirect`. However, inspecting the code I found a *private* constructor allowing arbitrary status codes and a cute comment that reads:

> We're open to adding more constructors upon request, if they make sense :)

Although unfortunate, I'd say my use-case *makes sense*.

## Solution

I added a function for `302 Found`, and another for `301 Moved Permanently` (following the same reasoning). They're basically clones of the existing constructors with a different Status Code.

## Unresolved questions

- It might be wise to expand the docs of the two functions I added pointing confused users to 307 and 308 instead, unless they know what they are doing.
- Maybe name it `Redirect::moved` instead of `Redirect::moved_permanently`.