### PR TITLE
docs(axum-extra): fix CookieJar request header guidance

### DIFF
--- a/axum-extra/src/extract/cookie/mod.rs
+++ b/axum-extra/src/extract/cookie/mod.rs
@@ -143,8 +143,8 @@ impl CookieJar {
     /// This is intended to be used in middleware and other places where it might be difficult to
     /// run extractors. Normally you should create `CookieJar`s through [`FromRequestParts`].
     ///
-    /// If you need a jar that contains the headers from a request use `impl From<&HeaderMap> for
-    /// CookieJar`.
+    /// If you need a jar that contains the headers from a request, use
+    /// [`CookieJar::from_headers`].
     ///
     /// [`FromRequestParts`]: axum::extract::FromRequestParts
     pub fn new() -> Self {


### PR DESCRIPTION
## Motivation

The documentation for `CookieJar::new` tells users to construct a jar from request headers with `From<&HeaderMap>`. `CookieJar` does not implement that conversion, so the guidance points to an API that cannot be used.

## Solution

Point the documentation to the existing `CookieJar::from_headers` constructor with an intra-doc link.

Verified with `cargo doc --package axum-extra --all-features --no-deps`.