### PR TITLE
Adding way to SSE Event (and Buffer) test for equality

### DIFF
--- a/axum/src/response/sse.rs
+++ b/axum/src/response/sse.rs
@@ -143,7 +143,7 @@ where
 /// Once finalized, it's immutable and cheap to clone.
 /// The buffer is active during the event building, but eventually
 /// becomes finalized to send http body frames as [`Bytes`].
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 enum Buffer {
     Active(BytesMut),
     Finalized(Bytes),
@@ -169,7 +169,7 @@ impl Buffer {
 }
 
 /// Server-sent event
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 #[must_use]
 pub struct Event {
     buffer: Buffer,

--- a/axum/src/response/sse.rs
+++ b/axum/src/response/sse.rs
@@ -143,7 +143,7 @@ where
 /// Once finalized, it's immutable and cheap to clone.
 /// The buffer is active during the event building, but eventually
 /// becomes finalized to send http body frames as [`Bytes`].
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 enum Buffer {
     Active(BytesMut),
     Finalized(Bytes),
@@ -169,7 +169,7 @@ impl Buffer {
 }
 
 /// Server-sent event
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 #[must_use]
 pub struct Event {
     buffer: Buffer,

--- a/axum/src/response/sse.rs
+++ b/axum/src/response/sse.rs
@@ -417,7 +417,6 @@ impl Event {
         buffer.put_u8(b'\n');
     }
 
-
     /// Turns the event to `Bytes` ready to be sent
     ///
     /// If the events is already finalized just returns the `Bytes` again

--- a/axum/src/response/sse.rs
+++ b/axum/src/response/sse.rs
@@ -417,7 +417,11 @@ impl Event {
         buffer.put_u8(b'\n');
     }
 
-    fn finalize(self) -> Bytes {
+
+    /// Turns the event to `Bytes` ready to be sent
+    ///
+    /// If the events is already finalized just returns the `Bytes` again
+    pub fn finalize(self) -> Bytes {
         match self.buffer {
             Buffer::Finalized(bytes) => bytes,
             Buffer::Active(mut bytes_mut) => {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/axum/blob/master/CONTRIBUTING.md
-->

## Motivation
I want to write some unit-Test for my API that use sse. I have a serpate function that creates the Event steam. It would be nice to just use `assert_eq()` . This requires the `PartialEq` Trait.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution
Just adding it to derive

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
