### PR TITLE
docs: remove stale ecosystem link from examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -2,6 +2,3 @@
 
 This folder contains numerous examples showing how to use axum. Each example is
 set up as its own crate so its dependencies are clear.
-
-For a list of what the community built with axum, please see the list
-[here](../ECOSYSTEM.md).


### PR DESCRIPTION
## Motivation

`ECOSYSTEM.md` was intentionally removed in #3737, but `examples/README.md`
still links to it. The remaining link is tracked in #3834.

## Solution

Remove the obsolete ecosystem paragraph from `examples/README.md`, consistent
with the earlier removal.

Fixes #3834.
