### PR TITLE
examples: Update to validator 0.21

### DIFF
--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -4909,12 +4909,11 @@ dependencies = [
 
 [[package]]
 name = "validator"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43fb22e1a008ece370ce08a3e9e4447a910e92621bb49b85d6e48a45397e7cfa"
+checksum = "c3d68c6633c483df6780cc5277a417c7c2d1bceee2649d06c8ab6b0fd2dd3c81"
 dependencies = [
  "idna",
- "once_cell",
  "regex",
  "serde",
  "serde_derive",

--- a/examples/validator/Cargo.toml
+++ b/examples/validator/Cargo.toml
@@ -11,7 +11,7 @@ thiserror = "2"
 tokio = { version = "1.0", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-validator = { version = "0.20.0", features = ["derive"] }
+validator = { version = "0.21", features = ["derive"] }
 
 [dev-dependencies]
 http-body-util = "0.1.0"


### PR DESCRIPTION
Updates to `validator` 0.21.