### PR TITLE
fix(axum-core): skip non-data frames in BytesMut

### DIFF
--- a/axum-core/CHANGELOG.md
+++ b/axum-core/CHANGELOG.md
@@ -14,9 +14,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **changed:** `impl IntoResponse for ()` (which gets called by
   `impl IntoResponse for HeaderMap`, `impl IntoResponse for Extensions` and
   others) now returns a body of unknown size.
+- **fixed:** Make the `BytesMut` extractor skip non-data body frames instead
+  of truncating the remaining buffered data ([#3811])
 
 [#3721]: https://github.com/tokio-rs/axum/pull/3721
 [#3742]: https://github.com/tokio-rs/axum/pull/3742
+[#3811]: https://github.com/tokio-rs/axum/pull/3811
 
 # 0.5.6
 

--- a/axum-core/CHANGELOG.md
+++ b/axum-core/CHANGELOG.md
@@ -14,8 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **changed:** `impl IntoResponse for ()` (which gets called by
   `impl IntoResponse for HeaderMap`, `impl IntoResponse for Extensions` and
   others) now returns a body of unknown size.
-- **fixed:** Make the `BytesMut` extractor skip non-data body frames instead
-  of truncating the remaining buffered data ([#3811])
+- **fixed:** Make the `BytesMut` extractor ignore non-data frames from custom
+  request bodies, matching the `Bytes` extractor ([#3811])
 
 [#3721]: https://github.com/tokio-rs/axum/pull/3721
 [#3742]: https://github.com/tokio-rs/axum/pull/3742

--- a/axum-core/src/extract/request_parts.rs
+++ b/axum-core/src/extract/request_parts.rs
@@ -89,6 +89,7 @@ async fn body_to_bytes_mut(body: &mut Body, bytes: &mut BytesMut) -> Result<(), 
         .map_err(FailedToBufferBody::from_err)?
     {
         let Ok(data) = frame.into_data() else {
+            // Match `Bytes` by ignoring non-data frames until the body ends.
             continue;
         };
         bytes.put(data);
@@ -174,18 +175,8 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::{Bytes, BytesMut, FromRequest, Request};
-    use crate::body::Body;
     use axum::{extract::Extension, routing::get, test_helpers::*, Router};
-    use bytes::Bytes as RawBytes;
-    use http::{HeaderMap, Method, StatusCode};
-    use http_body::Frame;
-    use std::{
-        collections::VecDeque,
-        convert::Infallible,
-        pin::Pin,
-        task::{Context, Poll},
-    };
+    use http::{Method, StatusCode};
 
     #[crate::test]
     async fn extract_request_parts() {
@@ -204,44 +195,5 @@ mod tests {
 
         let res = client.get("/").header("x-foo", "123").await;
         assert_eq!(res.status(), StatusCode::OK);
-    }
-
-    #[crate::test]
-    async fn bytes_mut_extractor_skips_non_data_frames() {
-        struct InterleavedFramesBody {
-            frames: VecDeque<Result<Frame<RawBytes>, Infallible>>,
-        }
-
-        impl http_body::Body for InterleavedFramesBody {
-            type Data = RawBytes;
-            type Error = Infallible;
-
-            fn poll_frame(
-                self: Pin<&mut Self>,
-                _cx: &mut Context<'_>,
-            ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
-                Poll::Ready(self.get_mut().frames.pop_front())
-            }
-        }
-
-        fn request() -> Request {
-            let body = InterleavedFramesBody {
-                frames: VecDeque::from(vec![
-                    Ok(Frame::data(RawBytes::from_static(b"hello "))),
-                    Ok(Frame::trailers(HeaderMap::new())),
-                    Ok(Frame::data(RawBytes::from_static(b"world"))),
-                ]),
-            };
-
-            Request::builder()
-                .body(Body::new(body))
-                .expect("request should build")
-        }
-
-        let bytes_mut = BytesMut::from_request(request(), &()).await.unwrap();
-        let bytes = Bytes::from_request(request(), &()).await.unwrap();
-
-        assert_eq!(&bytes_mut[..], b"hello world");
-        assert_eq!(&bytes[..], b"hello world");
     }
 }

--- a/axum-core/src/extract/request_parts.rs
+++ b/axum-core/src/extract/request_parts.rs
@@ -89,7 +89,7 @@ async fn body_to_bytes_mut(body: &mut Body, bytes: &mut BytesMut) -> Result<(), 
         .map_err(FailedToBufferBody::from_err)?
     {
         let Ok(data) = frame.into_data() else {
-            return Ok(());
+            continue;
         };
         bytes.put(data);
     }
@@ -174,8 +174,18 @@ where
 
 #[cfg(test)]
 mod tests {
+    use super::{Bytes, BytesMut, FromRequest, Request};
+    use crate::body::Body;
     use axum::{extract::Extension, routing::get, test_helpers::*, Router};
-    use http::{Method, StatusCode};
+    use bytes::Bytes as RawBytes;
+    use http::{HeaderMap, Method, StatusCode};
+    use http_body::Frame;
+    use std::{
+        collections::VecDeque,
+        convert::Infallible,
+        pin::Pin,
+        task::{Context, Poll},
+    };
 
     #[crate::test]
     async fn extract_request_parts() {
@@ -194,5 +204,44 @@ mod tests {
 
         let res = client.get("/").header("x-foo", "123").await;
         assert_eq!(res.status(), StatusCode::OK);
+    }
+
+    #[crate::test]
+    async fn bytes_mut_extractor_skips_non_data_frames() {
+        struct InterleavedFramesBody {
+            frames: VecDeque<Result<Frame<RawBytes>, Infallible>>,
+        }
+
+        impl http_body::Body for InterleavedFramesBody {
+            type Data = RawBytes;
+            type Error = Infallible;
+
+            fn poll_frame(
+                self: Pin<&mut Self>,
+                _cx: &mut Context<'_>,
+            ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+                Poll::Ready(self.get_mut().frames.pop_front())
+            }
+        }
+
+        fn request() -> Request {
+            let body = InterleavedFramesBody {
+                frames: VecDeque::from(vec![
+                    Ok(Frame::data(RawBytes::from_static(b"hello "))),
+                    Ok(Frame::trailers(HeaderMap::new())),
+                    Ok(Frame::data(RawBytes::from_static(b"world"))),
+                ]),
+            };
+
+            Request::builder()
+                .body(Body::new(body))
+                .expect("request should build")
+        }
+
+        let bytes_mut = BytesMut::from_request(request(), &()).await.unwrap();
+        let bytes = Bytes::from_request(request(), &()).await.unwrap();
+
+        assert_eq!(&bytes_mut[..], b"hello world");
+        assert_eq!(&bytes[..], b"hello world");
     }
 }


### PR DESCRIPTION
## Summary

- make the `BytesMut` extractor skip non-data body frames instead of stopping at the first one
- add a regression test covering an interleaved `data / non-data / data` body
- verify `BytesMut` now matches `Bytes` for that frame sequence

## Root cause

`body_to_bytes_mut` returned early when `frame.into_data()` failed. That meant the `BytesMut` extractor could truncate request bodies after a trailer or any other non-data frame, even though `Body::into_data_stream` already discards non-data frames and keeps polling.

## Testing

- `cargo test -p axum-core`
- `cargo check -p axum-core`
