### PR TITLE
remove unused import

### DIFF
--- a/axum/src/routing/tests/get_to_head.rs
+++ b/axum/src/routing/tests/get_to_head.rs
@@ -1,6 +1,5 @@
 use super::*;
 use http::Method;
-use tower::ServiceExt;
 
 mod for_handlers {
     use super::*;


### PR DESCRIPTION
Pipeline is failing with:
```
error: unused import: `tower::ServiceExt`
 --> axum/src/routing/tests/get_to_head.rs:3:5
  |
3 | use tower::ServiceExt;
  |     ^^^^^^^^^^^^^^^^^
  |
  = note: `-D unused-imports` implied by `-D warnings`
  = help: to override `-D warnings` add `#[allow(unused_imports)]`

error: could not compile `axum` (lib test) due to 1 previous error
```