### PR TITLE
fix!: resolve inconsistent trailing-slash behavior when nesting routers

### DIFF
--- a/axum/src/docs/routing/nest.md
+++ b/axum/src/docs/routing/nest.md
@@ -13,7 +13,9 @@ use axum::{
 
 let user_routes = Router::new().route("/{id}", get(|| async {}));
 
-let team_routes = Router::new().route("/", post(|| async {}));
+// `route("")` (rather than `route("/")`) so this matches the nesting prefix
+// exactly, with no trailing slash
+let team_routes = Router::new().route("", post(|| async {}));
 
 let api_routes = Router::new()
     .nest("/users", user_routes)
@@ -82,10 +84,10 @@ let app = Router::new()
 # let _: Router = app;
 ```
 
-Additionally, while the wildcard route `/foo/*rest` will not match the
-paths `/foo` or `/foo/`, a nested router at `/foo` will match the path `/foo`
-(but not `/foo/`), and a nested router at `/foo/` will match the path `/foo/`
-(but not `/foo`).
+Additionally, unlike the wildcard route `/foo/{*rest}` (which matches neither
+`/foo` nor `/foo/`), a router nested at `/foo` can match the prefix itself: the
+inner paths are appended to the prefix, so an inner `route("", _)` matches
+`/foo` (no trailing slash) and an inner `route("/", _)` matches `/foo/`.
 
 # Fallbacks
 
@@ -189,6 +191,8 @@ router.
   for more details.
 - If the route contains a wildcard (`*`).
 - If `path` is empty.
+- If `path` ends with a `/` (for example `"/foo/"`). Nest at `"/foo"` instead;
+  use an inner `route("/", _)` if you want to match `/foo/`.
 
 [`OriginalUri`]: crate::extract::OriginalUri
 [fallbacks]: Router::fallback

--- a/axum/src/docs/routing/route.md
+++ b/axum/src/docs/routing/route.md
@@ -134,6 +134,17 @@ let app = Router::new()
 # async fn delete_root() {}
 ```
 
+# Empty paths
+
+The empty path `""` is allowed. On its own it is unreachable, since request
+paths always start with `/`, so registering `route("", _)` on a top-level
+router will never match anything.
+
+It is meant to be used together with [`Router::nest`](crate::Router::nest): an
+inner `route("", _)` nested at `/foo` matches `/foo` exactly (with no trailing
+slash), whereas `route("/", _)` nested at `/foo` matches `/foo/`.
+
+
 # More examples
 
 ```rust
@@ -176,6 +187,8 @@ let app = Router::new()
 The static route `/foo` and the dynamic route `/{key}` are not considered to
 overlap and `/foo` will take precedence.
 
-Also panics if `path` is empty or does not start with `/` (for example `"Cargo.lock"`).
-When nesting routers with [`Router::nest`](crate::Router::nest), nested paths are still
-relative segments and must start with `/` (use `"/Cargo.lock"` rather than `"Cargo.lock"`).
+Also panics if `path` is non-empty and does not start with `/` (for example
+`"Cargo.lock"`). The empty path `""` is allowed; see [Empty paths](#empty-paths)
+above. When nesting routers with [`Router::nest`](crate::Router::nest), nested
+paths are still relative segments and must start with `/` (use `"/Cargo.lock"`
+rather than `"Cargo.lock"`).

--- a/axum/src/extract/nested_path.rs
+++ b/axum/src/extract/nested_path.rs
@@ -140,24 +140,6 @@ mod tests {
     }
 
     #[crate::test]
-    async fn one_level_of_nesting_with_trailing_slash() {
-        let api = Router::new().route(
-            "/users",
-            get(|nested_path: NestedPath| {
-                assert_eq!(nested_path.as_str(), "/api/");
-                async {}
-            }),
-        );
-
-        let app = Router::new().nest("/api/", api);
-
-        let client = TestClient::new(app);
-
-        let res = client.get("/api/users").await;
-        assert_eq!(res.status(), StatusCode::OK);
-    }
-
-    #[crate::test]
     async fn two_levels_of_nesting() {
         let api = Router::new().route(
             "/users",
@@ -168,24 +150,6 @@ mod tests {
         );
 
         let app = Router::new().nest("/api", Router::new().nest("/v2", api));
-
-        let client = TestClient::new(app);
-
-        let res = client.get("/api/v2/users").await;
-        assert_eq!(res.status(), StatusCode::OK);
-    }
-
-    #[crate::test]
-    async fn two_levels_of_nesting_with_trailing_slash() {
-        let api = Router::new().route(
-            "/users",
-            get(|nested_path: NestedPath| {
-                assert_eq!(nested_path.as_str(), "/api/v2");
-                async {}
-            }),
-        );
-
-        let app = Router::new().nest("/api/", Router::new().nest("/v2", api));
 
         let client = TestClient::new(app);
 

--- a/axum/src/routing/path_router.rs
+++ b/axum/src/routing/path_router.rs
@@ -222,11 +222,7 @@ where
         let path = validate_nest_path(self.v7_checks, path_to_nest_at)?;
         let prefix = path;
 
-        let path = if path.ends_with('/') {
-            format!("{path}{{*{NEST_TAIL_PARAM}}}")
-        } else {
-            format!("{path}/{{*{NEST_TAIL_PARAM}}}")
-        };
+        let path = format!("{path}/{{*{NEST_TAIL_PARAM}}}");
 
         let layer = (
             StripPrefix::layer(prefix),
@@ -448,6 +444,9 @@ fn validate_nest_path(v7_checks: bool, path: &str) -> Result<&str, &'static str>
     }
     if path.len() < 2 {
         return Err("Nesting at `/` is not supported.");
+    }
+    if path.ends_with("/") {
+        return Err("Nesting paths must not end with a `/`.");
     }
 
     if path.split('/').any(|segment| {

--- a/axum/src/routing/path_router.rs
+++ b/axum/src/routing/path_router.rs
@@ -21,7 +21,7 @@ pub(super) struct PathRouter<S> {
 
 fn validate_path(v7_checks: bool, path: &str) -> Result<(), &'static str> {
     if path.is_empty() {
-        return Err("Paths must start with a `/`. Use \"/\" for root routes");
+        return Ok(());
     } else if !path.starts_with('/') {
         return Err("Paths must start with a `/`");
     }

--- a/axum/src/routing/path_router.rs
+++ b/axum/src/routing/path_router.rs
@@ -464,13 +464,8 @@ fn validate_nest_path(v7_checks: bool, path: &str) -> Result<&str, &'static str>
 
 pub(crate) fn path_for_nested_route<'a>(prefix: &'a str, path: &'a str) -> Cow<'a, str> {
     debug_assert!(prefix.starts_with('/'));
-    debug_assert!(path.starts_with('/'));
+    debug_assert!(path.starts_with('/') || path.is_empty());
+    debug_assert!(!prefix.ends_with('/'));
 
-    if prefix.ends_with('/') {
-        format!("{prefix}{}", path.trim_start_matches('/')).into()
-    } else if path == "/" {
-        prefix.into()
-    } else {
-        format!("{prefix}{path}").into()
-    }
+    format!("{prefix}{path}").into()
 }

--- a/axum/src/routing/strip_prefix.rs
+++ b/axum/src/routing/strip_prefix.rs
@@ -86,6 +86,18 @@ fn strip_prefix(uri: &Uri, prefix: &str) -> Option<Uri> {
                     break;
                 }
             }
+            // the path has a trailing slash, but the prefix doesn't, so we don't
+            // remove it
+            //
+            // For example
+            // prefix = /foo
+            // path = /foo/
+            //
+            // The prefix matches, and the new path should be `/`
+            Item::First("") => {
+                *matching_prefix_length.as_mut().unwrap() -= 1;
+                break;
+            }
             // the path had more segments than the prefix but we got a match.
             //
             // For example:
@@ -108,11 +120,13 @@ fn strip_prefix(uri: &Uri, prefix: &str) -> Option<Uri> {
     // panic
     let after_prefix = uri.path().split_at(matching_prefix_length?).1;
 
-    let new_path_and_query = match (after_prefix.starts_with('/'), path_and_query.query()) {
-        (true, None) => after_prefix.parse().unwrap(),
-        (true, Some(query)) => format!("{after_prefix}?{query}").parse().unwrap(),
-        (false, None) => format!("/{after_prefix}").parse().unwrap(),
-        (false, Some(query)) => format!("/{after_prefix}?{query}").parse().unwrap(),
+    let new_path_and_query = match (after_prefix.chars().next(), path_and_query.query()) {
+        (None, None) => "".parse().unwrap(),
+        (None, Some(query)) => format!("?{query}").parse().unwrap(),
+        (Some('/'), None) => after_prefix.parse().unwrap(),
+        (Some('/'), Some(query)) => format!("{after_prefix}?{query}").parse().unwrap(),
+        (Some(_), None) => format!("/{after_prefix}").parse().unwrap(),
+        (Some(_), Some(query)) => format!("/{after_prefix}?{query}").parse().unwrap(),
     };
 
     let mut parts = uri.clone().into_parts();
@@ -241,13 +255,13 @@ mod tests {
         };
     }
 
-    test!(empty, uri = "/", prefix = "/", expected = Some("/"),);
+    test!(empty, uri = "/", prefix = "/", expected = Some(""),);
 
     test!(
         single_segment,
         uri = "/a",
         prefix = "/a",
-        expected = Some("/"),
+        expected = Some(""),
     );
 
     test!(
@@ -276,7 +290,7 @@ mod tests {
         single_segment_trailing_slash,
         uri = "/a/",
         prefix = "/a/",
-        expected = Some("/"),
+        expected = Some(""),
     );
 
     test!(
@@ -325,7 +339,7 @@ mod tests {
         multi_segment_trailing_slash,
         uri = "/a/b/",
         prefix = "/a/b/",
-        expected = Some("/"),
+        expected = Some(""),
     );
 
     test!(
@@ -342,18 +356,13 @@ mod tests {
         expected = Some("/"),
     );
 
-    test!(
-        param_0,
-        uri = "/",
-        prefix = "/{param}",
-        expected = Some("/"),
-    );
+    test!(param_0, uri = "/", prefix = "/{param}", expected = Some(""),);
 
     test!(
         param_1,
         uri = "/a",
         prefix = "/{param}",
-        expected = Some("/"),
+        expected = Some(""),
     );
 
     test!(
@@ -374,7 +383,7 @@ mod tests {
         param_4,
         uri = "/a/b",
         prefix = "/a/{param}",
-        expected = Some("/"),
+        expected = Some(""),
     );
 
     test!(
@@ -395,14 +404,14 @@ mod tests {
         param_7,
         uri = "/b/a",
         prefix = "/{param}/a",
-        expected = Some("/"),
+        expected = Some(""),
     );
 
     test!(
         param_8,
         uri = "/a/b/c",
         prefix = "/a/{param}/c",
-        expected = Some("/"),
+        expected = Some(""),
     );
 
     test!(
@@ -425,7 +434,7 @@ mod tests {
         param_12,
         uri = "/a/",
         prefix = "/{param}/",
-        expected = Some("/"),
+        expected = Some(""),
     );
 
     test!(

--- a/axum/src/routing/strip_prefix.rs
+++ b/axum/src/routing/strip_prefix.rs
@@ -86,25 +86,15 @@ fn strip_prefix(uri: &Uri, prefix: &str) -> Option<Uri> {
                     break;
                 }
             }
-            // the path has a trailing slash, but the prefix doesn't, so we don't
-            // remove it
-            //
-            // For example
-            // prefix = /foo
-            // path = /foo/
-            //
-            // The prefix matches, and the new path should be `/`
-            Item::First("") => {
-                *matching_prefix_length.as_mut().unwrap() -= 1;
-                break;
-            }
             // the path had more segments than the prefix but we got a match.
+            // Stop just before the `/` separating the matched prefix from the
+            // rest, so the remainder keeps its leading slash. This handles both
+            // a longer path and a bare trailing slash uniformly:
             //
-            // For example:
-            //
-            // prefix = /foo
-            // path   = /foo/bar
+            // prefix = /foo, path = /foo/bar  -> remainder `/bar`
+            // prefix = /foo, path = /foo/     -> remainder `/`
             Item::First(_) => {
+                *matching_prefix_length.as_mut().unwrap() -= 1;
                 break;
             }
             // the prefix had more segments than the path so there is no match

--- a/axum/src/routing/tests/merge.rs
+++ b/axum/src/routing/tests/merge.rs
@@ -226,9 +226,10 @@ async fn all_the_uris(
     }))
 }
 
-#[crate::test]
+// Not crate::test because nest_service attaches on the nesting route
+#[tokio::test]
 async fn nesting_and_seeing_the_right_uri() {
-    let one = Router::new().nest("/foo/", Router::new().route("/bar", get(all_the_uris)));
+    let one = Router::new().nest("/foo", Router::new().route("/bar", get(all_the_uris)));
     let two = Router::new().route("/foo", get(all_the_uris));
 
     let client = TestClient::new(one.merge(two));
@@ -256,10 +257,11 @@ async fn nesting_and_seeing_the_right_uri() {
     );
 }
 
-#[crate::test]
+// Not crate::test because nest_service attaches on the nesting route
+#[tokio::test]
 async fn nesting_and_seeing_the_right_uri_at_more_levels_of_nesting() {
     let one = Router::new().nest(
-        "/foo/",
+        "/foo",
         Router::new().nest("/bar", Router::new().route("/baz", get(all_the_uris))),
     );
     let two = Router::new().route("/foo", get(all_the_uris));

--- a/axum/src/routing/tests/mod.rs
+++ b/axum/src/routing/tests/mod.rs
@@ -678,10 +678,12 @@ async fn static_and_dynamic_paths() {
 }
 
 #[crate::test]
-#[should_panic(expected = "Paths must start with a `/`. Use \"/\" for root routes")]
 async fn empty_route() {
-    let app = Router::new().route("", get(|| async {}));
-    TestClient::new(app);
+    let app = Router::new().route("", get(|| async { "root" }));
+
+    let client = TestClient::new(app);
+    let res = client.get("/").await;
+    assert_eq!(res.status(), StatusCode::NOT_FOUND);
 }
 
 #[crate::test]

--- a/axum/src/routing/tests/mod.rs
+++ b/axum/src/routing/tests/mod.rs
@@ -1149,17 +1149,10 @@ fn method_router_fallback_with_state() {
 
 #[test]
 fn test_path_for_nested_route() {
-    assert_eq!(path_for_nested_route("/", "/"), "/");
-
-    assert_eq!(path_for_nested_route("/a", "/"), "/a");
-    assert_eq!(path_for_nested_route("/", "/b"), "/b");
-    assert_eq!(path_for_nested_route("/a/", "/"), "/a/");
-    assert_eq!(path_for_nested_route("/", "/b/"), "/b/");
-
+    assert_eq!(path_for_nested_route("/a", "/"), "/a/");
+    assert_eq!(path_for_nested_route("/a", ""), "/a");
     assert_eq!(path_for_nested_route("/a", "/b"), "/a/b");
-    assert_eq!(path_for_nested_route("/a/", "/b"), "/a/b");
     assert_eq!(path_for_nested_route("/a", "/b/"), "/a/b/");
-    assert_eq!(path_for_nested_route("/a/", "/b/"), "/a/b/");
 }
 
 #[crate::test]

--- a/axum/src/routing/tests/nest.rs
+++ b/axum/src/routing/tests/nest.rs
@@ -118,6 +118,12 @@ fn nest_service_no_slash() {
 }
 
 #[crate::test]
+#[should_panic(expected = "Nesting paths must not end with a `/`.")]
+async fn nest_no_ending_slash() {
+    let _: Router = Router::new().nest("/x/", Router::new());
+}
+
+#[crate::test]
 async fn nested_url_extractor() {
     let app = Router::new().nest(
         "/foo",

--- a/axum/src/routing/tests/nest.rs
+++ b/axum/src/routing/tests/nest.rs
@@ -64,10 +64,10 @@ async fn wrong_method_nest() {
 
     let client = TestClient::new(app);
 
-    let res = client.get("/foo").await;
+    let res = client.get("/foo/").await;
     assert_eq!(res.status(), StatusCode::OK);
 
-    let res = client.post("/foo").await;
+    let res = client.post("/foo/").await;
     assert_eq!(res.status(), StatusCode::METHOD_NOT_ALLOWED);
     assert_eq!(res.headers()[ALLOW], "GET,HEAD");
 
@@ -432,9 +432,11 @@ macro_rules! nested_route_test {
 }
 
 // test cases taken from https://github.com/tokio-rs/axum/issues/714#issuecomment-1058144460
-nested_route_test!(nest_1, nest = "/a", route = "/", expected = "/a");
-nested_route_test!(nest_2, nest = "/a", route = "/a", expected = "/a/a");
-nested_route_test!(nest_3, nest = "/a", route = "/a/", expected = "/a/a/");
+// Amended for https://github.com/tokio-rs/axum/issues/2659
+nested_route_test!(nest_1, nest = "/a", route = "/", expected = "/a/");
+nested_route_test!(nest_2, nest = "/a", route = "", expected = "/a");
+nested_route_test!(nest_3, nest = "/a", route = "/a", expected = "/a/a");
+nested_route_test!(nest_4, nest = "/a", route = "/a/", expected = "/a/a/");
 
 #[crate::test]
 #[should_panic(

--- a/axum/src/routing/tests/nest.rs
+++ b/axum/src/routing/tests/nest.rs
@@ -384,8 +384,7 @@ async fn nest_with_and_without_trailing() {
 async fn nesting_with_root_inner_router() {
     let app = Router::new()
         .nest_service("/service", Router::new().route("/", get(|| async {})))
-        .nest("/router", Router::new().route("/", get(|| async {})))
-        .nest("/router-slash/", Router::new().route("/", get(|| async {})));
+        .nest("/router", Router::new().route("/", get(|| async {})));
 
     let client = TestClient::new(app);
 
@@ -408,12 +407,6 @@ async fn nesting_with_root_inner_router() {
 
     let res = client.get("/router/").await;
     assert_eq!(res.status(), StatusCode::NOT_FOUND);
-
-    let res = client.get("/router-slash").await;
-    assert_eq!(res.status(), StatusCode::NOT_FOUND);
-
-    let res = client.get("/router-slash/").await;
-    assert_eq!(res.status(), StatusCode::OK);
 }
 
 macro_rules! nested_route_test {
@@ -442,9 +435,6 @@ macro_rules! nested_route_test {
 nested_route_test!(nest_1, nest = "/a", route = "/", expected = "/a");
 nested_route_test!(nest_2, nest = "/a", route = "/a", expected = "/a/a");
 nested_route_test!(nest_3, nest = "/a", route = "/a/", expected = "/a/a/");
-nested_route_test!(nest_4, nest = "/a/", route = "/", expected = "/a/");
-nested_route_test!(nest_5, nest = "/a/", route = "/a", expected = "/a/a");
-nested_route_test!(nest_6, nest = "/a/", route = "/a/", expected = "/a/a/");
 
 #[crate::test]
 #[should_panic(

--- a/axum/src/routing/tests/nest.rs
+++ b/axum/src/routing/tests/nest.rs
@@ -380,33 +380,24 @@ async fn nest_with_and_without_trailing() {
     assert_eq!(res.status(), StatusCode::OK);
 }
 
-#[tokio::test]
+#[crate::test]
 async fn nesting_with_root_inner_router() {
-    let app = Router::new()
-        .nest_service("/service", Router::new().route("/", get(|| async {})))
-        .nest("/router", Router::new().route("/", get(|| async {})));
+    let app = Router::new().nest(
+        "/router",
+        Router::new()
+            .route("/", get(|| async { "slash" }))
+            .route("", get(|| async { "no-slash" })),
+    );
 
     let client = TestClient::new(app);
 
-    // `/service/` does match the `/service` prefix and the remaining path is technically
-    // empty, which is the same as `/` which matches `.route("/", _)`
-    let res = client.get("/service").await;
-    assert_eq!(res.status(), StatusCode::OK);
-
-    // `/service/` does match the `/service` prefix and the remaining path is `/`
-    // which matches `.route("/", _)`
-    //
-    // this is perhaps a little surprising but don't think there is much we can do
-    let res = client.get("/service/").await;
-    assert_eq!(res.status(), StatusCode::OK);
-
-    // at least it does work like you'd expect when using `nest`
-
+    // `route("")` maps to `/router` (no trailing slash)
     let res = client.get("/router").await;
-    assert_eq!(res.status(), StatusCode::OK);
+    assert_eq!(res.text().await, "no-slash");
 
+    // `route("/")` maps to `/router/` (with trailing slash)
     let res = client.get("/router/").await;
-    assert_eq!(res.status(), StatusCode::NOT_FOUND);
+    assert_eq!(res.text().await, "slash");
 }
 
 macro_rules! nested_route_test {


### PR DESCRIPTION
Fixes #2659

## Motivation

  Fixes inconsistent behavior of `Router::nest()`, making trailing slashes distinctions explicit. These are breaking changes.

  - `nest("/foo", Router::new().route("", handler))` was not possible before, and only matches `/foo` (no trailing slash)
  - `nest("/foo", Router::new().route("/", handler))` matches `/foo/` (with trailing slash)
  - `nest("/foo/", ...)` now panics, trailing slashes on the nest path are disallowed

  ## Solution
  The PR consists of 4 smaller behavioral changes:
  - Allow route("", _)
      - Needed to be able to match the nest prefix exactly without a trailing slash when using nest()
      - This commit is self contained, all tests working.
  - Panic on nesting paths ending with `/`
      - Disallows the ambiguous nest paths like `/foo/`, reducing special cases.
      - The tests are left broken by this commit, and fixed by the two test commits that follow
  - Simplify nested path route to a plain concatenation
      - Now that trailing slashes are disallowed, path_for_nested_route can be simplified to a plain concatenation
      - Tests are broken by this commit, needing the following fix commit, and the last test commit to be fixed
  - Stop adding trailing slashes when stripping prefixes from an exact match
      - Required for the `route("", _)` vs `route("/", _)` distinction to work correctly. Without this change, the path `/foo` being stripped of the prefix `/foo` turns into `/`, matching the handler on route("/", _) when it should match the one on route("", _)

The route("", _) edge case without nesting, that was recommended in the original issue to do nothing, doesn't panic, it is simply unreachable, since HTTP request paths always start with "/"

No new tests have been added, some redundant ones have been deleted, and many have been modified covering the new behaviors.