### PR TITLE
fix(axum-extra): reject opaque Attachment filenames

### DIFF
--- a/axum-extra/src/response/attachment.rs
+++ b/axum-extra/src/response/attachment.rs
@@ -56,11 +56,12 @@ impl<T: IntoResponse> Attachment<T> {
     ///
     /// This updates the `Content-Disposition` header to add a filename.
     pub fn filename<H: TryInto<HeaderValue>>(mut self, value: H) -> Self {
-        self.filename = if let Ok(filename) = value.try_into() {
-            Some(filename)
-        } else {
-            error!("Attachment filename contains invalid characters");
-            None
+        self.filename = match value.try_into() {
+            Ok(filename) if filename.to_str().is_ok() => Some(filename),
+            _ => {
+                error!("Attachment filename contains invalid characters");
+                None
+            }
         };
         self
     }
@@ -126,6 +127,14 @@ mod tests {
             .into_response();
         let value = attachment.headers().get(CONTENT_DISPOSITION).unwrap();
         assert_eq!(value, "attachment; filename=\"report.pdf\"");
+    }
+
+    #[test]
+    fn attachment_with_opaque_filename() {
+        let filename = HeaderValue::from_bytes(b"report\xff.pdf").unwrap();
+        let attachment = Attachment::new("data").filename(filename).into_response();
+        let value = attachment.headers().get(CONTENT_DISPOSITION).unwrap();
+        assert_eq!(value, "attachment");
     }
 
     #[test]


### PR DESCRIPTION
## Motivation

`Attachment::filename` accepts any value that converts to `HeaderValue`. This includes values containing opaque bytes, which are valid header values but cannot be represented by `HeaderValue::to_str`.

`Attachment::into_response` currently calls `to_str().expect(...)` on the stored filename. Passing an opaque `HeaderValue` therefore causes response construction to panic.

## Solution

Validate that the converted `HeaderValue` has a string representation before storing it. If it does not, use the existing invalid-filename behavior: log an error and omit the filename from `Content-Disposition`.

Add a regression test using a filename containing `0xff` and verify the response falls back to `Content-Disposition: attachment`.

Verified with `cargo test -p axum-extra --lib --no-default-features --features attachment response::attachment::tests`.