### PR TITLE
feat(path): deserialize wildcard captures into Vec by splitting on /

### DIFF
--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -21,6 +21,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **added:** `IntoResponseParts` impl for `Redirect`, allowing it to be combined
   with a body in a response tuple ([#3721])
 - **added:** Add `RawPathParams::from_request_extensions` ([#3757])
+- **breaking:** `Path` now deserializes a sequence such as `Vec<String>` from a single
+  capture by splitting it on `/` (skipping empty segments), so wildcard captures can
+  be extracted as segments, both as the top-level type and as a struct field or tuple
+  element. Previously a top-level `Vec` deserialized a single capture into one element
+  and struct fields failed with an unsupported-type rejection ([#3621])
 - **changed:** `serve` has an additional generic argument and can now work with any response body
   type, not just `axum::body::Body` ([#3205])
 - **changed:** `Redirect` constructors now accept any `impl Into<String>` ([#3635])
@@ -39,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#3721]: https://github.com/tokio-rs/axum/pull/3721
 [#3742]: https://github.com/tokio-rs/axum/pull/3742
 [#3757]: https://github.com/tokio-rs/axum/pull/3757
+[#3621]: https://github.com/tokio-rs/axum/issues/3621
 
 # 0.8.9
 

--- a/axum/src/docs/routing/route.md
+++ b/axum/src/docs/routing/route.md
@@ -77,6 +77,34 @@ Note that `/{*key}` doesn't match empty segments. Thus:
 - `/{*key}` doesn't match `/` but does match `/a`, `/a/`, etc.
 - `/x/{*key}` doesn't match `/x` or `/x/` but does match `/x/a`, `/x/a/`, etc.
 
+Wildcard captures can be extracted as one string or deserialized into a
+sequence of segments:
+
+```rust
+use axum::{
+    Router,
+    routing::get,
+    extract::Path,
+};
+
+let app: Router = Router::new()
+    .route("/assets/{*path}", get(|Path(path): Path<String>| async move {
+        // for `/assets/css/main.css`, `path` is "css/main.css"
+    }))
+    .route("/files/{*segments}", get(|Path(segments): Path<Vec<String>>| async move {
+        // for `/files/foo/bar/baz`, `segments` is `["foo", "bar", "baz"]`
+    }));
+```
+
+When deserializing into a sequence, the capture is split on `/` and empty
+segments are skipped. Since captures are percent-decoded before they are
+split, a percent-encoded slash (`%2F`) also separates segments; this applies
+to any route with a single capture, not just wildcards. Note that
+`Vec<(String, String)>` keeps deserializing into the list of `(name, value)`
+pairs of all captures in the path, and that a top-level `Vec` of segments
+only applies to routes with a single capture — combine the wildcard with
+other captures using a tuple or struct instead.
+
 Wildcard captures can also be extracted using [`Path`](crate::extract::Path):
 
 ```rust

--- a/axum/src/extract/path/de.rs
+++ b/axum/src/extract/path/de.rs
@@ -4,7 +4,7 @@ use serde_core::{
     de::{self, DeserializeSeed, EnumAccess, Error, MapAccess, SeqAccess, VariantAccess, Visitor},
     forward_to_deserialize_any, Deserializer,
 };
-use std::{any::type_name, sync::Arc};
+use std::{any::type_name, str::Split, sync::Arc};
 
 macro_rules! unsupported_type {
     ($trait_fn:ident) => {
@@ -144,9 +144,29 @@ impl<'de> Deserializer<'de> for PathDeserializer<'de> {
     where
         V: Visitor<'de>,
     {
+        // A single capture, e.g. a wildcard, can also be deserialized into a
+        // sequence by splitting it on `/`. Since serde only reveals the
+        // element type once the first element is deserialized, the choice of
+        // interpretation is made there: a `(key, value)` tuple element keeps
+        // deserializing the parameter list like it does with multiple
+        // parameters, any other element type deserializes the split segments.
+        if let [(key, value)] = self.url_params {
+            let mut segments = value.split('/');
+            if let Some(first_segment) = segments.by_ref().find(|segment| !segment.is_empty()) {
+                return visitor.visit_seq(SingleParamSeqAccess {
+                    key: key.as_ref(),
+                    value: value.as_str(),
+                    first_segment,
+                    rest: segments,
+                    mode: SingleParamMode::Undecided,
+                });
+            }
+        }
+
         visitor.visit_seq(SeqDeserializer {
             params: self.url_params,
             idx: 0,
+            allow_seq: false,
         })
     }
 
@@ -162,6 +182,7 @@ impl<'de> Deserializer<'de> for PathDeserializer<'de> {
         visitor.visit_seq(SeqDeserializer {
             params: self.url_params,
             idx: 0,
+            allow_seq: true,
         })
     }
 
@@ -182,6 +203,7 @@ impl<'de> Deserializer<'de> for PathDeserializer<'de> {
         visitor.visit_seq(SeqDeserializer {
             params: self.url_params,
             idx: 0,
+            allow_seq: true,
         })
     }
 
@@ -232,7 +254,7 @@ impl<'de> Deserializer<'de> for PathDeserializer<'de> {
 struct MapDeserializer<'de> {
     params: &'de [(Arc<str>, PercentDecodedStr)],
     key: Option<KeyOrIdx<'de>>,
-    value: Option<&'de PercentDecodedStr>,
+    value: Option<&'de str>,
 }
 
 impl<'de> MapAccess<'de> for MapDeserializer<'de> {
@@ -244,7 +266,7 @@ impl<'de> MapAccess<'de> for MapDeserializer<'de> {
     {
         match self.params.split_first() {
             Some(((key, value), tail)) => {
-                self.value = Some(value);
+                self.value = Some(value.as_str());
                 self.params = tail;
                 self.key = Some(KeyOrIdx::Key(key));
                 seed.deserialize(KeyDeserializer { key }).map(Some)
@@ -261,6 +283,7 @@ impl<'de> MapAccess<'de> for MapDeserializer<'de> {
             Some(value) => seed.deserialize(ValueDeserializer {
                 key: self.key.take(),
                 value,
+                allow_seq: true,
             }),
             None => Err(PathDeserializationError::custom("value is missing")),
         }
@@ -314,19 +337,19 @@ macro_rules! parse_value {
                     let kind = match key {
                         KeyOrIdx::Key(key) => ErrorKind::ParseErrorAtKey {
                             key: key.to_owned(),
-                            value: self.value.as_str().to_owned(),
+                            value: self.value.to_owned(),
                             expected_type: $ty,
                         },
                         KeyOrIdx::Idx { idx: index, key: _ } => ErrorKind::ParseErrorAtIndex {
                             index,
-                            value: self.value.as_str().to_owned(),
+                            value: self.value.to_owned(),
                             expected_type: $ty,
                         },
                     };
                     PathDeserializationError::new(kind)
                 } else {
                     PathDeserializationError::new(ErrorKind::ParseError {
-                        value: self.value.as_str().to_owned(),
+                        value: self.value.to_owned(),
                         expected_type: $ty,
                     })
                 }
@@ -339,7 +362,11 @@ macro_rules! parse_value {
 #[derive(Debug)]
 struct ValueDeserializer<'de> {
     key: Option<KeyOrIdx<'de>>,
-    value: &'de PercentDecodedStr,
+    value: &'de str,
+    /// Whether the value may be split on `/` and deserialized into a
+    /// sequence. This only applies one level deep: a split segment cannot be
+    /// split again, keeping nested sequences unsupported.
+    allow_seq: bool,
 }
 
 impl<'de> Deserializer<'de> for ValueDeserializer<'de> {
@@ -382,7 +409,7 @@ impl<'de> Deserializer<'de> for ValueDeserializer<'de> {
                 if let (ErrorKind::Message(message), Some(key)) = (&e.kind, self.key.as_ref()) {
                     PathDeserializationError::new(ErrorKind::DeserializeError {
                         key: key.key().to_owned(),
-                        value: self.value.as_str().to_owned(),
+                        value: self.value.to_owned(),
                         message: message.to_owned(),
                     })
                 } else {
@@ -440,7 +467,7 @@ impl<'de> Deserializer<'de> for ValueDeserializer<'de> {
     {
         struct PairDeserializer<'de> {
             key: Option<KeyOrIdx<'de>>,
-            value: Option<&'de PercentDecodedStr>,
+            value: Option<&'de str>,
         }
 
         impl<'de> SeqAccess<'de> for PairDeserializer<'de> {
@@ -464,7 +491,13 @@ impl<'de> Deserializer<'de> for ValueDeserializer<'de> {
 
                 self.value
                     .take()
-                    .map(|value| seed.deserialize(ValueDeserializer { key: None, value }))
+                    .map(|value| {
+                        seed.deserialize(ValueDeserializer {
+                            key: None,
+                            value,
+                            allow_seq: false,
+                        })
+                    })
                     .transpose()
             }
         }
@@ -486,13 +519,20 @@ impl<'de> Deserializer<'de> for ValueDeserializer<'de> {
         }
     }
 
-    fn deserialize_seq<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    fn deserialize_seq<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
         V: Visitor<'de>,
     {
-        Err(PathDeserializationError::unsupported_type(type_name::<
-            V::Value,
-        >()))
+        if !self.allow_seq {
+            return Err(PathDeserializationError::unsupported_type(type_name::<
+                V::Value,
+            >()));
+        }
+
+        visitor.visit_seq(SplitValueSeqAccess {
+            key: self.key.as_ref().map(|key| KeyOrIdx::Key(key.key())),
+            segments: self.value.split('/'),
+        })
     }
 
     fn deserialize_tuple_struct<V>(
@@ -606,6 +646,10 @@ impl<'de> VariantAccess<'de> for UnitVariant {
 struct SeqDeserializer<'de> {
     params: &'de [(Arc<str>, PercentDecodedStr)],
     idx: usize,
+    /// `allow_seq` for the element deserializers: a tuple position may split
+    /// its value into a sequence, an element of a sequence may not, keeping
+    /// nested sequences unsupported.
+    allow_seq: bool,
 }
 
 impl<'de> SeqAccess<'de> for SeqDeserializer<'de> {
@@ -622,11 +666,231 @@ impl<'de> SeqAccess<'de> for SeqDeserializer<'de> {
                 self.idx += 1;
                 Ok(Some(seed.deserialize(ValueDeserializer {
                     key: Some(KeyOrIdx::Idx { idx, key }),
-                    value,
+                    value: value.as_str(),
+                    allow_seq: self.allow_seq,
                 })?))
             }
             None => Ok(None),
         }
+    }
+}
+
+/// [`SeqAccess`] deserializing a single value, e.g. a wildcard capture, into
+/// a sequence by splitting it on `/`.
+///
+/// Empty segments are skipped, so captures with leading, trailing, or
+/// consecutive slashes don't produce empty elements.
+struct SplitValueSeqAccess<'de> {
+    key: Option<KeyOrIdx<'de>>,
+    segments: Split<'de, char>,
+}
+
+impl<'de> SeqAccess<'de> for SplitValueSeqAccess<'de> {
+    type Error = PathDeserializationError;
+
+    fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, Self::Error>
+    where
+        T: DeserializeSeed<'de>,
+    {
+        for segment in self.segments.by_ref() {
+            if !segment.is_empty() {
+                return seed
+                    .deserialize(ValueDeserializer {
+                        key: self.key.clone(),
+                        value: segment,
+                        allow_seq: false,
+                    })
+                    .map(Some);
+            }
+        }
+
+        Ok(None)
+    }
+}
+
+enum SingleParamMode {
+    Undecided,
+    Split,
+    Done,
+}
+
+/// [`SeqAccess`] used when deserializing a sequence from exactly one
+/// parameter.
+///
+/// A sequence of `(key, value)` pairs deserializes the parameter list, like
+/// it does when there are multiple parameters, while any other element type
+/// deserializes the parameter's value split on `/`, which is how wildcard
+/// captures are deserialized into `Vec<T>`. Since serde only reveals the
+/// element type once the first element is deserialized, the choice between
+/// the two is made by [`FirstElementDeserializer`].
+struct SingleParamSeqAccess<'de> {
+    key: &'de str,
+    value: &'de str,
+    first_segment: &'de str,
+    rest: Split<'de, char>,
+    mode: SingleParamMode,
+}
+
+impl<'de> SeqAccess<'de> for SingleParamSeqAccess<'de> {
+    type Error = PathDeserializationError;
+
+    fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, Self::Error>
+    where
+        T: DeserializeSeed<'de>,
+    {
+        match self.mode {
+            SingleParamMode::Undecided => seed
+                .deserialize(FirstElementDeserializer { access: self })
+                .map(Some),
+            SingleParamMode::Split => self
+                .rest
+                .by_ref()
+                .find(|segment| !segment.is_empty())
+                .map(|segment| {
+                    seed.deserialize(ValueDeserializer {
+                        key: Some(KeyOrIdx::Key(self.key)),
+                        value: segment,
+                        allow_seq: false,
+                    })
+                })
+                .transpose(),
+            SingleParamMode::Done => Ok(None),
+        }
+    }
+}
+
+macro_rules! forward_to_split_value {
+    ($($trait_fn:ident)*) => {
+        $(
+            fn $trait_fn<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+            where
+                V: Visitor<'de>,
+            {
+                self.split_value().$trait_fn(visitor)
+            }
+        )*
+    };
+}
+
+/// Deserializer for the first element of a [`SingleParamSeqAccess`], which
+/// commits the sequence to one of the two interpretations based on the
+/// element type.
+struct FirstElementDeserializer<'a, 'de> {
+    access: &'a mut SingleParamSeqAccess<'de>,
+}
+
+impl<'de> FirstElementDeserializer<'_, 'de> {
+    /// Commit to deserializing the split segments of the parameter's value.
+    fn split_value(self) -> ValueDeserializer<'de> {
+        self.access.mode = SingleParamMode::Split;
+        ValueDeserializer {
+            key: Some(KeyOrIdx::Key(self.access.key)),
+            value: self.access.first_segment,
+            allow_seq: false,
+        }
+    }
+}
+
+impl<'de> Deserializer<'de> for FirstElementDeserializer<'_, 'de> {
+    type Error = PathDeserializationError;
+
+    forward_to_split_value!(
+        deserialize_any deserialize_bool
+        deserialize_i8 deserialize_i16 deserialize_i32 deserialize_i64 deserialize_i128
+        deserialize_u8 deserialize_u16 deserialize_u32 deserialize_u64 deserialize_u128
+        deserialize_f32 deserialize_f64
+        deserialize_char deserialize_str deserialize_string
+        deserialize_bytes deserialize_byte_buf
+        deserialize_unit deserialize_seq deserialize_map
+        deserialize_identifier deserialize_ignored_any
+    );
+
+    fn deserialize_tuple<V>(self, len: usize, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        // Commit to deserializing the parameter list into `(key, value)`
+        // pairs, preserving how a single parameter deserialized into
+        // `Vec<(String, String)>` before sequences of split segments were
+        // supported.
+        self.access.mode = SingleParamMode::Done;
+        ValueDeserializer {
+            key: Some(KeyOrIdx::Idx {
+                idx: 0,
+                key: self.access.key,
+            }),
+            value: self.access.value,
+            allow_seq: false,
+        }
+        .deserialize_tuple(len, visitor)
+    }
+
+    fn deserialize_unit_struct<V>(
+        self,
+        name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.split_value().deserialize_unit_struct(name, visitor)
+    }
+
+    fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        // Defer the choice of interpretation to the inner type.
+        visitor.visit_some(self)
+    }
+
+    fn deserialize_newtype_struct<V>(
+        self,
+        _name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        // Defer the choice of interpretation to the inner type.
+        visitor.visit_newtype_struct(self)
+    }
+
+    fn deserialize_tuple_struct<V>(
+        self,
+        name: &'static str,
+        len: usize,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.split_value()
+            .deserialize_tuple_struct(name, len, visitor)
+    }
+
+    fn deserialize_struct<V>(
+        self,
+        name: &'static str,
+        fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.split_value().deserialize_struct(name, fields, visitor)
+    }
+
+    fn deserialize_enum<V>(
+        self,
+        name: &'static str,
+        variants: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.split_value().deserialize_enum(name, variants, visitor)
     }
 }
 
@@ -766,6 +1030,154 @@ mod tests {
                 ("a".to_owned(), "foo".to_owned()),
                 ("b".to_owned(), "bar".to_owned())
             ]
+        );
+    }
+
+    #[test]
+    fn test_parse_wildcard_seq() {
+        let url_params = create_url_params(vec![("path", "x/y/z")]);
+        assert_eq!(
+            <Vec<String>>::deserialize(PathDeserializer::new(&url_params)).unwrap(),
+            vec!["x".to_owned(), "y".to_owned(), "z".to_owned()]
+        );
+
+        let url_params = create_url_params(vec![("ids", "1/-2/3")]);
+        assert_eq!(
+            <Vec<i32>>::deserialize(PathDeserializer::new(&url_params)).unwrap(),
+            vec![1, -2, 3]
+        );
+
+        let url_params = create_url_params(vec![("path", "A/B/c")]);
+        assert_eq!(
+            <Vec<MyEnum>>::deserialize(PathDeserializer::new(&url_params)).unwrap(),
+            vec![MyEnum::A, MyEnum::B, MyEnum::C]
+        );
+
+        // a value without any `/` deserializes into a single element
+        let url_params = create_url_params(vec![("path", "x")]);
+        assert_eq!(
+            <Vec<String>>::deserialize(PathDeserializer::new(&url_params)).unwrap(),
+            vec!["x".to_owned()]
+        );
+    }
+
+    #[test]
+    fn test_parse_wildcard_seq_empty_segments() {
+        for (value, expected) in [
+            ("x/", vec!["x"]),
+            ("/x", vec!["x"]),
+            ("x//y", vec!["x", "y"]),
+            ("x/y/", vec!["x", "y"]),
+        ] {
+            let url_params = create_url_params(vec![("path", value)]);
+            assert_eq!(
+                <Vec<String>>::deserialize(PathDeserializer::new(&url_params)).unwrap(),
+                expected,
+                "for {value:?}"
+            );
+        }
+
+        // values without any non-empty segment keep deserializing each
+        // parameter into one element
+        for value in ["", "/", "//"] {
+            let url_params = create_url_params(vec![("path", value)]);
+            assert_eq!(
+                <Vec<String>>::deserialize(PathDeserializer::new(&url_params)).unwrap(),
+                vec![value.to_owned()],
+                "for {value:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_parse_wildcard_seq_in_struct() {
+        #[derive(Debug, Deserialize, Eq, PartialEq)]
+        struct Params {
+            bucket: String,
+            key: Vec<String>,
+        }
+
+        let url_params = create_url_params(vec![("bucket", "my-bucket"), ("key", "a/b/c")]);
+        assert_eq!(
+            Params::deserialize(PathDeserializer::new(&url_params)).unwrap(),
+            Params {
+                bucket: "my-bucket".to_owned(),
+                key: vec!["a".to_owned(), "b".to_owned(), "c".to_owned()],
+            }
+        );
+    }
+
+    #[test]
+    fn test_parse_wildcard_seq_in_tuple() {
+        let url_params = create_url_params(vec![("bucket", "my-bucket"), ("key", "a/b")]);
+        assert_eq!(
+            <(String, Vec<String>)>::deserialize(PathDeserializer::new(&url_params)).unwrap(),
+            ("my-bucket".to_owned(), vec!["a".to_owned(), "b".to_owned()])
+        );
+
+        // empty segments are skipped in tuple position too
+        let url_params = create_url_params(vec![("bucket", "my-bucket"), ("key", "a/")]);
+        assert_eq!(
+            <(String, Vec<String>)>::deserialize(PathDeserializer::new(&url_params)).unwrap(),
+            ("my-bucket".to_owned(), vec!["a".to_owned()])
+        );
+    }
+
+    #[test]
+    fn test_parse_wildcard_seq_newtype_element() {
+        #[derive(Debug, Deserialize, Eq, PartialEq)]
+        struct Seg(String);
+
+        let url_params = create_url_params(vec![("path", "x/y")]);
+        assert_eq!(
+            <Vec<Seg>>::deserialize(PathDeserializer::new(&url_params)).unwrap(),
+            vec![Seg("x".to_owned()), Seg("y".to_owned())]
+        );
+    }
+
+    #[test]
+    fn test_parse_wildcard_seq_all_empty_segments_in_struct() {
+        #[derive(Debug, Deserialize, Eq, PartialEq)]
+        struct Params {
+            key: Vec<String>,
+        }
+
+        let url_params = create_url_params(vec![("key", "/")]);
+        assert_eq!(
+            Params::deserialize(PathDeserializer::new(&url_params)).unwrap(),
+            Params { key: vec![] }
+        );
+    }
+
+    #[test]
+    fn test_parse_seq_tuple_wrapped_pair_single_param() {
+        // the pair interpretation also applies to `Option`- or
+        // newtype-wrapped pairs
+        let url_params = create_url_params(vec![("a", "foo/bar")]);
+        assert_eq!(
+            <Vec<Option<(String, String)>>>::deserialize(PathDeserializer::new(&url_params))
+                .unwrap(),
+            vec![Some(("a".to_owned(), "foo/bar".to_owned()))]
+        );
+
+        #[derive(Debug, Deserialize, Eq, PartialEq)]
+        struct Pair((String, String));
+
+        let url_params = create_url_params(vec![("a", "foo/bar")]);
+        assert_eq!(
+            <Vec<Pair>>::deserialize(PathDeserializer::new(&url_params)).unwrap(),
+            vec![Pair(("a".to_owned(), "foo/bar".to_owned()))]
+        );
+    }
+
+    #[test]
+    fn test_parse_seq_tuple_string_string_single_param() {
+        // a single parameter still deserializes into `(key, value)` pairs,
+        // even if its value contains `/`
+        let url_params = create_url_params(vec![("a", "foo/bar")]);
+        assert_eq!(
+            <Vec<(String, String)>>::deserialize(PathDeserializer::new(&url_params)).unwrap(),
+            vec![("a".to_owned(), "foo/bar".to_owned())]
         );
     }
 
@@ -942,6 +1354,19 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_wildcard_seq_parse_error() {
+        test_parse_error!(
+            vec![("ids", "1/x/3")],
+            Vec<i32>,
+            ErrorKind::ParseErrorAtKey {
+                key: "ids".to_owned(),
+                value: "x".to_owned(),
+                expected_type: "i32",
+            }
+        );
+    }
+
+    #[test]
     fn test_parse_seq_wrong_tuple_length() {
         test_parse_error!(
             vec![("a", "false")],
@@ -956,6 +1381,15 @@ mod tests {
     fn test_parse_seq_seq() {
         test_parse_error!(
             vec![("a", "false")],
+            Vec<Vec<String>>,
+            ErrorKind::UnsupportedType {
+                name: "alloc::vec::Vec<alloc::string::String>",
+            }
+        );
+
+        // nested sequences are also unsupported with multiple parameters
+        test_parse_error!(
+            vec![("a", "x/y"), ("b", "z")],
             Vec<Vec<String>>,
             ErrorKind::UnsupportedType {
                 name: "alloc::vec::Vec<alloc::string::String>",

--- a/axum/src/extract/path/mod.rs
+++ b/axum/src/extract/path/mod.rs
@@ -883,6 +883,48 @@ mod tests {
     }
 
     #[crate::test]
+    async fn deserialize_wildcard_into_vec() {
+        let app = Router::new().route(
+            "/files/{*path}",
+            get(|Path(segments): Path<Vec<String>>| async move { segments.join(",") }),
+        );
+
+        let client = TestClient::new(app);
+
+        let res = client.get("/files/a/b/c").await;
+        assert_eq!(res.status(), StatusCode::OK);
+        assert_eq!(res.text().await, "a,b,c");
+
+        // captures are percent-decoded before they are split, so an encoded
+        // slash also separates segments
+        let res = client.get("/files/a%20b/c%2Fd").await;
+        assert_eq!(res.status(), StatusCode::OK);
+        assert_eq!(res.text().await, "a b,c,d");
+    }
+
+    #[crate::test]
+    async fn deserialize_wildcard_into_vec_in_struct() {
+        #[derive(Deserialize)]
+        struct Params {
+            bucket: String,
+            key: Vec<u32>,
+        }
+
+        let app = Router::new().route(
+            "/{bucket}/{*key}",
+            get(|Path(Params { bucket, key }): Path<Params>| async move {
+                assert_eq!(bucket, "my-bucket");
+                assert_eq!(key, [1, 2, 3]);
+            }),
+        );
+
+        let client = TestClient::new(app);
+
+        let res = client.get("/my-bucket/1/2/3").await;
+        assert_eq!(res.status(), StatusCode::OK);
+    }
+
+    #[crate::test]
     async fn type_that_uses_deserialize_any() {
         use time::Date;
 


### PR DESCRIPTION
Fixes #3621

## Motivation

When a route uses a wildcard capture like `/{*path}`, there's no ergonomic way to extract the individual path segments. A `Path<Vec<String>>` deserializes a single capture into a one-element vector containing the entire matched string, and using a `Vec<T>` inside a struct field (e.g., `struct Params { key: Vec<String> }`) fails with an unsupported-type rejection.

Users working with file-system-like routes (`/files/{*path}`) or S3-style APIs (`/{bucket}/{*key}`) need to manually split the captured string, which is boilerplate-heavy and error-prone.

## Solution

When a route has a **single path parameter** (typically a wildcard), the `Path` extractor now splits the captured value on `/` and deserializes each non-empty segment individually into the target sequence type. This works for:

- **Top-level**: `Path<Vec<String>>`, `Path<Vec<i32>>`, etc.
- **Struct fields**: `struct Params { bucket: String, key: Vec<String> }`
- **Tuple elements**: `(String, Vec<String>)`

### Key design decisions

- **Empty segments are skipped** — trailing slashes and double slashes don't produce empty strings in the output.
- **`Vec<(String, String)>` is unaffected** — it continues to deserialize into `(name, value)` pairs of all captures, preserving backward compatibility.
- **Percent-decoding happens before splitting** — since `matchit` delivers percent-decoded values, an encoded `/` (`%2F`) also acts as a separator.
- **All-empty segments edge case** — when the value has only empty segments (e.g., `/`), the behavior depends on context: in a struct field the result is an empty `Vec`, while at the top level the original single-element behavior is preserved.

