### PR TITLE
Treat CRLF as a single SSE line ending

### DIFF
--- a/axum/src/response/sse.rs
+++ b/axum/src/response/sse.rs
@@ -40,7 +40,6 @@ use http_body::Frame;
 use pin_project_lite::pin_project;
 use std::{
     fmt::{self, Write as _},
-    io::Write as _,
     mem,
     pin::Pin,
     task::{ready, Context, Poll},
@@ -179,8 +178,9 @@ pub struct Event {
 /// Expose [`Event`] as a [`std::fmt::Write`]
 /// such that any form of data can be written as data safely.
 ///
-/// This also ensures that newline characters `\r` and `\n`
-/// correctly trigger a split with a new `data: ` prefix.
+/// This also ensures that CRLF (`\r\n`), lone CR (`\r`), and lone LF (`\n`)
+/// line endings correctly trigger a split with a new `data: ` prefix. A CRLF
+/// pair is treated as a single line ending.
 ///
 /// # Panics
 ///
@@ -195,6 +195,10 @@ pub struct EventDataWriter {
     // this does not say anything about whether or not `event` contains
     // data or not.
     data_written: bool,
+
+    // A trailing CR might be followed by an LF in the next write. Defer the
+    // next `data: ` prefix until we know whether they form a CRLF pair.
+    pending_cr: bool,
 }
 
 impl Event {
@@ -218,6 +222,7 @@ impl Event {
         EventDataWriter {
             event: self,
             data_written: false,
+            pending_cr: false,
         }
     }
 
@@ -427,43 +432,67 @@ impl EventDataWriter {
     ///
     /// In case any data was written by this instance
     /// it will also write the trailing `\n` character.
-    pub fn into_event(self) -> Event {
-        let mut event = self.event;
+    pub fn into_event(mut self) -> Event {
         if self.data_written {
-            let _ = event.buffer.as_mut().write_char('\n');
+            let buffer = self.event.buffer.as_mut();
+            if self.pending_cr {
+                buffer.extend_from_slice(b"data: ");
+            }
+            let _ = buffer.write_char('\n');
         }
-        event
+        self.event
     }
 }
 
 impl EventDataWriter {
-    // Assumption: underlying writer never returns an error:
-    // <https://docs.rs/bytes/latest/src/bytes/buf/writer.rs.html#79-82>
     fn write_buf(&mut self, buf: &[u8]) -> usize {
         if buf.is_empty() {
             return 0;
         }
-
-        let buffer = self.event.buffer.as_mut();
 
         if !std::mem::replace(&mut self.data_written, true) {
             if self.event.flags.contains(EventFlags::HAS_DATA) {
                 panic!("Called `Event::data*` multiple times");
             }
 
-            let _ = buffer.write_str("data: ");
             self.event.flags.insert(EventFlags::HAS_DATA);
+            self.event.buffer.as_mut().extend_from_slice(b"data: ");
         }
 
-        let mut writer = buffer.writer();
-
+        let buffer = self.event.buffer.as_mut();
         let mut last_split = 0;
-        for delimiter in memchr::memchr2_iter(b'\n', b'\r', buf) {
-            let _ = writer.write_all(&buf[last_split..=delimiter]);
-            let _ = writer.write_all(b"data: ");
-            last_split = delimiter + 1;
+
+        if self.pending_cr {
+            if buf[0] == b'\n' {
+                buffer.put_u8(b'\n');
+                last_split = 1;
+            }
+            buffer.extend_from_slice(b"data: ");
+            self.pending_cr = false;
         }
-        let _ = writer.write_all(&buf[last_split..]);
+
+        while let Some(delimiter) = memchr::memchr2(b'\n', b'\r', &buf[last_split..]) {
+            let delimiter = last_split + delimiter;
+            buffer.extend_from_slice(&buf[last_split..=delimiter]);
+            last_split = delimiter + 1;
+
+            if buf[delimiter] == b'\r' {
+                match buf.get(last_split) {
+                    Some(b'\n') => {
+                        buffer.put_u8(b'\n');
+                        last_split += 1;
+                    }
+                    None => {
+                        self.pending_cr = true;
+                        break;
+                    }
+                    Some(_) => {}
+                }
+            }
+
+            buffer.extend_from_slice(b"data: ");
+        }
+        buffer.extend_from_slice(&buf[last_split..]);
 
         buf.len()
     }
@@ -677,6 +706,34 @@ mod tests {
             &*event.finalize(),
             b"data: moon star\ndata: sunset bye\rdata: \n\n"
         );
+    }
+
+    #[test]
+    fn crlf_is_one_line_ending() {
+        let event = Event::default().data("first\r\nsecond");
+
+        assert_eq!(&*event.finalize(), b"data: first\r\ndata: second\n\n");
+    }
+
+    #[test]
+    fn data_writer_output_is_independent_of_write_boundaries() {
+        let data = "first\r\nsecond\rthird\nfourth\r";
+        let expected = b"data: first\r\ndata: second\rdata: third\ndata: fourth\rdata: \n\n";
+
+        for first_split in 0..=data.len() {
+            for second_split in first_split..=data.len() {
+                let mut writer = Event::default().into_data_writer();
+                writer.write_str(&data[..first_split]).unwrap();
+                writer.write_str(&data[first_split..second_split]).unwrap();
+                writer.write_str(&data[second_split..]).unwrap();
+
+                assert_eq!(
+                    &*writer.into_event().finalize(),
+                    expected,
+                    "write boundaries at {first_split} and {second_split}"
+                );
+            }
+        }
     }
 
     #[test]

--- a/axum/src/response/sse.rs
+++ b/axum/src/response/sse.rs
@@ -40,6 +40,7 @@ use http_body::Frame;
 use pin_project_lite::pin_project;
 use std::{
     fmt::{self, Write as _},
+    io::Write as _,
     mem,
     pin::Pin,
     task::{ready, Context, Poll},
@@ -432,67 +433,61 @@ impl EventDataWriter {
     ///
     /// In case any data was written by this instance
     /// it will also write the trailing `\n` character.
-    pub fn into_event(mut self) -> Event {
+    pub fn into_event(self) -> Event {
+        let mut event = self.event;
         if self.data_written {
-            let buffer = self.event.buffer.as_mut();
+            let buffer = event.buffer.as_mut();
             if self.pending_cr {
-                buffer.extend_from_slice(b"data: ");
+                let _ = buffer.write_str("data: ");
             }
             let _ = buffer.write_char('\n');
         }
-        self.event
+        event
     }
 }
 
 impl EventDataWriter {
+    // Assumption: underlying writer never returns an error:
+    // <https://docs.rs/bytes/latest/src/bytes/buf/writer.rs.html#79-82>
     fn write_buf(&mut self, buf: &[u8]) -> usize {
         if buf.is_empty() {
             return 0;
         }
+
+        let pending_cr = mem::take(&mut self.pending_cr);
+        let buffer = self.event.buffer.as_mut();
 
         if !std::mem::replace(&mut self.data_written, true) {
             if self.event.flags.contains(EventFlags::HAS_DATA) {
                 panic!("Called `Event::data*` multiple times");
             }
 
+            let _ = buffer.write_str("data: ");
             self.event.flags.insert(EventFlags::HAS_DATA);
-            self.event.buffer.as_mut().extend_from_slice(b"data: ");
         }
 
-        let buffer = self.event.buffer.as_mut();
+        let mut writer = buffer.writer();
+
+        if pending_cr && buf[0] != b'\n' {
+            let _ = writer.write_all(b"data: ");
+        }
+
         let mut last_split = 0;
-
-        if self.pending_cr {
-            if buf[0] == b'\n' {
-                buffer.put_u8(b'\n');
-                last_split = 1;
+        for delimiter in memchr::memchr2_iter(b'\n', b'\r', buf) {
+            if buf[delimiter] == b'\r' && buf.get(delimiter + 1) == Some(&b'\n') {
+                continue;
             }
-            buffer.extend_from_slice(b"data: ");
-            self.pending_cr = false;
-        }
 
-        while let Some(delimiter) = memchr::memchr2(b'\n', b'\r', &buf[last_split..]) {
-            let delimiter = last_split + delimiter;
-            buffer.extend_from_slice(&buf[last_split..=delimiter]);
+            let _ = writer.write_all(&buf[last_split..=delimiter]);
             last_split = delimiter + 1;
 
-            if buf[delimiter] == b'\r' {
-                match buf.get(last_split) {
-                    Some(b'\n') => {
-                        buffer.put_u8(b'\n');
-                        last_split += 1;
-                    }
-                    None => {
-                        self.pending_cr = true;
-                        break;
-                    }
-                    Some(_) => {}
-                }
+            if buf[delimiter] != b'\r' || last_split != buf.len() {
+                let _ = writer.write_all(b"data: ");
             }
-
-            buffer.extend_from_slice(b"data: ");
         }
-        buffer.extend_from_slice(&buf[last_split..]);
+        let _ = writer.write_all(&buf[last_split..]);
+
+        self.pending_cr = buf.last() == Some(&b'\r');
 
         buf.len()
     }


### PR DESCRIPTION
## Motivation

The server-sent events parsing algorithm treats CRLF (`\r\n`) as a single
line ending. `EventDataWriter` currently handles every CR and LF independently,
so serializing data such as `first\r\nsecond` inserts an extra `data: ` field
between the CR and LF. Clients consequently decode an unexpected blank line.

The same issue occurs when the CR and LF are written in separate
`fmt::Write::write_str` calls.

## Solution

Track when a write ends with a CR and defer the next `data: ` prefix until the
following byte is known. A following LF completes one CRLF line ending;
otherwise, the CR is handled as a lone line ending. Finalizing the writer also
handles a pending trailing CR.

The `EventDataWriter` documentation now describes CRLF, lone CR, and lone LF
explicitly. Regression tests cover CRLF in one write and every pair of
boundaries that divides mixed line-ending data into three writes.

## Testing

- `cargo test --locked --workspace --all-features --tests`
- `cargo clippy --locked -p axum --lib --all-features -- -D warnings -A clippy::double_must_use`
- `cargo doc --locked -p axum --all-features --no-deps`