### PR TITLE
Prevent "?&" in TypedPath query params

### DIFF
--- a/axum-extra/src/routing/typed.rs
+++ b/axum-extra/src/routing/typed.rs
@@ -256,7 +256,7 @@ pub trait TypedPath: std::fmt::Display {
     ///     per_page: 10,
     /// });
     ///
-    /// assert_eq!(path.to_uri(), "/users?&page=1&per_page=10");
+    /// assert_eq!(path.to_uri(), "/users?page=1&per_page=10");
     /// ```
     ///
     /// # Panics
@@ -291,10 +291,12 @@ where
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut out = self.path.to_string();
-        if !out.contains('?') {
+
+        let params_start = out.find('?').map(|i| i + 1).unwrap_or_else(|| {
             out.push('?');
-        }
-        let mut urlencoder = form_urlencoded::Serializer::new(&mut out);
+            out.len()
+        });
+        let mut urlencoder = form_urlencoded::Serializer::for_suffix(&mut out, params_start);
         self.params
             .serialize(serde_html_form::ser::Serializer::new(&mut urlencoder))
             .unwrap_or_else(|err| {
@@ -410,12 +412,7 @@ mod tests {
 
         let uri = path.to_uri();
 
-        // according to [the spec] starting the params with `?&` is allowed specifically:
-        //
-        // > If bytes is the empty byte sequence, then continue.
-        //
-        // [the spec]: https://url.spec.whatwg.org/#urlencoded-parsing
-        assert_eq!(uri, "/users/1?&foo=foo&bar=123&baz=true");
+        assert_eq!(uri, "/users/1?foo=foo&bar=123&baz=true");
     }
 
     #[test]
@@ -430,7 +427,26 @@ mod tests {
 
         let uri = path.to_uri();
 
-        assert_eq!(uri, "/users/1?&foo=foo&bar=123&baz=true&qux=1337");
+        assert_eq!(uri, "/users/1?foo=foo&bar=123&baz=true&qux=1337");
+    }
+
+    #[test]
+    fn with_params_question_mark_no_params() {
+        #[derive(TypedPath)]
+        #[typed_path("/test?")]
+        struct EndsWithQuestionMark;
+
+        assert_eq!(EndsWithQuestionMark.to_uri(), "/test?");
+
+        let path = EndsWithQuestionMark.with_query_params(Params {
+            foo: "foo",
+            bar: 123,
+            baz: true,
+        });
+
+        let uri = path.to_uri();
+
+        assert_eq!(uri, "/test?foo=foo&bar=123&baz=true");
     }
 
     #[cfg(feature = "with-rejection")]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

When using `TypedPath`, serializing query parameters used to produce an ampersand after the question mark in the path:

```rs
#[derive(TypedPath)]
#[typed_path("/users")]
struct Users;

#[derive(Serialize)]
struct Pagination {
    page: u32,
    per_page: u32,
}

let path = Users.with_query_params(Pagination {
    page: 1,
    per_page: 10,
});

assert_eq!(path.to_uri(), "/users?&page=1&per_page=10"); // notice the "?&"
```

While this is technically not a problem (because it is allowed according to the spec as mentioned by the now removed comment in one of the test cases), I think this is not ideal behavior, especially if you end up exposing these paths to the end-users of your website.

I just think it is nicer (and more conventional) to get `/users?page=1&per_page=10` rather than `/users?&page=1&per_page=10`.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

The query parameter `Serializer` from the `form_urlencoded` crate provides a `for_suffix` constructor that can be used to indicate the starting position of the query parameters. Using this constructor makes it not insert the ampersand for the first query parameter after the question mark, as shown in the updated test cases.

I've also added a test case to make sure paths that end with a question mark are handled correctly.