### PR TITLE
Fix duplicate methods in the `Allow` header after merging `MethodRouter`s

### DIFF
--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **changed:** `Redirect` constructors now accept any `impl Into<String>` ([#3635])
 - **changed:** Updated `matchit` allowing for routes with captures and static prefixes and suffixes ([#3702])
 - **fixed:** Responses to `HEAD` will not accidentally reply with `content-length: 0` anymore ([#3742])
+- **fixed:** `MethodRouter::merge` no longer lists a method twice in the `Allow`
+  header (e.g. merging `get` and `head`) ([#3836])
 
 [#3158]: https://github.com/tokio-rs/axum/pull/3158
 [#3261]: https://github.com/tokio-rs/axum/pull/3261
@@ -38,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#3702]: https://github.com/tokio-rs/axum/pull/3702
 [#3721]: https://github.com/tokio-rs/axum/pull/3721
 [#3742]: https://github.com/tokio-rs/axum/pull/3742
+[#3836]: https://github.com/tokio-rs/axum/pull/3836
 [#3757]: https://github.com/tokio-rs/axum/pull/3757
 
 # 0.8.9

--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -27,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **changed:** Updated `matchit` allowing for routes with captures and static prefixes and suffixes ([#3702])
 - **fixed:** Responses to `HEAD` will not accidentally reply with `content-length: 0` anymore ([#3742])
 - **fixed:** `MethodRouter::merge` no longer lists a method twice in the `Allow`
-  header (e.g. merging `get` and `head`) ([#3836])
+  header after merging `get` and `head` ([#3836])
 
 [#3158]: https://github.com/tokio-rs/axum/pull/3158
 [#3261]: https://github.com/tokio-rs/axum/pull/3261

--- a/axum/src/routing/method_routing.rs
+++ b/axum/src/routing/method_routing.rs
@@ -574,10 +574,25 @@ impl AllowHeader {
             (Self::Skip, _) | (_, Self::Skip) => Self::Skip,
             (Self::None, Self::None) => Self::None,
             (Self::None, Self::Bytes(pick)) | (Self::Bytes(pick), Self::None) => Self::Bytes(pick),
-            (Self::Bytes(mut a), Self::Bytes(b)) => {
-                a.extend_from_slice(b",");
-                a.extend_from_slice(&b);
-                Self::Bytes(a)
+            (mut this @ Self::Bytes(_), Self::Bytes(b)) => {
+                // `b`'s methods can already be present in `this` — most notably
+                // `HEAD`, which `get` adds implicitly alongside `GET`. Fold them in
+                // through the same de-duplicating path used while building a router
+                // so a merged `Allow` header never lists a method twice.
+                match std::str::from_utf8(&b) {
+                    Ok(methods) => {
+                        for method in methods.split(',') {
+                            append_allow_header(&mut this, method);
+                        }
+                    }
+                    #[cfg(debug_assertions)]
+                    Err(_) => {
+                        panic!("`allow_header` contained invalid utf-8. This should never happen")
+                    }
+                    #[cfg(not(debug_assertions))]
+                    Err(_) => {}
+                }
+                this
             }
         }
     }
@@ -1222,7 +1237,7 @@ where
     }
 }
 
-fn append_allow_header(allow_header: &mut AllowHeader, method: &'static str) {
+fn append_allow_header(allow_header: &mut AllowHeader, method: &str) {
     match allow_header {
         AllowHeader::None => {
             *allow_header = AllowHeader::Bytes(BytesMut::from(method));
@@ -1543,6 +1558,20 @@ mod tests {
         let (status, headers, _) = call(Method::DELETE, &mut svc).await;
         assert_eq!(status, StatusCode::METHOD_NOT_ALLOWED);
         assert_eq!(headers[ALLOW], "PUT,PATCH,GET,HEAD");
+    }
+
+    #[crate::test]
+    async fn allow_header_merging_get_into_head() {
+        // `get` also serves `HEAD`, so its allow header is already `GET,HEAD`.
+        // Merging it with a separately built `head` route must not list `HEAD`
+        // twice.
+        let a = get(ok);
+        let b = head(created);
+        let mut svc = a.merge(b);
+
+        let (status, headers, _) = call(Method::DELETE, &mut svc).await;
+        assert_eq!(status, StatusCode::METHOD_NOT_ALLOWED);
+        assert_eq!(headers[ALLOW], "GET,HEAD");
     }
 
     #[crate::test]

--- a/axum/src/routing/method_routing.rs
+++ b/axum/src/routing/method_routing.rs
@@ -575,22 +575,16 @@ impl AllowHeader {
             (Self::None, Self::None) => Self::None,
             (Self::None, Self::Bytes(pick)) | (Self::Bytes(pick), Self::None) => Self::Bytes(pick),
             (mut this @ Self::Bytes(_), Self::Bytes(b)) => {
-                // `b`'s methods can already be present in `this` — most notably
-                // `HEAD`, which `get` adds implicitly alongside `GET`. Fold them in
-                // through the same de-duplicating path used while building a router
-                // so a merged `Allow` header never lists a method twice.
                 match std::str::from_utf8(&b) {
                     Ok(methods) => {
                         for method in methods.split(',') {
                             append_allow_header(&mut this, method);
                         }
                     }
-                    #[cfg(debug_assertions)]
                     Err(_) => {
+                        #[cfg(debug_assertions)]
                         panic!("`allow_header` contained invalid utf-8. This should never happen")
                     }
-                    #[cfg(not(debug_assertions))]
-                    Err(_) => {}
                 }
                 this
             }
@@ -1562,9 +1556,6 @@ mod tests {
 
     #[crate::test]
     async fn allow_header_merging_get_into_head() {
-        // `get` also serves `HEAD`, so its allow header is already `GET,HEAD`.
-        // Merging it with a separately built `head` route must not list `HEAD`
-        // twice.
         let a = get(ok);
         let b = head(created);
         let mut svc = a.merge(b);


### PR DESCRIPTION
## Motivation

`get` registers a handler for both `GET` and `HEAD`, so a `get` route's `Allow`
header value is `GET,HEAD`. When two `MethodRouter`s are merged, their `Allow`
header values are joined together. The join did not remove duplicates, so
merging a `get` route with a separately built `head` route produced an `Allow`
header of `GET,HEAD,HEAD`:

```rust
use axum::routing::{get, head, MethodRouter};

// GET (also serves HEAD) merged with an explicit HEAD handler
let router: MethodRouter = get(|| async {}).merge(head(|| async {}));
// a 405/OPTIONS response now carries `Allow: GET,HEAD,HEAD`
```

This is reachable through `Router::merge` as well, whenever the merged routers
have a `get` route on one side and an explicit `head` route on the other for the
same path. The builder path already guards against this: `append_allow_header`
skips a method that is already present, which is why `get(..).head(..)` on a
single router correctly yields `GET,HEAD`. Only the merge path was missing the
same guard.

## Solution

Route the `Bytes` + `Bytes` case of `AllowHeader::merge` through the existing
`append_allow_header` helper, one method at a time, so the merged value reuses
the same de-duplication the builder already performs. `append_allow_header` only
copies the bytes of the method it is given, so its parameter is relaxed from
`&'static str` to `&str` to accept the method names split out of the other
header value.

Behavior is otherwise unchanged: `None`/`Skip` states merge as before, and
merging routers with disjoint methods still concatenates them in order (the
existing `allow_header_when_merging` test, which expects `PUT,PATCH,GET,HEAD`,
still passes). A regression test covers merging a `get` route with a separate
`head` route and asserts the `Allow` header is `GET,HEAD`.

