### PR TITLE
chore(deps): bump base64 from 0.22 to 0.23

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,7 +105,7 @@ dependencies = [
  "axum-core",
  "axum-extra",
  "axum-macros",
- "base64",
+ "base64 0.23.0",
  "bytes",
  "form_urlencoded",
  "futures-core",
@@ -236,6 +236,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b25655df2c3cdd83c5e5b293b88acd880332b2ddadd7c30ac43144fdc0033da9"
+
+[[package]]
 name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -330,7 +336,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
 dependencies = [
  "aes-gcm",
- "base64",
+ "base64 0.22.1",
  "hkdf",
  "hmac",
  "percent-encoding",
@@ -640,7 +646,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "headers-core",
  "http",
@@ -756,7 +762,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -1325,7 +1331,7 @@ version = "0.12.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d0946410b9f7b082a427e4ef5c8ff541a88b357bc6c637c40db3a68ac70a36f"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -1833,7 +1839,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
  "async-compression",
- "base64",
+ "base64 0.22.1",
  "bitflags",
  "bytes",
  "futures-core",

--- a/axum/Cargo.toml
+++ b/axum/Cargo.toml
@@ -129,7 +129,7 @@ tower-service = "0.3"
 
 # optional dependencies
 axum-macros = { path = "../axum-macros", version = "0.5.1", optional = true }
-base64 = { version = "0.22.1", optional = true }
+base64 = { version = "0.23.0", optional = true }
 form_urlencoded = { version = "1.1.0", optional = true }
 futures-sink = { version = "0.3", optional = true }
 hyper = { version = "1.4.0", optional = true }

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -274,7 +274,7 @@ version = "0.8.9"
 dependencies = [
  "axum-core",
  "axum-macros",
- "base64 0.22.1",
+ "base64 0.23.0",
  "bytes",
  "form_urlencoded",
  "futures-core",
@@ -385,6 +385,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b25655df2c3cdd83c5e5b293b88acd880332b2ddadd7c30ac43144fdc0033da9"
 
 [[package]]
 name = "bb8"


### PR DESCRIPTION
## Motivation

`base64` v0.23 was released 4 days ago. The ecosystem is starting to upgrade and projects are starting to get duplicate dependency versions of base64.

## Solution

Upgrade axum to v0.23 so that we are 1 dependency closer to not depending on v0.22 anymore.