### PR TITLE
Return 501 Not Implemented for unrecognized HTTP methods

### DIFF
--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
+- **breaking:** Requests using an unrecognized HTTP method now receive `501 Not
+  Implemented` instead of `405 Method Not Allowed` from `MethodRouter`'s default
+  fallback, per RFC 9110. Routing custom methods via `any` or a custom fallback
+  is unaffected
 - **breaking:** Router fallbacks are now properly merged for nested routers ([#3158])
 - **breaking:** `#[from_request(via(Extractor))]` now uses the extractor's
   rejection type instead of `axum::response::Response` ([#3261])

--- a/axum/src/routing/method_routing.rs
+++ b/axum/src/routing/method_routing.rs
@@ -794,11 +794,17 @@ impl<S, E> MethodRouter<S, E>
 where
     S: Clone,
 {
-    /// Create a default `MethodRouter` that will respond with `405 Method Not Allowed` to all
-    /// requests.
+    /// Create a default `MethodRouter` that will respond with `405 Method Not Allowed` to
+    /// requests using a known method, and `501 Not Implemented` to requests using an
+    /// unknown method.
     pub fn new() -> Self {
-        let fallback = Route::new(service_fn(|_: Request| async {
-            Ok(StatusCode::METHOD_NOT_ALLOWED)
+        let fallback = Route::new(service_fn(|req: Request| async move {
+            let status = if MethodFilter::try_from(req.method().clone()).is_ok() {
+                StatusCode::METHOD_NOT_ALLOWED
+            } else {
+                StatusCode::NOT_IMPLEMENTED
+            };
+            Ok(status)
         }));
 
         Self {
@@ -1404,6 +1410,29 @@ mod tests {
         let (status, _, body) = call(Method::GET, &mut svc).await;
         assert_eq!(status, StatusCode::METHOD_NOT_ALLOWED);
         assert!(body.is_empty());
+    }
+
+    #[crate::test]
+    async fn unknown_method_not_implemented_by_default() {
+        let mut svc = MethodRouter::new().get(ok);
+        let (status, _, body) = call(Method::from_bytes(b"UNKNOWN").unwrap(), &mut svc).await;
+        assert_eq!(status, StatusCode::NOT_IMPLEMENTED);
+        assert!(body.is_empty());
+    }
+
+    #[crate::test]
+    async fn any_accepts_unknown_methods() {
+        let mut svc = any(ok);
+        let (status, _, body) = call(Method::from_bytes(b"UNKNOWN").unwrap(), &mut svc).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body, "ok");
+    }
+
+    #[crate::test]
+    async fn custom_fallback_accepts_unknown_methods() {
+        let mut svc = MethodRouter::new().get(ok).fallback(created);
+        let (status, _, _) = call(Method::from_bytes(b"UNKNOWN").unwrap(), &mut svc).await;
+        assert_eq!(status, StatusCode::CREATED);
     }
 
     #[crate::test]


### PR DESCRIPTION
Per [RFC 9110](https://www.rfc-editor.org/info/rfc9110/), 405 Method Not Allowed is for methods the server recognizes but the target resource does not allow, while 501 Not Implemented is for methods the server does not recognize at all. MethodRouter's default fallback previously returned 405 for both cases.

The default fallback now returns 501 for methods that don't map to a MethodFilter, keeping 405 (with the Allow header) for known methods. Custom methods routed via `any` or a user-set fallback are unaffected, since those replace the default fallback.

Fixes #3826