### PR TITLE
ci: updates for new clippy

### DIFF
--- a/axum-core/src/extract/mod.rs
+++ b/axum-core/src/extract/mod.rs
@@ -29,9 +29,11 @@ pub use self::{
 pub type Request<T = Body> = http::Request<T>;
 
 mod private {
+    #[allow(clippy::empty_enums)] // We cannot use `!` yet in our MSRV.
     #[derive(Debug, Clone, Copy)]
     pub enum ViaParts {}
 
+    #[allow(clippy::empty_enums)] // We cannot use `!` yet in our MSRV.
     #[derive(Debug, Clone, Copy)]
     pub enum ViaRequest {}
 }

--- a/axum/src/handler/mod.rs
+++ b/axum/src/handler/mod.rs
@@ -264,6 +264,7 @@ all_the_tuples!(impl_handler);
 mod private {
     // Marker type for `impl<T: IntoResponse> Handler for T`
     #[allow(missing_debug_implementations)]
+    #[allow(clippy::empty_enums)] // We cannot use `!` yet in our MSRV.
     pub enum IntoResponseHandler {}
 }
 

--- a/axum/src/routing/tests/mod.rs
+++ b/axum/src/routing/tests/mod.rs
@@ -1211,7 +1211,7 @@ async fn logging_rejections() {
 
     let events = capture_tracing::<RejectionEvent, _>(|| async {
         let app = Router::new()
-            .route("/extension", get(|_: Extension<Infallible>| async {}))
+            .route("/extension", get(|_: Extension<()>| async {}))
             .route("/string", post(|_: String| async {}));
 
         let client = TestClient::new(app);
@@ -1240,8 +1240,7 @@ async fn logging_rejections() {
                 fields: RejectionEvent {
                     message: "rejecting request".to_owned(),
                     status: 500,
-                    body: "Missing request extension: Extension of \
-                        type `core::convert::Infallible` was not found. \
+                    body: "Missing request extension: Extension of type `()` was not found. \
                         Perhaps you forgot to add it? See `axum::Extension`."
                         .to_owned(),
                     rejection_type: "axum::extract::rejection::MissingExtension".to_owned(),

--- a/axum/src/serve/mod.rs
+++ b/axum/src/serve/mod.rs
@@ -753,7 +753,7 @@ mod tests {
         }
     }
 
-    #[allow(dead_code, unused_must_use)]
+    #[allow(dead_code, unused)]
     async fn if_it_compiles_it_works() {
         #[derive(Clone, Debug)]
         struct UdsConnectInfo;


### PR DESCRIPTION
Clippy started suggesting to use `struct Empty(!)` instead of `enum Empty {}` but we cannot do that with our MSRV (or on stable).

"if it compiles it works" test started generating a warning on unreachable expressions on nightly so the allow uses now more permissive group of lints for unused code.

`Infallible` is now alias for `!` since current nightly and the name leaked to our tests, so I've changed the type.