### PR TITLE
docs: fix link reference for pull request template

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -165,10 +165,10 @@ A good commit message should describe what changed and why.
 ### Opening the Pull Request
 
 From within GitHub, opening a new Pull Request will present you with a
-[template] that should be filled out. Please try to do your best at filling out
+[template][pr_template] that should be filled out. Please try to do your best at filling out
 the details, but feel free to skip parts if you're not sure what to put.
 
-[template]: .github/PULL_REQUEST_TEMPLATE.md
+[pr_template]: .github/PULL_REQUEST_TEMPLATE.md
 
 ### Discuss and update
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

Hi! I noticed the link to the pull request template was overruled by the link for the issue template (both links are called `template`).

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

I renamed the link to `pr_template`, so now it links to the pull request template instead of the issue template.