### PR TITLE
Avoid shared shutdown waiter contention

### DIFF
--- a/axum/CHANGELOG.md
+++ b/axum/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **added:** Add `RawPathParams::from_request_extensions` ([#3757])
 - **changed:** `serve` has an additional generic argument and can now work with any response body
   type, not just `axum::body::Body` ([#3205])
+- **changed:** Reduced contention in `axum::serve` shutdown notification with many
+  active connections ([#3867])
 - **changed:** `Redirect` constructors now accept any `impl Into<String>` ([#3635])
 - **changed:** Updated `matchit` allowing for routes with captures and static prefixes and suffixes ([#3702])
 - **fixed:** Responses to `HEAD` will not accidentally reply with `content-length: 0` anymore ([#3742])
@@ -44,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#3836]: https://github.com/tokio-rs/axum/pull/3836
 [#3757]: https://github.com/tokio-rs/axum/pull/3757
 [#3801]: https://github.com/tokio-rs/axum/pull/3801
+[#3867]: https://github.com/tokio-rs/axum/pull/3867
 
 # 0.8.9
 

--- a/axum/src/serve/mod.rs
+++ b/axum/src/serve/mod.rs
@@ -329,7 +329,6 @@ where
             _marker,
         } = self;
 
-        // Receiver-side waits avoid contention in `Sender::closed`'s shared notification state.
         let (_signal_tx, signal_rx) = watch::channel(());
         let (_close_tx, close_rx) = watch::channel(());
 
@@ -457,7 +456,6 @@ where
             _marker,
         } = self;
 
-        // Receiver-side waits avoid contention in `Sender::closed`'s shared notification state.
         let (signal_tx, mut signal_rx) = watch::channel(());
         executor.execute(async move {
             signal.await;

--- a/axum/src/serve/mod.rs
+++ b/axum/src/serve/mod.rs
@@ -329,14 +329,14 @@ where
             _marker,
         } = self;
 
-        let (signal_tx, _signal_rx) = watch::channel(());
+        let (_signal_tx, signal_rx) = watch::channel(());
         let (_close_tx, close_rx) = watch::channel(());
 
         loop {
             let (io, remote_addr) = listener.accept().await;
             handle_connection(
                 &mut make_service,
-                &signal_tx,
+                signal_rx.clone(),
                 &close_rx,
                 io,
                 remote_addr,
@@ -456,18 +456,18 @@ where
             _marker,
         } = self;
 
-        let (signal_tx, signal_rx) = watch::channel(());
+        let (signal_tx, mut signal_rx) = watch::channel(());
         executor.execute(async move {
             signal.await;
             trace!("received graceful shutdown signal. Telling tasks to shutdown");
-            drop(signal_rx);
+            drop(signal_tx);
         });
 
         let (close_tx, close_rx) = watch::channel(());
 
         loop {
             let (io, remote_addr) =
-                match select(pin!(listener.accept()), pin!(signal_tx.closed())).await {
+                match select(pin!(listener.accept()), pin!(signal_rx.changed())).await {
                     Either::Left((conn, _)) => conn,
                     Either::Right(_) => {
                         trace!("signal received, not accepting new connections");
@@ -477,7 +477,7 @@ where
 
             handle_connection(
                 &mut make_service,
-                &signal_tx,
+                signal_rx.clone(),
                 &close_rx,
                 io,
                 remote_addr,
@@ -562,7 +562,7 @@ where
 
 async fn handle_connection<L, M, S, B, E>(
     make_service: &mut M,
-    signal_tx: &watch::Sender<()>,
+    mut signal_rx: watch::Receiver<()>,
     close_rx: &watch::Receiver<()>,
     io: <L as Listener>::Io,
     remote_addr: <L as Listener>::Addr,
@@ -598,7 +598,6 @@ async fn handle_connection<L, M, S, B, E>(
         .map_request(|req: Request<Incoming>| req.map(Body::new));
 
     let hyper_service = TowerToHyperService::new(tower_service);
-    let signal_tx = signal_tx.clone();
     let close_rx = close_rx.clone();
 
     let hyper_executor = HyperExecutor(executor.clone());
@@ -615,7 +614,7 @@ async fn handle_connection<L, M, S, B, E>(
         builder.http2().enable_connect_protocol();
 
         let mut conn = pin!(builder.serve_connection_with_upgrades(io, hyper_service));
-        let mut signal_closed = pin!(signal_tx.closed().fuse());
+        let mut signal_closed = pin!(signal_rx.changed().fuse());
 
         loop {
             match select(conn.as_mut(), &mut signal_closed).await {
@@ -1123,6 +1122,28 @@ mod tests {
             .await
             .expect("serve future did not resolve after in-flight request finished")
             .unwrap();
+    }
+
+    #[crate::test]
+    async fn dropping_serve_closes_connections() {
+        let (client, server) = io::duplex(1024);
+        let listener = ReadyListener(Some(server));
+        let server_task = tokio::spawn(serve(listener, Router::new()).into_future());
+
+        let stream = TokioIo::new(client);
+        let (sender, conn) = hyper::client::conn::http1::handshake::<_, Body>(stream)
+            .await
+            .unwrap();
+        let connection_task = tokio::spawn(conn);
+
+        server_task.abort();
+        assert!(server_task.await.unwrap_err().is_cancelled());
+
+        let _ = tokio::time::timeout(Duration::from_secs(2), connection_task)
+            .await
+            .expect("connection did not close after Serve was dropped")
+            .unwrap();
+        assert!(sender.is_closed());
     }
 
     // Asserts that `ListenerExt::tap_io` invokes its closure on every accepted

--- a/axum/src/serve/mod.rs
+++ b/axum/src/serve/mod.rs
@@ -329,6 +329,7 @@ where
             _marker,
         } = self;
 
+        // Receiver-side waits avoid contention in `Sender::closed`'s shared notification state.
         let (_signal_tx, signal_rx) = watch::channel(());
         let (_close_tx, close_rx) = watch::channel(());
 
@@ -336,7 +337,7 @@ where
             let (io, remote_addr) = listener.accept().await;
             handle_connection(
                 &mut make_service,
-                signal_rx.clone(),
+                &signal_rx,
                 &close_rx,
                 io,
                 remote_addr,
@@ -456,6 +457,7 @@ where
             _marker,
         } = self;
 
+        // Receiver-side waits avoid contention in `Sender::closed`'s shared notification state.
         let (signal_tx, mut signal_rx) = watch::channel(());
         executor.execute(async move {
             signal.await;
@@ -469,15 +471,18 @@ where
             let (io, remote_addr) =
                 match select(pin!(listener.accept()), pin!(signal_rx.changed())).await {
                     Either::Left((conn, _)) => conn,
-                    Either::Right(_) => {
+                    Either::Right((Err(_), _)) => {
                         trace!("signal received, not accepting new connections");
                         break;
+                    }
+                    Either::Right((Ok(()), _)) => {
+                        unreachable!("shutdown channel never sends values")
                     }
                 };
 
             handle_connection(
                 &mut make_service,
-                signal_rx.clone(),
+                &signal_rx,
                 &close_rx,
                 io,
                 remote_addr,
@@ -562,7 +567,7 @@ where
 
 async fn handle_connection<L, M, S, B, E>(
     make_service: &mut M,
-    mut signal_rx: watch::Receiver<()>,
+    signal_rx: &watch::Receiver<()>,
     close_rx: &watch::Receiver<()>,
     io: <L as Listener>::Io,
     remote_addr: <L as Listener>::Addr,
@@ -579,6 +584,7 @@ async fn handle_connection<L, M, S, B, E>(
     B::Error: Into<Box<dyn StdError + Send + Sync>>,
     E: Executor,
 {
+    let mut signal_rx = signal_rx.clone();
     let io = TokioIo::new(io);
 
     trace!("connection {remote_addr:?} accepted");
@@ -624,9 +630,12 @@ async fn handle_connection<L, M, S, B, E>(
                     }
                     break;
                 }
-                Either::Right(_) => {
+                Either::Right((Err(_), _)) => {
                     trace!("signal received in task, starting graceful shutdown");
                     conn.as_mut().graceful_shutdown();
+                }
+                Either::Right((Ok(()), _)) => {
+                    unreachable!("shutdown channel never sends values")
                 }
             }
         }
@@ -1122,28 +1131,6 @@ mod tests {
             .await
             .expect("serve future did not resolve after in-flight request finished")
             .unwrap();
-    }
-
-    #[crate::test]
-    async fn dropping_serve_closes_connections() {
-        let (client, server) = io::duplex(1024);
-        let listener = ReadyListener(Some(server));
-        let server_task = tokio::spawn(serve(listener, Router::new()).into_future());
-
-        let stream = TokioIo::new(client);
-        let (sender, conn) = hyper::client::conn::http1::handshake::<_, Body>(stream)
-            .await
-            .unwrap();
-        let connection_task = tokio::spawn(conn);
-
-        server_task.abort();
-        assert!(server_task.await.unwrap_err().is_cancelled());
-
-        let _ = tokio::time::timeout(Duration::from_secs(2), connection_task)
-            .await
-            .expect("connection did not close after Serve was dropped")
-            .unwrap();
-        assert!(sender.is_closed());
     }
 
     // Asserts that `ListenerExt::tap_io` invokes its closure on every accepted


### PR DESCRIPTION
## Motivation

`axum::serve` currently clones the shutdown `watch::Sender` for every accepted connection. Each connection polls `Sender::closed()`, so all connection shutdown waiters share synchronization state. This becomes expensive when many connections are active across many CPU cores.

Initial end-to-end benchmarks used [Dynamo](https://github.com/ai-dynamo/dynamo), a distributed inference serving framework that uses Axum for HTTP. Its frontend accepts OpenAI-compatible requests, performs tokenization and routing, and streams worker output to clients. These results were measured in a frontend-bound scenario. The only software difference between the two arms was the Axum build: unmodified Axum 0.8.9 versus Axum 0.8.9 with this patch.

| Dynamo end-to-end arm | Throughput | First response latency p50 | First response latency p95 | First response latency p99 |
|---|---:|---:|---:|---:|
| Unmodified Axum 0.8.9 | 1,000.3 req/s | 63.08 ms | 113.96 ms | 262.87 ms |
| Axum 0.8.9 with receiver fix | 1,897.9 req/s | 42.47 ms | 107.84 ms | 263.93 ms |

I also isolated this behavior in a standalone Axum benchmark. It used 4,096 persistent connections and finite responses with 32 256-byte SSE frames, one scheduler yield between frames, a stock `rewrk` client on another node, a 15-second warmup, and a 60-second measurement.

| Arm | Throughput | p99 latency | CPU/request |
|---|---:|---:|---:|
| Control | 151,990 req/s | 71.44 ms | 0.312 ms |
| Receiver fix | 180,091 req/s | 65.79 ms | 0.147 ms |

In an on-CPU profile of this benchmark, `Sender::closed` used 16.57% inclusive CPU in the control. Its shared mutex used 15.32% inclusive CPU, including 7.12% in the contended lock path. Those stacks disappeared with this change, while `Receiver::changed` used 4.14% inclusive CPU.

## Solution

Keep the shutdown sender in the server task and give each accepted connection its own cloned receiver. The accept loop and connection tasks wait on `Receiver::changed()`, and shutdown drops the sender to notify all receivers.

This keeps the public API and graceful shutdown behavior unchanged. Existing tests continue to cover graceful draining and custom executors.

## Validation

- `cargo test -p axum --all-features serve::tests`
- `cargo test --locked --workspace --all-features --all-targets`
- `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings`
- `cargo fmt --all --check`
- `git diff --check`
