### PR TITLE
fix(serve): include WebSocket tasks in graceful shutdown

### DIFF
--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -25,7 +25,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   type, not just `axum::body::Body` ([#3205])
 - **changed:** `Redirect` constructors now accept any `impl Into<String>` ([#3635])
 - **changed:** Updated `matchit` allowing for routes with captures and static prefixes and suffixes ([#3702])
+- **changed:** `Serve::with_graceful_shutdown` now includes WebSocket connections in the drain:
+  open sockets are sent a close frame and the server waits for their handler tasks. A handler
+  that never returns will now hold shutdown open (as with any in-flight response body) ([#3003])
 - **fixed:** Responses to `HEAD` will not accidentally reply with `content-length: 0` anymore ([#3742])
+- **fixed:** graceful shutdown no longer ignores WebSocket handler tasks; the server now waits
+  for them and initiates a close handshake on open sockets ([#3003])
 
 [#3158]: https://github.com/tokio-rs/axum/pull/3158
 [#3261]: https://github.com/tokio-rs/axum/pull/3261
@@ -39,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#3721]: https://github.com/tokio-rs/axum/pull/3721
 [#3742]: https://github.com/tokio-rs/axum/pull/3742
 [#3757]: https://github.com/tokio-rs/axum/pull/3757
+[#3003]: https://github.com/tokio-rs/axum/issues/3003
 
 # 0.8.9
 

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -25,12 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   type, not just `axum::body::Body` ([#3205])
 - **changed:** `Redirect` constructors now accept any `impl Into<String>` ([#3635])
 - **changed:** Updated `matchit` allowing for routes with captures and static prefixes and suffixes ([#3702])
-- **changed:** `Serve::with_graceful_shutdown` now includes WebSocket connections in the drain:
-  open sockets are sent a close frame and the server waits for their handler tasks. A handler
-  that never returns will now hold shutdown open (as with any in-flight response body) ([#3831])
 - **fixed:** Responses to `HEAD` will not accidentally reply with `content-length: 0` anymore ([#3742])
-- **fixed:** graceful shutdown no longer ignores WebSocket handler tasks; the server now waits
-  for them and initiates a close handshake on open sockets ([#3831])
+- **fixed:** `Serve::with_graceful_shutdown` now waits for WebSocket handler tasks and sends open
+  sockets a close frame, rather than leaving them running once the server has shut down. A handler
+  that never returns will now hold shutdown open, as with any in-flight response body ([#3831])
 
 [#3158]: https://github.com/tokio-rs/axum/pull/3158
 [#3261]: https://github.com/tokio-rs/axum/pull/3261

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -27,10 +27,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **changed:** Updated `matchit` allowing for routes with captures and static prefixes and suffixes ([#3702])
 - **changed:** `Serve::with_graceful_shutdown` now includes WebSocket connections in the drain:
   open sockets are sent a close frame and the server waits for their handler tasks. A handler
-  that never returns will now hold shutdown open (as with any in-flight response body) ([#3003])
+  that never returns will now hold shutdown open (as with any in-flight response body) ([#3831])
 - **fixed:** Responses to `HEAD` will not accidentally reply with `content-length: 0` anymore ([#3742])
 - **fixed:** graceful shutdown no longer ignores WebSocket handler tasks; the server now waits
-  for them and initiates a close handshake on open sockets ([#3003])
+  for them and initiates a close handshake on open sockets ([#3831])
 
 [#3158]: https://github.com/tokio-rs/axum/pull/3158
 [#3261]: https://github.com/tokio-rs/axum/pull/3261
@@ -44,7 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#3721]: https://github.com/tokio-rs/axum/pull/3721
 [#3742]: https://github.com/tokio-rs/axum/pull/3742
 [#3757]: https://github.com/tokio-rs/axum/pull/3757
-[#3003]: https://github.com/tokio-rs/axum/issues/3003
+[#3831]: https://github.com/tokio-rs/axum/pull/3831
 
 # 0.8.9
 

--- a/axum/src/extract/ws.rs
+++ b/axum/src/extract/ws.rs
@@ -88,11 +88,32 @@
 //! }
 //! ```
 //!
+//! # Graceful shutdown
+//!
+//! When the server is run with [`axum::serve`] and
+//! [`Serve::with_graceful_shutdown`], WebSocket connections take part in the
+//! shutdown. Once the shutdown signal fires, each open [`WebSocket`] sends a
+//! Close frame to its peer, and the server waits for the handler tasks to
+//! finish before resolving.
+//!
+//! In practice this means a handler with the usual read loop needs no changes:
+//! after the Close handshake completes, [`WebSocket::recv`] returns `None` and
+//! the loop ends. Handlers should treat `None` (or an `Err`) from `recv` as a
+//! signal to return. A handler that never polls the socket and never returns
+//! will still hold shutdown open, just like any other in-flight response body
+//! (Server-Sent Events behave the same way).
+//!
 //! [`StreamExt::split`]: https://docs.rs/futures/0.3.17/futures/stream/trait.StreamExt.html#method.split
+//! [`axum::serve`]: crate::serve()
+//! [`Serve::with_graceful_shutdown`]: crate::serve::Serve::with_graceful_shutdown
 
 use self::rejection::*;
 use super::FromRequestParts;
 use crate::{body::Bytes, response::Response, Error};
+// Only available when `axum::serve` is compiled in; the `ws` feature does not
+// imply `http1`/`http2`, so this must be gated exactly like the `serve` module.
+#[cfg(all(feature = "tokio", any(feature = "http1", feature = "http2")))]
+use crate::serve::GracefulPeer;
 use axum_core::body::Body;
 use futures_core::{FusedStream, Stream};
 use futures_sink::Sink;
@@ -140,6 +161,10 @@ pub struct WebSocketUpgrade<F = DefaultOnFailedUpgrade> {
     on_upgrade: hyper::upgrade::OnUpgrade,
     on_failed_upgrade: F,
     sec_websocket_protocol: BTreeSet<HeaderValue>,
+    /// Set when `axum::serve` is running with graceful shutdown; lets the
+    /// resulting socket participate in it. See [`GracefulPeer`].
+    #[cfg(all(feature = "tokio", any(feature = "http1", feature = "http2")))]
+    graceful: Option<GracefulPeer>,
 }
 
 impl<F> std::fmt::Debug for WebSocketUpgrade<F> {
@@ -337,11 +362,34 @@ impl<F> WebSocketUpgrade<F> {
             on_upgrade: self.on_upgrade,
             on_failed_upgrade: callback,
             sec_websocket_protocol: self.sec_websocket_protocol,
+            #[cfg(all(feature = "tokio", any(feature = "http1", feature = "http2")))]
+            graceful: self.graceful,
         }
     }
 
     /// Finalize upgrading the connection and call the provided callback with
     /// the stream.
+    ///
+    /// # Graceful shutdown
+    ///
+    /// When the server is run with [`axum::serve`] and
+    /// [`with_graceful_shutdown`], the spawned handler task participates in the
+    /// shutdown:
+    ///
+    /// * the server waits for this task to finish before resolving, and
+    /// * once shutdown begins the [`WebSocket`] automatically sends a Close
+    ///   frame to the peer.
+    ///
+    /// A handler that reads from the socket in the usual way — e.g.
+    /// `while let Some(msg) = socket.recv().await { .. }` — will therefore
+    /// observe the stream end and return on its own. A handler that never polls
+    /// the socket and never returns will still block shutdown, the same as any
+    /// other in-flight response body.
+    ///
+    /// See the [module docs](self) and [`axum::serve`] for details.
+    ///
+    /// [`axum::serve`]: crate::serve()
+    /// [`with_graceful_shutdown`]: crate::serve::Serve::with_graceful_shutdown
     #[must_use = "to set up the WebSocket connection, this response must be returned"]
     pub fn on_upgrade<C, Fut>(self, callback: C) -> Response
     where
@@ -355,7 +403,31 @@ impl<F> WebSocketUpgrade<F> {
 
         let protocol = self.protocol.clone();
 
+        // Derive the graceful-shutdown observer and the guard that keeps the
+        // server draining until this task ends. Both are `None` (a no-op) when
+        // graceful shutdown is not configured.
+        #[cfg(all(feature = "tokio", any(feature = "http1", feature = "http2")))]
+        let (shutdown, guard) = match self.graceful {
+            Some(peer) => {
+                let mut rx = peer.shutdown;
+                let shutdown: Pin<Box<dyn Future<Output = ()> + Send>> = Box::pin(async move {
+                    // Either a value is sent or all senders drop; both mean
+                    // "shutdown has begun".
+                    let _ = rx.changed().await;
+                });
+                (Some(shutdown), Some(peer.guard))
+            }
+            None => (None, None),
+        };
+        #[cfg(not(all(feature = "tokio", any(feature = "http1", feature = "http2"))))]
+        let shutdown: Option<Pin<Box<dyn Future<Output = ()> + Send>>> = None;
+
         tokio::spawn(async move {
+            // Hold the guard (if any) for the whole task so that
+            // `close_tx.closed()` in `axum::serve` waits for this handler.
+            #[cfg(all(feature = "tokio", any(feature = "http1", feature = "http2")))]
+            let _guard = guard;
+
             let upgraded = match on_upgrade.await {
                 Ok(upgraded) => upgraded,
                 Err(err) => {
@@ -371,6 +443,8 @@ impl<F> WebSocketUpgrade<F> {
             let socket = WebSocket {
                 inner: socket,
                 protocol,
+                shutdown,
+                close_state: CloseState::Idle,
             };
             callback(socket).await;
         });
@@ -494,6 +568,11 @@ where
             .remove::<hyper::upgrade::OnUpgrade>()
             .ok_or(ConnectionNotUpgradable)?;
 
+        // Present only when `axum::serve` is draining gracefully; see
+        // `GracefulPeer`.
+        #[cfg(all(feature = "tokio", any(feature = "http1", feature = "http2")))]
+        let graceful = parts.extensions.get::<GracefulPeer>().cloned();
+
         let sec_websocket_protocol = parts
             .headers
             .get_all(header::SEC_WEBSOCKET_PROTOCOL)
@@ -512,6 +591,8 @@ where
             on_upgrade,
             sec_websocket_protocol,
             on_failed_upgrade: DefaultOnFailedUpgrade,
+            #[cfg(all(feature = "tokio", any(feature = "http1", feature = "http2")))]
+            graceful,
         })
     }
 }
@@ -539,10 +620,38 @@ fn header_contains(headers: &HeaderMap, key: &HeaderName, value: &'static str) -
 /// A stream of WebSocket messages.
 ///
 /// See [the module level documentation](self) for more details.
-#[derive(Debug)]
 pub struct WebSocket {
     inner: WebSocketStream<TokioIo<hyper::upgrade::Upgraded>>,
     protocol: Option<HeaderValue>,
+    /// Resolves once a graceful shutdown has begun, prompting the socket to
+    /// send a Close frame. `None` when graceful shutdown is not configured, in
+    /// which case the socket behaves exactly as before.
+    shutdown: Option<Pin<Box<dyn Future<Output = ()> + Send>>>,
+    /// Tracks progress of the shutdown-initiated Close handshake.
+    close_state: CloseState,
+}
+
+/// Progress of the Close frame that the socket sends when graceful shutdown
+/// begins. See [`WebSocket`]'s [`Stream`] implementation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum CloseState {
+    /// No Close has been initiated (the default, and the terminal state once
+    /// the Close has been handed off or abandoned).
+    Idle,
+    /// Shutdown observed; a Close frame still needs to be enqueued.
+    Queued,
+    /// Close frame enqueued; flushing it out (best-effort).
+    Flushing,
+}
+
+impl std::fmt::Debug for WebSocket {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("WebSocket")
+            .field("inner", &self.inner)
+            .field("protocol", &self.protocol)
+            .field("close_state", &self.close_state)
+            .finish_non_exhaustive()
+    }
 }
 
 impl WebSocket {
@@ -588,9 +697,52 @@ impl FusedStream for WebSocket {
 impl Stream for WebSocket {
     type Item = Result<Message, Error>;
 
-    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        // `WebSocket` is `Unpin`, so we can operate on the fields directly.
+        let this = self.get_mut();
+
+        // If a graceful shutdown has begun, kick off the WebSocket closing
+        // handshake by sending a Close frame. This is best-effort: reads keep
+        // flowing afterwards, so the peer's Close response is still observed and
+        // the stream terminates, ending typical `recv` loops. A socket that is
+        // already closing simply skips this.
+        let shutdown_fired = match this.shutdown.as_mut() {
+            Some(shutdown) => shutdown.as_mut().poll(cx).is_ready(),
+            None => false,
+        };
+        if shutdown_fired {
+            // Do not poll the completed future again.
+            this.shutdown = None;
+            this.close_state = CloseState::Queued;
+        }
+
+        if this.close_state == CloseState::Queued {
+            match this.inner.poll_ready_unpin(cx) {
+                Poll::Ready(Ok(())) => {
+                    this.close_state = match this.inner.start_send_unpin(ts::Message::Close(None)) {
+                        Ok(()) => CloseState::Flushing,
+                        // Socket already closing/closed; nothing more to do.
+                        Err(_) => CloseState::Idle,
+                    };
+                }
+                // Already closing/closed; give up on sending our own Close.
+                Poll::Ready(Err(_)) => this.close_state = CloseState::Idle,
+                // Cannot buffer the Close yet; retry on a later poll. Fall
+                // through to reading so the connection keeps making progress.
+                Poll::Pending => {}
+            }
+        }
+
+        if this.close_state == CloseState::Flushing {
+            // Best-effort: if the flush is still pending the frame stays
+            // buffered and is driven out as the stream continues to be polled.
+            if this.inner.poll_flush_unpin(cx).is_ready() {
+                this.close_state = CloseState::Idle;
+            }
+        }
+
         loop {
-            match ready!(self.inner.poll_next_unpin(cx)) {
+            match ready!(this.inner.poll_next_unpin(cx)) {
                 Some(Ok(msg)) => {
                     if let Some(msg) = Message::from_tungstenite(msg) {
                         return Poll::Ready(Some(Ok(msg)));
@@ -1263,5 +1415,204 @@ mod tests {
             output,
             tungstenite::Message::Pong(Bytes::from_static(b"ping"))
         );
+    }
+
+    // Graceful-shutdown interaction. These need `axum::serve`, which is only
+    // available with `http1`/`http2` (the `ws` feature alone does not imply it).
+    #[cfg(all(feature = "tokio", any(feature = "http1", feature = "http2")))]
+    mod graceful_shutdown {
+        use super::*;
+        use crate::routing::any;
+        use std::future::IntoFuture as _;
+        use std::sync::Arc;
+        use std::time::Duration;
+        use tokio::net::{TcpListener, TcpStream};
+
+        async fn connect(addr: std::net::SocketAddr) -> WebSocketStream<TcpStream> {
+            let uri: http::Uri = format!("ws://{addr}/ws").try_into().unwrap();
+            let req = tungstenite::client::ClientRequestBuilder::new(uri);
+            let tcp = TcpStream::connect(addr).await.unwrap();
+            let (client, _resp) = tokio_tungstenite::client_async(req, tcp).await.unwrap();
+            client
+        }
+
+        // Drives the client to completion, returning whether a Close frame was
+        // observed. Reading to the end also flushes the client's own Close reply
+        // so the server's handshake (and thus the server) can complete.
+        async fn drain_until_closed(mut client: WebSocketStream<TcpStream>) -> bool {
+            let mut saw_close = false;
+            loop {
+                let next = tokio::time::timeout(Duration::from_secs(5), client.next())
+                    .await
+                    .expect("timed out waiting for client to read");
+                match next {
+                    Some(Ok(msg)) => {
+                        if msg.is_close() {
+                            saw_close = true;
+                        }
+                    }
+                    Some(Err(_)) | None => break,
+                }
+            }
+            saw_close
+        }
+
+        async fn assert_finished(marker: &Arc<()>) {
+            let mut count = Arc::strong_count(marker);
+            for _ in 0..50 {
+                if count == 1 {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+                count = Arc::strong_count(marker);
+            }
+            assert_eq!(count, 1, "WebSocket handler task did not finish");
+        }
+
+        // Regression test for https://github.com/tokio-rs/axum/issues/3003.
+        //
+        // A WebSocket handler looping on `recv()` used to be ignored by graceful
+        // shutdown: the upgraded task was detached, so the `serve` future
+        // returned while the handler kept running. Now the socket is sent a
+        // Close frame and the server waits for the handler task to finish.
+        #[crate::test]
+        async fn waits_for_websocket_and_closes_it() {
+            let marker = Arc::new(());
+
+            let app = {
+                let marker = marker.clone();
+                crate::Router::new().route(
+                    "/ws",
+                    any(move |ws: WebSocketUpgrade| {
+                        let marker = marker.clone();
+                        async move {
+                            ws.on_upgrade(move |mut socket| async move {
+                                // Held for the lifetime of the handler task so
+                                // we can observe (via strong_count) that it
+                                // really finished.
+                                let _marker = marker;
+                                while let Some(Ok(_)) = socket.recv().await {}
+                            })
+                        }
+                    }),
+                )
+            };
+
+            let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let addr = listener.local_addr().unwrap();
+
+            let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+            let server = tokio::spawn(
+                crate::serve(listener, app)
+                    .with_graceful_shutdown(async move {
+                        let _ = shutdown_rx.await;
+                    })
+                    .into_future(),
+            );
+
+            let client = connect(addr).await;
+
+            // Make sure the upgrade task is running and parked on `recv()`.
+            tokio::time::sleep(Duration::from_millis(50)).await;
+
+            // Trigger graceful shutdown.
+            shutdown_tx.send(()).unwrap();
+
+            let client_task = tokio::spawn(drain_until_closed(client));
+
+            // (b) the serve future completes within the timeout.
+            tokio::time::timeout(Duration::from_secs(5), server)
+                .await
+                .expect("serve future did not complete after graceful shutdown")
+                .expect("server task panicked");
+
+            // (a) the client observed a Close frame.
+            let saw_close = tokio::time::timeout(Duration::from_secs(5), client_task)
+                .await
+                .expect("client task hung")
+                .unwrap();
+            assert!(saw_close, "client never observed a Close frame");
+
+            // (c) the handler task finished and dropped its state.
+            assert_finished(&marker).await;
+        }
+
+        // As above, but the handler also sends messages periodically. Once the
+        // socket has sent its Close frame, further sends error and `recv` yields
+        // `None`, so the handler still terminates.
+        #[crate::test]
+        async fn waits_for_sending_websocket() {
+            let marker = Arc::new(());
+
+            let app = {
+                let marker = marker.clone();
+                crate::Router::new().route(
+                    "/ws",
+                    any(move |ws: WebSocketUpgrade| {
+                        let marker = marker.clone();
+                        async move {
+                            ws.on_upgrade(move |mut socket| async move {
+                                let _marker = marker;
+                                loop {
+                                    match tokio::time::timeout(
+                                        Duration::from_millis(20),
+                                        socket.recv(),
+                                    )
+                                    .await
+                                    {
+                                        Ok(Some(Ok(_))) => {}
+                                        Ok(Some(Err(_)) | None) => break,
+                                        // Idle: send a keep-alive tick.
+                                        Err(_) => {
+                                            if socket.send(Message::text("tick")).await.is_err() {
+                                                break;
+                                            }
+                                        }
+                                    }
+                                }
+                            })
+                        }
+                    }),
+                )
+            };
+
+            let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let addr = listener.local_addr().unwrap();
+
+            let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+            let server = tokio::spawn(
+                crate::serve(listener, app)
+                    .with_graceful_shutdown(async move {
+                        let _ = shutdown_rx.await;
+                    })
+                    .into_future(),
+            );
+
+            let mut client = connect(addr).await;
+
+            // Read a couple of ticks so we know the handler is live and sending.
+            for _ in 0..2 {
+                tokio::time::timeout(Duration::from_secs(5), client.next())
+                    .await
+                    .expect("timed out reading tick");
+            }
+
+            shutdown_tx.send(()).unwrap();
+
+            let client_task = tokio::spawn(drain_until_closed(client));
+
+            tokio::time::timeout(Duration::from_secs(5), server)
+                .await
+                .expect("serve future did not complete after graceful shutdown")
+                .expect("server task panicked");
+
+            let saw_close = tokio::time::timeout(Duration::from_secs(5), client_task)
+                .await
+                .expect("client task hung")
+                .unwrap();
+            assert!(saw_close, "client never observed a Close frame");
+
+            assert_finished(&marker).await;
+        }
     }
 }

--- a/axum/src/extract/ws.rs
+++ b/axum/src/extract/ws.rs
@@ -92,16 +92,14 @@
 //!
 //! When the server is run with [`axum::serve`] and
 //! [`Serve::with_graceful_shutdown`], WebSocket connections take part in the
-//! shutdown. Once the shutdown signal fires, each open [`WebSocket`] sends a
-//! Close frame to its peer, and the server waits for the handler tasks to
-//! finish before resolving.
+//! shutdown: once the signal fires each open [`WebSocket`] sends a Close frame
+//! to its peer, and the server waits for the handler tasks to finish before
+//! resolving.
 //!
-//! In practice this means a handler with the usual read loop needs no changes:
-//! after the Close handshake completes, [`WebSocket::recv`] returns `None` and
-//! the loop ends. Handlers should treat `None` (or an `Err`) from `recv` as a
-//! signal to return. A handler that never polls the socket and never returns
-//! will still hold shutdown open, just like any other in-flight response body
-//! (Server-Sent Events behave the same way).
+//! A handler with the usual read loop needs no changes — after the Close
+//! handshake [`WebSocket::recv`] returns `None`, so the loop ends and the task
+//! returns. A handler that never polls the socket and never returns will still
+//! hold shutdown open, like any other in-flight response body.
 //!
 //! [`StreamExt::split`]: https://docs.rs/futures/0.3.17/futures/stream/trait.StreamExt.html#method.split
 //! [`axum::serve`]: crate::serve()
@@ -372,21 +370,10 @@ impl<F> WebSocketUpgrade<F> {
     ///
     /// # Graceful shutdown
     ///
-    /// When the server is run with [`axum::serve`] and
-    /// [`with_graceful_shutdown`], the spawned handler task participates in the
-    /// shutdown:
-    ///
-    /// * the server waits for this task to finish before resolving, and
-    /// * once shutdown begins the [`WebSocket`] automatically sends a Close
-    ///   frame to the peer.
-    ///
-    /// A handler that reads from the socket in the usual way — e.g.
-    /// `while let Some(msg) = socket.recv().await { .. }` — will therefore
-    /// observe the stream end and return on its own. A handler that never polls
-    /// the socket and never returns will still block shutdown, the same as any
-    /// other in-flight response body.
-    ///
-    /// See the [module docs](self) and [`axum::serve`] for details.
+    /// Under [`axum::serve`] with [`with_graceful_shutdown`], the spawned task
+    /// takes part in the shutdown: the server waits for it to finish, and the
+    /// [`WebSocket`] is sent a Close frame once shutdown begins. See the
+    /// [module docs](self#graceful-shutdown) for the handler implications.
     ///
     /// [`axum::serve`]: crate::serve()
     /// [`with_graceful_shutdown`]: crate::serve::Serve::with_graceful_shutdown
@@ -403,18 +390,15 @@ impl<F> WebSocketUpgrade<F> {
 
         let protocol = self.protocol.clone();
 
-        // Derive the graceful-shutdown observer and the guard that keeps the
-        // server draining until this task ends. Both are `None` (a no-op) when
-        // graceful shutdown is not configured.
+        // With graceful shutdown configured, `shutdown` resolves once it begins
+        // and `guard` keeps the server draining until this task ends; both are
+        // `None` (a no-op) otherwise.
         #[cfg(all(feature = "tokio", any(feature = "http1", feature = "http2")))]
         let (shutdown, guard) = match self.graceful {
             Some(peer) => {
-                let mut rx = peer.shutdown;
-                let shutdown: Pin<Box<dyn Future<Output = ()> + Send>> = Box::pin(async move {
-                    // Either a value is sent or all senders drop; both mean
-                    // "shutdown has begun".
-                    let _ = rx.changed().await;
-                });
+                let signal = peer.shutdown;
+                let shutdown: Pin<Box<dyn Future<Output = ()> + Send>> =
+                    Box::pin(async move { signal.closed().await });
                 (Some(shutdown), Some(peer.guard))
             }
             None => (None, None),
@@ -701,11 +685,10 @@ impl Stream for WebSocket {
         // `WebSocket` is `Unpin`, so we can operate on the fields directly.
         let this = self.get_mut();
 
-        // If a graceful shutdown has begun, kick off the WebSocket closing
-        // handshake by sending a Close frame. This is best-effort: reads keep
-        // flowing afterwards, so the peer's Close response is still observed and
-        // the stream terminates, ending typical `recv` loops. A socket that is
-        // already closing simply skips this.
+        // Once graceful shutdown begins, start the closing handshake by sending
+        // a Close frame. Reads keep flowing afterwards, so the peer's Close
+        // reply is still observed and the stream terminates, ending typical
+        // `recv` loops.
         let shutdown_fired = match this.shutdown.as_mut() {
             Some(shutdown) => shutdown.as_mut().poll(cx).is_ready(),
             None => false,

--- a/axum/src/extract/ws.rs
+++ b/axum/src/extract/ws.rs
@@ -108,8 +108,7 @@
 use self::rejection::*;
 use super::FromRequestParts;
 use crate::{body::Bytes, response::Response, Error};
-// Only available when `axum::serve` is compiled in; the `ws` feature does not
-// imply `http1`/`http2`, so this must be gated exactly like the `serve` module.
+// Gated like `axum::serve` itself; the `ws` feature does not imply `http1`/`http2`.
 #[cfg(all(feature = "tokio", any(feature = "http1", feature = "http2")))]
 use crate::serve::GracefulPeer;
 use axum_core::body::Body;
@@ -159,8 +158,7 @@ pub struct WebSocketUpgrade<F = DefaultOnFailedUpgrade> {
     on_upgrade: hyper::upgrade::OnUpgrade,
     on_failed_upgrade: F,
     sec_websocket_protocol: BTreeSet<HeaderValue>,
-    /// Set when `axum::serve` is running with graceful shutdown; lets the
-    /// resulting socket participate in it. See [`GracefulPeer`].
+    /// Graceful-shutdown handle for the socket, if any. See [`GracefulPeer`].
     #[cfg(all(feature = "tokio", any(feature = "http1", feature = "http2")))]
     graceful: Option<GracefulPeer>,
 }
@@ -370,10 +368,9 @@ impl<F> WebSocketUpgrade<F> {
     ///
     /// # Graceful shutdown
     ///
-    /// Under [`axum::serve`] with [`with_graceful_shutdown`], the spawned task
-    /// takes part in the shutdown: the server waits for it to finish, and the
-    /// [`WebSocket`] is sent a Close frame once shutdown begins. See the
-    /// [module docs](self#graceful-shutdown) for the handler implications.
+    /// Under [`axum::serve`] with [`with_graceful_shutdown`] the spawned task
+    /// joins the shutdown and the socket is sent a Close frame once it begins.
+    /// See the [module docs](self#graceful-shutdown) for details.
     ///
     /// [`axum::serve`]: crate::serve()
     /// [`with_graceful_shutdown`]: crate::serve::Serve::with_graceful_shutdown
@@ -390,9 +387,6 @@ impl<F> WebSocketUpgrade<F> {
 
         let protocol = self.protocol.clone();
 
-        // With graceful shutdown configured, `shutdown` resolves once it begins
-        // and `guard` keeps the server draining until this task ends; both are
-        // `None` (a no-op) otherwise.
         #[cfg(all(feature = "tokio", any(feature = "http1", feature = "http2")))]
         let (shutdown, guard) = match self.graceful {
             Some(peer) => {
@@ -407,8 +401,7 @@ impl<F> WebSocketUpgrade<F> {
         let shutdown: Option<Pin<Box<dyn Future<Output = ()> + Send>>> = None;
 
         tokio::spawn(async move {
-            // Hold the guard (if any) for the whole task so that
-            // `close_tx.closed()` in `axum::serve` waits for this handler.
+            // Held for the task's lifetime to keep the shutdown drain open.
             #[cfg(all(feature = "tokio", any(feature = "http1", feature = "http2")))]
             let _guard = guard;
 
@@ -607,24 +600,19 @@ fn header_contains(headers: &HeaderMap, key: &HeaderName, value: &'static str) -
 pub struct WebSocket {
     inner: WebSocketStream<TokioIo<hyper::upgrade::Upgraded>>,
     protocol: Option<HeaderValue>,
-    /// Resolves once a graceful shutdown has begun, prompting the socket to
-    /// send a Close frame. `None` when graceful shutdown is not configured, in
-    /// which case the socket behaves exactly as before.
+    /// Resolves when graceful shutdown begins; `None` if not configured.
     shutdown: Option<Pin<Box<dyn Future<Output = ()> + Send>>>,
-    /// Tracks progress of the shutdown-initiated Close handshake.
     close_state: CloseState,
 }
 
-/// Progress of the Close frame that the socket sends when graceful shutdown
-/// begins. See [`WebSocket`]'s [`Stream`] implementation.
+/// Progress of the Close frame sent when graceful shutdown begins.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum CloseState {
-    /// No Close has been initiated (the default, and the terminal state once
-    /// the Close has been handed off or abandoned).
+    /// No Close queued (also the terminal state).
     Idle,
-    /// Shutdown observed; a Close frame still needs to be enqueued.
+    /// Shutdown seen; Close needs enqueuing.
     Queued,
-    /// Close frame enqueued; flushing it out (best-effort).
+    /// Close enqueued; flushing it out.
     Flushing,
 }
 
@@ -682,19 +670,15 @@ impl Stream for WebSocket {
     type Item = Result<Message, Error>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        // `WebSocket` is `Unpin`, so we can operate on the fields directly.
         let this = self.get_mut();
 
-        // Once graceful shutdown begins, start the closing handshake by sending
-        // a Close frame. Reads keep flowing afterwards, so the peer's Close
-        // reply is still observed and the stream terminates, ending typical
-        // `recv` loops.
+        // On shutdown, send a Close frame but keep reading so the peer's Close
+        // reply still ends the stream. Best-effort, so any failure falls through.
         let shutdown_fired = match this.shutdown.as_mut() {
             Some(shutdown) => shutdown.as_mut().poll(cx).is_ready(),
             None => false,
         };
         if shutdown_fired {
-            // Do not poll the completed future again.
             this.shutdown = None;
             this.close_state = CloseState::Queued;
         }
@@ -704,24 +688,16 @@ impl Stream for WebSocket {
                 Poll::Ready(Ok(())) => {
                     this.close_state = match this.inner.start_send_unpin(ts::Message::Close(None)) {
                         Ok(()) => CloseState::Flushing,
-                        // Socket already closing/closed; nothing more to do.
                         Err(_) => CloseState::Idle,
                     };
                 }
-                // Already closing/closed; give up on sending our own Close.
                 Poll::Ready(Err(_)) => this.close_state = CloseState::Idle,
-                // Cannot buffer the Close yet; retry on a later poll. Fall
-                // through to reading so the connection keeps making progress.
                 Poll::Pending => {}
             }
         }
 
-        if this.close_state == CloseState::Flushing {
-            // Best-effort: if the flush is still pending the frame stays
-            // buffered and is driven out as the stream continues to be polled.
-            if this.inner.poll_flush_unpin(cx).is_ready() {
-                this.close_state = CloseState::Idle;
-            }
+        if this.close_state == CloseState::Flushing && this.inner.poll_flush_unpin(cx).is_ready() {
+            this.close_state = CloseState::Idle;
         }
 
         loop {
@@ -1452,12 +1428,9 @@ mod tests {
             assert_eq!(count, 1, "WebSocket handler task did not finish");
         }
 
-        // Regression test for https://github.com/tokio-rs/axum/issues/3003.
-        //
-        // A WebSocket handler looping on `recv()` used to be ignored by graceful
-        // shutdown: the upgraded task was detached, so the `serve` future
-        // returned while the handler kept running. Now the socket is sent a
-        // Close frame and the server waits for the handler task to finish.
+        // Regression test for https://github.com/tokio-rs/axum/issues/3003. A
+        // recv() loop used to be detached and outlive graceful shutdown. Now it
+        // is sent a Close frame and the server waits for it.
         #[crate::test]
         async fn waits_for_websocket_and_closes_it() {
             let marker = Arc::new(());
@@ -1470,9 +1443,7 @@ mod tests {
                         let marker = marker.clone();
                         async move {
                             ws.on_upgrade(move |mut socket| async move {
-                                // Held for the lifetime of the handler task so
-                                // we can observe (via strong_count) that it
-                                // really finished.
+                                // Kept so strong_count proves the task finished.
                                 let _marker = marker;
                                 while let Some(Ok(_)) = socket.recv().await {}
                             })

--- a/axum/src/extract/ws.rs
+++ b/axum/src/extract/ws.rs
@@ -96,7 +96,7 @@
 //! to its peer, and the server waits for the handler tasks to finish before
 //! resolving.
 //!
-//! A handler with the usual read loop needs no changes — after the Close
+//! A handler with the usual read loop needs no changes. After the Close
 //! handshake [`WebSocket::recv`] returns `None`, so the loop ends and the task
 //! returns. A handler that never polls the socket and never returns will still
 //! hold shutdown open, like any other in-flight response body.

--- a/axum/src/extract/ws.rs
+++ b/axum/src/extract/ws.rs
@@ -437,7 +437,7 @@ impl<F> WebSocketUpgrade<F> {
     /// # Graceful shutdown
     ///
     /// Under [`axum::serve`] with [`with_graceful_shutdown`] the spawned task
-    /// joins the shutdown and the socket is sent a Close frame once it begins.
+    /// joins the shutdown and the socket is sent a close frame once it begins.
     /// See the [module docs](self#graceful-shutdown) for details.
     ///
     /// [`axum::serve`]: crate::serve()
@@ -455,9 +455,8 @@ impl<F> WebSocketUpgrade<F> {
 
         let protocol = self.protocol.clone();
 
-        // Boxed once per upgrade rather than rebuilt per poll, so a socket that
-        // is parked on a read stays registered on the watch channel instead of
-        // re-registering on every frame.
+        // Boxed once per upgrade so a socket parked on a read stays registered
+        // on the watch channel, rather than re-registering on every poll.
         #[cfg(all(feature = "tokio", any(feature = "http1", feature = "http2")))]
         let (shutdown, guard) = match self.graceful {
             Some(handle) => {
@@ -680,9 +679,7 @@ pub struct WebSocket {
 enum CloseState {
     /// Nothing queued. Also the terminal state.
     Idle,
-    /// Shutdown seen, close frame still needs enqueuing.
     Queued,
-    /// Close frame enqueued, flushing it out.
     Flushing,
 }
 
@@ -728,19 +725,22 @@ impl WebSocket {
     /// Once graceful shutdown starts, get a close frame on the wire.
     ///
     /// Best effort: reads and writes keep working whatever happens here, and a
-    /// socket that is already closing just stays closing. Called from both
-    /// halves of [`split`] so a handler that only reads or only writes still
-    /// closes.
+    /// socket that is already closing stays closing. Both halves of [`split`]
+    /// call it, so a handler that only reads or only writes still closes.
     ///
     /// [`split`]: https://docs.rs/futures/0.3.17/futures/stream/trait.StreamExt.html#method.split
     fn poll_shutdown_close(&mut self, cx: &mut Context<'_>) {
         let fired = match self.shutdown.as_mut() {
             Some(shutdown) => shutdown.as_mut().poll(cx).is_ready(),
-            None => return,
+            None => false,
         };
         if fired {
             self.shutdown = None;
             self.close_state = CloseState::Queued;
+        }
+
+        if self.close_state == CloseState::Idle {
+            return;
         }
 
         if self.close_state == CloseState::Queued {

--- a/axum/src/serve/mod.rs
+++ b/axum/src/serve/mod.rs
@@ -600,6 +600,10 @@ where
 /// [`WebSocketUpgrade`]: crate::extract::ws::WebSocketUpgrade
 /// [`guard`]: GracefulPeer::guard
 /// [`shutdown`]: GracefulPeer::shutdown
+// The only reader of these fields is the `ws` extractor; without the `ws`
+// feature they are write-only. That is fine: `guard` does its job by being
+// dropped (RAII), and `shutdown` is carried for the consumer.
+#[cfg_attr(not(feature = "ws"), allow(dead_code))]
 #[derive(Clone, Debug)]
 pub(crate) struct GracefulPeer {
     /// Resolves (with `Ok`) or errors once a graceful shutdown has begun.

--- a/axum/src/serve/mod.rs
+++ b/axum/src/serve/mod.rs
@@ -232,16 +232,13 @@ where
     ///
     /// # WebSocket connections
     ///
-    /// WebSocket connections (via [`WebSocketUpgrade`]) participate in the
+    /// WebSocket connections (via [`WebSocketUpgrade`]) take part in the
     /// shutdown: once the signal fires each open socket is sent a Close frame,
-    /// and this future waits for the WebSocket handler tasks to finish before
-    /// resolving. A well-behaved handler that reads with
-    /// `while let Some(msg) = socket.recv().await` observes the stream end and
-    /// returns on its own.
+    /// and this future waits for the handler tasks to finish before resolving.
+    /// A handler that never returns still blocks shutdown, like any other
+    /// in-flight response body. See the [`ws` module docs] for details.
     ///
-    /// A handler that ignores socket closure — never polling the socket and
-    /// never returning — will still block shutdown, the same trust model as any
-    /// other in-flight response body (Server-Sent Events behave this way too).
+    /// [`ws` module docs]: crate::extract::ws#graceful-shutdown
     ///
     /// # Return Value
     ///
@@ -470,19 +467,9 @@ where
         } = self;
 
         let (signal_tx, signal_rx) = watch::channel(());
-        // A second channel dedicated to telling upgraded connections (e.g.
-        // WebSockets) that shutdown has begun. `signal_rx` being dropped wakes
-        // the per-connection tasks so hyper can start its graceful shutdown,
-        // but an upgraded connection's io has been handed off and is no longer
-        // tracked by hyper, so it needs its own notification.
-        let (shutdown_tx, shutdown_rx) = watch::channel(());
         executor.execute(async move {
             signal.await;
             trace!("received graceful shutdown signal. Telling tasks to shutdown");
-            // Tell upgraded connections to start closing. Receivers treat a
-            // `changed()` error (all senders dropped) the same as a received
-            // value, so it is fine for `shutdown_tx` to drop with this task.
-            let _ = shutdown_tx.send(());
             drop(signal_rx);
         });
 
@@ -502,7 +489,7 @@ where
                 &signal_tx,
                 &close_rx,
                 Some(GracefulPeer {
-                    shutdown: shutdown_rx.clone(),
+                    shutdown: signal_tx.clone(),
                     guard: close_rx.clone(),
                 }),
                 io,
@@ -586,30 +573,23 @@ where
     }
 }
 
-/// Handle to let an upgraded connection (e.g. a WebSocket) participate in
-/// graceful shutdown.
-///
-/// When [`Serve::with_graceful_shutdown`] is used, a `GracefulPeer` is inserted
-/// into the request extensions of upgrade requests (see [`handle_connection`]).
-/// [`WebSocketUpgrade`] picks it up so that:
-///
-/// * holding [`guard`] (a clone of the connection's `close_rx`) keeps
-///   `close_tx.closed()` from resolving until the upgraded task finishes, and
-/// * observing [`shutdown`] lets the socket start closing when shutdown begins.
+/// Lets an upgraded connection (e.g. a WebSocket) take part in graceful
+/// shutdown. Inserted into the extensions of upgrade requests by
+/// [`handle_connection`] when [`Serve::with_graceful_shutdown`] is used, and
+/// read by [`WebSocketUpgrade`].
 ///
 /// [`WebSocketUpgrade`]: crate::extract::ws::WebSocketUpgrade
-/// [`guard`]: GracefulPeer::guard
-/// [`shutdown`]: GracefulPeer::shutdown
-// The only reader of these fields is the `ws` extractor; without the `ws`
-// feature they are write-only. That is fine: `guard` does its job by being
-// dropped (RAII), and `shutdown` is carried for the consumer.
+// The `ws` extractor is the only reader; without the `ws` feature the fields
+// are written but never read, so the lint would fire on this shared code.
 #[cfg_attr(not(feature = "ws"), allow(dead_code))]
 #[derive(Clone, Debug)]
 pub(crate) struct GracefulPeer {
-    /// Resolves (with `Ok`) or errors once a graceful shutdown has begun.
-    pub(crate) shutdown: watch::Receiver<()>,
-    /// A clone of the connection's `close_rx`; keeping it alive blocks
-    /// `close_tx.closed()`.
+    /// A sender for the accept loop's signal channel. Awaiting its `closed()`
+    /// resolves once shutdown begins — the same edge the accept loop and the
+    /// per-connection tasks already wait on (the sole receiver is dropped).
+    pub(crate) shutdown: watch::Sender<()>,
+    /// A clone of the connection's `close_rx`; holding it keeps
+    /// `close_tx.closed()` from resolving until the upgraded task finishes.
     pub(crate) guard: watch::Receiver<()>,
 }
 
@@ -651,10 +631,8 @@ async fn handle_connection<L, M, S, B, E>(
         .unwrap_or_else(|err| match err {})
         .map_request(move |req: Request<Incoming>| {
             let mut req = req.map(Body::new);
-            // When graceful shutdown is configured, let upgrade requests (e.g.
-            // WebSockets) opt into the shutdown machinery by inserting a
-            // `GracefulPeer` into their extensions. The non-upgrade hot path
-            // pays only a single header lookup and no allocation.
+            // On upgrade requests, hand the upgraded task (e.g. a WebSocket) a
+            // `GracefulPeer` so it can take part in graceful shutdown.
             if let Some(graceful) = &graceful {
                 if req.headers().contains_key(http::header::UPGRADE)
                     || req.method() == http::Method::CONNECT

--- a/axum/src/serve/mod.rs
+++ b/axum/src/serve/mod.rs
@@ -230,10 +230,25 @@ where
     /// }
     /// ```
     ///
+    /// # WebSocket connections
+    ///
+    /// WebSocket connections (via [`WebSocketUpgrade`]) participate in the
+    /// shutdown: once the signal fires each open socket is sent a Close frame,
+    /// and this future waits for the WebSocket handler tasks to finish before
+    /// resolving. A well-behaved handler that reads with
+    /// `while let Some(msg) = socket.recv().await` observes the stream end and
+    /// returns on its own.
+    ///
+    /// A handler that ignores socket closure — never polling the socket and
+    /// never returning — will still block shutdown, the same trust model as any
+    /// other in-flight response body (Server-Sent Events behave this way too).
+    ///
     /// # Return Value
     ///
     /// Similarly to [`serve`], although this future resolves to `io::Result<()>`, it will never
     /// error. It returns `Ok(())` only after the `signal` future completes.
+    ///
+    /// [`WebSocketUpgrade`]: crate::extract::ws::WebSocketUpgrade
     pub fn with_graceful_shutdown<F>(self, signal: F) -> WithGracefulShutdown<L, M, S, F, B, E>
     where
         F: Future<Output = ()> + Send + 'static,
@@ -335,6 +350,7 @@ where
                 &mut make_service,
                 &signal_tx,
                 &close_rx,
+                None,
                 io,
                 remote_addr,
                 &executor,
@@ -454,9 +470,19 @@ where
         } = self;
 
         let (signal_tx, signal_rx) = watch::channel(());
+        // A second channel dedicated to telling upgraded connections (e.g.
+        // WebSockets) that shutdown has begun. `signal_rx` being dropped wakes
+        // the per-connection tasks so hyper can start its graceful shutdown,
+        // but an upgraded connection's io has been handed off and is no longer
+        // tracked by hyper, so it needs its own notification.
+        let (shutdown_tx, shutdown_rx) = watch::channel(());
         executor.execute(async move {
             signal.await;
             trace!("received graceful shutdown signal. Telling tasks to shutdown");
+            // Tell upgraded connections to start closing. Receivers treat a
+            // `changed()` error (all senders dropped) the same as a received
+            // value, so it is fine for `shutdown_tx` to drop with this task.
+            let _ = shutdown_tx.send(());
             drop(signal_rx);
         });
 
@@ -475,6 +501,10 @@ where
                 &mut make_service,
                 &signal_tx,
                 &close_rx,
+                Some(GracefulPeer {
+                    shutdown: shutdown_rx.clone(),
+                    guard: close_rx.clone(),
+                }),
                 io,
                 remote_addr,
                 &executor,
@@ -556,10 +586,34 @@ where
     }
 }
 
+/// Handle to let an upgraded connection (e.g. a WebSocket) participate in
+/// graceful shutdown.
+///
+/// When [`Serve::with_graceful_shutdown`] is used, a `GracefulPeer` is inserted
+/// into the request extensions of upgrade requests (see [`handle_connection`]).
+/// [`WebSocketUpgrade`] picks it up so that:
+///
+/// * holding [`guard`] (a clone of the connection's `close_rx`) keeps
+///   `close_tx.closed()` from resolving until the upgraded task finishes, and
+/// * observing [`shutdown`] lets the socket start closing when shutdown begins.
+///
+/// [`WebSocketUpgrade`]: crate::extract::ws::WebSocketUpgrade
+/// [`guard`]: GracefulPeer::guard
+/// [`shutdown`]: GracefulPeer::shutdown
+#[derive(Clone, Debug)]
+pub(crate) struct GracefulPeer {
+    /// Resolves (with `Ok`) or errors once a graceful shutdown has begun.
+    pub(crate) shutdown: watch::Receiver<()>,
+    /// A clone of the connection's `close_rx`; keeping it alive blocks
+    /// `close_tx.closed()`.
+    pub(crate) guard: watch::Receiver<()>,
+}
+
 async fn handle_connection<L, M, S, B, E>(
     make_service: &mut M,
     signal_tx: &watch::Sender<()>,
     close_rx: &watch::Receiver<()>,
+    graceful: Option<GracefulPeer>,
     io: <L as Listener>::Io,
     remote_addr: <L as Listener>::Addr,
     executor: &E,
@@ -591,7 +645,21 @@ async fn handle_connection<L, M, S, B, E>(
         })
         .await
         .unwrap_or_else(|err| match err {})
-        .map_request(|req: Request<Incoming>| req.map(Body::new));
+        .map_request(move |req: Request<Incoming>| {
+            let mut req = req.map(Body::new);
+            // When graceful shutdown is configured, let upgrade requests (e.g.
+            // WebSockets) opt into the shutdown machinery by inserting a
+            // `GracefulPeer` into their extensions. The non-upgrade hot path
+            // pays only a single header lookup and no allocation.
+            if let Some(graceful) = &graceful {
+                if req.headers().contains_key(http::header::UPGRADE)
+                    || req.method() == http::Method::CONNECT
+                {
+                    req.extensions_mut().insert(graceful.clone());
+                }
+            }
+            req
+        });
 
     let hyper_service = TowerToHyperService::new(tower_service);
     let signal_tx = signal_tx.clone();

--- a/axum/src/serve/mod.rs
+++ b/axum/src/serve/mod.rs
@@ -230,22 +230,10 @@ where
     /// }
     /// ```
     ///
-    /// # WebSocket connections
-    ///
-    /// WebSocket connections (via [`WebSocketUpgrade`]) take part in the
-    /// shutdown: once the signal fires each open socket is sent a Close frame,
-    /// and this future waits for the handler tasks to finish before resolving.
-    /// A handler that never returns still blocks shutdown, like any other
-    /// in-flight response body. See the [`ws` module docs] for details.
-    ///
-    /// [`ws` module docs]: crate::extract::ws#graceful-shutdown
-    ///
     /// # Return Value
     ///
     /// Similarly to [`serve`], although this future resolves to `io::Result<()>`, it will never
     /// error. It returns `Ok(())` only after the `signal` future completes.
-    ///
-    /// [`WebSocketUpgrade`]: crate::extract::ws::WebSocketUpgrade
     pub fn with_graceful_shutdown<F>(self, signal: F) -> WithGracefulShutdown<L, M, S, F, B, E>
     where
         F: Future<Output = ()> + Send + 'static,
@@ -347,7 +335,6 @@ where
                 &mut make_service,
                 &signal_tx,
                 &close_rx,
-                None,
                 io,
                 remote_addr,
                 &executor,
@@ -488,10 +475,6 @@ where
                 &mut make_service,
                 &signal_tx,
                 &close_rx,
-                Some(GracefulPeer {
-                    shutdown: signal_tx.clone(),
-                    guard: close_rx.clone(),
-                }),
                 io,
                 remote_addr,
                 &executor,
@@ -574,22 +557,17 @@ where
 }
 
 /// Lets an upgraded connection (e.g. a WebSocket) take part in graceful
-/// shutdown. Inserted into the extensions of upgrade requests by
-/// [`handle_connection`] when [`Serve::with_graceful_shutdown`] is used, and
-/// read by [`WebSocketUpgrade`].
+/// shutdown. Inserted into every request's extensions and read by
+/// [`WebSocketUpgrade`].
 ///
 /// [`WebSocketUpgrade`]: crate::extract::ws::WebSocketUpgrade
-// The `ws` extractor is the only reader; without the `ws` feature the fields
-// are written but never read, so the lint would fire on this shared code.
+// Only read by the `ws` extractor.
 #[cfg_attr(not(feature = "ws"), allow(dead_code))]
 #[derive(Clone, Debug)]
 pub(crate) struct GracefulPeer {
-    /// A sender for the accept loop's signal channel. Awaiting its `closed()`
-    /// resolves once shutdown begins — the same edge the accept loop and the
-    /// per-connection tasks already wait on (the sole receiver is dropped).
+    /// Resolves via `closed()` when shutdown begins.
     pub(crate) shutdown: watch::Sender<()>,
-    /// A clone of the connection's `close_rx`; holding it keeps
-    /// `close_tx.closed()` from resolving until the upgraded task finishes.
+    /// Held by the upgraded task to keep the drain open.
     pub(crate) guard: watch::Receiver<()>,
 }
 
@@ -597,7 +575,6 @@ async fn handle_connection<L, M, S, B, E>(
     make_service: &mut M,
     signal_tx: &watch::Sender<()>,
     close_rx: &watch::Receiver<()>,
-    graceful: Option<GracefulPeer>,
     io: <L as Listener>::Io,
     remote_addr: <L as Listener>::Addr,
     executor: &E,
@@ -622,6 +599,12 @@ async fn handle_connection<L, M, S, B, E>(
         .await
         .unwrap_or_else(|err| match err {});
 
+    // Attached to every request; inert unless graceful shutdown is running.
+    let graceful = GracefulPeer {
+        shutdown: signal_tx.clone(),
+        guard: close_rx.clone(),
+    };
+
     let tower_service = make_service
         .call(IncomingStream {
             io: &io,
@@ -631,15 +614,7 @@ async fn handle_connection<L, M, S, B, E>(
         .unwrap_or_else(|err| match err {})
         .map_request(move |req: Request<Incoming>| {
             let mut req = req.map(Body::new);
-            // On upgrade requests, hand the upgraded task (e.g. a WebSocket) a
-            // `GracefulPeer` so it can take part in graceful shutdown.
-            if let Some(graceful) = &graceful {
-                if req.headers().contains_key(http::header::UPGRADE)
-                    || req.method() == http::Method::CONNECT
-                {
-                    req.extensions_mut().insert(graceful.clone());
-                }
-            }
+            req.extensions_mut().insert(graceful.clone());
             req
         });
 

--- a/axum/src/serve/mod.rs
+++ b/axum/src/serve/mod.rs
@@ -496,6 +496,7 @@ where
             .await;
         }
 
+        // Both hold a `close_rx` clone, which is what the drain below waits on.
         drop(graceful);
         drop(close_rx);
         drop(listener);


### PR DESCRIPTION
## Motivation

`axum::serve(..).with_graceful_shutdown(signal)` stops accepting, drains connections, and waits for every connection task via a `close_rx` guard. WebSocket handlers escape all of it. `WebSocketUpgrade::on_upgrade` spawns a bare `tokio::spawn`, and once hyper hands off the upgraded io the connection task exits. The shutdown future then resolves while sockets are still live, so handler state (`Arc`s, file handles) outlives "shutdown", and nothing even tells the peer to close (#3003).

This matches the direction already sketched in the issue threads: "Propagating some kind of a channel there so that we keep track of it for the purpose of graceful shutdown should be easy enough" (#3003), the `ShutdownToken`-via-extension idea from #2673, and the extension-based proposal later in the #3003 thread.

## Solution

Two halves.

**Tracking.** `handle_connection` already holds the `signal_tx` and `close_rx` for the connection, so it builds a `pub(crate) GracefulPeer { shutdown, guard }` from those two and inserts it into every request's extensions. `WebSocketUpgrade` picks it up during extraction, and the spawned handler task holds the `close_rx` clone for its lifetime, so `close_tx.closed()` waits for WebSocket handlers exactly as it does for in-flight requests.

There is no second channel. The socket observes the same `signal` channel the accept loop uses, watching it from the sender side via `closed()`, since a receiver clone would keep the accept loop's own `signal_tx.closed()` from ever firing.

Under plain `serve` the extension is inserted just the same, but `Serve::run` holds its signal receiver for the lifetime of a future that never returns, so the signal can never fire and both halves stay inert.

**Closing.** On upgrade the socket receives a boxed observer for that signal, one allocation per WebSocket upgrade and nothing per message. `WebSocket`'s `Stream` impl polls it before reading. When shutdown begins it enqueues a `Close` frame through the Sink half, best-effort, with a small `Idle`/`Queued`/`Flushing` state machine that tolerates already-closing sockets and `Pending` sinks by falling through to reads so the connection keeps progressing. Reads keep flowing, the peer's Close reply ends the stream, and the typical `while let Some(msg) = socket.recv().await` loop returns on its own with no application changes. This is tungstenite's sanctioned close-initiation path, where `start_send(Close)` sets `ClosedByUs` and `read()` auto-flushes pending close frames.

**Behavior note, intentional and documented.** With graceful shutdown configured, a handler that ignores socket closure and never returns now blocks shutdown, where before it was silently orphaned. That is the same trust model as any in-flight response body, since an unfinished SSE stream blocks shutdown the same way (#2673). It is documented in the ws module docs, which `on_upgrade` links to.

The regression test reproduces #3003 end to end, with a recv-loop handler holding an outside `Arc`, a real client over TCP, and the signal fired, asserting that the client sees a Close frame, that the serve future completes, and that `Arc::strong_count` returns to 1. With the tracking neutered to simulate the old behavior, both graceful-shutdown tests fail with the client hung and the socket never closed. A second test covers a handler that also sends, where send-after-Close errors and the handler exits.

Anticipated questions:

- *Why not a public `ShutdownToken` extractor?* More API surface, and it pushes work onto every application. The `pub(crate)` handle is the natural seed for that as a follow-up if wanted.
- *Can the injected Close corrupt a concurrent user send via `split()`?* No. `SplitSink`/`SplitStream` serialize through a `BiLock` and frames are discrete. Post-Close user sends get tungstenite's documented `SendAfterClosing` error, and only during shutdown.
- *Middleware semantics?* Layers still see the request complete at response time, which is pre-existing and noted in #3003. This PR narrows the tracking gap only.
- *Does a peer that never replies to Close hang shutdown?* The handler's recv loop ends on peer Close, or on error or EOF. A silent peer keeps the socket open, matching the SSE trust model. A hard deadline can still be enforced by racing the serve future against a timeout, unchanged from today.

Everything is feature-gated exactly like the `serve` module (`tokio` plus `http1`/`http2`), since `ws` alone doesn't imply a server. Per-feature combos (`tokio` alone, `http1` alone, `ws` alone, no-default) compile clean under `-D warnings`.

No `unsafe`, no new dependencies beyond plain `tokio::sync::watch`, MSRV untouched. The CHANGELOG carries a single `fixed` entry.

Fixes #3003
