### PR TITLE
fix(axum): don't enable `tokio/macros` feature

### DIFF
--- a/axum/Cargo.toml
+++ b/axum/Cargo.toml
@@ -72,9 +72,7 @@ query = [
 tokio = [
     "dep:hyper-util",
     "dep:tokio",
-    "tokio/rt",
     "tower/make",
-    "tokio/macros",
 ]
 tower-log = ["tower/log"]
 tracing = ["dep:tracing", "axum-core/tracing"]
@@ -102,10 +100,10 @@ __private_docs = [
 __private = ["tokio", "http1", "dep:reqwest"]
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-tokio = { package = "tokio", version = "1.44", features = ["time", "net"], optional = true }
+tokio = { package = "tokio", version = "1.44", features = ["time", "rt", "net"], optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-tokio = { package = "tokio", version = "1.44", features = ["time"], optional = true }
+tokio = { package = "tokio", version = "1.44", features = ["time", "rt"], optional = true }
 
 [dependencies]
 axum-core = { path = "../axum-core", version = "0.5.6" }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

I'm trying to minimize the dependency tree of a project I'm working on. I noticed that `tokio` had its `macros` feature enabled only because of `axum`, and this feature pulls in the `tokio-macros` crate. It's one crate, but it's still nice to avoid compiling code that's unused anyway.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

I removed the `tokio/macros` features. I checked that `axum` still compiles without any changes to the code at all and that all tests pass. I also manually skimmed through uses of `tokio` with ripgrep and found no use of `tokio`'s macros outside of tests (and this feature is already once again enabled in `dev-dependencies` anyway).

I also found it strange that the `tokio` feature enables `tokio` _and_ lists some of its features, yet the table below also lists some of `tokio`'s features. That's why I moved the remaining `rt` feature to that table.