### PR TITLE
Clarify how to handle extractor rejections

### DIFF
--- a/axum/src/docs/extract.md
+++ b/axum/src/docs/extract.md
@@ -194,6 +194,9 @@ and all others implement [`FromRequestParts`].
 
 # Handling extractor rejections
 
+For request-parts extractors, [`extract::Result<T>`](crate::extract::Result) infers
+the rejection type, so you can write `axum::extract::Result<Path<u64>>`.
+
 If you want to handle the case of an extractor failing within a specific
 handler, you can wrap it in `Result`, with the error being the rejection type
 of the extractor:

--- a/axum/src/docs/extract.md
+++ b/axum/src/docs/extract.md
@@ -194,12 +194,51 @@ and all others implement [`FromRequestParts`].
 
 # Handling extractor rejections
 
-For request-parts extractors, [`extract::Result<T>`](crate::extract::Result) infers
-the rejection type, so you can write `axum::extract::Result<Path<u64>>`.
+If an extractor fails, axum normally returns its rejection as a response without
+calling your handler. To handle the rejection in the handler, wrap the extractor
+in [`Result`](std::result::Result). The first type parameter is the extractor and
+the second is its rejection type. For example, use `Result<Path<u64>, PathRejection>`
+for a path parameter or `Result<Json<Value>, JsonRejection>` for a JSON body.
 
-If you want to handle the case of an extractor failing within a specific
-handler, you can wrap it in `Result`, with the error being the rejection type
-of the extractor:
+Rejection types for axum's built-in extractors are available in the
+[`rejection`] module. This works for both [`FromRequestParts`] extractors such as
+[`Path`] and [`FromRequest`] extractors such as [`Json`].
+
+For example, this handler returns a custom error response when a path parameter
+cannot be parsed as a `u64`:
+
+```rust
+use axum::{
+    extract::{Path, rejection::PathRejection},
+    http::StatusCode,
+    routing::get,
+    Router,
+};
+
+async fn get_user(path: Result<Path<u64>, PathRejection>) -> Result<String, (StatusCode, String)> {
+    match path {
+        Ok(Path(id)) => Ok(format!("User {id}")),
+        Err(err) => Err((StatusCode::BAD_REQUEST, format!("Invalid path: {err}"))),
+    }
+}
+
+# #[tokio::main]
+# async fn main() {
+let app = Router::new().route("/users/{id}", get(get_user));
+# use axum::{body::{Body, to_bytes}, http::Request};
+# use tower::ServiceExt;
+# let response = app.clone().oneshot(Request::builder().uri("/users/42").body(Body::empty()).unwrap()).await.unwrap();
+# assert_eq!(response.status(), StatusCode::OK);
+# assert_eq!(to_bytes(response.into_body(), usize::MAX).await.unwrap(), "User 42");
+# let response = app.oneshot(Request::builder().uri("/users/invalid").body(Body::empty()).unwrap()).await.unwrap();
+# assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+# let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+# assert!(std::str::from_utf8(&body).unwrap().starts_with("Invalid path: "));
+# }
+```
+
+For a JSON body, use [`JsonRejection`](rejection::JsonRejection). You can match
+its variants to handle different causes of rejection:
 
 ```rust,no_run
 use axum::{

--- a/axum/src/extract/mod.rs
+++ b/axum/src/extract/mod.rs
@@ -2,6 +2,47 @@
 
 use http::header::{self, HeaderMap};
 
+/// A result whose error type is the rejection of a [`FromRequestParts`] extractor.
+///
+/// Use this to handle an extractor's rejection in the handler instead of automatically
+/// returning it as a response.
+///
+/// ```
+/// use axum::{extract::{Path, Result}, routing::get, Router};
+///
+/// async fn handler(path: Result<Path<u64>>) -> String {
+///     match path {
+///         Ok(Path(id)) => format!("Item {id}"),
+///         Err(rejection) => format!("Invalid path: {rejection}"),
+///     }
+/// }
+///
+/// let app = Router::new().route("/{id}", get(handler));
+/// # let _: Router = app;
+/// ```
+///
+/// `S` is the state type used by the extractor and defaults to `()`. For extractors
+/// that require application state, specify it explicitly:
+///
+/// ```
+/// use axum::{extract::{Result, State}, routing::post, Router};
+///
+/// #[derive(Clone)]
+/// struct AppState;
+///
+/// async fn handler(state: Result<State<AppState>, AppState>, body: String) -> String {
+///     let Ok(State(state)) = state;
+///     body
+/// }
+///
+/// let app = Router::new().route("/", post(handler)).with_state(AppState);
+/// # let _: Router = app;
+/// ```
+///
+/// This alias is for request-parts extractors. For body-consuming extractors such
+/// as `Json`, use [`std::result::Result`] with their rejection type.
+pub type Result<T, S = ()> = std::result::Result<T, <T as FromRequestParts<S>>::Rejection>;
+
 #[cfg(feature = "tokio")]
 pub mod connect_info;
 pub mod path;
@@ -94,7 +135,50 @@ pub(super) fn has_content_type(headers: &HeaderMap, expected_content_type: &mime
 
 #[cfg(test)]
 mod tests {
+    use super::{Path, Result, State};
     use crate::{routing::get, test_helpers::*, Router};
+    use http::StatusCode;
+
+    #[crate::test]
+    async fn result_alias_handles_path_rejection() {
+        let app = Router::new().route(
+            "/{id}",
+            get(|path: Result<Path<u64>>| async move {
+                match path {
+                    Ok(Path(id)) => format!("Item {id}"),
+                    Err(_) => "Invalid path".to_owned(),
+                }
+            }),
+        );
+        let client = TestClient::new(app);
+        assert_eq!(client.get("/42").await.text().await, "Item 42");
+        let response = client.get("/invalid").await;
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(response.text().await, "Invalid path");
+    }
+
+    #[crate::test]
+    async fn result_alias_with_state_and_body() {
+        #[derive(Clone)]
+        struct AppState(&'static str);
+
+        let app = Router::new()
+            .route(
+                "/",
+                get(
+                    |state: Result<State<AppState>, AppState>, body: String| async move {
+                        let Ok(State(state)) = state;
+                        format!("{}: {body}", state.0)
+                    },
+                ),
+            )
+            .with_state(AppState("state"));
+        let client = TestClient::new(app);
+        assert_eq!(
+            client.get("/").body("body").await.text().await,
+            "state: body"
+        );
+    }
 
     #[crate::test]
     async fn consume_body() {

--- a/axum/src/extract/mod.rs
+++ b/axum/src/extract/mod.rs
@@ -31,7 +31,7 @@ use http::header::{self, HeaderMap};
 /// struct AppState;
 ///
 /// async fn handler(state: Result<State<AppState>, AppState>, body: String) -> String {
-///     let Ok(State(state)) = state;
+///     let State(state) = state.unwrap();
 ///     body
 /// }
 ///
@@ -167,7 +167,7 @@ mod tests {
                 "/",
                 get(
                     |state: Result<State<AppState>, AppState>, body: String| async move {
-                        let Ok(State(state)) = state;
+                        let State(state) = state.unwrap();
                         format!("{}: {body}", state.0)
                     },
                 ),

--- a/axum/src/extract/mod.rs
+++ b/axum/src/extract/mod.rs
@@ -2,47 +2,6 @@
 
 use http::header::{self, HeaderMap};
 
-/// A result whose error type is the rejection of a [`FromRequestParts`] extractor.
-///
-/// Use this to handle an extractor's rejection in the handler instead of automatically
-/// returning it as a response.
-///
-/// ```
-/// use axum::{extract::{Path, Result}, routing::get, Router};
-///
-/// async fn handler(path: Result<Path<u64>>) -> String {
-///     match path {
-///         Ok(Path(id)) => format!("Item {id}"),
-///         Err(rejection) => format!("Invalid path: {rejection}"),
-///     }
-/// }
-///
-/// let app = Router::new().route("/{id}", get(handler));
-/// # let _: Router = app;
-/// ```
-///
-/// `S` is the state type used by the extractor and defaults to `()`. For extractors
-/// that require application state, specify it explicitly:
-///
-/// ```
-/// use axum::{extract::{Result, State}, routing::post, Router};
-///
-/// #[derive(Clone)]
-/// struct AppState;
-///
-/// async fn handler(state: Result<State<AppState>, AppState>, body: String) -> String {
-///     let State(state) = state.unwrap();
-///     body
-/// }
-///
-/// let app = Router::new().route("/", post(handler)).with_state(AppState);
-/// # let _: Router = app;
-/// ```
-///
-/// This alias is for request-parts extractors. For body-consuming extractors such
-/// as `Json`, use [`std::result::Result`] with their rejection type.
-pub type Result<T, S = ()> = std::result::Result<T, <T as FromRequestParts<S>>::Rejection>;
-
 #[cfg(feature = "tokio")]
 pub mod connect_info;
 pub mod path;
@@ -135,50 +94,7 @@ pub(super) fn has_content_type(headers: &HeaderMap, expected_content_type: &mime
 
 #[cfg(test)]
 mod tests {
-    use super::{Path, Result, State};
     use crate::{routing::get, test_helpers::*, Router};
-    use http::StatusCode;
-
-    #[crate::test]
-    async fn result_alias_handles_path_rejection() {
-        let app = Router::new().route(
-            "/{id}",
-            get(|path: Result<Path<u64>>| async move {
-                match path {
-                    Ok(Path(id)) => format!("Item {id}"),
-                    Err(_) => "Invalid path".to_owned(),
-                }
-            }),
-        );
-        let client = TestClient::new(app);
-        assert_eq!(client.get("/42").await.text().await, "Item 42");
-        let response = client.get("/invalid").await;
-        assert_eq!(response.status(), StatusCode::OK);
-        assert_eq!(response.text().await, "Invalid path");
-    }
-
-    #[crate::test]
-    async fn result_alias_with_state_and_body() {
-        #[derive(Clone)]
-        struct AppState(&'static str);
-
-        let app = Router::new()
-            .route(
-                "/",
-                get(
-                    |state: Result<State<AppState>, AppState>, body: String| async move {
-                        let State(state) = state.unwrap();
-                        format!("{}: {body}", state.0)
-                    },
-                ),
-            )
-            .with_state(AppState("state"));
-        let client = TestClient::new(app);
-        assert_eq!(
-            client.get("/").body("body").await.text().await,
-            "state: body"
-        );
-    }
 
     #[crate::test]
     async fn consume_body() {

--- a/axum/src/extract/rejection.rs
+++ b/axum/src/extract/rejection.rs
@@ -1,4 +1,7 @@
 //! Rejection response types.
+//!
+//! See [Handling extractor rejections](../index.html#handling-extractor-rejections)
+//! for examples of handling these errors in a handler.
 
 use axum_core::__composite_rejection as composite_rejection;
 use axum_core::__define_rejection as define_rejection;


### PR DESCRIPTION
## Summary

Explain how to choose the error type in `Result<T, E>` when handling extractor rejections. Add a `Path` example alongside the existing `Json` example, and link the guide and rejection module in both directions.

The path example demonstrates a custom error response and tests successful and rejected requests.

Refs #3878 and #3877.

## Testing

- `cargo test --locked -p axum --all-features --doc`: 177 passed, 1 ignored. The new path example checks both response status and body; the existing JSON example compiles.
- `cargo doc --locked -p axum --all-features --no-deps` with `RUSTDOCFLAGS="-D rustdoc::all -A rustdoc::private-doc-tests"`: passed. Verified both links in the generated HTML.
- `cargo fmt --all --check`: passed.

Checks ran on Windows with Rust 1.98.1.
