### PR TITLE
fix err very large

### DIFF
--- a/examples/consume-body-in-extractor-or-middleware/src/main.rs
+++ b/examples/consume-body-in-extractor-or-middleware/src/main.rs
@@ -38,6 +38,7 @@ async fn main() {
 }
 
 // middleware that shows how to consume the request body upfront
+#[allow(clippy::result_large_err)]
 async fn print_request_body(request: Request, next: Next) -> Result<impl IntoResponse, Response> {
     let request = buffer_request_body(request).await?;
 
@@ -46,6 +47,7 @@ async fn print_request_body(request: Request, next: Next) -> Result<impl IntoRes
 
 // the trick is to take the request apart, buffer the body, do what you need to do, then put
 // the request back together
+#[allow(clippy::result_large_err)]
 async fn buffer_request_body(request: Request) -> Result<Request, Response> {
     let (parts, body) = request.into_parts();
 


### PR DESCRIPTION
CI pipeline is failing with:
```
error: the `Err`-variant returned from this function is very large
  --> consume-body-in-extractor-or-middleware/src/main.rs:41:62
   |
41 | async fn print_request_body(request: Request, next: Next) -> Result<impl IntoResponse, Response> {
   |                                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the `Err`-variant is at least 128 bytes
   |
   = help: try reducing the size of `axum::http::Response<axum::body::Body>`, for example by boxing large elements or replacing it with `Box<axum::http::Response<axum::body::Body>>`
   = help: for further information visit https://rust-lang.github.io/rust-clippy/beta/index.html#result_large_err
   = note: `-D clippy::result-large-err` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::result_large_err)]`
```

As this is about an example, I decided to allow this.